### PR TITLE
[receiver/mysqlreceiver] add version check to prevent unsupported replica query error

### DIFF
--- a/.chloggen/mysqlreceiver-add-version-check.yaml
+++ b/.chloggen/mysqlreceiver-add-version-check.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds a version check to make sure replica query is supported
+
+# One or more tracking issues related to the change
+issues: [19469]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -163,6 +163,10 @@ func (c *mockClient) Connect() error {
 	return nil
 }
 
+func (c *mockClient) getVersion() (string, error) {
+	return "8.0.27", nil
+}
+
 func (c *mockClient) getGlobalStats() (map[string]string, error) {
 	return readFile(c.globalStatsFile)
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This pr fixes the error `You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'REPLICA STATUS` when running mysql on an older mysql instance. This was achieved by adding a version check before making the `REPLICA STATUS` query since the query is not supported on older instances.

**Link to tracking Issue:** <Issue number if applicable>
#19469 

**Testing:** <Describe what testing was performed and which tests were added.>
Testing the receiver using a `mysql:5.7.36` container image, I no longer receiving the error generated before with the added validation check. The MySQL integration test and other unit tests still pass as expected.

**Documentation:** <Describe the documentation added.>