### PR TITLE
[exporter/datadog] Set gzip compression for native metrics export

### DIFF
--- a/.chloggen/datadog-metric-compression.yaml
+++ b/.chloggen/datadog-metric-compression.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable gzip compression for metric payloads submitted by native Datadog client
+
+# One or more tracking issues related to the change
+issues: [17373]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -20,11 +20,15 @@ import (
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.uber.org/zap"
 	zorkian "gopkg.in/zorkian/go-datadog-api.v2"
 )
+
+// GZipSubmitMetricsOptionalParameters is used to enable gzip compression for metric payloads submitted by native datadog client
+var GZipSubmitMetricsOptionalParameters = datadogV2.NewSubmitMetricsOptionalParameters().WithContentEncoding(datadogV2.METRICCONTENTENCODING_GZIP)
 
 // CreateAPIClient creates a new Datadog API client
 func CreateAPIClient(buildInfo component.BuildInfo, endpoint string, settings exporterhelper.TimeoutSettings, insecureSkipVerify bool) *datadog.APIClient {

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -226,7 +226,8 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pmetric.Metr
 			exp.params.Logger.Debug("exporting native Datadog payload", zap.Any("metric", ms))
 			_, experr := exp.retrier.DoWithRetries(ctx, func(context.Context) error {
 				ctx = clientutil.GetRequestContext(ctx, string(exp.cfg.API.Key))
-				_, httpresp, merr := exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: ms})
+				param := datadogV2.NewSubmitMetricsOptionalParameters().WithContentEncoding(datadogV2.METRICCONTENTENCODING_GZIP)
+				_, httpresp, merr := exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: ms}, *param)
 				return clientutil.WrapError(merr, httpresp)
 			})
 			err = multierr.Append(err, experr)

--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -226,8 +226,7 @@ func (exp *metricsExporter) PushMetricsData(ctx context.Context, md pmetric.Metr
 			exp.params.Logger.Debug("exporting native Datadog payload", zap.Any("metric", ms))
 			_, experr := exp.retrier.DoWithRetries(ctx, func(context.Context) error {
 				ctx = clientutil.GetRequestContext(ctx, string(exp.cfg.API.Key))
-				param := datadogV2.NewSubmitMetricsOptionalParameters().WithContentEncoding(datadogV2.METRICCONTENTENCODING_GZIP)
-				_, httpresp, merr := exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: ms}, *param)
+				_, httpresp, merr := exp.metricsAPI.SubmitMetrics(ctx, datadogV2.MetricPayload{Series: ms}, *clientutil.GZipSubmitMetricsOptionalParameters)
 				return clientutil.WrapError(merr, httpresp)
 			})
 			err = multierr.Append(err, experr)

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -141,7 +141,7 @@ func (exp *traceExporter) exportUsageMetrics(ctx context.Context, hosts map[stri
 		}
 		_, err = exp.retrier.DoWithRetries(ctx, func(context.Context) error {
 			ctx2 := clientutil.GetRequestContext(ctx, string(exp.cfg.API.Key))
-			_, httpresp, merr := exp.metricsAPI.SubmitMetrics(ctx2, datadogV2.MetricPayload{Series: series})
+			_, httpresp, merr := exp.metricsAPI.SubmitMetrics(ctx2, datadogV2.MetricPayload{Series: series}, *clientutil.GZipSubmitMetricsOptionalParameters)
 			return clientutil.WrapError(merr, httpresp)
 		})
 	} else {

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -181,8 +181,8 @@ func TestTracesSource(t *testing.T) {
 	// body found in data.
 	getHostTagsV2 := func(data []byte) (host string, tags []string) {
 		buf := bytes.NewBuffer(data)
-		reader, err := gzip.NewReader(buf)
-		assert.NoError(err)
+		reader, derr := gzip.NewReader(buf)
+		assert.NoError(derr)
 		dec := json.NewDecoder(reader)
 		var p datadogV2.MetricPayload
 		assert.NoError(dec.Decode(&p))

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -16,6 +16,7 @@ package datadogexporter
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -179,8 +180,12 @@ func TestTracesSource(t *testing.T) {
 	// getHostTagsV2 extracts the host and tags from the native DatadogV2 metrics series payload
 	// body found in data.
 	getHostTagsV2 := func(data []byte) (host string, tags []string) {
+		buf := bytes.NewBuffer(data)
+		reader, err := gzip.NewReader(buf)
+		assert.NoError(err)
+		dec := json.NewDecoder(reader)
 		var p datadogV2.MetricPayload
-		assert.NoError(json.Unmarshal(data, &p))
+		assert.NoError(dec.Decode(&p))
 		assert.Len(p.Series, 1)
 		assert.Len(p.Series[0].Resources, 1)
 		return *p.Series[0].Resources[0].Name, p.Series[0].Tags


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Set gzip compression for Datadog native metrics export