### PR TITLE
[exporter/googlecloud] Remove retry_on_failure config

### DIFF
--- a/.chloggen/gcp-disable-retry-default.yaml
+++ b/.chloggen/gcp-disable-retry-default.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlecloudexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disable retry helper by default in GCP and GMP exporter configs.
+
+# One or more tracking issues related to the change
+issues: [19203]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -42,11 +42,6 @@ These instructions are to get you up and running quickly with the GCP exporter i
           http:
     exporters:
       googlecloud:
-        # Google Cloud Monitoring returns an error if any of the points are invalid, but still accepts the valid points.
-        # Retrying successfully sent points is guaranteed to fail because the points were already written.
-        # This results in a loop of unnecessary retries.  For now, disable retry_on_failure.
-        retry_on_failure:
-          enabled: false
         log:
           default_log_name: opentelemetry.io/collector-exported-log
     processors:
@@ -173,7 +168,7 @@ The following configuration options are supported:
     - `regex`: Match resource keys by regex.
   - `compression` (optional): Enable gzip compression for gRPC requests (valid vlaues: `gzip`).
 - `retry_on_failure` (optional): Configuration for how to handle retries when sending data to Google Cloud fails.
-  - `enabled` (default = true)
+  - `enabled` (default = false)
   - `initial_interval` (default = 5s): Time to wait after the first failure before retrying; ignored if `enabled` is `false`
   - `max_interval` (default = 30s): Is the upper bound on backoff; ignored if `enabled` is `false`
   - `max_elapsed_time` (default = 120s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`

--- a/exporter/googlecloudexporter/factory.go
+++ b/exporter/googlecloudexporter/factory.go
@@ -54,9 +54,11 @@ func NewFactory() exporter.Factory {
 
 // createDefaultConfig creates the default configuration for exporter.
 func createDefaultConfig() component.Config {
+	retrySettings := exporterhelper.NewDefaultRetrySettings()
+	retrySettings.Enabled = false
 	return &Config{
 		TimeoutSettings: exporterhelper.TimeoutSettings{Timeout: defaultTimeout},
-		RetrySettings:   exporterhelper.NewDefaultRetrySettings(),
+		RetrySettings:   retrySettings,
 		QueueSettings:   exporterhelper.NewDefaultQueueSettings(),
 		Config:          collector.DefaultConfig(),
 	}

--- a/exporter/googlemanagedprometheusexporter/README.md
+++ b/exporter/googlemanagedprometheusexporter/README.md
@@ -20,7 +20,7 @@ The following configuration options are supported:
   - `endpoint` (optional): Endpoint where metric data is going to be sent to. Replaces `endpoint`.
 - `use_insecure` (optional): If true, use gRPC as their communication transport. Only has effect if Endpoint is not "".
 - `retry_on_failure` (optional): Configuration for how to handle retries when sending data to Google Cloud fails.
-  - `enabled` (default = true)
+  - `enabled` (default = false)
   - `initial_interval` (default = 5s): Time to wait after the first failure before retrying; ignored if `enabled` is `false`
   - `max_interval` (default = 30s): Is the upper bound on backoff; ignored if `enabled` is `false`
   - `max_elapsed_time` (default = 120s): Is the maximum amount of time spent trying to send a batch; ignored if `enabled` is `false`

--- a/exporter/googlemanagedprometheusexporter/factory.go
+++ b/exporter/googlemanagedprometheusexporter/factory.go
@@ -43,9 +43,11 @@ func NewFactory() exporter.Factory {
 
 // createDefaultConfig creates the default configuration for exporter.
 func createDefaultConfig() component.Config {
+	retrySettings := exporterhelper.NewDefaultRetrySettings()
+	retrySettings.Enabled = false
 	return &Config{
 		TimeoutSettings: exporterhelper.TimeoutSettings{Timeout: defaultTimeout},
-		RetrySettings:   exporterhelper.NewDefaultRetrySettings(),
+		RetrySettings:   retrySettings,
 		QueueSettings:   exporterhelper.NewDefaultQueueSettings(),
 	}
 }


### PR DESCRIPTION
**Description:** The `retry_on_failure` helper can create scenarios where it is constantly retrying points that we know will always fail. For this reason we recommended disabling it. It could be useful for timeouts with traces, but the tracing client has been updated to retry on default, so this helper is redundant now.

Disabling it (rather than removing it entirely) to not break configs, but we might want to just remove it from the exporters in the future.

**Link to tracking Issue:** https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/578

**Testing:** n/a

**Documentation:** updated here