### PR TITLE
[connectors/spanmetrics] Use enum type to configure histogram units.

### DIFF
--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -21,6 +21,8 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector/internal/metrics"
 )
 
 const (
@@ -71,7 +73,7 @@ type Config struct {
 }
 
 type HistogramConfig struct {
-	Unit        string                      `mapstructure:"unit"`
+	Unit        metrics.Unit                `mapstructure:"unit"`
 	Exponential *ExponentialHistogramConfig `mapstructure:"exponential"`
 	Explicit    *ExplicitHistogramConfig    `mapstructure:"explicit"`
 }
@@ -103,11 +105,6 @@ func (c Config) Validate() error {
 
 	if c.Histogram.Explicit != nil && c.Histogram.Exponential != nil {
 		return errors.New("use either `explicit` or `exponential` buckets histogram")
-	}
-
-	unit := c.Histogram.Unit
-	if unit != "s" && unit != "ms" {
-		return fmt.Errorf("allowed units are 'ms' and 's', got: '%s'", c.Histogram.Unit)
 	}
 	return nil
 }

--- a/connector/spanmetricsconnector/config_test.go
+++ b/connector/spanmetricsconnector/config_test.go
@@ -25,6 +25,8 @@ import (
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/multierr"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector/internal/metrics"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -58,7 +60,7 @@ func TestLoadConfig(t *testing.T) {
 				DimensionsCacheSize:  1500,
 				MetricsFlushInterval: 30 * time.Second,
 				Histogram: HistogramConfig{
-					Unit: "s",
+					Unit: metrics.Seconds,
 					Explicit: &ExplicitHistogramConfig{
 						Buckets: []time.Duration{
 							10 * time.Millisecond,
@@ -76,7 +78,7 @@ func TestLoadConfig(t *testing.T) {
 				DimensionsCacheSize:    1000,
 				MetricsFlushInterval:   15 * time.Second,
 				Histogram: HistogramConfig{
-					Unit: "ms",
+					Unit: metrics.Milliseconds,
 					Exponential: &ExponentialHistogramConfig{
 						MaxSize: 10,
 					},
@@ -89,7 +91,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			id:           component.NewIDWithName(typeStr, "invalid_histogram_unit"),
-			errorMessage: "allowed units are 'ms' and 's', got: 'h'",
+			errorMessage: "unknown Unit \"h\"",
 		},
 	}
 
@@ -101,7 +103,6 @@ func TestLoadConfig(t *testing.T) {
 			sub, err := cm.Sub(tt.id.String())
 			require.NoError(t, err)
 			err = component.UnmarshalConfig(sub, cfg)
-			require.NoError(t, err)
 
 			if tt.expected == nil {
 				err = multierr.Append(err, component.ValidateConfig(cfg))

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -47,7 +47,7 @@ const (
 	metricNameDuration = "duration"
 	metricNameCalls    = "calls"
 
-	defaultUnit = "ms"
+	defaultUnit = metrics.Milliseconds
 )
 
 type connectorImp struct {
@@ -145,11 +145,11 @@ func newConnector(logger *zap.Logger, config component.Config, ticker *clock.Tic
 }
 
 // unitDivider returns a unit divider to convert nanoseconds to milliseconds or seconds.
-func unitDivider(s string) int64 {
-	return map[string]int64{
-		"s":  time.Second.Nanoseconds(),
-		"ms": time.Millisecond.Nanoseconds(),
-	}[s]
+func unitDivider(u metrics.Unit) int64 {
+	return map[metrics.Unit]int64{
+		metrics.Seconds:      time.Second.Nanoseconds(),
+		metrics.Milliseconds: time.Millisecond.Nanoseconds(),
+	}[u]
 }
 
 func durationsToUnits(vs []time.Duration, unitDivider int64) []float64 {
@@ -241,7 +241,7 @@ func (p *connectorImp) buildMetrics() pmetric.Metrics {
 func (p *connectorImp) buildDurationMetric(ilm pmetric.ScopeMetrics) {
 	m := ilm.Metrics().AppendEmpty()
 	m.SetName(buildMetricName(p.config.Namespace, metricNameDuration))
-	m.SetUnit(p.config.Histogram.Unit)
+	m.SetUnit(p.config.Histogram.Unit.String())
 
 	p.histograms.BuildMetrics(m, p.startTimestamp, p.config.GetAggregationTemporality())
 }

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -144,7 +144,7 @@ func verifyConsumeMetricsInput(t testing.TB, input pmetric.Metrics, expectedTemp
 
 	h := m.At(1)
 	assert.Equal(t, metricNameDuration, h.Name())
-	assert.Equal(t, defaultUnit, h.Unit())
+	assert.Equal(t, defaultUnit.String(), h.Unit())
 
 	// The remaining 3 data points are for duration.
 	if h.Type() == pmetric.MetricTypeExponentialHistogram {
@@ -937,7 +937,7 @@ func TestBuildMetricName(t *testing.T) {
 func TestConnector_durationsToUnits(t *testing.T) {
 	tests := []struct {
 		input []time.Duration
-		unit  string
+		unit  metrics.Unit
 		want  []float64
 	}{
 		{
@@ -957,7 +957,7 @@ func TestConnector_durationsToUnits(t *testing.T) {
 				3 * time.Millisecond,
 				3 * time.Second,
 			},
-			unit: "s",
+			unit: metrics.Seconds,
 			want: []float64{3e-09, 3e-06, 0.003, 3},
 		},
 		{

--- a/connector/spanmetricsconnector/internal/metrics/unit.go
+++ b/connector/spanmetricsconnector/internal/metrics/unit.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package metrics
+package metrics // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector/internal/metrics"
 
 import (
 	"encoding"

--- a/connector/spanmetricsconnector/internal/metrics/unit.go
+++ b/connector/spanmetricsconnector/internal/metrics/unit.go
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"encoding"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	Milliseconds Unit = iota
+	Seconds
+
+	MillisecondsStr = "ms"
+	SecondsStr      = "s"
+)
+
+type Unit int8
+
+var _ encoding.TextMarshaler = (*Unit)(nil)
+var _ encoding.TextUnmarshaler = (*Unit)(nil)
+
+func (u Unit) String() string {
+	switch u {
+	case Milliseconds:
+		return MillisecondsStr
+	case Seconds:
+		return SecondsStr
+	}
+	return ""
+}
+
+// MarshalText marshals Unit to text.
+func (u Unit) MarshalText() (text []byte, err error) {
+	return []byte(u.String()), nil
+}
+
+// UnmarshalText unmarshalls text to a Unit.
+func (u *Unit) UnmarshalText(text []byte) error {
+	if u == nil {
+		return errors.New("cannot unmarshal to a nil *Unit")
+	}
+
+	str := strings.ToLower(string(text))
+	switch str {
+	case strings.ToLower(MillisecondsStr):
+		*u = Milliseconds
+		return nil
+	case strings.ToLower(SecondsStr):
+		*u = Seconds
+		return nil
+	}
+	return fmt.Errorf("unknown Unit %q, allowed units are %q and %q", str, MillisecondsStr, SecondsStr)
+}

--- a/connector/spanmetricsconnector/internal/metrics/unit_test.go
+++ b/connector/spanmetricsconnector/internal/metrics/unit_test.go
@@ -1,0 +1,91 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalText(t *testing.T) {
+	tests := []struct {
+		str  []string
+		unit Unit
+		err  bool
+	}{
+		{
+			str:  []string{"ms", "Ms", "MS"},
+			unit: Milliseconds,
+		},
+		{
+			str:  []string{"s", "S"},
+			unit: Seconds,
+		},
+		{
+			str: []string{"h", "H"},
+			err: true,
+		},
+		{
+			str: []string{""},
+			err: true,
+		},
+	}
+
+	for _, tt := range tests {
+		for _, str := range tt.str {
+			t.Run(str, func(t *testing.T) {
+				var u Unit
+				err := u.UnmarshalText([]byte(str))
+				if tt.err {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.Equal(t, tt.unit, u)
+				}
+			})
+		}
+	}
+}
+
+func TestUnmarshalTextNilUnit(t *testing.T) {
+	lvl := (*Unit)(nil)
+	assert.Error(t, lvl.UnmarshalText([]byte(MillisecondsStr)))
+}
+
+func TestUnitStringMarshal(t *testing.T) {
+	tests := []struct {
+		str  string
+		unit Unit
+		err  bool
+	}{
+		{
+			str:  SecondsStr,
+			unit: Seconds,
+		},
+		{
+			str:  MillisecondsStr,
+			unit: Milliseconds,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.str, func(t *testing.T) {
+			assert.Equal(t, tt.str, tt.unit.String())
+			got, err := tt.unit.MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.str, string(got))
+		})
+	}
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Use enum type to configure histogram units. Follow up on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/19370#discussion_r1130979710