### PR TITLE
[chore][receiver/dockerstats] fix docs for `excluded_image` option

### DIFF
--- a/receiver/dockerstatsreceiver/README.md
+++ b/receiver/dockerstatsreceiver/README.md
@@ -29,11 +29,11 @@ as the specified metric label key.
 - `excluded_images` (no default, all running containers monitored): A list of strings,
 [regexes](https://golang.org/pkg/regexp/), or [globs](https://github.com/gobwas/glob) whose referent container image
 names will not be among the queried containers. `!`-prefixed negations are possible for all item types to signify that
-only unmatched container image names should be monitored.
+only unmatched container image names should be excluded.
     - Regexes must be placed between `/` characters: `/my?egex/`.  Negations are to be outside the forward slashes:
-    `!/my?egex/` will monitor all containers whose name doesn't match the compiled regex `my?egex`.
+    `!/my?egex/` will exclude all containers whose name doesn't match the compiled regex `my?egex`.
     - Globs are non-regex items (e.g. `/items/`) containing any of the following: `*[]{}?`.  Negations are supported:
-    `!my*container` will monitor all containers whose image name doesn't match the blob `my*container`.
+    `!my*container` will exclude all containers whose image name doesn't match the blob `my*container`.
 - `timeout` (default = `5s`): The request timeout for any docker daemon query.
 - `api_version` (default = `1.22`): The Docker client API version (must be 1.22+). [Docker API versions](https://docs.docker.com/engine/api/).
 - `metrics` (defaults at [./documentation.md](./documentation.md)): Enables/disables individual metrics. See [./documentation.md](./documentation.md) for full detail.


### PR DESCRIPTION
# Problem
The documentation of this config option mentions negations, for example:
> `!`-prefixed negations are possible for all item types to signify that only unmatched container image names should be monitored.

I'm not sure how to understand `monitored` in this context. As I understand it, this means that if we specify a negation, for example `!nginx-*`, then every image that **does match** glob `nginx-*` will be **excluded**, but that doesn't make much sense. First of all, it would mean that it is the same functionality as like without the negations. Second of all, this doesn't seem to match the tests, for example:

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/25c6c0e4fad1f28be6a8c9498c0057388eb242b7/receiver/dockerstatsreceiver/integration_test.go#L182

Here we exclude glob `*redis*` and then expect that the redis image won't be scraped (which makes sense and is consisted with the documentation).

And here:

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/25c6c0e4fad1f28be6a8c9498c0057388eb242b7/receiver/dockerstatsreceiver/integration_test.go#L214

we use a negation `!*nginx*` and then expect that the metrics will eventually be scraped for image `docker.io/library/nginx:1.17` (which does match glob `*nginx*`). 

# Proposed fix
Change word `monitor` to `exclude` to indicate that these negations in fact exclude everything besides a given pattern. 

It is also possible that I did not understand the idea of excluding images, in that case, please explain it to me and make the docs easier to understand.