### PR TITLE
make new reader during the rotation and exclude the same file each cycle

### DIFF
--- a/.chloggen/fix-new-rotation-file-data-loss.yaml
+++ b/.chloggen/fix-new-rotation-file-data-loss.yaml
@@ -8,7 +8,7 @@ component: filelogreceiver
 note: If two files have the same fingerprint, make new reader during the rotation and exclude the same file each cycle
 
 # One or more tracking issues related to the change
-issues: []
+issues: [19765]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-new-rotation-file-data-loss.yaml
+++ b/.chloggen/fix-new-rotation-file-data-loss.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: If two files have the same fingerprint, make new reader during the rotation and exclude the same file each cycle
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -174,6 +174,7 @@ func (c Config) buildManager(logger *zap.SugaredLogger, emit EmitFunc, factory s
 		deleteAfterRead: c.DeleteAfterRead,
 		knownFiles:      make([]*Reader, 0, 10),
 		seenPaths:       make(map[string]struct{}, 100),
+		excludePaths:    make(map[string]struct{}, 100),
 	}, nil
 }
 

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -174,7 +174,7 @@ func (c Config) buildManager(logger *zap.SugaredLogger, emit EmitFunc, factory s
 		deleteAfterRead: c.DeleteAfterRead,
 		knownFiles:      make([]*Reader, 0, 10),
 		seenPaths:       make(map[string]struct{}, 100),
-		excludePaths:    make(map[string]struct{}, 100),
+		excludePaths:    make(map[string]int64, 100),
 	}, nil
 }
 

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -47,7 +47,7 @@ type Manager struct {
 
 	knownFiles []*Reader
 	seenPaths  map[string]struct{}
-	//exclude by same fingerprint
+	// exclude by same fingerprint
 	excludePaths map[string]struct{}
 }
 
@@ -248,9 +248,9 @@ OUTER:
 					infoJ, _ := files[j].Stat()
 					infoI, _ := files[i].Stat()
 					if infoJ.Size() > infoI.Size() {
-						//Keep the smaller file
-						//if both the file before rotation and the file after rotation are included , and they have same fingerprint
-						//the file after rotation should be read
+						// Keep the smaller file
+						// if both the file before rotation and the file after rotation are included , and they have same fingerprint
+						// the file after rotation should be read
 						deleteIndex = j
 					}
 				}
@@ -264,6 +264,7 @@ OUTER:
 					m.Errorf("problem closing file", "file", files[deleteIndex].Name())
 				}
 				noExclude = false
