### PR TITLE
[processor/k8sattributes] Remove deprecated `pod_association` fields

### DIFF
--- a/.chloggen/k8sattributes-remove-deprecated-association-fields.yaml
+++ b/.chloggen/k8sattributes-remove-deprecated-association-fields.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove support of deprecated `pod_association` fields
+
+# One or more tracking issues related to the change
+issues: [19642]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Fields are now nested under the pod_association::sources

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -241,18 +241,6 @@ type FieldFilterConfig struct {
 // PodAssociationConfig contain single rule how to associate Pod metadata
 // with logs, spans and metrics
 type PodAssociationConfig struct {
-	// Deprecated: Sources should be used to provide From and Name.
-	// If this is set, From and Name are going to be used as Sources' ones
-	// From represents the source of the association.
-	// Allowed values are "connection" and "resource_attribute".
-	From string `mapstructure:"from"`
-
-	// Deprecated: Sources should be used to provide From and Name.
-	// If this is set, From and Name are going to be used as Sources' ones
-	// Name represents extracted key name.
-	// e.g. ip, pod_uid, k8s.pod.ip
-	Name string `mapstructure:"name"`
-
 	// List of pod association sources which should be taken
 	// to identify pod
 	Sources []PodAssociationSourceConfig `mapstructure:"sources"`

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -103,11 +103,6 @@ func TestLoadConfig(t *testing.T) {
 							},
 						},
 					},
-					// Deprecated way
-					{
-						From: "resource_attribute",
-						Name: "k8s.pod.uid",
-					},
 				},
 				Exclude: ExcludeConfig{
 					Pods: []ExcludePodConfig{

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -297,28 +297,16 @@ func withExtractPodAssociations(podAssociations ...PodAssociationConfig) option 
 
 			var name string
 
-			if association.From != "" {
-				if association.From == kube.ConnectionSource {
+			for _, associationSource := range association.Sources {
+				if associationSource.From == kube.ConnectionSource {
 					name = ""
 				} else {
-					name = association.Name
+					name = associationSource.Name
 				}
 				assoc.Sources = append(assoc.Sources, kube.AssociationSource{
-					From: association.From,
+					From: associationSource.From,
 					Name: name,
 				})
-			} else {
-				for _, associationSource := range association.Sources {
-					if associationSource.From == kube.ConnectionSource {
-						name = ""
-					} else {
-						name = associationSource.Name
-					}
-					assoc.Sources = append(assoc.Sources, kube.AssociationSource{
-						From: associationSource.From,
-						Name: name,
-					})
-				}
 			}
 			associations = append(associations, assoc)
 		}

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -717,43 +717,6 @@ func TestWithExtractPodAssociation(t *testing.T) {
 			},
 		},
 		{
-			"deprecated",
-			[]PodAssociationConfig{
-				{
-					From: "label",
-					Name: "ip",
-				},
-			},
-			[]kube.Association{
-				{
-					Sources: []kube.AssociationSource{
-						{
-							From: "label",
-							Name: "ip",
-						},
-					},
-				},
-			},
-		},
-		{
-			"connection deprecated",
-			[]PodAssociationConfig{
-				{
-					From: "connection",
-					Name: "ip",
-				},
-			},
-			[]kube.Association{
-				{
-					Sources: []kube.AssociationSource{
-						{
-							From: "connection",
-						},
-					},
-				},
-			},
-		},
-		{
 			"connection",
 			[]PodAssociationConfig{
 				{

--- a/processor/k8sattributesprocessor/testdata/config.yaml
+++ b/processor/k8sattributesprocessor/testdata/config.yaml
@@ -66,9 +66,6 @@ k8sattributes/2:
     - sources:
       - from: connection
         name: ip
-    # deprecated way
-    - from: resource_attribute
-      name: k8s.pod.uid
 
   exclude:
     pods:


### PR DESCRIPTION
Remove deprecated fields `from` and `name` in `pod_association` items. 

`sources` field introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/8465 should be used instead.

Migration example:

```
k8sattributes:
  pod_association:
    - from: resource_attribute
      name: ip
```

should be replaced with

```
k8sattributes:
  pod_association:
    - sources:
      - from: resource_attribute
        name: ip
```
