### PR TITLE
[exporter/awsxray] Fix DynamoDB table name translation

### DIFF
--- a/.chloggen/xray-exporter-dynamodb-translation-fix.yaml
+++ b/.chloggen/xray-exporter-dynamodb-translation-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'awsxrayexporter'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixed DynamoDB table name from being set as an empty string when reading from attributes"
+
+# One or more tracking issues related to the change
+issues: [19204]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -43,6 +43,7 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 		requestID    string
 		queueURL     string
 		tableName    string
+		tableNames   []string
 		sdk          string
 		sdkName      string
 		sdkLanguage  string
@@ -167,8 +168,14 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 		queueURL = value.Str()
 	}
 	if value, ok := attributes[conventions.AttributeAWSDynamoDBTableNames]; ok {
-		if value.Slice().Len() > 0 {
+		if value.Slice().Len() == 1 {
 			tableName = value.Slice().At(0).Str()
+		} else if value.Slice().Len() > 1 {
+			tableName = ""
+			tableNames = []string{}
+			for i := 0; i < value.Slice().Len(); i++ {
+				tableNames = append(tableNames, value.Slice().At(i).Str())
+			}
 		}
 	}
 
@@ -266,6 +273,7 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 		RequestID:    awsxray.String(requestID),
 		QueueURL:     awsxray.String(queueURL),
 		TableName:    awsxray.String(tableName),
+		TableNames:   tableNames,
 	}
 	return filtered, awsData
 }

--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -167,7 +167,9 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 		queueURL = value.Str()
 	}
 	if value, ok := attributes[conventions.AttributeAWSDynamoDBTableNames]; ok {
-		tableName = value.Str()
+		if value.Slice().Len() > 0 {
+			tableName = value.Slice().At(0).Str()
+		}
 	}
 
 	// EC2 - add ec2 metadata to xray request if

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -305,7 +305,8 @@ func TestAwsWithDynamoDbAlternateAttribute(t *testing.T) {
 func TestAwsWithDynamoDbSemConvAttributes(t *testing.T) {
 	tableName := "MyTable"
 	attributes := make(map[string]pcommon.Value)
-	attributes[conventions.AttributeAWSDynamoDBTableNames] = pcommon.NewValueStr(tableName)
+	attributes[conventions.AttributeAWSDynamoDBTableNames] = pcommon.NewValueSlice()
+	attributes[conventions.AttributeAWSDynamoDBTableNames].Slice().AppendEmpty().SetStr(tableName)
 
 	filtered, awsData := makeAws(attributes, pcommon.NewResource(), nil)
 

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -781,6 +781,38 @@ func TestFilteredAttributesMetadata(t *testing.T) {
 	}, segment.Metadata["default"]["map_value"])
 }
 
+func TestSpanWithSingleDynamoDBTableHasTableName(t *testing.T) {
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes[conventions.AttributeAWSDynamoDBTableNames] = []string{"table1"}
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, nil, false, nil)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, "table1", *segment.AWS.TableName)
+	assert.Nil(t, segment.AWS.TableNames)
+	assert.Equal(t, []interface{}{"table1"}, segment.Metadata["default"][conventions.AttributeAWSDynamoDBTableNames])
+}
+
+func TestSpanWithMultipleDynamoDBTablesHasTableNames(t *testing.T) {
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes[conventions.AttributeAWSDynamoDBTableNames] = []string{"table1", "table2"}
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, nil, false, nil)
+
+	assert.NotNil(t, segment)
+	assert.Nil(t, segment.AWS.TableName)
+	assert.Equal(t, []string{"table1", "table2"}, segment.AWS.TableNames)
+	assert.Equal(t, []interface{}{"table1", "table2"}, segment.Metadata["default"][conventions.AttributeAWSDynamoDBTableNames])
+}
+
 func TestSegmentWithLogGroupsFromConfig(t *testing.T) {
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()

--- a/internal/aws/xray/tracesegment.go
+++ b/internal/aws/xray/tracesegment.go
@@ -111,13 +111,14 @@ type AWSData struct {
 	XRay      *XRayMetaData      `json:"xray,omitempty"`
 
 	// For both segment and subsegments
-	AccountID    *string `json:"account_id,omitempty"`
-	Operation    *string `json:"operation,omitempty"`
-	RemoteRegion *string `json:"region,omitempty"`
-	RequestID    *string `json:"request_id,omitempty"`
-	QueueURL     *string `json:"queue_url,omitempty"`
-	TableName    *string `json:"table_name,omitempty"`
-	Retries      *int64  `json:"retries,omitempty"`
+	AccountID    *string  `json:"account_id,omitempty"`
+	Operation    *string  `json:"operation,omitempty"`
+	RemoteRegion *string  `json:"region,omitempty"`
+	RequestID    *string  `json:"request_id,omitempty"`
+	QueueURL     *string  `json:"queue_url,omitempty"`
+	TableName    *string  `json:"table_name,omitempty"`
+	TableNames   []string `json:"table_names,omitempty"`
+	Retries      *int64   `json:"retries,omitempty"`
 }
 
 // EC2Metadata represents the EC2 metadata field


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
DynamoDB nodes in XRay Service Map are without table names. It looks like that the XRay Segment created from the exporter does not contain the dynamodb table name in the aws section. However it should since the addition of the table name [is done here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/awsxrayexporter/internal/translator/aws.go#L169-L171).

Turns out the bug is that `tableName = value.Str()` is incorrect, and will [return an empty string](https://pkg.go.dev/go.opentelemetry.io/collector/pdata/pcommon#Value.Str) as `value = attributes[conventions.AttributeAWSDynamoDBTableNames]` is not of value type string. The actual type of `attributes[conventions.AttributeAWSDynamoDBTableNames]` is a `Slice` ([reference](https://github.com/open-telemetry/opentelemetry-collector/blob/semconv/v0.72.0/semconv/v1.6.1/generated_trace.go#L985-L991)). The corresponding unit test also incorrectly assumes that this value is a string and not a slice.

Another issue found was that the exporter doesn't have logic to include `table_names` in the segment if there are multiple table names.

The fix is to get the first element's string value of the Slice (if it exists) instead if the Slice is of length 1. If the slice has multiple elements, then `table_names` is set in the segment.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Fixed unit test should tests this case.
- `attributes[conventions.AttributeAWSDynamoDBTableNames]` is set as a slice instead of a string.

**Documentation:** <Describe the documentation added.>