### PR TITLE
[exporter/signalfx] update translation rule to use a copy of system.cpu.time & system.paging.operations and leave the original one intact

### DIFF
--- a/.chloggen/sfx-exporter-translation-rule.yaml
+++ b/.chloggen/sfx-exporter-translation-rule.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: use a copy of system.cpu.time and system.paging.operations when splitting the metric, this will allow the user to send the original metric
+
+# One or more tracking issues related to the change
+issues: [19743]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -84,8 +84,11 @@ translation_rules:
     sf_temp.cpu.utilization: 100
 
 # convert cpu metrics
+- action: copy_metrics
+  mapping:
+    system.cpu.time: sf_temp.system.cpu.time
 - action: split_metric
-  metric_name: system.cpu.time
+  metric_name: sf_temp.system.cpu.time
   dimension_key: state
   mapping:
     idle: sf_temp.cpu.idle
@@ -369,8 +372,11 @@ translation_rules:
     sf_temp.memory.utilization: 100
 
 # Virtual memory metrics
+- action: copy_metrics
+  mapping:
+    system.paging.operations: sf_temp.system.paging.operations
 - action: split_metric
-  metric_name: system.paging.operations
+  metric_name: sf_temp.system.paging.operations
   dimension_key: direction
   mapping:
     page_in: sf_temp.system.paging.operations.page_in
@@ -448,9 +454,11 @@ translation_rules:
     sf_temp.memory.used: true
     sf_temp.system.cpu.delta: true
     sf_temp.system.cpu.total: true
+    sf_temp.system.cpu.time: true
     sf_temp.system.cpu.usage: true
     sf_temp.system.filesystem.usage: true
     sf_temp.system.memory.usage: true
+    sf_temp.system.paging.operations: true
     sf_temp.system.paging.operations.page_in: true
     sf_temp.system.paging.operations.page_out: true
 `


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
In the config option `include`, the signalfx exporter readme uses the metric `system.cpu.time` in the example https://github.com/open-telemetry/opentelemetry-collector-contrib/blame/00404678de26ba3863166c3181f79790c984ec63/exporter/signalfxexporter/README.md#L166

This example does not work as the original copy `system.cpu.time` is getting split and renamed. 
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/ed2383afacfb4be20780f780b44fdd7dfd8653d7/exporter/signalfxexporter/internal/translation/constants.go#L87-L98

This fix uses a copy of the metric instead, this allows the user, if they chose to, to emit the original metric `system.cpu.time`

Update: same applies to `system.paging.operations` which I also fixed
**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
manual verification
**Documentation:** <Describe the documentation added.>