### PR TITLE
[exporter/sentry] Add environment config to transaction

### DIFF
--- a/.chloggen/fix-sentry-exporter-environment.yaml
+++ b/.chloggen/fix-sentry-exporter-environment.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sentry/sentryexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix `environment` configuration not being tracked properly on sentry.
+
+# One or more tracking issues related to the change
+issues: [18694]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: For sentry export, the environment value should have been attached to transaction.

--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -82,6 +82,7 @@ var canonicalCodesGrpcMap = map[string]sentry.SpanStatus{
 // SentryExporter defines the Sentry Exporter.
 type SentryExporter struct {
 	transport transport
+	environment string
 }
 
 // pushTraceData takes an incoming OpenTelemetry trace, converts them into Sentry spans and transactions
@@ -121,7 +122,7 @@ func (s *SentryExporter) pushTraceData(_ context.Context, td ptrace.Traces) erro
 				// If the span is not a root span, we can either associate it with an existing
 				// transaction, or we can temporarily consider it an orphan span.
 				if spanIsTransaction(otelSpan) {
-					transactionMap[sentrySpan.SpanID] = transactionFromSpan(sentrySpan)
+					transactionMap[sentrySpan.SpanID] = transactionFromSpan(sentrySpan, s.environment)
 					idMap[sentrySpan.SpanID] = sentrySpan.SpanID
 				} else {
 					if rootSpanID, ok := idMap[sentrySpan.ParentSpanID]; ok {
@@ -143,7 +144,7 @@ func (s *SentryExporter) pushTraceData(_ context.Context, td ptrace.Traces) erro
 	// the spans with a transaction. As such, we must classify the remaining spans as orphans or not.
 	orphanSpans := classifyAsOrphanSpans(maybeOrphanSpans, len(maybeOrphanSpans)+1, idMap, transactionMap)
 
-	transactions := generateTransactions(transactionMap, orphanSpans)
+	transactions := generateTransactions(transactionMap, orphanSpans, s.environment)
 
 	transactions = append(transactions, exceptionEvents...)
 
@@ -153,7 +154,7 @@ func (s *SentryExporter) pushTraceData(_ context.Context, td ptrace.Traces) erro
 }
 
 // generateTransactions creates a set of Sentry transactions from a transaction map and orphan spans.
-func generateTransactions(transactionMap map[sentry.SpanID]*sentry.Event, orphanSpans []*sentry.Span) []*sentry.Event {
+func generateTransactions(transactionMap map[sentry.SpanID]*sentry.Event, orphanSpans []*sentry.Span, environment string) []*sentry.Event {
 	transactions := make([]*sentry.Event, 0, len(transactionMap)+len(orphanSpans))
 
 	for _, t := range transactionMap {
@@ -161,7 +162,7 @@ func generateTransactions(transactionMap map[sentry.SpanID]*sentry.Event, orphan
 	}
 
 	for _, orphanSpan := range orphanSpans {
-		t := transactionFromSpan(orphanSpan)
+		t := transactionFromSpan(orphanSpan, environment)
 		transactions = append(transactions, t)
 	}
 
@@ -434,7 +435,7 @@ func spanIsTransaction(s ptrace.Span) bool {
 }
 
 // transactionFromSpan converts a span to a transaction.
-func transactionFromSpan(span *sentry.Span) *sentry.Event {
+func transactionFromSpan(span *sentry.Span, environment string) *sentry.Event {
 	transaction := sentry.NewEvent()
 	transaction.EventID = generateEventID()
 
@@ -456,6 +457,9 @@ func transactionFromSpan(span *sentry.Span) *sentry.Event {
 	transaction.Tags = span.Tags
 	transaction.Timestamp = span.EndTime
 	transaction.Transaction = span.Description
+	if environment != "" {
+		transaction.Environment = environment
+	}
 
 	return transaction
 }
@@ -492,6 +496,7 @@ func CreateSentryExporter(config *Config, set exporter.CreateSettings) (exporter
 
 	s := &SentryExporter{
 		transport: transport,
+		environment: config.Environment,
 	}
 
 	return exporterhelper.NewTracesExporter(

--- a/exporter/sentryexporter/sentry_exporter.go
+++ b/exporter/sentryexporter/sentry_exporter.go
@@ -81,7 +81,7 @@ var canonicalCodesGrpcMap = map[string]sentry.SpanStatus{
 
 // SentryExporter defines the Sentry Exporter.
 type SentryExporter struct {
-	transport transport
+	transport   transport
 	environment string
 }
 
@@ -495,7 +495,7 @@ func CreateSentryExporter(config *Config, set exporter.CreateSettings) (exporter
 	transport.Configure(clientOptions)
 
 	s := &SentryExporter{
-		transport: transport,
+		transport:   transport,
 		environment: config.Environment,
 	}
 

--- a/exporter/sentryexporter/sentry_exporter_test.go
+++ b/exporter/sentryexporter/sentry_exporter_test.go
@@ -162,8 +162,9 @@ func SpanIDFromHex(s string) sentry.SpanID {
 
 func generateEmptyTransactionMap(spans ...*sentry.Span) map[sentry.SpanID]*sentry.Event {
 	transactionMap := make(map[sentry.SpanID]*sentry.Event)
+	environment := "development"
 	for _, span := range spans {
-		transactionMap[span.SpanID] = transactionFromSpan(span)
+		transactionMap[span.SpanID] = transactionFromSpan(span, environment)
 	}
 	return transactionMap
 }
@@ -654,8 +655,9 @@ func TestClassifyOrphanSpans(t *testing.T) {
 func TestGenerateTransactions(t *testing.T) {
 	transactionMap := generateEmptyTransactionMap(rootSpan1, rootSpan2)
 	orphanSpans := generateOrphanSpansFromSpans(orphanSpan1, childSpan1)
+	environment := "staging"
 
-	transactions := generateTransactions(transactionMap, orphanSpans)
+	transactions := generateTransactions(transactionMap, orphanSpans, environment)
 
 	assert.Len(t, transactions, 4)
 }
@@ -770,9 +772,10 @@ func TestTransactionContextFromSpanMarshalEvent(t *testing.T) {
 		},
 	}
 
+	environment := "production"
 	for _, test := range testCases {
 		t.Run(test.testName, func(t *testing.T) {
-			event := transactionFromSpan(test.span)
+			event := transactionFromSpan(test.span, environment)
 			// mimic what sentry is doing internally
 			// see: https://github.com/getsentry/sentry-go/blob/v0.13.0/transport.go#L66-L70
 			d, err := json.Marshal(event.Contexts)


### PR DESCRIPTION
Description:
Fixing a bug - Fix an issue with the sentry exporter not tracking the correct environment value configured via the `YAML` file in the OpenTelemetry Collector.

Previously, I added the sentry environment config and included it in the `clientOptions` (see PR #18695). However, the environment value isn't getting tracked. It turned out that the exporter was using the `transport` layer instead of the sentry golang SDK directly (as specified in `transport.go`).

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/sentryexporter/transport.go#L36-L41

Can I just set the `environment` value from the config and pass it to the `transactionFromSpan` so it can be attached to the `transaction` like this? I'm looking forward to any feedback or suggestions.

I really need this option since it would be too much of a hassle if I need to edit all of my projects if I need to set the sentry_environment value somewhere else, like in `span` for example, as they have different infrastructure environment with different env value that can be easily configured via `YAML`

Link to tracking Issue:
Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18694

Testing:
Added environment to transaction from span