### PR TITLE
[processor/spanmetrics] Deprecate spanmetrics processor.

### DIFF
--- a/.chloggen/spanmetrics-deprecate-processor.yaml
+++ b/.chloggen/spanmetrics-deprecate-processor.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the `spanmetrics` processor in favour if the `spanmetrics` connector.
+
+# One or more tracking issues related to the change
+issues: [19736]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Please note that the `spanmetrics` connector contains breaking changes related to configurations
+  metrics names and attributes. Please see the `spanmetrics` connector README for more information.  

--- a/.chloggen/spanmetrics-deprecate-processor.yaml
+++ b/.chloggen/spanmetrics-deprecate-processor.yaml
@@ -5,7 +5,7 @@ change_type: deprecation
 component: spanmetricsprocessor
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Deprecate the `spanmetrics` processor in favour if the `spanmetrics` connector.
+note: Deprecate the `spanmetrics` processor in favour of the `spanmetrics` connector.
 
 # One or more tracking issues related to the change
 issues: [19736]

--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -6,7 +6,8 @@
 | Supported pipeline types | traces        |
 | Distributions            | [contrib]     |
 
-**Note**: The `spanmetrics` processor will be deprecated in favour of the [spanmetrics](../../connector/spanmetricsconnector/README.md) connector.
+**Note**: The `spanmetrics` processor is **deprecated** in favour of the [spanmetrics](../../connector/spanmetricsconnector/README.md) connector.
+
 **Note:** Currently experimental and subject to breaking changes (e.g. change from processor to exporter/translator component).
 See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/403.
 

--- a/processor/spanmetricsprocessor/README.md
+++ b/processor/spanmetricsprocessor/README.md
@@ -1,10 +1,10 @@
 # Span Metrics Processor
 
-| Status                   |               |
-| ------------------------ |---------------|
-| Stability                | [development] |
-| Supported pipeline types | traces        |
-| Distributions            | [contrib]     |
+| Status                   |              |
+| ------------------------ |--------------|
+| Stability                | [deprecated] |
+| Supported pipeline types | traces       |
+| Distributions            | [contrib]    |
 
 **Note**: The `spanmetrics` processor is **deprecated** in favour of the [spanmetrics](../../connector/spanmetricsconnector/README.md) connector.
 
@@ -141,5 +141,5 @@ service:
 
 For more example configuration covering various other use cases, please visit the [testdata directory](./testdata).
 
-[development]: https://github.com/open-telemetry/opentelemetry-collector#development
+[deprecated]: https://github.com/open-telemetry/opentelemetry-collector#deprecated
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/processor/spanmetricsprocessor/factory.go
+++ b/processor/spanmetricsprocessor/factory.go
@@ -28,7 +28,7 @@ const (
 	// The value of "type" key in configuration.
 	typeStr = "spanmetrics"
 	// The stability level of the processor.
-	stability = component.StabilityLevelDevelopment
+	stability = component.StabilityLevelDeprecated
 )
 
 // NewFactory creates a factory for the spanmetrics processor.

--- a/processor/spanmetricsprocessor/go.mod
+++ b/processor/spanmetricsprocessor/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsprocessor instead.
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor
 
 go 1.19

--- a/processor/spanmetricsprocessor/go.mod
+++ b/processor/spanmetricsprocessor/go.mod
@@ -1,4 +1,4 @@
-// Deprecated: use github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsprocessor instead.
+// Deprecated: use github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector instead.
 module github.com/open-telemetry/opentelemetry-collector-contrib/processor/spanmetricsprocessor
 
 go 1.19


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Deprecate the spanmetrics processor in favor of the spanmetrics connector.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19736



**Documentation:** <Describe the documentation added.>
`spanmetrics` processor readme.