### PR TITLE
[processor/filter] Add error_mode configuration option

### DIFF
--- a/.chloggen/fp-error-mode.yaml
+++ b/.chloggen/fp-error-mode.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filterprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `error_mode` configuration option that allows specifying how errors from OTTL conditions should be handled.
+
+# One or more tracking issues related to the change
+issues: [19142]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -317,6 +317,15 @@ The same relationship applies to metrics and datapoints.
 If all span events for a span are dropped, the span will be left intact.
 If all datapoints for a metric are dropped, the metric will also be dropped.
 
+The filter processor also allows configuring an optional field, `error_mode`, which will determine how the processor reacts to errors that occur while processing an OTTL condition.
+
+| error_mode            | description                                                                                                                |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------|
+| ignore                | The processor ignores errors returned by conditions and continues on to the next condition.  This is the recommended mode. |
+| propagate             | The processor returns the error up the pipeline.  This will result in the payload being dropped from the collector.        |
+
+If not specified, `propagate` will be used.
+
 ### OTTL Functions
 
 The filter processor has access to all the [factory functions of the OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/ottlfuncs#ottl-functions)
@@ -354,6 +363,7 @@ Examples:
 ```yaml
 processors:
   filter/ottl:
+    error_mode: ignore
     traces:
       span:
         - 'attributes["container.name"] == "app_container_1"'

--- a/processor/filterprocessor/config.go
+++ b/processor/filterprocessor/config.go
@@ -35,6 +35,13 @@ import (
 
 // Config defines configuration for Resource processor.
 type Config struct {
+	// ErrorMode determines how the processor reacts to errors that occur while processing an OTTL condition.
+	// Valid values are `ignore` and `propagate`.
+	// `ignore` means the processor ignores errors returned by conditions and continues on to the next condition. This is the recommended mode.
+	// `propagate` means the processor returns the error up the pipeline.  This will result in the payload being dropped from the collector.
+	// The default value is `propagate`.
+	ErrorMode ottl.ErrorMode `mapstructure:"error_mode"`
+
 	Metrics MetricFilters `mapstructure:"metrics"`
 
 	Logs LogFilters `mapstructure:"logs"`

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filtermetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset"
 	fsregexp "github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset/regexp"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
 // TestLoadingConfigRegexp tests loading testdata/config_strict.yaml
@@ -52,6 +53,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "empty"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Include: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Strict,
@@ -61,6 +63,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "include"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Include: testDataMetricProperties,
 				},
@@ -68,6 +71,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "exclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Exclude: testDataMetricProperties,
 				},
@@ -75,6 +79,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "includeexclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Include: testDataMetricProperties,
 					Exclude: &filtermetric.MatchProperties{
@@ -134,6 +139,7 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "empty"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: &LogMatchProperties{
 						LogMatchType: Strict,
@@ -143,6 +149,7 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "include"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 				},
@@ -150,6 +157,7 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "exclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Exclude: testDataLogPropertiesExclude,
 				},
@@ -157,6 +165,7 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "includeexclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 					Exclude: testDataLogPropertiesExclude,
@@ -203,6 +212,7 @@ func TestLoadingConfigSeverityLogsStrict(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "include"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 				},
@@ -210,6 +220,7 @@ func TestLoadingConfigSeverityLogsStrict(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "exclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Exclude: testDataLogPropertiesExclude,
 				},
@@ -217,6 +228,7 @@ func TestLoadingConfigSeverityLogsStrict(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "includeexclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 					Exclude: testDataLogPropertiesExclude,
@@ -262,6 +274,7 @@ func TestLoadingConfigSeverityLogsRegexp(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "include"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 				},
@@ -269,6 +282,7 @@ func TestLoadingConfigSeverityLogsRegexp(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "exclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Exclude: testDataLogPropertiesExclude,
 				},
@@ -276,6 +290,7 @@ func TestLoadingConfigSeverityLogsRegexp(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "includeexclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 					Exclude: testDataLogPropertiesExclude,
@@ -322,6 +337,7 @@ func TestLoadingConfigBodyLogsStrict(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "include"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 				},
@@ -329,6 +345,7 @@ func TestLoadingConfigBodyLogsStrict(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "exclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Exclude: testDataLogPropertiesExclude,
 				},
@@ -336,6 +353,7 @@ func TestLoadingConfigBodyLogsStrict(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "includeexclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 					Exclude: testDataLogPropertiesExclude,
@@ -382,6 +400,7 @@ func TestLoadingConfigBodyLogsRegexp(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "include"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 				},
@@ -389,6 +408,7 @@ func TestLoadingConfigBodyLogsRegexp(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "exclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Exclude: testDataLogPropertiesExclude,
 				},
@@ -396,6 +416,7 @@ func TestLoadingConfigBodyLogsRegexp(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "includeexclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 					Exclude: testDataLogPropertiesExclude,
@@ -444,6 +465,7 @@ func TestLoadingConfigMinSeverityNumberLogs(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "include"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 				},
@@ -451,6 +473,7 @@ func TestLoadingConfigMinSeverityNumberLogs(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "exclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Exclude: testDataLogPropertiesExclude,
 				},
@@ -458,6 +481,7 @@ func TestLoadingConfigMinSeverityNumberLogs(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "includeexclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
 					Include: testDataLogPropertiesInclude,
 					Exclude: testDataLogPropertiesExclude,
@@ -510,6 +534,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "include"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Include: testDataMetricProperties,
 				},
@@ -517,6 +542,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "exclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Exclude: testDataMetricProperties,
 				},
@@ -524,6 +550,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "unlimitedcache"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Include: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Regexp,
@@ -537,6 +564,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 		}, {
 			id: component.NewIDWithName("filter", "limitedcache"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Exclude: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Regexp,
@@ -577,6 +605,7 @@ func TestLoadingSpans(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "spans"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Spans: filterconfig.MatchConfig{
 					Include: &filterconfig.MatchProperties{
 						Config: filterset.Config{
@@ -626,6 +655,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "empty"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Include: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Expr,
@@ -636,6 +666,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "include"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Include: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Expr,
@@ -650,6 +681,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "exclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Exclude: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Expr,
@@ -664,6 +696,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "includeexclude"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
 					Include: &filtermetric.MatchProperties{
 						MatchType: filtermetric.Expr,
@@ -822,6 +855,7 @@ func TestLoadingConfigOTTL(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "ottl"),
 			expected: &Config{
+				ErrorMode: ottl.IgnoreError,
 				Traces: TraceFilters{
 					SpanConditions: []string{
 						`attributes["test"] == "pass"`,
@@ -848,6 +882,7 @@ func TestLoadingConfigOTTL(t *testing.T) {
 		{
 			id: component.NewIDWithName("filter", "multiline"),
 			expected: &Config{
+				ErrorMode: ottl.PropagateError,
 				Traces: TraceFilters{
 					SpanConditions: []string{
 						`attributes["test"] == "pass"`,

--- a/processor/filterprocessor/factory.go
+++ b/processor/filterprocessor/factory.go
@@ -21,6 +21,8 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
 const (
@@ -44,7 +46,9 @@ func NewFactory() processor.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{
+		ErrorMode: ottl.PropagateError,
+	}
 }
 
 func createMetricsProcessor(

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -27,6 +27,8 @@ import (
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/processor/processortest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
 func TestType(t *testing.T) {
@@ -39,7 +41,9 @@ func TestType(t *testing.T) {
 func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.Equal(t, cfg, &Config{})
+	assert.Equal(t, cfg, &Config{
+		ErrorMode: ottl.PropagateError,
+	})
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 }
 

--- a/processor/filterprocessor/logs.go
+++ b/processor/filterprocessor/logs.go
@@ -28,7 +28,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterlog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 )
 
@@ -42,7 +41,7 @@ func newFilterLogsProcessor(set component.TelemetrySettings, cfg *Config) (*filt
 		logger: set.Logger,
 	}
 	if cfg.Logs.LogConditions != nil {
-		skipExpr, err := filterottl.NewBoolExprForLog(cfg.Logs.LogConditions, filterottl.StandardLogFuncs(), ottl.PropagateError, set)
+		skipExpr, err := filterottl.NewBoolExprForLog(cfg.Logs.LogConditions, filterottl.StandardLogFuncs(), cfg.ErrorMode, set)
 		if err != nil {
 			return nil, err
 		}

--- a/processor/filterprocessor/metrics.go
+++ b/processor/filterprocessor/metrics.go
@@ -51,14 +51,14 @@ func newFilterMetricProcessor(set component.TelemetrySettings, cfg *Config) (*fi
 	}
 	if cfg.Metrics.MetricConditions != nil || cfg.Metrics.DataPointConditions != nil {
 		if cfg.Metrics.MetricConditions != nil {
-			fsp.skipMetricExpr, err = filterottl.NewBoolExprForMetric(cfg.Metrics.MetricConditions, common.MetricFunctions(), ottl.PropagateError, set)
+			fsp.skipMetricExpr, err = filterottl.NewBoolExprForMetric(cfg.Metrics.MetricConditions, common.MetricFunctions(), cfg.ErrorMode, set)
 			if err != nil {
 				return nil, err
 			}
 		}
 
 		if cfg.Metrics.DataPointConditions != nil {
-			fsp.skipDataPointExpr, err = filterottl.NewBoolExprForDataPoint(cfg.Metrics.DataPointConditions, filterottl.StandardDataPointFuncs(), ottl.PropagateError, set)
+			fsp.skipDataPointExpr, err = filterottl.NewBoolExprForDataPoint(cfg.Metrics.DataPointConditions, filterottl.StandardDataPointFuncs(), cfg.ErrorMode, set)
 			if err != nil {
 				return nil, err
 			}

--- a/processor/filterprocessor/metrics.go
+++ b/processor/filterprocessor/metrics.go
@@ -30,7 +30,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filtermetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlresource"

--- a/processor/filterprocessor/testdata/config_ottl.yaml
+++ b/processor/filterprocessor/testdata/config_ottl.yaml
@@ -1,4 +1,5 @@
 filter/ottl:
+  error_mode: ignore
   traces:
     span:
       - 'attributes["test"] == "pass"'

--- a/processor/filterprocessor/traces.go
+++ b/processor/filterprocessor/traces.go
@@ -44,13 +44,13 @@ func newFilterSpansProcessor(set component.TelemetrySettings, cfg *Config) (*fil
 	}
 	if cfg.Traces.SpanConditions != nil || cfg.Traces.SpanEventConditions != nil {
 		if cfg.Traces.SpanConditions != nil {
-			fsp.skipSpanExpr, err = filterottl.NewBoolExprForSpan(cfg.Traces.SpanConditions, filterottl.StandardSpanFuncs(), ottl.PropagateError, set)
+			fsp.skipSpanExpr, err = filterottl.NewBoolExprForSpan(cfg.Traces.SpanConditions, filterottl.StandardSpanFuncs(), cfg.ErrorMode, set)
 			if err != nil {
 				return nil, err
 			}
 		}
 		if cfg.Traces.SpanEventConditions != nil {
-			fsp.skipSpanEventExpr, err = filterottl.NewBoolExprForSpanEvent(cfg.Traces.SpanEventConditions, filterottl.StandardSpanEventFuncs(), ottl.PropagateError, set)
+			fsp.skipSpanEventExpr, err = filterottl.NewBoolExprForSpanEvent(cfg.Traces.SpanEventConditions, filterottl.StandardSpanEventFuncs(), cfg.ErrorMode, set)
 			if err != nil {
 				return nil, err
 			}

--- a/processor/filterprocessor/traces.go
+++ b/processor/filterprocessor/traces.go
@@ -26,7 +26,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/expr"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterspan"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspanevent"
 )


### PR DESCRIPTION
**Description:** 
Add error_mode configuration option.  This option allows configuring how the processor handles errors that occur when evaluating OTTL conditions.

**Link to tracking Issue:**

Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16519

Depends on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/18930

**Testing:** 
Updated tests

**Documentation:**
Updated documentation