### PR TITLE
[chore] fix flaky ssh receiver tests

### DIFF
--- a/receiver/sshcheckreceiver/scraper_test.go
+++ b/receiver/sshcheckreceiver/scraper_test.go
@@ -68,7 +68,6 @@ func setupSSHServer(t *testing.T) *opensshContainer {
 	require.NotNil(t, container)
 
 	mappedPort, err := container.MappedPort(ctx, "2222")
-	print(mappedPort)
 	require.NoError(t, err)
 
 	hostIP, err := container.Host(ctx)


### PR DESCRIPTION
Use the port mapping rather than the hardcoded port 2222.

Fixes #18536
Fixes #19473