### PR TITLE
internal/clientutil: account for nil http response

### DIFF
--- a/.chloggen/gbbr_nil-resp.yaml
+++ b/.chloggen/gbbr_nil-resp.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix nil panic when metrics API request can not be built.
+
+# One or more tracking issues related to the change
+issues: [19158]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/datadogexporter/internal/clientutil/error_converter.go
+++ b/exporter/datadogexporter/internal/clientutil/error_converter.go
@@ -29,5 +29,5 @@ func WrapError(err error, resp *http.Response) error {
 }
 
 func isNonRetriable(resp *http.Response) bool {
-	return resp.StatusCode == 400 || resp.StatusCode == 404 || resp.StatusCode == 413 || resp.StatusCode == 403
+	return resp == nil || resp.StatusCode == 400 || resp.StatusCode == 404 || resp.StatusCode == 413 || resp.StatusCode == 403
 }


### PR DESCRIPTION
The datadog-api-client-go's (*MetricsAPI).SubmitMetrics call *can* and *will* return nil in cases where it can not build the request. This has not been accounted for and resulted in a panic.

This change fixes that by concluding that a nil http response means a non-retriable error.

Closes #19158
