### PR TITLE
[pkg/ottl] Update Statements to implement filter.BoolExpr

### DIFF
--- a/.chloggen/ottl-add-eval-to-statements.yaml
+++ b/.chloggen/ottl-add-eval-to-statements.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add Eval function to Statements
+
+# One or more tracking issues related to the change
+issues: [18915]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -213,12 +213,12 @@ func (s *Statements[K]) Execute(ctx context.Context, tCtx K) error {
 }
 
 // Eval returns true if any statement's condition is true and returns false otherwise.
-// Does execute the function of the statement if the condition was true.
+// Does not execute the statement's function.
 // When errorMode is `propagate`, errors cause the evaluation to be false and an error is returned.
 // When errorMode is `ignore`, errors cause evaluation to continue to the next statement.
 func (s *Statements[K]) Eval(ctx context.Context, tCtx K) (bool, error) {
 	for _, statement := range s.statements {
-		_, match, err := statement.Execute(ctx, tCtx)
+		match, err := statement.condition.Eval(ctx, tCtx)
 		if err != nil {
 			if s.errorMode == PropagateError {
 				err = fmt.Errorf("failed to eval statement: %v, %w", statement.origText, err)

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -212,7 +212,8 @@ func (s *Statements[K]) Execute(ctx context.Context, tCtx K) error {
 	return nil
 }
 
-// Eval returns true if any statement is true and returns false otherwise.
+// Eval returns true if any statement's condition is true and returns false otherwise.
+// Does execute the function of the statement if the condition was true.
 // When errorMode is `propagate`, errors cause the evaluation to be false and an error is returned.
 // When errorMode is `ignore`, errors cause evaluation to continue to the next statement.
 func (s *Statements[K]) Eval(ctx context.Context, tCtx K) (bool, error) {

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -211,3 +211,24 @@ func (s *Statements[K]) Execute(ctx context.Context, tCtx K) error {
 	}
 	return nil
 }
+
+// Eval returns true if any statement is true and returns false otherwise.
+// When errorMode is `propagate`, errors cause the evaluation to be false and an error is returned.
+// When errorMode is `ignore`, errors cause evaluation to continue to the next statement.
+func (s *Statements[K]) Eval(ctx context.Context, tCtx K) (bool, error) {
+	for _, statement := range s.statements {
+		_, match, err := statement.Execute(ctx, tCtx)
+		if err != nil {
+			if s.errorMode == PropagateError {
+				err = fmt.Errorf("failed to eval statement: %v, %w", statement.origText, err)
+				return false, err
+			}
+			s.telemetrySettings.Logger.Warn("failed to eval statement", zap.Error(err), zap.String("statement", statement.origText))
+			continue
+		}
+		if match {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -1437,7 +1437,11 @@ func Test_Statements_Eval(t *testing.T) {
 			for _, condition := range tt.conditions {
 				rawStatements = append(rawStatements, &Statement[interface{}]{
 					condition: BoolExpr[any]{condition},
-					function:  Expr[any]{exprFunc: func(ctx context.Context, tCtx interface{}) (interface{}, error) { return nil, nil }},
+					function: Expr[any]{
+						exprFunc: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+							return nil, fmt.Errorf("function should not be called")
+						},
+					},
 				})
 			}
 
@@ -1477,7 +1481,11 @@ func Test_Statements_Eval_Error(t *testing.T) {
 			for _, condition := range tt.conditions {
 				rawStatements = append(rawStatements, &Statement[interface{}]{
 					condition: BoolExpr[any]{condition},
-					function:  Expr[any]{exprFunc: func(ctx context.Context, tCtx interface{}) (interface{}, error) { return nil, nil }},
+					function: Expr[any]{
+						exprFunc: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+							return nil, fmt.Errorf("function should not be called")
+						},
+					},
 				})
 			}
 

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -1312,7 +1312,7 @@ func Test_Execute(t *testing.T) {
 	}
 }
 
-func Test_Execute_Error(t *testing.T) {
+func Test_Statements_Execute_Error(t *testing.T) {
 	tests := []struct {
 		name      string
 		condition boolExpressionEvaluator[interface{}]
@@ -1379,6 +1379,117 @@ func Test_Execute_Error(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func Test_Statements_Eval(t *testing.T) {
+	tests := []struct {
+		name           string
+		conditions     []boolExpressionEvaluator[interface{}]
+		function       ExprFunc[interface{}]
+		errorMode      ErrorMode
+		expectedResult bool
+	}{
+		{
+			name: "True",
+			conditions: []boolExpressionEvaluator[interface{}]{
+				alwaysTrue[interface{}],
+			},
+			errorMode:      IgnoreError,
+			expectedResult: true,
+		},
+		{
+			name: "At least one True",
+			conditions: []boolExpressionEvaluator[interface{}]{
+				alwaysFalse[interface{}],
+				alwaysFalse[interface{}],
+				alwaysTrue[interface{}],
+			},
+			errorMode:      IgnoreError,
+			expectedResult: true,
+		},
+		{
+			name: "False",
+			conditions: []boolExpressionEvaluator[interface{}]{
+				alwaysFalse[interface{}],
+				alwaysFalse[interface{}],
+			},
+			errorMode:      IgnoreError,
+			expectedResult: false,
+		},
+		{
+			name: "Error is false when using Ignore",
+			conditions: []boolExpressionEvaluator[interface{}]{
+				alwaysFalse[interface{}],
+				func(context.Context, interface{}) (bool, error) {
+					return true, fmt.Errorf("test")
+				},
+				alwaysTrue[interface{}],
+			},
+			errorMode:      IgnoreError,
+			expectedResult: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rawStatements []*Statement[interface{}]
+			for _, condition := range tt.conditions {
+				rawStatements = append(rawStatements, &Statement[interface{}]{
+					condition: BoolExpr[any]{condition},
+					function:  Expr[any]{exprFunc: func(ctx context.Context, tCtx interface{}) (interface{}, error) { return nil, nil }},
+				})
+			}
+
+			statements := Statements[interface{}]{
+				statements:        rawStatements,
+				telemetrySettings: componenttest.NewNopTelemetrySettings(),
+				errorMode:         tt.errorMode,
+			}
+
+			result, err := statements.Eval(context.Background(), nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func Test_Statements_Eval_Error(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []boolExpressionEvaluator[interface{}]
+		function   ExprFunc[interface{}]
+		errorMode  ErrorMode
+	}{
+		{
+			name: "Propagate Error from function",
+			conditions: []boolExpressionEvaluator[interface{}]{
+				func(context.Context, interface{}) (bool, error) {
+					return true, fmt.Errorf("test")
+				},
+			},
+			errorMode: PropagateError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rawStatements []*Statement[interface{}]
+			for _, condition := range tt.conditions {
+				rawStatements = append(rawStatements, &Statement[interface{}]{
+					condition: BoolExpr[any]{condition},
+					function:  Expr[any]{exprFunc: func(ctx context.Context, tCtx interface{}) (interface{}, error) { return nil, nil }},
+				})
+			}
+
+			statements := Statements[interface{}]{
+				statements:        rawStatements,
+				telemetrySettings: componenttest.NewNopTelemetrySettings(),
+				errorMode:         tt.errorMode,
+			}
+
+			result, err := statements.Eval(context.Background(), nil)
+			assert.Error(t, err)
+			assert.False(t, result)
 		})
 	}
 }


### PR DESCRIPTION
**Description:** 
Updates the `Statements` struct to implement the `internal/filter.BoolExpr` interface.  This is the first step to adding a `filterottl` package to make filtering with ottl in components simpler.

**Link to tracking Issue:** 
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18642

**Testing:** 
Added unit tests

**Documentation:** 
Added docs comments