### PR TITLE
[receiver/file] fix usage of assert.Equal in a test

### DIFF
--- a/receiver/filereceiver/receiver_test.go
+++ b/receiver/filereceiver/receiver_test.go
@@ -37,10 +37,10 @@ func TestReceiver(t *testing.T) {
 	}
 	err := r.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
-	const numExpectedMetrics = 10
 	assert.Eventually(t, func() bool {
-		return assert.Equal(t, numExpectedMetrics, tc.numConsumed())
-	}, time.Second, 10*time.Millisecond)
+		const numExpectedMetrics = 10
+		return numExpectedMetrics == tc.numConsumed()
+	}, 2*time.Second, 100*time.Millisecond)
 	err = r.Shutdown(context.Background())
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This attempts to address
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19337

**Description:** I was unable to reproduce this on Windows locally, but there's a high chance that this fix will address the problem. In addition, this change increases the timeout and tick time in case the system is busy while running the test.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19337

**Testing:** Unit tested on Windows.