### PR TITLE
add sharedcomponent to splunk hec receiver

### DIFF
--- a/.chloggen/add-sharedcomponent-splunk-hec-receiver.yaml
+++ b/.chloggen/add-sharedcomponent-splunk-hec-receiver.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/splunkhec
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds sharedcomponent to Splunk HEC Receiver
+
+# One or more tracking issues related to the change
+issues: [18734]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/splunkhecreceiver/factory_test.go
+++ b/receiver/splunkhecreceiver/factory_test.go
@@ -67,3 +67,21 @@ func TestCreateNilNextConsumerLogs(t *testing.T) {
 	assert.EqualError(t, err, "nil logsConsumer")
 	assert.Nil(t, mReceiver, "receiver creation failed")
 }
+
+func TestMultipleLogsReceivers(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Endpoint = "localhost:1"
+	mockLogsConsumer := consumertest.NewNop()
+	mReceiver, _ := createLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, mockLogsConsumer)
+	mReceiver2, _ := createLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, mockLogsConsumer)
+	assert.Equal(t, mReceiver, mReceiver2)
+}
+
+func TestMultipleMetricsReceivers(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Endpoint = "localhost:1"
+	mockMetricsConsumer := consumertest.NewNop()
+	mReceiver, _ := createLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, mockMetricsConsumer)
+	mReceiver2, _ := createLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, mockMetricsConsumer)
+	assert.Equal(t, mReceiver, mReceiver2)
+}

--- a/receiver/splunkhecreceiver/go.mod
+++ b/receiver/splunkhecreceiver/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.72.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.72.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.72.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.72.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.72.0
 	github.com/stretchr/testify v1.8.2
@@ -73,3 +74,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/corei
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr => ../../pkg/batchperresourceattr
 
 retract v0.65.0
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent => ../../internal/sharedcomponent


### PR DESCRIPTION
**Description:** 
Add sharedcomponent to the Splunk HEC receiver. This allows reusing the same receiver in pipelines: it fixes `:8088: bind: address already in use` issue.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18734

**Testing:** 
Manual testing, unit tests

**Documentation:**
Nothing new added