### PR TITLE
[connectors/spanmetrics] Add optional `seconds` unit support for recording duration measurements.

### DIFF
--- a/.chloggen/spanmetrics-support-seconds-unit.yaml
+++ b/.chloggen/spanmetrics-support-seconds-unit.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:  Add optional `seconds` unit support for recording generated duration measurements.
+
+# One or more tracking issues related to the change
+issues: [18698]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `unit` is configurable. The allowed values are `ms` and `s`.
+  The default `unit` is `ms`.

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -42,6 +42,7 @@ The following settings can be optionally configured:
 
 - `histogram` (default: `explicit_buckets`): Use to configure the type of histogram to record
   calculated from spans latency measurements.
+  - `unit` (default: `ms`, allowed values: `ms`, `s`): The time unit for recording duration measurements.  
   - `explicit`:
     - `buckets`: the list of durations defining the latency histogram buckets. Default
       buckets: `[2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]`

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -42,7 +42,7 @@ The following settings can be optionally configured:
 
 - `histogram` (default: `explicit_buckets`): Use to configure the type of histogram to record
   calculated from spans latency measurements.
-  - `unit` (default: `ms`, allowed values: `ms`, `s`): The time unit for recording duration measurements.  
+  - `unit` (default: `ms`, allowed values: `ms`, `s`): The time unit for recording duration measurements.
   - `explicit`:
     - `buckets`: the list of durations defining the latency histogram buckets. Default
       buckets: `[2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]`

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -71,6 +71,7 @@ type Config struct {
 }
 
 type HistogramConfig struct {
+	Unit        string                      `mapstructure:"unit"`
 	Exponential *ExponentialHistogramConfig `mapstructure:"exponential"`
 	Explicit    *ExplicitHistogramConfig    `mapstructure:"explicit"`
 }
@@ -104,6 +105,10 @@ func (c Config) Validate() error {
 		return errors.New("use either `explicit` or `exponential` buckets histogram")
 	}
 
+	unit := c.Histogram.Unit
+	if unit != "s" && unit != "ms" {
+		return fmt.Errorf("allowed units are 'ms' and 's', got: '%s'", c.Histogram.Unit)
+	}
 	return nil
 }
 

