### PR TITLE
[receiver/splunkhec] Accepts query param for raw path

### DIFF
--- a/.chloggen/splunkhecreceiver-add-query-param-for-raw.yaml
+++ b/.chloggen/splunkhecreceiver-add-query-param-for-raw.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: splunkhecreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Appends query param (index, source, sourcetype) for raw path
+note: Appends query param (index, source, sourcetype, and host) for raw path
 
 # One or more tracking issues related to the change
 issues: [19632]

--- a/.chloggen/splunkhecreceiver-add-query-param-for-raw.yaml
+++ b/.chloggen/splunkhecreceiver-add-query-param-for-raw.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Appends query param (index, source, sourcetype) for raw path
+
+# One or more tracking issues related to the change
+issues: [19632]

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -30,7 +30,6 @@ const (
 	DefaultSourceTypeLabel     = "com.splunk.sourcetype"
 	DefaultSourceLabel         = "com.splunk.source"
 	DefaultIndexLabel          = "com.splunk.index"
-	DefaultHostLabel           = "com.splunk.host"
 	DefaultNameLabel           = "otel.log.name"
 	DefaultSeverityTextLabel   = "otel.log.severity.text"
 	DefaultSeverityNumberLabel = "otel.log.severity.number"

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -30,6 +30,7 @@ const (
 	DefaultSourceTypeLabel     = "com.splunk.sourcetype"
 	DefaultSourceLabel         = "com.splunk.source"
 	DefaultIndexLabel          = "com.splunk.index"
+	DefaultHostLabel           = "com.splunk.host"
 	DefaultNameLabel           = "otel.log.name"
 	DefaultSeverityTextLabel   = "otel.log.severity.text"
 	DefaultSeverityNumberLabel = "otel.log.severity.number"

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -54,12 +54,6 @@ const (
 	// Centralizing some HTTP and related string constants.
 	gzipEncoding              = "gzip"
 	httpContentEncodingHeader = "Content-Encoding"
-
-	// splunk metadata
-	index      = "index"
-	source     = "source"
-	sourcetype = "sourcetype"
-	host       = "host"
 )
 
 var (

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -60,6 +60,7 @@ const (
 	index      = "index"
 	source     = "source"
 	sourcetype = "sourcetype"
+	host       = "host"
 )
 
 var (
@@ -82,6 +83,7 @@ var (
 		index:      splunk.DefaultIndexLabel,
 		source:     splunk.DefaultSourceLabel,
 		sourcetype: splunk.DefaultSourceTypeLabel,
+		host:       splunk.DefaultHostLabel,
 	}
 )
 
@@ -514,6 +516,10 @@ func getMetadataKey(hecAttr splunk.HecToOtelAttrs, rKey, rDefault string) string
 	case sourcetype:
 		if hecAttr.SourceType != "" {
 			return hecAttr.SourceType
+		}
+	case host:
+		if hecAttr.Host != "" {
+			return hecAttr.Host
 		}
 	}
 	return rDefault

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -1100,7 +1100,7 @@ func Test_splunkhecReceiver_rawReqHasmetadataInResource(t *testing.T) {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
 				req := httptest.NewRequest("POST",
-					"http://localhost/foo?index=bar&source=bar&sourcetype=bar",
+					"http://localhost/foo?index=bar&source=bar&sourcetype=bar&host=bar",
 					bytes.NewReader(msgBytes))
 				return req
 			}(),
@@ -1109,7 +1109,7 @@ func Test_splunkhecReceiver_rawReqHasmetadataInResource(t *testing.T) {
 				resources := got[0].ResourceLogs()
 				assert.Equal(t, 1, resources.Len())
 				resource := resources.At(0).Resource().Attributes()
-				assert.Equal(t, 3, resource.Len())
+				assert.Equal(t, 4, resource.Len())
 				for _, k := range []string{splunk.DefaultIndexLabel, splunk.DefaultSourceLabel, splunk.DefaultSourceTypeLabel} {
 					v, ok := resource.Get(k)
 					if !ok {
@@ -1194,6 +1194,7 @@ func Test_splunkhecReceiver_rawReqUseConfigurableMetadataKey(t *testing.T) {
 		Source:     "com.source.foo",
 		SourceType: "com.sourcetype.foo",
 		Index:      "com.index.foo",
+		Host:       "com.host.foo",
 	}
 
 	currentTime := float64(time.Now().UnixNano()) / 1e6
@@ -1218,7 +1219,7 @@ func Test_splunkhecReceiver_rawReqUseConfigurableMetadataKey(t *testing.T) {
 		msgBytes, err := json.Marshal(splunkMsg)
 		require.NoError(t, err)
 		req := httptest.NewRequest("POST",
-			"http://localhost/foo?index=bar&source=bar&sourcetype=bar",
+			"http://localhost/foo?index=bar&source=bar&sourcetype=bar&host=bar",
 			bytes.NewReader(msgBytes))
 		return req
 	}())
@@ -1232,7 +1233,7 @@ func Test_splunkhecReceiver_rawReqUseConfigurableMetadataKey(t *testing.T) {
 	resources := got[0].ResourceLogs()
 	assert.Equal(t, 1, resources.Len())
 	resource := resources.At(0).Resource().Attributes()
-	assert.Equal(t, 3, resource.Len())
+	assert.Equal(t, 4, resource.Len())
 	for _, k := range []string{config.HecToOtelAttrs.Index, config.HecToOtelAttrs.SourceType, config.HecToOtelAttrs.Source} {
 		v, ok := resource.Get(k)
 		if !ok {

--- a/receiver/splunkhecreceiver/splunk_to_logdata.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata.go
@@ -15,7 +15,9 @@
 package splunkhecreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver"
 
 import (
+	"bufio"
 	"errors"
+	"net/url"
 	"sort"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -41,18 +43,7 @@ func splunkHecToLogData(logger *zap.Logger, events []*splunk.Event, resourceCust
 			rl := ld.ResourceLogs().AppendEmpty()
 			sl = rl.ScopeLogs().AppendEmpty()
 			scopeLogsMap[key] = sl
-			if event.Host != "" {
-				rl.Resource().Attributes().PutStr(config.HecToOtelAttrs.Host, event.Host)
-			}
-			if event.Source != "" {
-				rl.Resource().Attributes().PutStr(config.HecToOtelAttrs.Source, event.Source)
-			}
-			if event.SourceType != "" {
-				rl.Resource().Attributes().PutStr(config.HecToOtelAttrs.SourceType, event.SourceType)
-			}
-			if event.Index != "" {
-				rl.Resource().Attributes().PutStr(config.HecToOtelAttrs.Index, event.Index)
-			}
+			appendSplunkMetadata(rl, config.HecToOtelAttrs, event.Host, event.Source, event.SourceType, event.Index)
 			if resourceCustomizer != nil {
 				resourceCustomizer(rl.Resource())
 			}
@@ -86,6 +77,40 @@ func splunkHecToLogData(logger *zap.Logger, events []*splunk.Event, resourceCust
 	}
 
 	return ld, nil
+}
+
+// splunkHecRawToLogData transforms raw splunk event into log
+func splunkHecRawToLogData(sc *bufio.Scanner, query url.Values, resourceCustomizer func(pcommon.Resource), config *Config) (plog.Logs, int) {
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	appendSplunkMetadata(rl, config.HecToOtelAttrs, query.Get(host), query.Get(source), query.Get(sourcetype), query.Get(index))
+	if resourceCustomizer != nil {
+		resourceCustomizer(rl.Resource())
+	}
+
+	sl := rl.ScopeLogs().AppendEmpty()
+	for sc.Scan() {
+		logRecord := sl.LogRecords().AppendEmpty()
+		logLine := sc.Text()
+		logRecord.Body().SetStr(logLine)
+	}
+
+	return ld, sl.LogRecords().Len()
+}
+
+func appendSplunkMetadata(rl plog.ResourceLogs, attrs splunk.HecToOtelAttrs, host, source, sourceType, index string) {
+	if host != "" {
+		rl.Resource().Attributes().PutStr(attrs.Host, host)
+	}
+	if source != "" {
+		rl.Resource().Attributes().PutStr(attrs.Source, source)
+	}
+	if sourceType != "" {
+		rl.Resource().Attributes().PutStr(attrs.SourceType, sourceType)
+	}
+	if index != "" {
+		rl.Resource().Attributes().PutStr(attrs.Index, index)
+	}
 }
 
 func convertToValue(logger *zap.Logger, src interface{}, dest pcommon.Value) error {

--- a/receiver/splunkhecreceiver/splunk_to_logdata.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata.go
@@ -27,6 +27,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
 
+const (
+	// splunk metadata
+	index      = "index"
+	source     = "source"
+	sourcetype = "sourcetype"
+	host       = "host"
+)
+
 var (
 	errCannotConvertValue = errors.New("cannot convert field value to attribute")
 )


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
HEC raw accepts sourcetype, source, and index query params.

**Link to tracking Issue:** [#19221](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19221)

**Testing:** Unit test validating params 

**Documentation:** None, as this ensure feature parity with splunk's documentation of [HEC raw](https://docs.splunk.com/Documentation/SplunkCloud/9.0.2209/Data/HTTPEventCollectortokenmanagement#:~:text=3...%20Hello%2C%20world!%27-,Send%20raw%20batched%20events%20to%20HEC,-The%20following%20example)