### PR TITLE
[exporter/awsxray] Allow indexing of special attributes that have been filtered out

### DIFF
--- a/.chloggen/xray-exporter-allow-index-special-attributes.yaml
+++ b/.chloggen/xray-exporter-allow-index-special-attributes.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'awsxrayexporter'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow additions of special attributes to the list of indexable attributes in the AWS X-Ray exporter when explicitly listed by the user"
+
+# One or more tracking issues related to the change
+issues: [19173]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -99,6 +99,8 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 		return nil, err
 	}
 
+	attributes := span.Attributes()
+
 	var (
 		startTime                                          = timestampToFloatSeconds(span.StartTimestamp())
 		endTime                                            = timestampToFloatSeconds(span.EndTimestamp())
@@ -108,14 +110,13 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 		awsfiltered, aws                                   = makeAws(causefiltered, resource, logGroupNames)
 		service                                            = makeService(resource)
 		sqlfiltered, sql                                   = makeSQL(span, awsfiltered)
-		user, annotations, metadata                        = makeXRayAttributes(sqlfiltered, resource, storeResource, indexedAttrs, indexAllAttrs)
+		additionalAttrs                                    = addSpecialAttributes(sqlfiltered, indexedAttrs, attributes)
+		user, annotations, metadata                        = makeXRayAttributes(additionalAttrs, resource, storeResource, indexedAttrs, indexAllAttrs)
 		name                                               string
 		namespace                                          string
 	)
 
 	// X-Ray segment names are service names, unlike span names which are methods. Try to find a service name.
-
-	attributes := span.Attributes()
 
 	// peer.service should always be prioritized for segment names when set because it is what the user decided.
 	if peerService, ok := attributes.Get(conventions.AttributePeerService); ok {
@@ -318,6 +319,19 @@ func convertToAmazonTraceID(traceID pcommon.TraceID) (string, error) {
 
 func timestampToFloatSeconds(ts pcommon.Timestamp) float64 {
 	return float64(ts) / float64(time.Second)
+}
+
+func addSpecialAttributes(attributes map[string]pcommon.Value, indexedAttrs []string, unfilteredAttributes pcommon.Map) map[string]pcommon.Value {
+	for _, name := range indexedAttrs {
+		// Index attributes that have been filtered out before if explicitly added
+		_, filteredIn := attributes[name]
+		unfilteredAttribute, filteredOut := unfilteredAttributes.Get(name)
+		if !filteredIn && filteredOut {
+			attributes[name] = unfilteredAttribute
+		}
+	}
+
+	return attributes
 }
 
 func makeXRayAttributes(attributes map[string]pcommon.Value, resource pcommon.Resource, storeResource bool, indexedAttrs []string, indexAllAttrs bool) (

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -323,10 +323,10 @@ func timestampToFloatSeconds(ts pcommon.Timestamp) float64 {
 
 func addSpecialAttributes(attributes map[string]pcommon.Value, indexedAttrs []string, unfilteredAttributes pcommon.Map) map[string]pcommon.Value {
 	for _, name := range indexedAttrs {
-		// Index attributes that have been filtered out before if explicitly added
-		_, filteredIn := attributes[name]
-		unfilteredAttribute, filteredOut := unfilteredAttributes.Get(name)
-		if !filteredIn && filteredOut {
+		// Allow attributes that have been filtered out before if explicitly added to be annotated/indexed
+		_, isAnnotatable := attributes[name]
+		unfilteredAttribute, attributeExists := unfilteredAttributes.Get(name)
+		if !isAnnotatable && attributeExists {
 			attributes[name] = unfilteredAttribute
 		}
 	}

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -552,6 +552,55 @@ func TestResourceAttributesNotIndexedIfSubsegment(t *testing.T) {
 	assert.Empty(t, segment.Metadata)
 }
 
+func TestSpanWithSpecialAttributesAsListed(t *testing.T) {
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes[awsxray.AWSOperationAttribute] = "aws_operation_val"
+	attributes[conventions.AttributeRPCMethod] = "rpc_method_val"
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventions.AttributeRPCMethod}, false, nil)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, 2, len(segment.Annotations))
+	assert.Equal(t, "aws_operation_val", segment.Annotations["aws_operation"])
+	assert.Equal(t, "rpc_method_val", segment.Annotations["rpc_method"])
+}
+
+func TestSpanWithSpecialAttributesAsListedAndIndexAll(t *testing.T) {
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes[awsxray.AWSOperationAttribute] = "aws_operation_val"
+	attributes[conventions.AttributeRPCMethod] = "rpc_method_val"
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventions.AttributeRPCMethod}, true, nil)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, "aws_operation_val", segment.Annotations["aws_operation"])
+	assert.Equal(t, "rpc_method_val", segment.Annotations["rpc_method"])
+}
+
+func TestSpanWithSpecialAttributesNotListedAndIndexAll(t *testing.T) {
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes[awsxray.AWSOperationAttribute] = "val1"
+	attributes[conventions.AttributeRPCMethod] = "val2"
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, nil, true, nil)
+
+	assert.NotNil(t, segment)
+	assert.Nil(t, segment.Annotations["aws_operation"])
+	assert.Nil(t, segment.Annotations["rpc_method"])
+}
+
 func TestOriginNotAws(t *testing.T) {
 	spanName := "/test"
 	parentSpanID := newSegmentID()


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

If rpc.method (or aws.operation) is in the indexed_attributes list, it will not appear as an annotation.

Issue stems from:
- the makeAws function filters out aws.operation which can carry the rpc.method when aws.operation was not set
- The filtered attributes is then filtered again for some database stuff by makeSQL function
- The filtered (again) attributes finally are processed by makeXRayAttributes function which handles annotations and metadata

[Example location of attributes being filtered](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/awsxrayexporter/internal/translator/aws.go#L135-L138)

Due to the filtering, `aws.operation` or `rcp.method` attributes cannot become annotations. The reason why this is currently the case is likely to avoid duplicate data because these special attributes are already present in a different section of trace, but not indexed.

The change in this commit is to allow these special attributes to be able to be annotations when explicitly listed in `indexedAttrs`. The filtered attributes list is now checked in `addSpecialAttributes` to see if there are any missing attributes that are explicitly listed to be index that does exists in the unfiltered attributes list. These missing attributes are added into the filtered attributes list.

Note - if `indexAllAttrs` is true AND the special attributes are NOT in `indexedAttrs`, then these attributes should not be indexed/annotated.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests ensures that the attributes that have been filtered out previously (aws.operation, rpc.method), are now able to be annotations when explicitly listed.

Unit test cases:
- indexedAttrs includes special attributes, do not index all -> should annotate special attributes
- indexedAttrs includes special attributes, do index all -> should annotate special attributes
- indexedAttrs doesn't includes special attributes, do index all -> should NOT annotate special attributes

**Documentation:** <Describe the documentation added.>