### PR TITLE
[chore] Remove sqlite compilation warnings

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -14,6 +14,7 @@ SRC_ROOT := $(shell git rev-parse --show-toplevel)
 
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""
+GOTEST_ENV?=
 GOTEST_OPT?= -race -timeout 300s -parallel 4 --tags=$(GO_BUILD_TAGS)
 GOTEST_INTEGRATION_OPT?= -race -timeout 360s -parallel 4
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
@@ -96,9 +97,9 @@ common: checklicense lint misspell
 .PHONY: test
 test:
 	if [ "$(RUNNING_ON_GITHUB_ACTION)" = "true" ]; then \
-		$(GOTEST) $(GOTEST_OPT) -v ./... 2>&1 | tee -a ./foresight-test-report.txt; \
+		$(GOTEST_ENV) $(GOTEST) $(GOTEST_OPT) -v ./... 2>&1 | tee -a ./foresight-test-report.txt; \
 	else \
-		$(GOTEST) $(GOTEST_OPT) ./...; \
+		$(GOTEST_ENV) $(GOTEST) $(GOTEST_OPT) ./...; \
 	fi
 	
 .PHONY: do-unit-tests-with-cover

--- a/extension/storage/Makefile
+++ b/extension/storage/Makefile
@@ -1,1 +1,3 @@
 include ../../Makefile.Common
+
+GOTEST_ENV += CGO_CFLAGS="-g -O2 -Wno-return-local-addr -Wno-unknown-warning-option"


### PR DESCRIPTION
This PR adds a CGO flag to the `make test` command for the `extension/storage` extension that explicitly disables warnings from the sqlite go library. See https://github.com/mattn/go-sqlite3/issues/803 for context. Note I also added `-Wno-unknown-warning-option` as some versions of gcc do not recognize the `-Wno-return-local-addr` flag.

This PR will remove those warnings from the build:
```
# github.com/mattn/go-sqlite3
sqlite3-binding.c: In function ‘sqlite3SelectNew’:
sqlite3-binding.c:128049:10: warning: function may return address of local variable [-Wreturn-local-addr]
128049 |   return pNew;
       |          ^~~~
sqlite3-binding.c:128009:10: note: declared here
128009 |   Select standin;
       |          ^~~~~~~
```