### PR TITLE
[chore] Process stale issues and PRs in ascending order

### DIFF
--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -19,4 +19,5 @@ jobs:
           days-before-pr-close: 14
           days-before-issue-close: 60
           exempt-issue-labels: 'never stale'
+          ascending: true
 


### PR DESCRIPTION
**Description:**

Process PRs and issues in ascending order, which will grab the oldest issues first instead of grabbing the newest issues first. Setting this option is [recommended by the action authors](https://github.com/actions/stale#ascending) when the number of items exceeds the `operations-per-run` limit, for which the default is 30. Both our issues and PRs are being affected by this, so this setting is appropriate for both cases. We probably want to leave `operations-per-run` at the default setting since we want to avoid hitting the GitHub API rate limits.