### PR TITLE
[translator/loki] loki exporter add raw log export format

### DIFF
--- a/.chloggen/loki-exporter-add-raw-log-export-format.yaml
+++ b/.chloggen/loki-exporter-add-raw-log-export-format.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: translator/loki
+note: Loki add raw log export format
+issues: [ 18888 ]

--- a/exporter/lokiexporter/README.md
+++ b/exporter/lokiexporter/README.md
@@ -126,6 +126,7 @@ The following formats are supported:
 
 - `logfmt`: Write logs as [logfmt](https://brandur.org/logfmt) lines.
 - `json`: Write logs as JSON objects. It is the default format if no hint is present.
+- `raw`: Write the body of the log message as string representation.
 
 ## Severity
 

--- a/pkg/translator/loki/convert.go
+++ b/pkg/translator/loki/convert.go
@@ -35,6 +35,7 @@ const (
 const (
 	formatJSON   string = "json"
 	formatLogfmt string = "logfmt"
+	formatRaw    string = "raw"
 )
 
 func convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs pcommon.Map) model.LabelSet {
@@ -170,14 +171,23 @@ func convertLogToLogfmtEntry(lr plog.LogRecord, res pcommon.Resource, scope pcom
 	}, nil
 }
 
+func convertLogToLogRawEntry(lr plog.LogRecord) (*push.Entry, error) {
+	return &push.Entry{
+		Timestamp: timestampFromLogRecord(lr),
+		Line:      lr.Body().Str(),
+	}, nil
+}
+
 func convertLogToLokiEntry(lr plog.LogRecord, res pcommon.Resource, format string, scope pcommon.InstrumentationScope) (*push.Entry, error) {
 	switch format {
 	case formatJSON:
 		return convertLogToJSONEntry(lr, res, scope)
 	case formatLogfmt:
 		return convertLogToLogfmtEntry(lr, res, scope)
+	case formatRaw:
+		return convertLogToLogRawEntry(lr)
 	default:
-		return nil, fmt.Errorf("invalid format %s. Expected one of: %s, %s", format, formatJSON, formatLogfmt)
+		return nil, fmt.Errorf("invalid format %s. Expected one of: %s, %s, %s", format, formatJSON, formatLogfmt, formatRaw)
 	}
 
 }

--- a/pkg/translator/loki/convert.go
+++ b/pkg/translator/loki/convert.go
@@ -174,7 +174,7 @@ func convertLogToLogfmtEntry(lr plog.LogRecord, res pcommon.Resource, scope pcom
 func convertLogToLogRawEntry(lr plog.LogRecord) (*push.Entry, error) {
 	return &push.Entry{
 		Timestamp: timestampFromLogRecord(lr),
-		Line:      lr.Body().Str(),
+		Line:      lr.Body().AsString(),
 	}, nil
 }
 

--- a/pkg/translator/loki/convert_test.go
+++ b/pkg/translator/loki/convert_test.go
@@ -15,6 +15,7 @@
 package loki // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki"
 
 import (
+	"github.com/grafana/loki/pkg/push"
 	"testing"
 
 	"github.com/prometheus/common/model"
@@ -285,4 +286,17 @@ func TestGetNestedAttribute(t *testing.T) {
 	// verify
 	assert.Equal(t, "guarana", attr.AsString())
 	assert.True(t, ok)
+}
+
+func TestConvertLogToLogRawEntry(t *testing.T) {
+	log, _, _ := exampleLog()
+
+	expectedLogEntry := &push.Entry{
+		Timestamp: timestampFromLogRecord(log),
+		Line:      "Example log",
+	}
+
+	out, err := convertLogToLogRawEntry(log)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedLogEntry, out)
 }

--- a/pkg/translator/loki/convert_test.go
+++ b/pkg/translator/loki/convert_test.go
@@ -15,9 +15,9 @@
 package loki // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki"
 
 import (
-	"github.com/grafana/loki/pkg/push"
 	"testing"
 
+	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -290,6 +290,7 @@ func TestGetNestedAttribute(t *testing.T) {
 
 func TestConvertLogToLogRawEntry(t *testing.T) {
 	log, _, _ := exampleLog()
+	log.SetTimestamp(pcommon.NewTimestampFromTime(timeNow()))
 
 	expectedLogEntry := &push.Entry{
 		Timestamp: timestampFromLogRecord(log),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

As discussed in [slack](https://cloud-native.slack.com/archives/C01N6P7KR6W/p1676899714780589), right now when using the loki exporter, to access the raw log message we need to run a query like this:
```
{exporter=OTLP} | json | line_format `{{.body}}`
```
To avoid having to parse the log messages twice, I propose introducing `raw` format. Instead of sending the whole log record (including attributes and resources attributes) as a json, just send the body containing the actual log message.


**Link to tracking Issue:** <Issue number if applicable>

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18742

**Testing:** <Describe what testing was performed and which tests were added.>
Tested in our testing environment with locally built image.

![Screenshot 2023-02-28 at 18 49 15](https://user-images.githubusercontent.com/7171250/222171812-c0a54148-1967-413d-bfc8-91e459798d8e.png)

**Documentation:** <Describe the documentation added.>