### PR TITLE
[receiver/splunkhec] Align hec receiver errors messages to splunk enterprise

### DIFF
--- a/.chloggen/splunkhecreceiver-align-error-message.yaml
+++ b/.chloggen/splunkhecreceiver-align-error-message.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: align error message with splunk enterprise to include No Data, Invalid Data Format, Event field is required, and  Event field cannot be blank
+
+# One or more tracking issues related to the change
+issues: [19219]

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -253,6 +253,7 @@ func (r *splunkReceiver) handleRawReq(resp http.ResponseWriter, req *http.Reques
 	}
 
 	if req.ContentLength == 0 {
+		r.obsrecv.EndLogsOp(ctx, typeStr, 0, nil)
 		r.failRequest(ctx, resp, http.StatusBadRequest, noDataRespBody, 0, nil)
 		return
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

implement HEC event error messages:
- [x] 400 No data
- [x] 400 Invalid Data Format
- [x] 400 Event field is required
- [x] 400 Event field cannot be blank

implement HEC raw error messages:
- [x] 400 No data

**Link to tracking Issue:** #19219

**Testing:** unit tested

**Documentation:** this is to align with [Splunk enterprise's error message ](https://docs.splunk.com/Documentation/Splunk/9.0.4/RESTREF/RESTinput#services.2Fcollector)