### PR TITLE
elasticsearchexporter: use configured dedup and dedot values

### DIFF
--- a/.chloggen/elastic-exporter-mapping-config-use.yaml
+++ b/.chloggen/elastic-exporter-mapping-config-use.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: use mapping.dedup and mapping.dedot configuration values
+
+# One or more tracking issues related to the change
+issues: [19419]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/elasticsearchexporter/logs_exporter.go
+++ b/exporter/elasticsearchexporter/logs_exporter.go
@@ -61,8 +61,7 @@ func newLogsExporter(logger *zap.Logger, cfg *Config) (*elasticsearchLogsExporte
 		maxAttempts = cfg.Retry.MaxRequests
 	}
 
-	// TODO: Apply encoding and field mapping settings.
-	model := &encodeModel{dedup: true, dedot: false}
+	model := &encodeModel{dedup: cfg.Mapping.Dedup, dedot: cfg.Mapping.Dedot}
 
 	indexStr := cfg.LogsIndex
 	if cfg.Index != "" {

--- a/exporter/elasticsearchexporter/logs_exporter_test.go
+++ b/exporter/elasticsearchexporter/logs_exporter_test.go
@@ -40,9 +40,8 @@ func TestExporter_New(t *testing.T) {
 	}
 	successWithInternalModel := func(expectedModel *encodeModel) validate {
 		return func(t *testing.T, exporter *elasticsearchLogsExporter, err error) {
-			require.Nil(t, err)
-			require.NotNil(t, exporter)
-			require.EqualValues(t, expectedModel, exporter.model)
+			assert.Nil(t, err)
+			assert.EqualValues(t, expectedModel, exporter.model)
 		}
 	}
 	successWithDeprecatedIndexOption := func(index string) validate {

--- a/exporter/elasticsearchexporter/logs_exporter_test.go
+++ b/exporter/elasticsearchexporter/logs_exporter_test.go
@@ -38,6 +38,13 @@ func TestExporter_New(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, exporter)
 	}
+	successWithInternalModel := func(expectedModel *encodeModel) validate {
+		return func(t *testing.T, exporter *elasticsearchLogsExporter, err error) {
+			require.Nil(t, err)
+			require.NotNil(t, exporter)
+			require.EqualValues(t, expectedModel, exporter.model)
+		}
+	}
 	successWithDeprecatedIndexOption := func(index string) validate {
 		return func(t *testing.T, exporter *elasticsearchLogsExporter, err error) {
 			require.Nil(t, err)
@@ -118,6 +125,14 @@ func TestExporter_New(t *testing.T) {
 				}
 			}),
 			want: success,
+		},
+		"create with custom dedup and dedot values": {
+			config: withDefaultConfig(func(cfg *Config) {
+				cfg.Endpoints = []string{"test:9200"}
+				cfg.Mapping.Dedot = false
+				cfg.Mapping.Dedup = true
+			}),
+			want: successWithInternalModel(&encodeModel{dedot: false, dedup: true}),
 		},
 	}
 

--- a/exporter/elasticsearchexporter/trace_exporter.go
+++ b/exporter/elasticsearchexporter/trace_exporter.go
@@ -57,8 +57,7 @@ func newTracesExporter(logger *zap.Logger, cfg *Config) (*elasticsearchTracesExp
 		maxAttempts = cfg.Retry.MaxRequests
 	}
 
-	// TODO: Apply encoding and field mapping settings.
-	model := &encodeModel{dedup: true, dedot: false}
+	model := &encodeModel{dedup: cfg.Mapping.Dedup, dedot: cfg.Mapping.Dedot}
 
 	return &elasticsearchTracesExporter{
 		logger:      logger,

--- a/exporter/elasticsearchexporter/traces_exporter_test.go
+++ b/exporter/elasticsearchexporter/traces_exporter_test.go
@@ -41,9 +41,8 @@ func TestTracesExporter_New(t *testing.T) {
 	}
 	successWithInternalModel := func(expectedModel *encodeModel) validate {
 		return func(t *testing.T, exporter *elasticsearchTracesExporter, err error) {
-			require.Nil(t, err)
-			require.NotNil(t, exporter)
-			require.EqualValues(t, expectedModel, exporter.model)
+			assert.Nil(t, err)
+			assert.EqualValues(t, expectedModel, exporter.model)
 		}
 	}
 

--- a/exporter/elasticsearchexporter/traces_exporter_test.go
+++ b/exporter/elasticsearchexporter/traces_exporter_test.go
@@ -39,6 +39,13 @@ func TestTracesExporter_New(t *testing.T) {
 		require.Nil(t, err)
 		require.NotNil(t, exporter)
 	}
+	successWithInternalModel := func(expectedModel *encodeModel) validate {
+		return func(t *testing.T, exporter *elasticsearchTracesExporter, err error) {
+			require.Nil(t, err)
+			require.NotNil(t, exporter)
+			require.EqualValues(t, expectedModel, exporter.model)
+		}
+	}
 
 	failWith := func(want error) validate {
 		return func(t *testing.T, exporter *elasticsearchTracesExporter, err error) {
@@ -96,6 +103,14 @@ func TestTracesExporter_New(t *testing.T) {
 				cfg.CloudID = "foo:YmFyLmNsb3VkLmVzLmlvJGFiYzEyMyRkZWY0NTY="
 			}),
 			want: failWithMessage("Addresses and CloudID are set"),
+		},
+		"create with custom dedup and dedot values": {
+			config: withDefaultConfig(func(cfg *Config) {
+				cfg.Endpoints = []string{"test:9200"}
+				cfg.Mapping.Dedot = false
+				cfg.Mapping.Dedup = true
+			}),
+			want: successWithInternalModel(&encodeModel{dedot: false, dedup: true}),
 		},
 	}
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fixes bug in elasticsearch exporter where `mapping.dedup` and `mapping.dedot` values aren't used, even though they are documented as having an effect.

**Link to tracking Issue:** #19419