### PR TITLE
[receiver/mongodbatlas] Dont panic on inaccessible file storage

### DIFF
--- a/.chloggen/dont-panic-on-inaccessible-file-storage.yaml
+++ b/.chloggen/dont-panic-on-inaccessible-file-storage.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbatlasreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes issue where on a failed start we don't try to checkpoint with an unset storage client.
+
+# One or more tracking issues related to the change
+issues: [19191]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mongodbatlasreceiver/events.go
+++ b/receiver/mongodbatlasreceiver/events.go
@@ -69,16 +69,17 @@ type eventRecord struct {
 
 func newEventsReceiver(settings rcvr.CreateSettings, c *Config, consumer consumer.Logs) *eventsReceiver {
 	r := &eventsReceiver{
-		client:       internal.NewMongoDBAtlasClient(c.PublicKey, c.PrivateKey, c.RetrySettings, settings.Logger),
-		cfg:          c,
-		logger:       settings.Logger,
-		id:           settings.ID,
-		storageID:    c.StorageID,
-		consumer:     consumer,
-		pollInterval: c.Events.PollInterval,
-		wg:           &sync.WaitGroup{},
-		maxPages:     int(c.Events.MaxPages),
-		pageSize:     int(c.Events.PageSize),
+		client:        internal.NewMongoDBAtlasClient(c.PublicKey, c.PrivateKey, c.RetrySettings, settings.Logger),
+		cfg:           c,
+		logger:        settings.Logger,
+		id:            settings.ID,
+		storageID:     c.StorageID,
+		consumer:      consumer,
+		pollInterval:  c.Events.PollInterval,
+		wg:            &sync.WaitGroup{},
+		maxPages:      int(c.Events.MaxPages),
+		pageSize:      int(c.Events.PageSize),
+		storageClient: storage.NewNopClient(),
 	}
 
 	if r.maxPages == 0 {
@@ -114,10 +115,6 @@ func (er *eventsReceiver) Shutdown(ctx context.Context) error {
 	er.logger.Debug("Shutting down events receiver")
 	er.cancel()
 	er.wg.Wait()
-	// if storageClient was never set, we shouldn't try to checkpoint
-	if er.storageClient == nil {
-		return nil
-	}
 	return er.checkpoint(ctx)
 }
 

--- a/receiver/mongodbatlasreceiver/events.go
+++ b/receiver/mongodbatlasreceiver/events.go
@@ -228,6 +228,11 @@ func (er *eventsReceiver) transformEvents(now pcommon.Timestamp, events []*mongo
 }
 
 func (er *eventsReceiver) checkpoint(ctx context.Context) error {
+	// if storageClient was never set, we shouldn't try to checkpoint
+	if er.storageClient == nil {
+		return nil
+	}
+
 	marshalBytes, err := json.Marshal(er.record)
 	if err != nil {
 		return fmt.Errorf("unable to write checkpoint: %w", err)

--- a/receiver/mongodbatlasreceiver/events.go
+++ b/receiver/mongodbatlasreceiver/events.go
@@ -114,6 +114,10 @@ func (er *eventsReceiver) Shutdown(ctx context.Context) error {
 	er.logger.Debug("Shutting down events receiver")
 	er.cancel()
 	er.wg.Wait()
+	// if storageClient was never set, we shouldn't try to checkpoint
+	if er.storageClient == nil {
+		return nil
+	}
 	return er.checkpoint(ctx)
 }
 
@@ -228,11 +232,6 @@ func (er *eventsReceiver) transformEvents(now pcommon.Timestamp, events []*mongo
 }
 
 func (er *eventsReceiver) checkpoint(ctx context.Context) error {
-	// if storageClient was never set, we shouldn't try to checkpoint
-	if er.storageClient == nil {
-		return nil
-	}
-
 	marshalBytes, err := json.Marshal(er.record)
 	if err != nil {
 		return fmt.Errorf("unable to write checkpoint: %w", err)


### PR DESCRIPTION
**Description:** On the start function of the events receiver we can fail and return an error, shutdown still gets called which had the potential to nil pointer exception because Start never finished.

**Link to tracking Issue:** Resolves #19191

**Testing:** 

Behavior before:

```
{"level":"fatal","ts":"2023-03-03T10:41:26.398-0500","caller":"collector/main.go:113","msg":"RunService returned error","error":"failed to start service: failed while starting collector: collector panicked with error: runtime error: invalid memory address or nil pointer dereference. Panic stacktrace: goroutine 44 [running]:\nruntime/debug.Stack()\n\t/usr/local/opt/go/libexec/src/runtime/debug/stack.go:24 +0x65\ngithub.com/observiq/observiq-otel-collector/collector.(*collector).Run.func1.1()\n\t/Users/keithschmitt/go-workspace/src/github.com/observiq/observiq-collector/collector/collector.go:114 +0x5d\npanic({0x105001ac0, 0x10a3a1e10})\n\t/usr/local/opt/go/libexec/src/runtime/panic.go:884 +0x212\ngithub.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver.(*eventsReceiver).checkpoint(0xc000eca820, {0x10698b4f8, 0xc000c76740})\n\t/Users/keithschmitt/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver@v0.72.0/events.go:235 +0x90\ngithub.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver.(*eventsReceiver).Shutdown(0xc000eca820, {0x10698b4f8, 0xc000c76740})\n\t/Users/keithschmitt/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver@v0.72.0/events.go:117 +0x85\ngithub.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver.(*combinedLogsReceiver).Shutdown(0xc000ecde78, {0x10698b4f8, 0xc000c76740})\n\t/Users/keithschmitt/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver@v0.72.0/combined_logs.go:73 +0xdd\ngo.opentelemetry.io/collector/service.(*pipelinesGraph).ShutdownAll(0x0?, {0x10698b4f8, 0xc000c76740})\n\t/Users/keithschmitt/go/pkg/mod/go.opentelemetry.io/collector@v0.72.0/service/graph.go:296 +0xc9\ngo.opentelemetry.io/collector/service.(*Service).Shutdown(0xc0003add80, {0x10698b4f8, 0xc000c76740})\n\t/Users/keithschmitt/go/pkg/mod/go.opentelemetry.io/collector@v0.72.0/service/service.go:172 +0xd9\ngo.opentelemetry.io/collector/otelcol.(*Collector).setupConfigurationComponents(0xc000c7a000, {0x10698b4f8, 0xc000c76740})\n\t/Users/keithschmitt/go/pkg/mod/go.opentelemetry.io/collector@v0.72.0/otelcol/collector.go:183 +0x628\ngo.opentelemetry.io/collector/otelcol.(*Collector).Run(0xc000c7a000, {0x10698b4f8, 0xc000c76740})\n\t/Users/keithschmitt/go/pkg/mod/go.opentelemetry.io/collector@v0.72.0/otelcol/collector.go:207 +0x65\ngithub.com/observiq/observiq-otel-collector/collector.(*collector).Run.func1()\n\t/Users/keithschmitt/go-workspace/src/github.com/observiq/observiq-collector/collector/collector.go:131 +0xc5\ncreated by github.com/observiq/observiq-otel-collector/collector.(*collector).Run\n\t/Users/keithschmitt/go-workspace/src/github.com/observiq/observiq-collector/collector/collector.go:107 +0x512\n","stacktrace":"main.main\n\t/Users/keithschmitt/go-workspace/src/github.com/observiq/observiq-collector/cmd/collector/main.go:113\nruntime.main\n\t/usr/local/opt/go/libexec/src/runtime/proc.go:250"}
```

Behavior after (desired):

```
otelcontribcol...	{"Version": "0.71.0-dev", "NumCPU": 12}
2023-03-03T10:54:52.086-0500	info	extensions/extensions.go:41	Starting extensions...
2023-03-03T10:54:52.086-0500	info	extensions/extensions.go:44	Extension is starting...	{"kind": "extension", "name": "file_storage"}
2023-03-03T10:54:52.086-0500	info	extensions/extensions.go:48	Extension started.	{"kind": "extension", "name": "file_storage"}
2023-03-03T10:54:52.086-0500	info	service/service.go:166	Starting shutdown...
2023-03-03T10:54:52.086-0500	info	extensions/extensions.go:55	Stopping extensions...
2023-03-03T10:54:52.086-0500	info	service/service.go:180	Shutdown complete.
Error: cannot start pipelines: failed to get storage client: open tmp/receiver_mongodbatlas_: permission denied
2023/03/03 10:54:52 collector server run finished with error: cannot start pipelines: failed to get storage
```


**Documentation:** New changelog entry