### PR TITLE
[mdatagen] only generate metrics if metrics are present

### DIFF
--- a/.chloggen/codeboten_mdatagen-metrics.yaml
+++ b/.chloggen/codeboten_mdatagen-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow mdatagen to support components that do not produce metrics.
+
+# One or more tracking issues related to the change
+issues: [19772]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This allows us to define metadata.yaml files for components that don't generate metrics, specifically in support of generating the status table.

--- a/cmd/mdatagen/main.go
+++ b/cmd/mdatagen/main.go
@@ -62,10 +62,6 @@ func run(ymlPath string) error {
 	if err = os.MkdirAll(filepath.Join(codeDir, "testdata"), 0700); err != nil {
 		return fmt.Errorf("unable to create output directory %q: %w", codeDir, err)
 	}
-	if err = generateFile(filepath.Join(tmplDir, "metrics.go.tmpl"),
-		filepath.Join(codeDir, "generated_metrics.go"), md); err != nil {
-		return err
-	}
 	if len(md.Status.Stability) > 0 {
 		if err = generateFile(filepath.Join(tmplDir, "status.go.tmpl"),
 			filepath.Join(codeDir, "generated_status.go"), md); err != nil {
@@ -78,6 +74,13 @@ func run(ymlPath string) error {
 			md, statusStart, statusEnd); err != nil {
 			return err
 		}
+	}
+	if len(md.Metrics) == 0 {
+		return nil
+	}
+	if err = generateFile(filepath.Join(tmplDir, "metrics.go.tmpl"),
+		filepath.Join(codeDir, "generated_metrics.go"), md); err != nil {
+		return err
 	}
 	if err = generateFile(filepath.Join(tmplDir, "testdata", "config.yaml.tmpl"),
 		filepath.Join(codeDir, "testdata", "config.yaml"), md); err != nil {


### PR DESCRIPTION
This allows us to define metadata.yaml files for components that don't generate metrics.

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19175