+
 				fps = append(fps[:deleteIndex], fps[deleteIndex+1:]...)
 				files = append(files[:deleteIndex], files[deleteIndex+1:]...)
 				if fpjExclude {

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -220,7 +220,7 @@ func (m *Manager) makeReaders(filesPaths []string) []*Reader {
 		fps = append(fps, fp)
 	}
 
-	noExclude :=true
+	noExclude := true
 
 	// Exclude any empty fingerprints or duplicate fingerprints to avoid doubling up on copy-truncate files
 OUTER:
@@ -241,8 +241,8 @@ OUTER:
 			if fp.StartsWith(fp2) || fp2.StartsWith(fp) {
 				// Exclude the same file
 				deleteIndex := i
-				_,fpjExclude := m.excludePaths[files[j].Name()]
-				_,fpiExclude := m.excludePaths[files[i].Name()]
+				_, fpjExclude := m.excludePaths[files[j].Name()]
+				_, fpiExclude := m.excludePaths[files[i].Name()]
 
 				if !fpiExclude && !fpjExclude {
 					infoJ, _ := files[j].Stat()
@@ -269,7 +269,7 @@ OUTER:
 				files = append(files[:deleteIndex], files[deleteIndex+1:]...)
 				if fpjExclude {
 					j--
-				}else{
+				} else {
 					i--
 					continue OUTER
 				}

--- a/pkg/stanza/fileconsumer/roller_other.go
+++ b/pkg/stanza/fileconsumer/roller_other.go
@@ -19,6 +19,7 @@ package fileconsumer // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"context"
+	"os"
 	"sync"
 )
 
@@ -35,8 +36,10 @@ func (r *detectLostFiles) readLostFiles(ctx context.Context, readers []*Reader) 
 	lostReaders := make([]*Reader, 0, len(r.oldReaders))
 OUTER:
 	for _, oldReader := range r.oldReaders {
+		oldFileStat, _ := oldReader.file.Stat()
 		for _, reader := range readers {
-			if reader.Fingerprint.StartsWith(oldReader.Fingerprint) {
+			newFileStat, _ := reader.file.Stat()
+			if os.SameFile(newFileStat, oldFileStat) {
 				continue OUTER
 			}
 		}

--- a/pkg/stanza/fileconsumer/rotation_test.go
+++ b/pkg/stanza/fileconsumer/rotation_test.go
@@ -597,7 +597,7 @@ func TestFileMovedWhileOff_BigFiles(t *testing.T) {
 	waitForToken(t, emitCalls, log2)
 }
 
-//Reading a file with a multi-cycle should work well
+// Reading a file with a multi-cycle should work well
 func TestTenPollCycleForOneFile(t *testing.T) {
 	if runtime.GOOS == windowsOS {
 		t.Skip("Rotation tests have been flaky on Windows. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16331")
@@ -624,8 +624,8 @@ func TestTenPollCycleForOneFile(t *testing.T) {
 
 }
 
-//If the rotation is done with the same fingerprint between the pre-rotated file and  the post-rotated file  ,
-//and the file does not grow rapidly after the  rotation  , there should be no data loss
+// If the rotation is done with the same fingerprint between the pre-rotated file and  the post-rotated file  ,
+// and the file does not grow rapidly after the  rotation  , there should be no data loss
 func TestSlowFileSameFingerprintAfterRotation(t *testing.T){
 	if runtime.GOOS == windowsOS {
 		t.Skip("Rotation tests have been flaky on Windows. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16331")
@@ -653,7 +653,7 @@ func TestSlowFileSameFingerprintAfterRotation(t *testing.T){
 	waitForToken(t,emitCalls,[]byte("123"))
 	waitForToken(t,emitCalls,[]byte("456"))
 
-	//The rotation is performed  and the rotation file is excluded
+	// The rotation is performed  and the rotation file is excluded
 	rotationFile := openTempWithPattern(t, tempDir,"*.log.1")
 	_, err := originalFile.Seek(0, 0)
 	require.NoError(t,err)
@@ -667,8 +667,8 @@ func TestSlowFileSameFingerprintAfterRotation(t *testing.T){
 	_, err = originalFile.Seek(0, 0)
 	require.NoError(t, err)
 
-	//The first 16 bytes indicate that the file after rotation has the same fingerprint as the file before rotation
-	//Write a total of 21 bytes to indicate that the rotated file will be written slowly before the next read
+	// The first 16 bytes indicate that the file after rotation has the same fingerprint as the file before rotation
+	// Write a total of 21 bytes to indicate that the rotated file will be written slowly before the next read
 	writeString(t,originalFile,"aaaaaaaaaaaaaaaa\n")
 	writeString(t,originalFile,"bbb\n")
 	writeString(t,originalFile,"cc\n")
@@ -678,9 +678,9 @@ func TestSlowFileSameFingerprintAfterRotation(t *testing.T){
 	waitForToken(t,emitCalls,[]byte("cc"))
 }
 
-//If the rotation is done with the same fingerprint between the pre-rotated file and  the post-rotated file  ,
-//and the file does grows rapidly after the  rotation  , there will be data loss
-//Note: there is no metric/log yet to tell people to  increase the fingerprint size
+// If the rotation is done with the same fingerprint between the pre-rotated file and  the post-rotated file  ,
+// and the file does grows rapidly after the  rotation  , there will be data loss
+// Note: there is no metric/log yet to tell people to  increase the fingerprint size
 func TestFastFileSameFingerprintAfterRotation(t *testing.T){
 	if runtime.GOOS == windowsOS {
 		t.Skip("Rotation tests have been flaky on Windows. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16331")
@@ -708,7 +708,7 @@ func TestFastFileSameFingerprintAfterRotation(t *testing.T){
 	waitForToken(t,emitCalls,[]byte("123"))
 	waitForToken(t,emitCalls,[]byte("456"))
 
-	//The rotation is performed  and the rotation file is excluded
+	// The rotation is performed  and the rotation file is excluded
 	rotationFile := openTempWithPattern(t, tempDir,"*.log.1")
 	_, err := originalFile.Seek(0, 0)
 	require.NoError(t,err)
@@ -722,19 +722,19 @@ func TestFastFileSameFingerprintAfterRotation(t *testing.T){
 	_, err = originalFile.Seek(0, 0)
 	require.NoError(t, err)
 
-	//The first 16 bytes indicate that the file after rotation has the same fingerprint as the file before rotation
-	//Write a total of 25 bytes to indicate that the rotated file will be written quickly before the next read
+	// The first 16 bytes indicate that the file after rotation has the same fingerprint as the file before rotation
+	// Write a total of 25 bytes to indicate that the rotated file will be written quickly before the next read
 	writeString(t,originalFile,"aaaaaaaaaaaaaaaa\n")
 	writeString(t,originalFile,"bbb\n")
 	writeString(t,originalFile,"ccc\n")
 	writeString(t,originalFile,"ddd\n")
 
-	//data lost before ddd
+	// data lost before ddd
 	waitForToken(t,emitCalls,[]byte("ddd"))
 
 }
 
-//Always exclude the same file
+// Always exclude the same file
 func TestTwoSameFingerprintFileIngestOnyOneFileContent(t *testing.T){
 	if runtime.GOOS == windowsOS {
 		t.Skip("Rotation tests have been flaky on Windows. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16331")
@@ -746,14 +746,10 @@ func TestTwoSameFingerprintFileIngestOnyOneFileContent(t *testing.T){
 	cfg.FingerprintSize = 16
 	cfg.StartAt = "beginning"
 	operator, emitCalls := buildTestManager(t, cfg)
-	require.NoError(t, operator.Start(testutil.NewMockPersister("test")))
-	defer func() {
-		require.NoError(t, operator.Stop())
-	}()
+	operator.persister = testutil.NewMockPersister("test")
 
 	file1 := openTempWithPattern(t,tempDir,"*.log1")
 	file2 := openTempWithPattern(t,tempDir,"*.log2")
-
 
 	fileExcluded := file2.Name()
 
@@ -762,29 +758,36 @@ func TestTwoSameFingerprintFileIngestOnyOneFileContent(t *testing.T){
 		writeString(t,file1, content+"\n")
 		if i == 0 {
 			writeString(t,file2, content+"\n")
+			operator.poll(context.Background())
 			waitForToken(t,emitCalls,[]byte(content))
-			if _,ok :=operator.excludePaths[file1.Name()]; ok{
-				fileExcluded = file1.Name()
-			}
 		}else{
 			writeString(t,file2, content+"zzzz\n")
-			if _, ok := operator.excludePaths[file1.Name()]; ok {
+			operator.poll(context.Background())
+			if fileExcluded == file1.Name() {
 				waitForToken(t,emitCalls,[]byte(content+"zzzz"))
 			}else{
 				waitForToken(t,emitCalls,[]byte(content))
 			}
+
 		}
+		expectNoTokens(t,emitCalls)
+		operator.wg.Wait()
+
+		if i == 0  {
+			if _,ok :=operator.excludePaths[file1.Name()]; ok{
+				fileExcluded = file1.Name()
+			}
+		}
+
 		require.Equal(t,1, len(operator.excludePaths))
 		require.Contains(t, operator.excludePaths, fileExcluded)
-
-		expectNoTokens(t,emitCalls)
 	}
 }
 
 
-//If the rotation is done with the same fingerprint between the pre-rotated file and  the post-rotated file  ,
-//the file does not grow rapidly after the  rotation  , and the pre-rotated file still append data
-//there should be no data loss and no data reading chaos
+// If the rotation is done with the same fingerprint between the pre-rotated file and  the post-rotated file  ,
+// the file does not grow rapidly after the  rotation  , and the pre-rotated file still append data
+// there should be no data loss and no data reading chaos
 func TestSlowFileSameFingerprintAfterRotationWithoutExclude(t *testing.T){
 	if runtime.GOOS == windowsOS {
 		t.Skip("Rotation tests have been flaky on Windows. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16331")
@@ -812,7 +815,7 @@ func TestSlowFileSameFingerprintAfterRotationWithoutExclude(t *testing.T){
 	waitForToken(t,emitCalls,[]byte("456"))
 	operator.wg.Wait()
 
-	//The rotation is performed  and the rotation file is included
+	// The rotation is performed  and the rotation file is included
 	rotationFile := openTemp(t, tempDir)
 	_, err := originalFile.Seek(0, 0)
 	require.NoError(t,err)
@@ -826,7 +829,7 @@ func TestSlowFileSameFingerprintAfterRotationWithoutExclude(t *testing.T){
 	_, err = originalFile.Seek(0, 0)
 	require.NoError(t, err)
 
-	//write 19 bytes to indicate that rotation File write slow before next read
+	// write 19 bytes to indicate that rotation File write slow before next read
 	writeString(t,originalFile,"aaaaaaaaaaaaaaaa\n")
 	writeString(t,originalFile,"bbb\n")
 
@@ -836,8 +839,8 @@ func TestSlowFileSameFingerprintAfterRotationWithoutExclude(t *testing.T){
 	operator.wg.Wait()
 
 
-	//Write data to the rotation file.
-	//As the rotation file is excluded due to the fingerprint check , there should be no data output
+	// Write data to the rotation file.
+	// As the rotation file is excluded due to the fingerprint check , there should be no data output
 	require.Contains(t,operator.excludePaths,rotationFile.Name())
 	writeString(t,rotationFile,"7891011121314151617\n")
 	operator.poll(context.Background())
@@ -847,7 +850,7 @@ func TestSlowFileSameFingerprintAfterRotationWithoutExclude(t *testing.T){
 	writeString(t,originalFile,"ccc\n")
 	writeString(t,originalFile,"ddd\n")
 
-	//no chaos
+	// no chaos
 	operator.poll(context.Background())
 	waitForToken(t,emitCalls,[]byte("ccc"))
 	waitForToken(t,emitCalls,[]byte("ddd"))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->


If the rotation is done with the same fingerprint between the pre-rotated file and the post-rotated file , there will be data loss

**Link to tracking Issue:** <Issue number if applicable>

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19765

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19428

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>