### PR TITLE
[CI] [chore] Increase timeout for CodeQL-Build job

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   CodeQL-Build:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       # Force CodeQL to run the extraction on the files compiled by our custom


### PR DESCRIPTION
It frequently times out. Example: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/4361662175/jobs/7625759590