### PR TITLE
[translator/loki] Convert dots to underscores in labels names

### DIFF
--- a/.chloggen/lokiexporter-dots-to-underscores-label-name-normalization.yaml
+++ b/.chloggen/lokiexporter-dots-to-underscores-label-name-normalization.yaml
@@ -14,4 +14,6 @@ issues: [14113]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  Loki doesn't support label names containing dots. After normalization, all dots in label names are replaced with underscores
+  Loki doesn't support label names containing dots. |
+  Users had to convert dot-separated attributes into underscore-separated attributes before promoting them to Loki labels. |
+  From now on users can drop relabeling from their configuration. All dots in label names will be replaced with underscores automatically before sending request to Loki.

--- a/.chloggen/lokiexporter-dots-to-underscores-label-name-normalization.yaml
+++ b/.chloggen/lokiexporter-dots-to-underscores-label-name-normalization.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: translator/loki
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Added normalization so label name to follow Prometheus label names standard
+note: Normalize label names so they follow the Prometheus label names standard
 
 # One or more tracking issues related to the change
 issues: [14113]

--- a/.chloggen/lokiexporter-dots-to-underscores-label-name-normalization.yaml
+++ b/.chloggen/lokiexporter-dots-to-underscores-label-name-normalization.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: translator/loki
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added normalization so label name to follow Prometheus label names standard
+
+# One or more tracking issues related to the change
+issues: [14113]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Loki doesn't support label names containing dots. After normalization, all dots in label names are replaced with underscores

--- a/exporter/lokiexporter/README.md
+++ b/exporter/lokiexporter/README.md
@@ -34,25 +34,18 @@ processors:
   attributes:
     actions:
       - action: insert
-        key: event_domain
-        from_attribute: event.domain
-      - action: insert
         key: loki.attribute.labels
-        value: event_domain
+        value: event.domain
 
   resource:
     attributes:
       - action: insert
-        key: service_name
-        from_attribute: service.name
-      - action: insert
         key: loki.resource.labels
-        value: service_name
+        value: service.name
 ```
 
-Currently, Loki does not support labels with dots.
-That’s why to add Loki label based on `event.domain` OTLP attribute we need to specify two actions. The first one inserts a new attribute `event_domain` from the OTLP attribute `event.domain`. The second one is a hint for Loki, specifying that the `event_domain` attribute should be placed as a Loki label.
-The same approach is applicable to placing Loki labels from resource attribute `service.name`.
+Currently, Loki does not support label names with dots. 
+That's why lokiexporter normalizes label names to follow Prometheus label names standard before sending requests to Loki.
 
 Default labels:
 - `job=service.namespace/service.name`
@@ -98,10 +91,7 @@ processors:
     attributes:
     - action: insert
       key: loki.tenant
-      value: host_name
-    - action: insert
-      key: host_name
-      from_attribute: host.name
+      value: host.name
 ```
 
 In this case the value of the `host.name` resource attribute is used to group logs

--- a/exporter/lokiexporter/README.md
+++ b/exporter/lokiexporter/README.md
@@ -46,6 +46,7 @@ processors:
 
 Currently, Loki does not support label names with dots. 
 That's why lokiexporter normalizes label names to follow Prometheus label names standard before sending requests to Loki.
