### PR TITLE
[chore] kubelet client: build url using go builtin to join path.

### DIFF
--- a/internal/kubelet/client.go
+++ b/internal/kubelet/client.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -238,9 +239,12 @@ func (c *clientImpl) Get(path string) ([]byte, error) {
 	return body, nil
 }
 
-func (c *clientImpl) buildReq(path string) (*http.Request, error) {
-	url := c.baseURL + path
-	req, err := http.NewRequest("GET", url, nil)
+func (c *clientImpl) buildReq(p string) (*http.Request, error) {
+	reqURL, err := url.JoinPath(c.baseURL, p)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("GET", reqURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kubelet/client_test.go
+++ b/internal/kubelet/client_test.go
@@ -235,7 +235,7 @@ func TestBuildReq(t *testing.T) {
 
 func TestBuildBadReq(t *testing.T) {
 	p := &saClientProvider{
-		endpoint:   "localhost:9876",
+		endpoint:   "[]localhost:9876",
 		caCertPath: certPath,
 		tokenPath:  "./testdata/token",
 		logger:     zap.NewNop(),
@@ -243,7 +243,7 @@ func TestBuildBadReq(t *testing.T) {
 	cl, err := p.BuildClient()
 	require.NoError(t, err)
 	require.NoError(t, err)
-	_, err = cl.(*clientImpl).buildReq(" ")
+	_, err = cl.(*clientImpl).buildReq("")
 	require.Error(t, err)
 }
 
@@ -260,12 +260,12 @@ func TestFailedRT(t *testing.T) {
 
 func TestBadReq(t *testing.T) {
 	tr := &fakeRoundTripper{}
-	baseURL := "http://localhost:9876"
+	baseURL := "http://[]localhost:9876"
 	client := &clientImpl{
 		baseURL:    baseURL,
 		httpClient: http.Client{Transport: tr},
 	}
-	_, err := client.Get(" ")
+	_, err := client.Get("")
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Use url.JoinPath to build kubelet client url 

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
unit tests.

**Documentation:** <Describe the documentation added.>