### PR TITLE
[jaeger/receiver] Fix span status translation

### DIFF
--- a/.chloggen/fix-jaeger-reciever-span-status-translation.yaml
+++ b/.chloggen/fix-jaeger-reciever-span-status-translation.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/jaeger
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix translation of span status
+
+# One or more tracking issues related to the change
+issues: [19171]

--- a/pkg/translator/jaeger/jaegerproto_to_traces.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces.go
@@ -222,11 +222,11 @@ func jSpanToInternal(span *model.Span, dest ptrace.Span) {
 	attrs := dest.Attributes()
 	attrs.EnsureCapacity(len(span.Tags))
 	jTagsToInternalAttributes(span.Tags, attrs)
-	setInternalSpanStatus(attrs, dest)
 	if spanKindAttr, ok := attrs.Get(tracetranslator.TagSpanKind); ok {
 		dest.SetKind(jSpanKindToInternal(spanKindAttr.Str()))
 		attrs.Remove(tracetranslator.TagSpanKind)
 	}
+	setInternalSpanStatus(attrs, dest)
 
 	dest.TraceState().FromRaw(getTraceStateFromAttrs(attrs))
 

--- a/pkg/translator/jaeger/jaegerproto_to_traces_test.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces_test.go
@@ -277,6 +277,44 @@ func TestProtoToTraces(t *testing.T) {
 				}},
 			td: generateTracesSpanWithTwoParents(),
 		},
+		{
+			name: "no-error-from-server-span-with-4xx-http-code",
+			jb: []*model.Batch{
+				{
+					Process: &model.Process{
+						ServiceName: tracetranslator.ResourceNoServiceName,
+					},
+					Spans: []*model.Span{
+						{
+							StartTime: testSpanStartTime,
+							Duration:  testSpanEndTime.Sub(testSpanStartTime),
+							Tags: []model.KeyValue{
+								{
+									Key:   tracetranslator.TagSpanKind,
+									VType: model.ValueType_STRING,
+									VStr:  string(tracetranslator.OpenTracingSpanKindServer),
+								},
+								{
+									Key:   conventions.AttributeHTTPStatusCode,
+									VType: model.ValueType_STRING,
+									VStr:  "404",
+								},
+							},
+						},
+					},
+				}},
+			td: func() ptrace.Traces {
+				traces := ptrace.NewTraces()
+				span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+				span.SetStartTimestamp(testSpanStartTimestamp)
+				span.SetEndTimestamp(testSpanEndTimestamp)
+				span.SetKind(ptrace.SpanKindClient)
+				span.SetKind(ptrace.SpanKindServer)
+				span.Status().SetCode(ptrace.StatusCodeUnset)
+				span.Attributes().PutStr(conventions.AttributeHTTPStatusCode, "404")
+				return traces
+			}(),
+		},
 	}
 
 	for _, test := range tests {
@@ -662,6 +700,7 @@ func generateTracesOneSpanNoResource() ptrace.Traces {
 	span.SetStartTimestamp(testSpanStartTimestamp)
 	span.SetEndTimestamp(testSpanEndTimestamp)
 	span.SetKind(ptrace.SpanKindClient)
+	span.Status().SetCode(ptrace.StatusCodeError)
 	span.Events().At(0).SetTimestamp(testSpanEventTimestamp)
 	span.Events().At(0).SetDroppedAttributesCount(0)
 	span.Events().At(0).SetName("event-with-attr")
@@ -845,7 +884,7 @@ func generateTracesTwoSpansChildParent() ptrace.Traces {
 	span.SetTraceID(spans.At(0).TraceID())
 	span.SetStartTimestamp(spans.At(0).StartTimestamp())
 	span.SetEndTimestamp(spans.At(0).EndTimestamp())
-	span.Status().SetCode(ptrace.StatusCodeError)
+	span.Status().SetCode(ptrace.StatusCodeUnset)
 	span.Attributes().PutInt(conventions.AttributeHTTPStatusCode, 404)
 	return td
 }

--- a/pkg/translator/jaeger/jaegerthrift_to_traces.go
+++ b/pkg/translator/jaeger/jaegerthrift_to_traces.go
@@ -106,11 +106,11 @@ func jThriftSpanToInternal(span *jaeger.Span, dest ptrace.Span) {
 	attrs := dest.Attributes()
 	attrs.EnsureCapacity(len(span.Tags))
 	jThriftTagsToInternalAttributes(span.Tags, attrs)
-	setInternalSpanStatus(attrs, dest)
 	if spanKindAttr, ok := attrs.Get(tracetranslator.TagSpanKind); ok {
 		dest.SetKind(jSpanKindToInternal(spanKindAttr.Str()))
 		attrs.Remove(tracetranslator.TagSpanKind)
 	}
+	setInternalSpanStatus(attrs, dest)
 
 	// drop the attributes slice if all of them were replaced during translation
 	if attrs.Len() == 0 {

--- a/pkg/translator/jaeger/traces_to_jaegerproto_test.go
+++ b/pkg/translator/jaeger/traces_to_jaegerproto_test.go
@@ -289,7 +289,7 @@ func TestInternalTracesToJaegerProto(t *testing.T) {
 				},
 				Spans: []*model.Span{
 					generateProtoSpan(),
-					generateProtoChildSpanWithErrorTags(),
+					generateProtoChildSpan(),
 				},
 			},
 			err: nil,
@@ -389,25 +389,6 @@ func generateJProtoSpanWithEventAttribute() *model.Span {
 			VStr:  "must-be-used-instead-of-event-name",
 		},
 	}
-	return span
-}
-
-// generateProtoChildSpanWithErrorTags generates a jaeger span to be used in
-// internal->jaeger translation test. It supposed to be the same as generateProtoChildSpan
-// that used in jaeger->internal, but jaeger->internal translation infers status code from http status if
-// status.code is not set, so the pipeline jaeger->internal->jaeger adds two more tags as the result in that case.
-func generateProtoChildSpanWithErrorTags() *model.Span {
-	span := generateProtoChildSpan()
-	span.Tags = append(span.Tags, model.KeyValue{
-		Key:   conventions.OtelStatusCode,
-		VType: model.ValueType_STRING,
-		VStr:  statusError,
-	})
-	span.Tags = append(span.Tags, model.KeyValue{
-		Key:   tracetranslator.TagError,
-		VBool: true,
-		VType: model.ValueType_BOOL,
-	})
 	return span
 }
 


### PR DESCRIPTION
In jaeger->pdata translation, the OTel span status is set based on several sources, and one of them is [span kind](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/translator/jaeger/jaegerproto_to_traces.go#L306), but span kind is not set at the point when the status translation occurs, it's set right after that. This fix makes sure that span kind is set before the span status translation.
