### PR TITLE
[fileconsumer] Exclude 'eof' field from reader encoding

### DIFF
--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -43,7 +43,7 @@ type Reader struct {
 	generation     int
 	file           *os.File
 	fileAttributes *FileAttributes
-	eof            bool
+	eof            bool `json:"-"` // json tag excludes embedded fields from storage
 }
 
 // offsetToEnd sets the starting offset


### PR DESCRIPTION
The `Reader` struct may be encoded and stored via a storage extension. Therefore, it is important to encode only the fields that are necessary to reload the `Reader` struct. 

The `eof` field is meant to indicate a temporary state that is updated with each poll cycle, so it does not need to be stored. We should exclude this setting so that it may be removed or changed in the future if necessary without any risk to breaking stored Readers. This field was added [since the last release](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/19138) so this is not a breaking change.