### PR TITLE
[connectors/spanmetrics] Remote deprecated `latency_histogram_buckets` configuration parameter.

### DIFF
--- a/.chloggen/spanmetrics-drop-latency-hist-bucket-config.yaml
+++ b/.chloggen/spanmetrics-drop-latency-hist-bucket-config.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `latency_histogram_buckets` configuration parameter.
+
+# One or more tracking issues related to the change
+issues: [19372]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Use the `histogram` configuration section to provide buckets for
+  explicit buckets histogram metrics. 

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -49,8 +49,6 @@ The following settings can be optionally configured:
       buckets: `[2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]`
   - `exponential`:
     - `max_size` (default: 160) the maximum number of buckets per positive or negative number range.
-- `latency_histogram_buckets` (deprecated): the list of durations defining the latency histogram buckets.
-  - Default: `[2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]`
 - `dimensions`: the list of dimensions to add together with the default dimensions defined above.
   
   Each additional dimension is defined with a `name` which is looked up in the span's collection of attributes or

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -42,11 +42,6 @@ type Dimension struct {
 
 // Config defines the configuration options for spanmetricsconnector.
 type Config struct {
-	// LatencyHistogramBuckets is the list of durations representing latency histogram buckets.
-	// See defaultLatencyHistogramBucketsMs in connector.go for the default value.
-	// Deprecated: use HistogramConfig to configure explicit histogram buckets
-	LatencyHistogramBuckets []time.Duration `mapstructure:"latency_histogram_buckets"`
-
 	// Dimensions defines the list of additional dimensions on top of the provided:
 	// - service.name
 	// - span.kind

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -137,12 +137,6 @@ func (p *connectorImp) initHistogramMetrics() metrics.HistogramMetrics {
 		return metrics.NewExponentialHistogramMetrics(maxSize)
 	}
 	bounds := defaultHistogramBucketsMs
-	// TODO remove deprecated `latency_histogram_buckets`
-	if cfg.LatencyHistogramBuckets != nil {
-		p.logger.Warn("latency_histogram_buckets is deprecated. " +
-			"Use `histogram: explicit: buckets` to set histogram buckets")
-		bounds = durationsToUnits(cfg.LatencyHistogramBuckets, unitDivider(cfg.Histogram.Unit))
-	}
 	if cfg.Histogram.Explicit != nil && cfg.Histogram.Explicit.Buckets != nil {
 		bounds = durationsToUnits(cfg.Histogram.Explicit.Buckets, unitDivider(cfg.Histogram.Unit))
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Remote deprecated `latency_histogram_buckets` configuration parameter.

The component is not added to distribution yet, so probably is not used by anyone, it also has the `in development status`.
I'll also provide this information in the future `spanmetrics` processor to `spanmetrics` connector migration section.