+More information on label normalization could be found [here](../../pkg/translator/prometheus/README.md#Labels)
 
 Default labels:
 - `job=service.namespace/service.name`

--- a/exporter/lokiexporter/go.mod
+++ b/exporter/lokiexporter/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.74.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rs/cors v1.8.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
@@ -64,5 +65,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/commo
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki => ../../pkg/translator/loki
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus => ../../pkg/translator/prometheus
 
 retract v0.65.0

--- a/exporter/lokiexporter/next_exporter_test.go
+++ b/exporter/lokiexporter/next_exporter_test.go
@@ -51,7 +51,7 @@ func TestPushLogData(t *testing.T) {
 			hints: map[string]interface{}{
 				"loki.attribute.labels": "host.name",
 			},
-			expectedLabel: `{exporter="OTLP", host.name="guarana"}`,
+			expectedLabel: `{exporter="OTLP", host_name="guarana"}`,
 			expectedLine:  `{"traceid":"01020304000000000000000000000000","attributes":{"http.status":200}}`,
 		},
 		{
@@ -63,7 +63,7 @@ func TestPushLogData(t *testing.T) {
 			hints: map[string]interface{}{
 				"loki.resource.labels": "host.name",
 			},
-			expectedLabel: `{exporter="OTLP", host.name="guarana"}`,
+			expectedLabel: `{exporter="OTLP", host_name="guarana"}`,
 			expectedLine:  `{"traceid":"01020304000000000000000000000000","resources":{"region.az":"eu-west-1a"}}`,
 		},
 	}
@@ -169,11 +169,11 @@ func TestLogsToLokiRequestWithGroupingByTenant(t *testing.T) {
 				label string
 			}{
 				"1": {
-					label: `{exporter="OTLP", tenant.id="1"}`,
+					label: `{exporter="OTLP", tenant_id="1"}`,
 					line:  `{"attributes":{"http.status":200}}`,
 				},
 				"2": {
-					label: `{exporter="OTLP", tenant.id="2"}`,
+					label: `{exporter="OTLP", tenant_id="2"}`,
 					line:  `{"attributes":{"http.status":200}}`,
 				},
 			},
@@ -233,11 +233,11 @@ func TestLogsToLokiRequestWithGroupingByTenant(t *testing.T) {
 				label string
 			}{
 				"1": {
-					label: `{exporter="OTLP", tenant.id="1"}`,
+					label: `{exporter="OTLP", tenant_id="1"}`,
 					line:  `{"attributes":{"http.status":200}}`,
 				},
 				"2": {
-					label: `{exporter="OTLP", tenant.id="2"}`,
+					label: `{exporter="OTLP", tenant_id="2"}`,
 					line:  `{"attributes":{"http.status":200}}`,
 				},
 			},

--- a/pkg/translator/loki/go.mod
+++ b/pkg/translator/loki/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logfmt/logfmt v0.5.1
 	github.com/grafana/loki/pkg/push v0.0.0-20230127072203-4e8cc8d71928
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.74.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.74.0
 	github.com/prometheus/common v0.42.0
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/collector/pdata v1.0.0-rc8
@@ -21,6 +22,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	go.opentelemetry.io/collector/featuregate v0.74.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
@@ -31,6 +33,10 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus => ../../../pkg/translator/prometheus
+
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../../internal/coreinternal
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../../internal/common
 
 retract v0.65.0

--- a/pkg/translator/loki/go.sum
+++ b/pkg/translator/loki/go.sum
@@ -41,6 +41,8 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.opentelemetry.io/collector/featuregate v0.74.0 h1:hzkzhi6pvjqEK5+CkVBJX69wpEEYqgtTFMHGlZFsQyE=
+go.opentelemetry.io/collector/featuregate v0.74.0/go.mod h1:pmVMr98Ps6QKyEHiVPN7o3Qd8K//M2NapfOv5BMWvA0=
 go.opentelemetry.io/collector/pdata v1.0.0-rc8 h1:vBikWdZFsRiT5dVsLQhnE99w3edM7eem3Q9dSqMlStE=
 go.opentelemetry.io/collector/pdata v1.0.0-rc8/go.mod h1:BVCBhWgclYCh7Oi6BkMiQfRa6MXv1uRTlKXuL5oBby8=
 go.opentelemetry.io/collector/semconv v0.74.0 h1:tPpbz87CPu/pM2/fSEKBJWXTvWvUJvEChbQkzdhWQHE=

--- a/pkg/translator/loki/logs_to_loki_test.go
+++ b/pkg/translator/loki/logs_to_loki_test.go
@@ -58,7 +58,7 @@ func TestLogsToLokiRequestWithGroupingByTenant(t *testing.T) {
 					PushRequest: &push.PushRequest{
 						Streams: []push.Stream{
 							{
-								Labels: `{exporter="OTLP", tenant.id="1"}`,
+								Labels: `{exporter="OTLP", tenant_id="1"}`,
 								Entries: []push.Entry{
 									{
 										Line: `{"attributes":{"http.status":200}}`,
@@ -71,7 +71,7 @@ func TestLogsToLokiRequestWithGroupingByTenant(t *testing.T) {
 					PushRequest: &push.PushRequest{
 						Streams: []push.Stream{
 							{
-								Labels: `{exporter="OTLP", tenant.id="2"}`,
+								Labels: `{exporter="OTLP", tenant_id="2"}`,
 								Entries: []push.Entry{
 									{
 										Line: `{"attributes":{"http.status":200}}`,
@@ -110,7 +110,7 @@ func TestLogsToLokiRequestWithGroupingByTenant(t *testing.T) {
 					PushRequest: &push.PushRequest{
 						Streams: []push.Stream{
 							{
-								Labels: `{exporter="OTLP", tenant.id="11"}`,
+								Labels: `{exporter="OTLP", tenant_id="11"}`,
 								Entries: []push.Entry{
 									{
 										Line: `{"attributes":{"http.status":200}}`,
@@ -123,7 +123,7 @@ func TestLogsToLokiRequestWithGroupingByTenant(t *testing.T) {
 					PushRequest: &push.PushRequest{
 						Streams: []push.Stream{
 							{
-								Labels: `{exporter="OTLP", tenant.id="12"}`,
+								Labels: `{exporter="OTLP", tenant_id="12"}`,
 								Entries: []push.Entry{
 									{
 										Line: `{"attributes":{"http.status":200}}`,
@@ -196,7 +196,7 @@ func TestLogsToLokiRequestWithGroupingByTenant(t *testing.T) {
 					PushRequest: &push.PushRequest{
 						Streams: []push.Stream{
 							{
-								Labels: `{exporter="OTLP", tenant.id="21"}`,
+								Labels: `{exporter="OTLP", tenant_id="21"}`,
 								Entries: []push.Entry{
 									{
 										Line: `{"attributes":{"http.status":200}}`,
@@ -209,7 +209,7 @@ func TestLogsToLokiRequestWithGroupingByTenant(t *testing.T) {
 					PushRequest: &push.PushRequest{
 						Streams: []push.Stream{
 							{
-								Labels: `{exporter="OTLP", tenant.id="22"}`,
+								Labels: `{exporter="OTLP", tenant_id="22"}`,
 								Entries: []push.Entry{
 									{
 										Line: `{"attributes":{"http.status":200}}`,
@@ -265,7 +265,7 @@ func TestLogsToLokiRequestWithoutTenant(t *testing.T) {
 			hints: map[string]interface{}{
 				hintAttributes: "host.name",
 			},
-			expectedLabel: `{exporter="OTLP", host.name="guarana"}`,
+			expectedLabel: `{exporter="OTLP", host_name="guarana"}`,
 			expectedLines: []string{
 				`{"traceid":"01000000000000000000000000000000","attributes":{"http.status":200}}`,
 				`{"traceid":"02000000000000000000000000000000","attributes":{"http.status":200}}`,
@@ -281,7 +281,7 @@ func TestLogsToLokiRequestWithoutTenant(t *testing.T) {
 			hints: map[string]interface{}{
 				hintResources: "host.name",
 			},
-			expectedLabel: `{exporter="OTLP", host.name="guarana"}`,
+			expectedLabel: `{exporter="OTLP", host_name="guarana"}`,
 			expectedLines: []string{
 				`{"traceid":"01000000000000000000000000000000","resources":{"region.az":"eu-west-1a"}}`,
 				`{"traceid":"02000000000000000000000000000000","resources":{"region.az":"eu-west-1a"}}`,
@@ -298,7 +298,7 @@ func TestLogsToLokiRequestWithoutTenant(t *testing.T) {
 				hintAttributes: "host.name",
 				hintFormat:     formatLogfmt,
 			},
-			expectedLabel: `{exporter="OTLP", host.name="guarana"}`,
+			expectedLabel: `{exporter="OTLP", host_name="guarana"}`,
 			expectedLines: []string{
 				`traceID=01000000000000000000000000000000 attribute_http.status=200`,
 				`traceID=02000000000000000000000000000000 attribute_http.status=200`,


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Loki doesn't support label names containing dots.
Added label names normalization to follow Prometheus label names standard. Dots in label names will be converted to underscores before sending them to Loki

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14113