--- a/connector/spanmetricsconnector/config_test.go
+++ b/connector/spanmetricsconnector/config_test.go
@@ -58,6 +58,7 @@ func TestLoadConfig(t *testing.T) {
 				DimensionsCacheSize:  1500,
 				MetricsFlushInterval: 30 * time.Second,
 				Histogram: HistogramConfig{
+					Unit: "s",
 					Explicit: &ExplicitHistogramConfig{
 						Buckets: []time.Duration{
 							10 * time.Millisecond,
@@ -75,6 +76,7 @@ func TestLoadConfig(t *testing.T) {
 				DimensionsCacheSize:    1000,
 				MetricsFlushInterval:   15 * time.Second,
 				Histogram: HistogramConfig{
+					Unit: "ms",
 					Exponential: &ExponentialHistogramConfig{
 						MaxSize: 10,
 					},
@@ -84,6 +86,10 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id:           component.NewIDWithName(typeStr, "exponential_and_explicit_histogram"),
 			errorMessage: "use either `explicit` or `exponential` buckets histogram",
+		},
+		{
+			id:           component.NewIDWithName(typeStr, "invalid_histogram_unit"),
+			errorMessage: "allowed units are 'ms' and 's', got: 'h'",
 		},
 	}
 

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -46,7 +46,14 @@ const (
 
 	metricNameLatency = "latency"
 	metricNameCalls   = "calls"
+
+	defaultUnit = "ms"
 )
+
+var units = map[string]int64{
+	"s":  time.Second.Nanoseconds(),
+	"ms": time.Millisecond.Nanoseconds(),
+}
 
 type connectorImp struct {
 	lock   sync.Mutex
@@ -64,6 +71,9 @@ type connectorImp struct {
 	// Metrics
 	histograms metrics.HistogramMetrics
 	sums       metrics.SumMetrics
+
+	// unit divider, used to convert nanoseconds to milliseconds or seconds
+	unit int64
 
 	keyBuf *bytes.Buffer
 
@@ -107,6 +117,7 @@ func newConnector(logger *zap.Logger, config component.Config, ticker *clock.Tic
 		return nil, err
 	}
 
+	unit := units[cfg.Histogram.Unit]
 	var histograms metrics.HistogramMetrics
 	if cfg.Histogram.Exponential != nil {
 		maxSize := cfg.Histogram.Exponential.MaxSize
@@ -120,10 +131,10 @@ func newConnector(logger *zap.Logger, config component.Config, ticker *clock.Tic
 		if cfg.LatencyHistogramBuckets != nil {
 			logger.Warn("latency_histogram_buckets is deprecated. " +
 				"Use `histogram: explicit: buckets` to set histogram buckets")
-			bounds = mapDurationsToMillis(cfg.LatencyHistogramBuckets)
+			bounds = durationsToUnits(cfg.LatencyHistogramBuckets, unit)
 		}
 		if cfg.Histogram.Explicit != nil && cfg.Histogram.Explicit.Buckets != nil {
-			bounds = mapDurationsToMillis(cfg.Histogram.Explicit.Buckets)
+			bounds = durationsToUnits(cfg.Histogram.Explicit.Buckets, unit)
 		}
 		histograms = metrics.NewExplicitHistogramMetrics(bounds)
 	}
@@ -134,6 +145,7 @@ func newConnector(logger *zap.Logger, config component.Config, ticker *clock.Tic
 		startTimestamp:        pcommon.NewTimestampFromTime(time.Now()),
 		histograms:            histograms,
 		sums:                  metrics.NewSumMetrics(),
+		unit:                  unit,
 		dimensions:            newDimensions(cfg.Dimensions),
 		keyBuf:                bytes.NewBuffer(make([]byte, 0, 1024)),
 		metricKeyToDimensions: metricKeyToDimensionsCache,
@@ -142,16 +154,10 @@ func newConnector(logger *zap.Logger, config component.Config, ticker *clock.Tic
 	}, nil
 }
 
-// durationToMillis converts the given duration to the number of milliseconds it represents.
-// Note that this can return sub-millisecond (i.e. < 1ms) values as well.
-func durationToMillis(d time.Duration) float64 {
-	return float64(d.Nanoseconds()) / float64(time.Millisecond.Nanoseconds())
-}
-
-func mapDurationsToMillis(vs []time.Duration) []float64 {
+func durationsToUnits(vs []time.Duration, unitDivider int64) []float64 {
 	vsm := make([]float64, len(vs))
 	for i, v := range vs {
-		vsm[i] = durationToMillis(v)
+		vsm[i] = float64(v.Nanoseconds()) / float64(unitDivider)
 	}
 	return vsm
 }
@@ -237,7 +243,7 @@ func (p *connectorImp) buildMetrics() pmetric.Metrics {
 func (p *connectorImp) buildLatencyMetrics(ilm pmetric.ScopeMetrics) {
 	m := ilm.Metrics().AppendEmpty()
 	m.SetName(buildMetricName(p.config.Namespace, metricNameLatency))
-	m.SetUnit("ms")
+	m.SetUnit(p.config.Histogram.Unit)
 
 	p.histograms.BuildMetrics(m, p.startTimestamp, p.config.GetAggregationTemporality())
 }
@@ -285,11 +291,11 @@ func (p *connectorImp) aggregateMetrics(traces ptrace.Traces) {
 			for k := 0; k < spans.Len(); k++ {
 				span := spans.At(k)
 				// Protect against end timestamps before start timestamps. Assume 0 duration.
-				latencyMs := float64(0)
+				latency := float64(0)
 				startTime := span.StartTimestamp()
 				endTime := span.EndTimestamp()
 				if endTime > startTime {
-					latencyMs = float64(endTime-startTime) / float64(time.Millisecond.Nanoseconds())
+					latency = float64(endTime-startTime) / float64(p.unit)
 				}
 				key := p.buildKey(serviceName, span, p.dimensions, resourceAttr)
 
@@ -301,9 +307,9 @@ func (p *connectorImp) aggregateMetrics(traces ptrace.Traces) {
 
 				// aggregate histogram metrics
 				h := p.histograms.GetOrCreate(key, attributes)
-				h.Observe(latencyMs)
+				h.Observe(latency)
 				if !span.TraceID().IsEmpty() {
-					h.AddExemplar(span.TraceID(), span.SpanID(), latencyMs)
+					h.AddExemplar(span.TraceID(), span.SpanID(), latency)
 				}
 
 				// aggregate sums metrics

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -763,7 +763,7 @@ func newConnectorImp(
 		logger:          logger,
 		config:          Config{AggregationTemporality: temporality, Histogram: HistogramConfig{Unit: defaultUnit}},
 		metricsConsumer: mcon,
-		unit:            units[defaultUnit],
+		unitDivider:     unitDividers[defaultUnit],
 		startTimestamp:  pcommon.NewTimestampFromTime(time.Now()),
 		histograms:      histograms(),
 		sums:            metrics.NewSumMetrics(),
@@ -967,7 +967,7 @@ func TestConnector_durationsToUnits(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			got := durationsToUnits(tt.input, units[tt.unit])
+			got := durationsToUnits(tt.input, unitDividers[tt.unit])
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -763,7 +763,6 @@ func newConnectorImp(
 		logger:          logger,
 		config:          Config{AggregationTemporality: temporality, Histogram: HistogramConfig{Unit: defaultUnit}},
 		metricsConsumer: mcon,
-		unitDivider:     unitDividers[defaultUnit](),
 		startTimestamp:  pcommon.NewTimestampFromTime(time.Now()),
 		histograms:      histograms(),
 		sums:            metrics.NewSumMetrics(),
@@ -968,7 +967,7 @@ func TestConnector_durationsToUnits(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			got := durationsToUnits(tt.input, unitDividers[tt.unit]())
+			got := durationsToUnits(tt.input, unitDivider(tt.unit))
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -763,7 +763,7 @@ func newConnectorImp(
 		logger:          logger,
 		config:          Config{AggregationTemporality: temporality, Histogram: HistogramConfig{Unit: defaultUnit}},
 		metricsConsumer: mcon,
-		unitDivider:     unitDividers[defaultUnit],
+		unitDivider:     unitDividers[defaultUnit](),
 		startTimestamp:  pcommon.NewTimestampFromTime(time.Now()),
 		histograms:      histograms(),
 		sums:            metrics.NewSumMetrics(),
@@ -962,12 +962,13 @@ func TestConnector_durationsToUnits(t *testing.T) {
 		},
 		{
 			input: []time.Duration{},
+			unit:  defaultUnit,
 			want:  []float64{},
 		},
 	}
 	for _, tt := range tests {
 		t.Run("", func(t *testing.T) {
-			got := durationsToUnits(tt.input, unitDividers[tt.unit])
+			got := durationsToUnits(tt.input, unitDividers[tt.unit]())
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/connector/spanmetricsconnector/factory.go
+++ b/connector/spanmetricsconnector/factory.go
@@ -45,6 +45,7 @@ func createDefaultConfig() component.Config {
 		AggregationTemporality: "AGGREGATION_TEMPORALITY_CUMULATIVE",
 		DimensionsCacheSize:    defaultDimensionsCacheSize,
 		MetricsFlushInterval:   15 * time.Second,
+		Histogram:              HistogramConfig{Unit: defaultUnit},
 	}
 }
 

--- a/connector/spanmetricsconnector/testdata/config.yaml
+++ b/connector/spanmetricsconnector/testdata/config.yaml
@@ -9,6 +9,7 @@ spanmetrics/default_explicit_histogram:
 # configuration with all possible parameters
 spanmetrics/full:
   histogram:
+    unit: "s"
     explicit:
       buckets: [ 10ms, 100ms, 250ms ]
 
@@ -50,3 +51,7 @@ spanmetrics/exponential_and_explicit_histogram:
       max_size: 10
     explicit:
       buckets: [ 10ms, 100ms, 250ms ]
+
+spanmetrics/invalid_histogram_unit:
+  histogram:
+    unit: "h"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Add `seconds` unit support for generating histogram (for both explicit / exponetial buckets) metrics. Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18698

One example of the `seconds` unit usage would be the case when `spanmetrics` payload that includes histograms is exported with Prometheus exporter or Prometheus remote write exporter to some Prometheus storage. See also https://github.com/open-telemetry/opentelemetry-specification/issues/2977


**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18698

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests

**Documentation:** <Describe the documentation added.>
README