### PR TITLE
[receiver/file] add capability to replay metrics in time

### DIFF
--- a/.chloggen/filereceiver-3.yaml
+++ b/.chloggen/filereceiver-3.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update file receiver to be able to replay metrics in time.
+
+# One or more tracking issues related to the change
+issues: [14638]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/filereceiver/README.md
+++ b/receiver/filereceiver/README.md
@@ -15,14 +15,24 @@ or telemetry other than metrics are not supported at this time.
 
 ## Getting Started
 
-The following settings are required:
+The following setting is required:
 
 - `path` [no default]: the file in the same format as written by a File Exporter.
+
+The following setting is optional:
+
+- `throttle` [default: 1]: a determines how fast telemetry is replayed. A value of `0` means
+  that it will be replayed as fast as the system will allow. A value of `1` means that it will
+  be replayed at the same rate as the data came in, as indicated by the timestamps on the
+  input file's telemetry data. Higher values mean that the replay speed will be slower by a
+  multiple of the throttle value. Values can be decimals, e.g. `0.5` means that telemetry will be
+  replayed at 2x the rate indicated by the telemetry's timestamps.
 
 ## Example
 
 ```yaml
 receivers:
   file:
-    path: ./foo
+    path: my-telemetry-file
+    throttle: 0.5
 ```

--- a/receiver/filereceiver/config.go
+++ b/receiver/filereceiver/config.go
@@ -24,15 +24,27 @@ import (
 type Config struct {
 	// Path of the file to read from. Path is relative to current directory.
 	Path string `mapstructure:"path"`
+	// Throttle determines how fast telemetry is replayed. A value of zero means
+	// that it will be replayed as fast as the system will allow. A value of 1 means
+	// that it will be replayed at the same rate as the data came in, as indicated
+	// by the timestamps on the input file's telemetry data. Higher values mean that
+	// replay will be slower by a corresponding amount. Use a value between 0 and 1
+	// to replay telemetry at a higher speed. Default: 1.
+	Throttle float64 `mapstructure:"throttle"`
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{
+		Throttle: 1,
+	}
 }
 
 func (c Config) Validate() error {
 	if c.Path == "" {
 		return errors.New("path cannot be empty")
+	}
+	if c.Throttle < 0 {
+		return errors.New("throttle cannot be negative")
 	}
 	return nil
 }

--- a/receiver/filereceiver/config_test.go
+++ b/receiver/filereceiver/config_test.go
@@ -46,12 +46,15 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id:           component.NewIDWithName(typeStr, ""),
 			errorMessage: "path cannot be empty",
-		},
-		{
+		}, {
 			id: component.NewIDWithName(typeStr, "1"),
 			expected: &Config{
-				Path: "./filename.json",
+				Path:     "./filename.json",
+				Throttle: 1,
 			},
+		}, {
+			id:           component.NewIDWithName(typeStr, "2"),
+			errorMessage: "throttle cannot be negative",
 		},
 	}
 

--- a/receiver/filereceiver/factory.go
+++ b/receiver/filereceiver/factory.go
@@ -46,5 +46,6 @@ func createMetricsReceiver(
 		consumer: consumer,
 		path:     cfg.Path,
 		logger:   settings.Logger,
+		throttle: cfg.Throttle,
 	}, nil
 }

--- a/receiver/filereceiver/file_reader.go
+++ b/receiver/filereceiver/file_reader.go
@@ -23,8 +23,8 @@ import (
 	"os"
 
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.uber.org/zap"
 )
 
 // stringReader is the only function we use from *bufio.Reader. We define it
