### PR TITLE
Don't auto-assign dashpole while i'm out on leave

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -12,7 +12,7 @@ assigneeGroups:
   approvers_maintainers:
     # Approvers
     - Aneurysm9
-    - dashpole
+    # - dashpole is out on leave
     - evan-bradley
     - MovieStoreGuy
     - TylerHelmuth


### PR DESCRIPTION
**Description:** <Describe what has changed.>
remove dashpole from the autoassign list while i'm out on leave.