### PR TITLE
[receiver/awsecscontainermetricsreceiver] Add `ServiceName` metadata to be retrieved from task metadata endpoint (PR)

### DIFF
--- a/.chloggen/awsecscontainermetrics_add_servicename.yaml
+++ b/.chloggen/awsecscontainermetrics_add_servicename.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsecscontainermetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ServiceName from task metadata endpoint
+
+# One or more tracking issues related to the change
+issues: [19728]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/aws/ecsutil/metadata.go
+++ b/internal/aws/ecsutil/metadata.go
@@ -26,7 +26,7 @@ type TaskMetadata struct {
 	PullStartedAt    string              `json:"PullStartedAt,omitempty"`
 	PullStoppedAt    string              `json:"PullStoppedAt,omitempty"`
 	Revision         string              `json:"Revision,omitempty"`
-	ServiceName      string							 `json:"ServiceName,omitempty"`
+	ServiceName      string              `json:"ServiceName,omitempty"`
 	TaskARN          string              `json:"TaskARN,omitempty"`
 }
 

--- a/internal/aws/ecsutil/metadata.go
+++ b/internal/aws/ecsutil/metadata.go
@@ -26,6 +26,7 @@ type TaskMetadata struct {
 	PullStartedAt    string              `json:"PullStartedAt,omitempty"`
 	PullStoppedAt    string              `json:"PullStoppedAt,omitempty"`
 	Revision         string              `json:"Revision,omitempty"`
+	ServiceName			 string							 `json:"ServiceName,omitempty"`
 	TaskARN          string              `json:"TaskARN,omitempty"`
 }
 

--- a/internal/aws/ecsutil/metadata.go
+++ b/internal/aws/ecsutil/metadata.go
@@ -26,7 +26,7 @@ type TaskMetadata struct {
 	PullStartedAt    string              `json:"PullStartedAt,omitempty"`
 	PullStoppedAt    string              `json:"PullStoppedAt,omitempty"`
 	Revision         string              `json:"Revision,omitempty"`
-	ServiceName			 string							 `json:"ServiceName,omitempty"`
+	ServiceName      string							 `json:"ServiceName,omitempty"`
 	TaskARN          string              `json:"TaskARN,omitempty"`
 }
 

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource.go
@@ -63,7 +63,7 @@ func taskResource(tm ecsutil.TaskMetadata) pcommon.Resource {
 	resource.Attributes().PutStr(attributeECSTaskRevision, tm.Revision)
 	resource.Attributes().PutStr(conventions.AttributeAWSECSTaskRevision, tm.Revision)
 
-	resource.Attributes().PutStr(attributeECSServiceName, "undefined")
+	resource.Attributes().PutStr(attributeECSServiceName, tm.ServiceName)
 
 	resource.Attributes().PutStr(conventions.AttributeCloudAvailabilityZone, tm.AvailabilityZone)
 	resource.Attributes().PutStr(attributeECSTaskPullStartedAt, tm.PullStartedAt)

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource_test.go
@@ -105,6 +105,7 @@ func TestTaskResource(t *testing.T) {
 		PullStoppedAt:    "2020-10-02T00:43:06.31288465Z",
 		KnownStatus:      "RUNNING",
 		LaunchType:       "EC2",
+		ServiceName:      "MyService",
 	}
 	r := taskResource(tm)
 	require.NotNil(t, r)
@@ -126,6 +127,7 @@ func TestTaskResource(t *testing.T) {
 		conventions.AttributeAWSECSLaunchtype:      conventions.AttributeAWSECSLaunchtypeEC2,
 		conventions.AttributeCloudRegion:           "us-west-2",
 		conventions.AttributeCloudAccountID:        "111122223333",
+		attributeECSServiceName:                    "MyService",
 	}
 
 	verifyAttributeMap(t, expected, attrMap)
@@ -142,6 +144,7 @@ func TestTaskResourceWithClusterARN(t *testing.T) {
 		PullStoppedAt:    "2020-10-02T00:43:06.31288465Z",
 		KnownStatus:      "RUNNING",
 		LaunchType:       "EC2",
+		ServiceName:      "MyService",
 	}
 	r := taskResource(tm)
 	require.NotNil(t, r)
@@ -164,6 +167,7 @@ func TestTaskResourceWithClusterARN(t *testing.T) {
 		conventions.AttributeAWSECSLaunchtype:      conventions.AttributeAWSECSLaunchtypeEC2,
 		conventions.AttributeCloudRegion:           "us-west-2",
 		conventions.AttributeCloudAccountID:        "803860917211",
+		attributeECSServiceName:                    "MyService",
 	}
 
 	verifyAttributeMap(t, expected, attrMap)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
See tracking issue for description of problem being addressed.

**Link to tracking Issue:** <Issue number if applicable>
#19728 

**Testing:** <Describe what testing was performed and which tests were added.>
`go test -v` in /receivers/awsecscontainermetricsreceiver`

**Documentation:** <Describe the documentation added.>