### PR TITLE
[chore] remove codeowner for mongodbatlas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -195,7 +195,7 @@ receiver/kafkareceiver/                                  @open-telemetry/collect
 receiver/kubeletstatsreceiver/                           @open-telemetry/collector-contrib-approvers @dmitryax
 receiver/memcachedreceiver/                              @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/mongodbreceiver/                                @open-telemetry/collector-contrib-approvers @djaglowski @schmikei
-receiver/mongodbatlasreceiver/                           @open-telemetry/collector-contrib-approvers @zenmoto
+receiver/mongodbatlasreceiver/                           @open-telemetry/collector-contrib-approvers
 receiver/mysqlreceiver/                                  @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/nginxreceiver/                                  @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/nsxtreceiver/                                   @open-telemetry/collector-contrib-approvers @dashpole @schmikei

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -195,7 +195,7 @@ receiver/kafkareceiver/                                  @open-telemetry/collect
 receiver/kubeletstatsreceiver/                           @open-telemetry/collector-contrib-approvers @dmitryax
 receiver/memcachedreceiver/                              @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/mongodbreceiver/                                @open-telemetry/collector-contrib-approvers @djaglowski @schmikei
-receiver/mongodbatlasreceiver/                           @open-telemetry/collector-contrib-approvers
+receiver/mongodbatlasreceiver/                           @open-telemetry/collector-contrib-approvers @djaglowski @schmikei
 receiver/mysqlreceiver/                                  @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/nginxreceiver/                                  @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/nsxtreceiver/                                   @open-telemetry/collector-contrib-approvers @dashpole @schmikei


### PR DESCRIPTION
Remove @zenmoto, after discussion, as mongodbatlas as he doesn't have the bandwidth to address issues for this component.

If you are interested to maintain this component, please make sure to reach out to the maintainers.