@@ -35,37 +35,35 @@ type stringReader interface {
 
 // fileReader
 type fileReader struct {
-	logger       *zap.Logger
 	stringReader stringReader
 	unm          pmetric.Unmarshaler
 	consumer     consumer.Metrics
+	timer        *replayTimer
 }
 
-func newFileReader(logger *zap.Logger, consumer consumer.Metrics, file *os.File) fileReader {
+func newFileReader(consumer consumer.Metrics, file *os.File, timer *replayTimer) fileReader {
 	return fileReader{
-		logger:       logger,
 		consumer:     consumer,
 		stringReader: bufio.NewReader(file),
 		unm:          &pmetric.JSONUnmarshaler{},
+		timer:        timer,
 	}
 }
 
 // readAll calls readline for each line in the file until all lines have been
 // read or the context is cancelled.
-func (fr fileReader) readAll(ctx context.Context) {
+func (fr fileReader) readAll(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		default:
 			err := fr.readLine(ctx)
 			if err != nil {
 				if errors.Is(err, io.EOF) {
-					fr.logger.Debug("EOF reached")
-					return
+					return nil
 				}
-				fr.logger.Error("error reading line", zap.Error(err))
-				return
+				return err
 			}
 		}
 	}
@@ -82,5 +80,61 @@ func (fr fileReader) readLine(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal metrics: %w", err)
 	}
+	err = fr.timer.wait(ctx, getFirstTimestamp(metrics))
+	if err != nil {
+		return fmt.Errorf("readLine interrupted while waiting for timer: %w", err)
+	}
 	return fr.consumer.ConsumeMetrics(ctx, metrics)
+}
+
+func getFirstTimestamp(metrics pmetric.Metrics) pcommon.Timestamp {
+	resourceMetrics := metrics.ResourceMetrics()
+	if resourceMetrics.Len() == 0 {
+		return 0
+	}
+	scopeMetrics := resourceMetrics.At(0).ScopeMetrics()
+	if scopeMetrics.Len() == 0 {
+		return 0
+	}
+	metricSlice := scopeMetrics.At(0).Metrics()
+	if metricSlice.Len() == 0 {
+		return 0
+	}
+	return getFirstTimestampFromMetric(metricSlice.At(0))
+}
+
+func getFirstTimestampFromMetric(metric pmetric.Metric) pcommon.Timestamp {
+	switch metric.Type() {
+	case pmetric.MetricTypeGauge:
+		dps := metric.Gauge().DataPoints()
+		if dps.Len() == 0 {
+			return 0
+		}
+		return dps.At(0).Timestamp()
+	case pmetric.MetricTypeSum:
+		dps := metric.Sum().DataPoints()
+		if dps.Len() == 0 {
+			return 0
+		}
+		return dps.At(0).Timestamp()
+	case pmetric.MetricTypeSummary:
+		dps := metric.Summary().DataPoints()
+		if dps.Len() == 0 {
+			return 0
+		}
+		return dps.At(0).Timestamp()
+	case pmetric.MetricTypeHistogram:
+		dps := metric.Histogram().DataPoints()
+		if dps.Len() == 0 {
+			return 0
+		}
+		return dps.At(0).Timestamp()
+	case pmetric.MetricTypeExponentialHistogram:
+		dps := metric.ExponentialHistogram().DataPoints()
+		if dps.Len() == 0 {
+			return 0
+		}
+		return dps.At(0).Timestamp()
+	}
+	return 0
 }

--- a/receiver/filereceiver/file_reader_test.go
+++ b/receiver/filereceiver/file_reader_test.go
@@ -19,19 +19,19 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.uber.org/zap"
 )
 
 func TestFileReader_Readline(t *testing.T) {
 	tc := testConsumer{}
 	f, err := os.Open(filepath.Join("testdata", "metrics.json"))
 	require.NoError(t, err)
-	fr := newFileReader(zap.NewNop(), &tc, f)
+	fr := newFileReader(&tc, f, newReplayTimer(0))
 	err = fr.readLine(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(tc.consumed))
@@ -47,12 +47,36 @@ func TestFileReader_Readline(t *testing.T) {
 func TestFileReader_Cancellation(t *testing.T) {
 	fr := fileReader{
 		consumer:     consumertest.NewNop(),
-		logger:       zap.NewNop(),
 		stringReader: blockingStringReader{},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	go fr.readAll(ctx)
+	go func() {
+		_ = fr.readAll(ctx)
+	}()
 	cancel()
+}
+
+func TestFileReader_ReadAll(t *testing.T) {
+	tc := testConsumer{}
+	f, err := os.Open(filepath.Join("testdata", "metrics.json"))
+	require.NoError(t, err)
+	sleeper := &fakeSleeper{}
+	rt := &replayTimer{
+		throttle:  2,
+		sleepFunc: sleeper.fakeSleep,
+	}
+	fr := newFileReader(&tc, f, rt)
+	err = fr.readAll(context.Background())
+	require.NoError(t, err)
+	const expectedSleeps = 10
+	assert.Len(t, sleeper.durations, expectedSleeps)
+	assert.EqualValues(t, 0, sleeper.durations[0])
+	for i := 1; i < expectedSleeps; i++ {
+		expected := time.Second * 4
+		actual := sleeper.durations[i]
+		delta := time.Millisecond * 10
+		assert.InDelta(t, float64(expected), float64(actual), float64(delta))
+	}
 }
 
 type blockingStringReader struct {

--- a/receiver/filereceiver/receiver.go
+++ b/receiver/filereceiver/receiver.go
@@ -16,7 +16,9 @@ package filereceiver // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"go.opentelemetry.io/collector/component"
@@ -29,6 +31,7 @@ type fileReceiver struct {
 	path     string
 	logger   *zap.Logger
 	cancel   context.CancelFunc
+	throttle float64
 }
 
 func (r *fileReceiver) Start(_ context.Context, _ component.Host) error {
@@ -40,8 +43,17 @@ func (r *fileReceiver) Start(_ context.Context, _ component.Host) error {
 		return fmt.Errorf("failed to open file %q: %w", r.path, err)
 	}
 
-	fr := newFileReader(r.logger, r.consumer, file)
-	go fr.readAll(ctx)
+	fr := newFileReader(r.consumer, file, newReplayTimer(r.throttle))
+	go func() {
+		err := fr.readAll(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				r.logger.Debug("EOF reached")
+			} else {
+				r.logger.Error("failed to read input file", zap.Error(err))
+			}
+		}
+	}()
 	return nil
 }
 

--- a/receiver/filereceiver/replay_timer.go
+++ b/receiver/filereceiver/replay_timer.go
@@ -1,0 +1,64 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filereceiver"
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type replayTimer struct {
+	prev      pcommon.Timestamp
+	throttle  float64 // set to 1.0 to replay at same speed, 2.0 for half speed, etc.
+	sleepFunc func(ctx context.Context, d time.Duration) error
+}
+
+func newReplayTimer(throttle float64) *replayTimer {
+	return &replayTimer{
+		throttle:  throttle,
+		sleepFunc: sleepWithContext,
+	}
+}
+
+func (t *replayTimer) wait(ctx context.Context, next pcommon.Timestamp) error {
+	if next == 0 {
+		return nil
+	}
+	var sleepDuration pcommon.Timestamp
+	if t.prev > 0 {
+		sleepDuration = pcommon.Timestamp(float64(next-t.prev) * t.throttle)
+	}
+	t.prev = next
+	err := t.sleepFunc(ctx, time.Duration(sleepDuration))
+	if err != nil {
+		return fmt.Errorf("context cancelled while waiting for replay timer: %w", err)
+	}
+	return nil
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/receiver/filereceiver/replay_timer_test.go
+++ b/receiver/filereceiver/replay_timer_test.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filereceiver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestReplayTimer(t *testing.T) {
+	s := &fakeSleeper{}
+	timer := &replayTimer{
+		throttle:  0.5,
+		sleepFunc: s.fakeSleep,
+	}
+	firstMetricTime := time.Date(2020, time.January, 1, 1, 0, 0, 0, time.UTC)
+	err := timer.wait(context.Background(), pcommon.NewTimestampFromTime(firstMetricTime))
+	require.NoError(t, err)
+	secondMetricTime := firstMetricTime.Add(time.Second * 10)
+	err = timer.wait(context.Background(), pcommon.NewTimestampFromTime(secondMetricTime))
+	require.NoError(t, err)
+	err = timer.wait(context.Background(), 0)
+	require.NoError(t, err)
+	assert.Equal(t, s.durations, []time.Duration{0, time.Second * 5})
+}
+
+type fakeSleeper struct {
+	durations []time.Duration
+}
+
+func (t *fakeSleeper) fakeSleep(_ context.Context, d time.Duration) error {
+	t.durations = append(t.durations, d)
+	return nil
+}

--- a/receiver/filereceiver/testdata/config.yaml
+++ b/receiver/filereceiver/testdata/config.yaml
@@ -1,3 +1,6 @@
 file:
 file/1:
   path: ./filename.json
+file/2:
+  path: ./filename.json
+  throttle: -1


### PR DESCRIPTION
**Description:** This change adds the ability to replay metrics at the same rate that they were originally received. (I also have a change to update the timestamps to current values but left that out for now to keep the diff smaller.)

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14638

**Testing:** Unit tests pass.

**Documentation:** Updated README with new capability and config field.