### PR TITLE
[chore] add tests for internal/components.go components in preparation of moving tests to cmd/otelcontribcol

### DIFF
--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -1046,3 +1046,5 @@ replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api
 
 // It appears that the v0.2.0 tag was modified.  Replacing with v0.2.1
 replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristretto v0.2.1
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling => ../../extension/jaegerremotesampling

--- a/exporter/coralogixexporter/logs_client.go
+++ b/exporter/coralogixexporter/logs_client.go
@@ -74,6 +74,9 @@ func (e *logsExporter) start(ctx context.Context, host component.Host) (err erro
 }
 
 func (e *logsExporter) shutdown(context.Context) error {
+	if e.clientConn == nil {
+		return nil
+	}
 	return e.clientConn.Close()
 }
 

--- a/exporter/coralogixexporter/metrics_client.go
+++ b/exporter/coralogixexporter/metrics_client.go
@@ -98,6 +98,9 @@ func (e *exporter) pushMetrics(ctx context.Context, md pmetric.Metrics) error {
 }
 
 func (e *exporter) shutdown(context.Context) error {
+	if e.clientConn == nil {
+		return nil
+	}
 	return e.clientConn.Close()
 }
 

--- a/exporter/coralogixexporter/traces_client.go
+++ b/exporter/coralogixexporter/traces_client.go
@@ -95,6 +95,9 @@ func (e *tracesExporter) pushTraces(ctx context.Context, td ptrace.Traces) error
 	return nil
 }
 func (e *tracesExporter) shutdown(context.Context) error {
+	if e.clientConn == nil {
+		return nil
+	}
 	return e.clientConn.Close()
 }
 

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -294,12 +294,12 @@ func (f *factory) createTracesExporter(
 		tracex, err2 := newTracesExporter(ctx, set, cfg, &f.onceMetadata, hostProvider, traceagent)
 		if err2 != nil {
 			cancel()
+			f.wg.Wait() // then wait for shutdown
 			return nil, err2
 		}
 		pusher = tracex.consumeTraces
 		stop = func(context.Context) error {
-			cancel()    // first cancel context
-			f.wg.Wait() // then wait for shutdown
+			cancel() // first cancel context
 			return nil
 		}
 	}
