### PR TITLE
[exporter/googlemanagedprometheus] Document client config settings for GMP exporter

### DIFF
--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -177,6 +177,7 @@ The following configuration options are supported:
   - `prefix` (default = `workload.googleapis.com`): The prefix to add to metrics.
   - `endpoint` (default = monitoring.googleapis.com): Endpoint where metric data is going to be sent to.
   - `use_insecure` (default = false): If true, use gRPC as their communication transport. Only has effect if Endpoint is not "".
+  - `grpc_pool_size` (optional): Set the size of the connection pool in the GCP client.
   - `known_domains` (default = [googleapis.com, kubernetes.io, istio.io, knative.dev]): If a metric belongs to one of these domains it does not get a prefix.
   - `skip_create_descriptor` (default = false): If set to true, do not send metric descriptors to GCM.
   - `instrumentation_library_labels` (default = true): If true, set the instrumentation_source and instrumentation_version labels.
@@ -197,12 +198,14 @@ The following configuration options are supported:
 - `trace` (optional): Configuration for sending traces to Cloud Trace.
   - `endpoint` (default = cloudtrace.googleapis.com): Endpoint where trace data is going to be sent to.
   - `use_insecure` (default = false): If true. use gRPC as their communication transport. Only has effect if Endpoint is not "". Replaces `use_insecure`.
+  - `grpc_pool_size` (optional): Set the size of the connection pool in the GCP client.
   - `attribute_mappings` (optional): AttributeMappings determines how to map from OpenTelemetry attribute keys to Google Cloud Trace keys.  By default, it changes http and service keys so that they appear more prominently in the UI.
     - `key`: Key is the OpenTelemetry attribute key
     - `replacement`: Replacement is the attribute sent to Google Cloud Trace
 - `log` (optional): Configuration for sending metrics to Cloud Logging.
   - `endpoint` (default = logging.googleapis.com): Endpoint where log data is going to be sent to. D
   - `use_insecure` (default = false): If true, use gRPC as their communication transport. Only has effect if Endpoint is not "".
+  - `grpc_pool_size` (optional): Set the size of the connection pool in the GCP client.
   - `default_log_name` (optional): Defines a default name for log entries. If left unset, and a log entry does not have the `gcp.log_name` attribute set, the exporter will return an error processing that entry.
   - `resource_filters` (default = []): If provided, resource attributes matching any filter will be included in log labels. Can be defined by `prefix`, `regex`, or `prefix` AND `regex`.
     - `prefix`: Match resource keys by prefix.

--- a/exporter/googlemanagedprometheusexporter/README.md
+++ b/exporter/googlemanagedprometheusexporter/README.md
@@ -22,8 +22,11 @@ The following configuration options are supported:
 - `project` (optional): GCP project identifier.
 - `user_agent` (optional): Override the user agent string sent on requests to Cloud Monitoring (currently only applies to metrics). Specify `{{version}}` to include the application version number. Defaults to `opentelemetry-collector-contrib {{version}}`.
 - `metric`(optional): Configuration for sending metrics to Cloud Monitoring.
+  - `prefix` (default = `prometheus.googleapis.com`): Configure the prefix of metrics sent to GoogleManagedPrometheus. Changing this prefix is not recommended, as it may cause metrics to not be queryable with promql in the Cloud Monitoring UI.
   - `endpoint` (optional): Endpoint where metric data is going to be sent to. Replaces `endpoint`.
-- `use_insecure` (optional): If true, use gRPC as their communication transport. Only has effect if Endpoint is not "".
+  - `use_insecure` (optional): If true, use gRPC as their communication transport. Only has effect if Endpoint is not "".
+  - `compression` (optional): Enable gzip compression for gRPC requests (valid vlaues: `gzip`).
+  - `grpc_pool_size` (optional): Set the size of the connection pool in the GCP client.
 - `retry_on_failure` (optional): Configuration for how to handle retries when sending data to Google Cloud fails.
   - `enabled` (default = false)
   - `initial_interval` (default = 5s): Time to wait after the first failure before retrying; ignored if `enabled` is `false`

--- a/exporter/googlemanagedprometheusexporter/config_test.go
+++ b/exporter/googlemanagedprometheusexporter/config_test.go
@@ -29,7 +29,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Exporters), 3)
+	assert.Equal(t, len(cfg.Exporters), 4)
 
 	r0 := cfg.Exporters[component.NewID(metadata.Type)].(*Config)
 	assert.Equal(t, r0, factory.CreateDefaultConfig().(*Config))
@@ -63,4 +63,12 @@ func TestLoadConfig(t *testing.T) {
 	r2Expected := factory.CreateDefaultConfig().(*Config)
 	r2Expected.GMPConfig.MetricConfig.Prefix = "my-metric-domain.com"
 	assert.Equal(t, r2, r2Expected)
+
+	r3 := cfg.Exporters[component.NewIDWithName(typeStr, "clientconfig")].(*Config)
+	r3Expected := factory.CreateDefaultConfig().(*Config)
+	r3Expected.GMPConfig.MetricConfig.ClientConfig.Compression = "gzip"
+	r3Expected.GMPConfig.MetricConfig.ClientConfig.Endpoint = "foobar"
+	r3Expected.GMPConfig.MetricConfig.ClientConfig.UseInsecure = true
+	r3Expected.GMPConfig.MetricConfig.ClientConfig.GRPCPoolSize = 1
+	assert.Equal(t, r3, r3Expected)
 }

--- a/exporter/googlemanagedprometheusexporter/config_test.go
+++ b/exporter/googlemanagedprometheusexporter/config_test.go
@@ -64,7 +64,7 @@ func TestLoadConfig(t *testing.T) {
 	r2Expected.GMPConfig.MetricConfig.Prefix = "my-metric-domain.com"
 	assert.Equal(t, r2, r2Expected)
 
-	r3 := cfg.Exporters[component.NewIDWithName(typeStr, "clientconfig")].(*Config)
+	r3 := cfg.Exporters[component.NewIDWithName(metadata.Type, "clientconfig")].(*Config)
 	r3Expected := factory.CreateDefaultConfig().(*Config)
 	r3Expected.GMPConfig.MetricConfig.ClientConfig.Compression = "gzip"
 	r3Expected.GMPConfig.MetricConfig.ClientConfig.Endpoint = "foobar"

--- a/exporter/googlemanagedprometheusexporter/testdata/config.yaml
+++ b/exporter/googlemanagedprometheusexporter/testdata/config.yaml
@@ -22,6 +22,12 @@ exporters:
   googlemanagedprometheus/customprefix:
     metric:
       prefix: my-metric-domain.com
+  googlemanagedprometheus/clientconfig:
+    metric:
+      compression: gzip
+      endpoint: "foobar"
+      use_insecure: true
+      grpc_pool_size: 1
 
 
 service:


### PR DESCRIPTION
**Description:** These client config settings are not currently documented for GMP:
* `compression` (this is an option in managed GMP, so we should document it here too)
* `grpc_pool_size`

Also, it looks like `use_insecure` wasn't documented at the right level. Added testdata for these client config settings to verify.

Also added `grpc_pool_size` to the GCP exporter because I noticed it wasn't documented there either.

**Link to tracking Issue:** n/a

**Testing:** updated testdata in this PR

**Documentation:** this PR