### PR TITLE
ci(build-package): upgrade to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,9 +1,9 @@
 name: build-and-test
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
 env:
   TEST_RESULTS: testbed/tests/results/junit/results.xml
@@ -465,7 +465,7 @@ jobs:
 
   build-package:
     # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [cross-compile]
     strategy:
       fail-fast: false
@@ -484,7 +484,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: "2.6"
       - name: Install fpm
         run: gem install --no-document fpm -v 1.11.0
       - name: Download Collector Binaries
@@ -632,14 +632,14 @@ jobs:
       - name: Build Docker Image
         if: steps.check.outputs.passed == 'true'
         run: |
-            make docker-otelcontribcol
-            docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
-            docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:latest
+          make docker-otelcontribcol
+          docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
+          docker tag otelcontribcol:latest otel/opentelemetry-collector-contrib-dev:latest
       - name: Validate Docker Image
         if: steps.check.outputs.passed == 'true'
         run: |
-            docker run otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA --version
-            docker run otel/opentelemetry-collector-contrib-dev:latest --version
+          docker run otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA --version
+          docker run otel/opentelemetry-collector-contrib-dev:latest --version
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -648,8 +648,8 @@ jobs:
       - name: Push Docker Image
         if: steps.check.outputs.passed == 'true'
         run: |
-            docker push otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
-            docker push otel/opentelemetry-collector-contrib-dev:latest
+          docker push otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
+          docker push otel/opentelemetry-collector-contrib-dev:latest
   publish-stable:
     runs-on: ubuntu-latest
     needs: [lint, unittest, integration-tests, build-package]
@@ -671,4 +671,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.github_tag.outputs.tag }}
-


### PR DESCRIPTION
**Description:** <Describe what has changed.>

The `build-package` job in the CI workflow was temporarily set to run on `ubuntu-20.04` instead of using the `ubuntu-latest` tag (because the job failed).
This PR aims to fix this by using `ubuntu-latest` tag.

**Link to tracking Issue:** 
Closes #16450 
