### PR TITLE
[processor/k8sattributes] Remove deprecated extract.metadata options

### DIFF
--- a/.chloggen/k8sattributes-remove-deprecated-metadata-fields.yaml
+++ b/.chloggen/k8sattributes-remove-deprecated-metadata-fields.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove support of deprecated options in extract.metadata field
+
+# One or more tracking issues related to the change
+issues: [19438]

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -22,7 +22,6 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
@@ -161,7 +160,6 @@ func createKubernetesProcessor(
 ) (*kubernetesprocessor, error) {
 	kp := &kubernetesprocessor{logger: params.Logger}
 
-	warnDeprecatedMetadataConfig(kp.logger, cfg)
 	warnDeprecatedPodAssociationConfig(kp.logger, cfg)
 
 	err := errWrongKeyConfig(cfg)
@@ -212,41 +210,6 @@ func createProcessorOpts(cfg component.Config) []option {
 	opts = append(opts, withExcludes(oCfg.Exclude))
 
 	return opts
-}
-
-func warnDeprecatedMetadataConfig(logger *zap.Logger, cfg component.Config) {
-	oCfg := cfg.(*Config)
-	for _, field := range oCfg.Extract.Metadata {
-		var oldName, newName string
-		switch field {
-		case metdataNamespace:
-			oldName = metdataNamespace
-			newName = conventions.AttributeK8SNamespaceName
-		case metadataPodName:
-			oldName = metadataPodName
-			newName = conventions.AttributeK8SPodName
-		case metadataPodUID:
-			oldName = metadataPodUID
-			newName = conventions.AttributeK8SPodUID
-		case metadataStartTime:
-			oldName = metadataStartTime
-			newName = metadataPodStartTime
-		case metadataDeployment:
-			oldName = metadataDeployment
-			newName = conventions.AttributeK8SDeploymentName
-		case metadataNode:
-			oldName = metadataNode
-			newName = conventions.AttributeK8SNodeName
-		case deprecatedMetadataCluster:
-			logger.Warn("cluster metadata param has been deprecated and will be removed soon")
-		case conventions.AttributeK8SClusterName:
-			logger.Warn("k8s.cluster.name metadata param has been deprecated and will be removed soon")
-		}
-		if oldName != "" {
-			logger.Warn(fmt.Sprintf("%s has been deprecated in favor of %s for k8s-tagger processor", oldName, newName))
-		}
-	}
-
 }
 
 func errWrongKeyConfig(cfg component.Config) error {

--- a/processor/k8sattributesprocessor/factory_test.go
+++ b/processor/k8sattributesprocessor/factory_test.go
@@ -70,23 +70,3 @@ func TestCreateProcessor(t *testing.T) {
 	// Switch it back so other tests run afterwards will not fail on unexpected state
 	kubeClientProvider = realClient
 }
-
-func TestCreateProcessorWithDeprecatedSettings(t *testing.T) {
-	factory := NewFactory()
-
-	cfg := factory.CreateDefaultConfig()
-	oCfg := cfg.(*Config)
-	oCfg.Extract.Metadata = []string{"k8s.cluster.name"}
-
-	params := processortest.NewNopCreateSettings()
-
-	realClient := kubeClientProvider
-	kubeClientProvider = newFakeClient
-
-	tp, err := factory.CreateTracesProcessor(context.Background(), params, cfg, consumertest.NewNop())
-	assert.NotNil(t, tp)
-	assert.NoError(t, err)
-
-	// Switch it back so other tests run afterwards will not fail on unexpected state
-	kubeClientProvider = realClient
-}

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -31,18 +31,8 @@ const (
 	filterOPNotEquals    = "not-equals"
 	filterOPExists       = "exists"
 	filterOPDoesNotExist = "does-not-exist"
-	// Used for maintaining backward compatibility
-	metdataNamespace   = "namespace"
-	metadataPodName    = "podName"
-	metadataPodUID     = "podUID"
-	metadataStartTime  = "startTime"
-	metadataDeployment = "deployment"
-	metadataNode       = "node"
-	// Will be removed when new fields get merged to https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/opentelemetry.go
 	metadataPodStartTime = "k8s.pod.start_time"
 	specPodHostName      = "k8s.pod.hostname"
-	// This one was deprecated, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9886
-	deprecatedMetadataCluster = "cluster"
 )
 
 // option represents a configuration option that can be passes.
@@ -85,20 +75,17 @@ func withExtractMetadata(fields ...string) option {
 		}
 		for _, field := range fields {
 			switch field {
-			// Old conventions handled by the cases metdataNamespace, metadataPodName, metadataPodUID,
-			// metadataStartTime, metadataDeployment, deprecatedMetadataCluster, metadataNode are being supported for backward compatibility.
-			// These will be removed when new conventions get merged to https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/opentelemetry.go
-			case metdataNamespace, conventions.AttributeK8SNamespaceName:
+			case conventions.AttributeK8SNamespaceName:
 				p.rules.Namespace = true
-			case metadataPodName, conventions.AttributeK8SPodName:
+			case conventions.AttributeK8SPodName:
 				p.rules.PodName = true
-			case metadataPodUID, conventions.AttributeK8SPodUID:
+			case conventions.AttributeK8SPodUID:
 				p.rules.PodUID = true
 			case specPodHostName:
 				p.rules.PodHostName = true
-			case metadataStartTime, metadataPodStartTime:
+			case metadataPodStartTime:
 				p.rules.StartTime = true
-			case metadataDeployment, conventions.AttributeK8SDeploymentName:
+			case conventions.AttributeK8SDeploymentName:
 				p.rules.Deployment = true
 			case conventions.AttributeK8SReplicaSetName:
 				p.rules.ReplicaSetName = true
@@ -118,7 +105,7 @@ func withExtractMetadata(fields ...string) option {
 				p.rules.JobUID = true
 			case conventions.AttributeK8SCronJobName:
 				p.rules.CronJobName = true
-			case metadataNode, conventions.AttributeK8SNodeName:
+			case conventions.AttributeK8SNodeName:
 				p.rules.Node = true
 			case conventions.AttributeContainerID:
 				p.rules.ContainerID = true
@@ -126,8 +113,6 @@ func withExtractMetadata(fields ...string) option {
 				p.rules.ContainerImageName = true
 			case conventions.AttributeContainerImageTag:
 				p.rules.ContainerImageTag = true
-			case deprecatedMetadataCluster, conventions.AttributeK8SClusterName:
-				// This one is deprecated, ignore it
 			default:
 				return fmt.Errorf("\"%s\" is not a supported metadata field", field)
 			}


### PR DESCRIPTION
Remove support of deprecated options in the `extract.metadata` field. It's already a year passed since they were deprecated.