@@ -346,6 +346,7 @@ func (f *factory) createLogsExporter(
 		exp, err := newLogsExporter(ctx, set, cfg, &f.onceMetadata, hostProvider)
 		if err != nil {
 			cancel()
+			f.wg.Wait() // then wait for shutdown
 			return nil, err
 		}
 		pusher = exp.consumeLogs

--- a/exporter/influxdbexporter/exporter.go
+++ b/exporter/influxdbexporter/exporter.go
@@ -33,6 +33,7 @@ type tracesExporter struct {
 	logger    common.Logger
 	writer    *influxHTTPWriter
 	converter *otel2influx.OtelTracesToLineProtocol
+	started   bool
 }
 
 func newTracesExporter(config *Config, settings exporter.CreateSettings) (*tracesExporter, error) {
@@ -65,12 +66,16 @@ func (e *tracesExporter) pushTraces(ctx context.Context, td ptrace.Traces) error
 
 func (e *tracesExporter) Start(ctx context.Context, host component.Host) error {
 	e.logger.Debug("starting traces exporter")
+	e.started = true
 	return multierr.Combine(
 		e.writer.Start(ctx, host),
 		e.converter.Start(ctx, host))
 }
 
 func (e *tracesExporter) Shutdown(ctx context.Context) error {
+	if !e.started {
+		return nil
+	}
 	return e.converter.Shutdown(ctx)
 }
 

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -39,7 +39,7 @@ var _ exporter.Logs = (*logExporterImp)(nil)
 type logExporterImp struct {
 	loadBalancer loadBalancer
 
-	stopped    bool
+	started    bool
 	shutdownWg sync.WaitGroup
 }
 
@@ -65,11 +65,15 @@ func (e *logExporterImp) Capabilities() consumer.Capabilities {
 }
 
 func (e *logExporterImp) Start(ctx context.Context, host component.Host) error {
+	e.started = true
 	return e.loadBalancer.Start(ctx, host)
 }
 
 func (e *logExporterImp) Shutdown(context.Context) error {
-	e.stopped = true
+	if !e.started {
+		return nil
+	}
+	e.started = false
 	e.shutdownWg.Wait()
 	return nil
 }

--- a/exporter/opencensusexporter/opencensus.go
+++ b/exporter/opencensusexporter/opencensus.go
@@ -112,6 +112,9 @@ func (oce *ocExporter) start(ctx context.Context, host component.Host) error {
 }
 
 func (oce *ocExporter) shutdown(context.Context) error {
+	if oce.grpcClientConn == nil {
+		return nil
+	}
 	if oce.tracesClients != nil {
 		// First remove all the clients from the channel.
 		for i := 0; i < oce.cfg.NumWorkers; i++ {

--- a/exporter/skywalkingexporter/skywalking.go
+++ b/exporter/skywalkingexporter/skywalking.go
@@ -99,6 +99,9 @@ func (oce *swExporter) start(ctx context.Context, host component.Host) error {
 }
 
 func (oce *swExporter) shutdown(context.Context) error {
+	if oce.grpcClientConn == nil {
+		return nil
+	}
 	if oce.logsClients != nil {
 		// First remove all the clients from the channel.
 		for i := 0; i < oce.cfg.NumStreams; i++ {

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder v0.73.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling v0.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver v0.73.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver v0.73.0
@@ -397,6 +398,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/golang-lru v0.6.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/nomad/api v0.0.0-20230124213148-69fd1a0e4bf7 // indirect
 	github.com/hashicorp/serf v0.10.1 // indirect
 	github.com/hetznercloud/hcloud-go v1.39.0 // indirect
@@ -442,6 +444,7 @@ require (
 	github.com/linode/linodego v1.12.0 // indirect
 	github.com/logicmonitor/lm-data-sdk-go v1.0.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20220517141722-cf486979b281 // indirect
+	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-ieproxy v0.0.9 // indirect
@@ -515,6 +518,8 @@ require (
 	github.com/panta/machineid v1.0.2 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/paulmach/orb v0.9.0 // indirect
+	github.com/pelletier/go-toml v1.9.5 // indirect
+	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/philhofer/fwd v1.1.2 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
@@ -552,8 +557,11 @@ require (
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/viper v1.14.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.615 // indirect
 	github.com/tg123/go-htpasswd v1.2.1 // indirect
@@ -776,6 +784,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/head
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension => ./extension/healthcheckextension
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/httpforwarder => ./extension/httpforwarder
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling => ./extension/jaegerremotesampling
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension => ./extension/oauth2clientauthextension
 

--- a/go.sum
+++ b/go.sum
@@ -1747,6 +1747,7 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
+github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/internal/components/exporters_test.go
+++ b/internal/components/exporters_test.go
@@ -552,8 +552,6 @@ func verifyExporterShutdown(tb testing.TB, factory exporter.Factory, getConfigFn
 		r, err := createFn(ctx, expCreateSettings, getConfigFn())
 		if errors.Is(err, component.ErrDataTypeIsNotSupported) {
 			continue
-		} else if err != nil {
-			require.NoError(tb, err)
 		}
 		if r == nil {
 			continue

--- a/internal/components/receivers_test.go
+++ b/internal/components/receivers_test.go
@@ -426,11 +426,16 @@ func TestDefaultReceivers(t *testing.T) {
 		},
 	}
 
-	assert.Len(t, tests, len(rcvrFactories), "All receivers must be added to the lifecycle suite")
+	receiverCount := 0
 	for _, tt := range tests {
+		_, ok := rcvrFactories[tt.receiver]
+		if !ok {
+			// not part of the distro, skipping.
+			continue
+		}
+		receiverCount++
 		t.Run(string(tt.receiver), func(t *testing.T) {
-			factory, ok := rcvrFactories[tt.receiver]
-			require.True(t, ok)
+			factory := rcvrFactories[tt.receiver]
 			assert.Equal(t, tt.receiver, factory.Type())
 
 			verifyReceiverShutdown(t, factory, tt.getConfigFn)
@@ -440,6 +445,7 @@ func TestDefaultReceivers(t *testing.T) {
 			}
 		})
 	}
+	assert.Len(t, rcvrFactories, receiverCount, "All receivers must be added to the lifecycle suite")
 }
 
 // getReceiverConfigFn is used customize the configuration passed to the verification.


### PR DESCRIPTION
Add tests for all distro components, and specifically tests the lifecycle of exporters and makes sure they can shutdown safely without being started first.

This PR is a smaller take on #19456 - we're just dealing with component tests.

In a future PR, we can move all component tests under cmd/otelcontribcol and remove the need to maintain the internal/* go files.