### PR TITLE
[pkg/ottl] Add PMapGetter for getting pdata maps

### DIFF
--- a/.chloggen/ottl-use-mapgetter.yaml
+++ b/.chloggen/ottl-use-mapgetter.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add typed getter for `pcommon.map` and update related functions to us it.
+note: Add typed getter for `pcommon.map` and update related functions to use it.
 
 # One or more tracking issues related to the change
 issues: [19781]

--- a/.chloggen/ottl-use-mapgetter.yaml
+++ b/.chloggen/ottl-use-mapgetter.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: pkg/ottl
@@ -13,4 +13,4 @@ issues: [19781]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: Using the impacted functions, such as `keep_keys` or `replace_all_patterns`, without a `pcommon.map` will now result in an error. Only pass these function paths that result in a `pcommon.map` or set `ErrorMode` to `IgnoreError`.

--- a/.chloggen/ottl-use-mapgetter.yaml
+++ b/.chloggen/ottl-use-mapgetter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add typed getter for `pcommon.map` and update related functions to us it.
+
+# One or more tracking issues related to the change
+issues: [19781]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -17,6 +17,8 @@ package ottl // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"context"
 	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 type ExprFunc[K any] func(ctx context.Context, tCtx K) (interface{}, error)
@@ -95,6 +97,10 @@ type StringGetter[K any] interface {
 
 type IntGetter[K any] interface {
 	Get(ctx context.Context, tCtx K) (int64, error)
+}
+
+type PMapGetter[K any] interface {
+	Get(ctx context.Context, tCtx K) (pcommon.Map, error)
 }
 
 type StandardTypeGetter[K any, T any] struct {

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 type PathExpressionParser[K any] func(*Path) (GetSetter[K], error)
@@ -125,6 +127,12 @@ func (p *Parser[K]) buildSliceArg(argVal value, argType reflect.Type) (any, erro
 			return nil, err
 		}
 		return arg, nil
+	case strings.HasPrefix(name, "PMapGetter"):
+		arg, err := buildSlice[PMapGetter[K]](argVal, argType, p.buildArg, name)
+		if err != nil {
+			return nil, err
+		}
+		return arg, nil
 	case strings.HasPrefix(name, "StringGetter"):
 		arg, err := buildSlice[StringGetter[K]](argVal, argType, p.buildArg, name)
 		if err != nil {
@@ -169,6 +177,12 @@ func (p *Parser[K]) buildArg(argVal value, argType reflect.Type) (any, error) {
 			return nil, err
 		}
 		return StandardTypeGetter[K, int64]{Getter: arg.Get}, nil
+	case strings.HasPrefix(name, "PMapGetter"):
+		arg, err := p.newGetter(argVal)
+		if err != nil {
+			return nil, err
+		}
+		return StandardTypeGetter[K, pcommon.Map]{Getter: arg.Get}, nil
 	case name == "Enum":
 		arg, err := p.enumParser(argVal.Enum)
 		if err != nil {

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -509,6 +509,43 @@ func Test_NewFunctionCall(t *testing.T) {
 			want: 2,
 		},
 		{
+			name: "pmapgetter slice arg",
+			inv: invocation{
+				Function: "testing_pmapgetter_slice",
+				Arguments: []value{
+					{
+						List: &list{
+							Values: []value{
+								{
+									Literal: &mathExprLiteral{
+										Path: &Path{
+											Fields: []Field{
+												{
+													Name: "name",
+												},
+											},
+										},
+									},
+								},
+								{
+									Literal: &mathExprLiteral{
+										Path: &Path{
+											Fields: []Field{
+												{
+													Name: "name",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: 2,
+		},
+		{
 			name: "setter arg",
 			inv: invocation{
 				Function: "testing_setter",
@@ -665,6 +702,26 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Literal: &mathExprLiteral{
 							Int: ottltest.Intp(1),
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "pmapgetter arg",
+			inv: invocation{
+				Function: "testing_pmapgetter",
+				Arguments: []value{
+					{
+						Literal: &mathExprLiteral{
+							Path: &Path{
+								Fields: []Field{
+									{
+										Name: "name",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -908,6 +965,12 @@ func functionWithStringGetterSlice(getters []Getter[interface{}]) (ExprFunc[inte
 	}, nil
 }
 
+func functionWithPMapGetterSlice(getters []PMapGetter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return len(getters), nil
+	}, nil
+}
+
 func functionWithSetter(Setter[interface{}]) (ExprFunc[interface{}], error) {
 	return func(context.Context, interface{}) (interface{}, error) {
 		return "anything", nil
@@ -933,6 +996,12 @@ func functionWithStringGetter(StringGetter[interface{}]) (ExprFunc[interface{}],
 }
 
 func functionWithIntGetter(IntGetter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return "anything", nil
+	}, nil
+}
+
+func functionWithPMapGetter(PMapGetter[interface{}]) (ExprFunc[interface{}], error) {
 	return func(context.Context, interface{}) (interface{}, error) {
 		return "anything", nil
 	}, nil
@@ -1007,11 +1076,13 @@ func defaultFunctionsForTests() map[string]interface{} {
 	functions["testing_byte_slice"] = functionWithByteSlice
 	functions["testing_getter_slice"] = functionWithGetterSlice
 	functions["testing_stringgetter_slice"] = functionWithStringGetterSlice
+	functions["testing_pmapgetter_slice"] = functionWithPMapGetterSlice
 	functions["testing_setter"] = functionWithSetter
 	functions["testing_getsetter"] = functionWithGetSetter
 	functions["testing_getter"] = functionWithGetter
 	functions["testing_stringgetter"] = functionWithStringGetter
 	functions["testing_intgetter"] = functionWithIntGetter
+	functions["testing_pmapgetter"] = functionWithPMapGetter
 	functions["testing_string"] = functionWithString
 	functions["testing_float"] = functionWithFloat
 	functions["testing_int"] = functionWithInt

--- a/pkg/ottl/ottlfuncs/func_delete_key.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key.go
@@ -17,24 +17,16 @@ package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-c
 import (
 	"context"
 
-	"go.opentelemetry.io/collector/pdata/pcommon"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func DeleteKey[K any](target ottl.Getter[K], key string) (ottl.ExprFunc[K], error) {
+func DeleteKey[K any](target ottl.PMapGetter[K], key string) (ottl.ExprFunc[K], error) {
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
 		val, err := target.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
-		if val == nil {
-			return nil, nil
-		}
-
-		if attrs, ok := val.(pcommon.Map); ok {
-			attrs.Remove(key)
-		}
+		val.Remove(key)
 		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_delete_key_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key_test.go
@@ -30,7 +30,7 @@ func Test_deleteKey(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardGetSetter[pcommon.Map]{
+	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -38,7 +38,7 @@ func Test_deleteKey(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		target ottl.Getter[pcommon.Map]
+		target ottl.PMapGetter[pcommon.Map]
 		key    string
 		want   func(pcommon.Map)
 	}{
@@ -92,13 +92,9 @@ func Test_deleteKey(t *testing.T) {
 
 func Test_deleteKey_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 
@@ -106,20 +102,14 @@ func Test_deleteKey_bad_input(t *testing.T) {
 
 	exprFunc, err := DeleteKey[interface{}](target, key)
 	assert.NoError(t, err)
-	result, err := exprFunc(nil, input)
-	assert.NoError(t, err)
-	assert.Nil(t, result)
-	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
+	_, err = exprFunc(nil, input)
+	assert.Error(t, err)
 }
 
 func Test_deleteKey_get_nil(t *testing.T) {
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 
@@ -127,7 +117,6 @@ func Test_deleteKey_get_nil(t *testing.T) {
 
 	exprFunc, err := DeleteKey[interface{}](target, key)
 	assert.NoError(t, err)
-	result, err := exprFunc(nil, nil)
-	assert.NoError(t, err)
-	assert.Nil(t, result)
+	_, err = exprFunc(nil, nil)
+	assert.Error(t, err)
 }

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys.go
@@ -24,7 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func DeleteMatchingKeys[K any](target ottl.Getter[K], pattern string) (ottl.ExprFunc[K], error) {
+func DeleteMatchingKeys[K any](target ottl.PMapGetter[K], pattern string) (ottl.ExprFunc[K], error) {
 	compiledPattern, err := regexp.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to delete_matching_keys is not a valid pattern: %w", err)
@@ -34,15 +34,9 @@ func DeleteMatchingKeys[K any](target ottl.Getter[K], pattern string) (ottl.Expr
 		if err != nil {
 			return nil, err
 		}
-		if val == nil {
-			return nil, nil
-		}
-
-		if attrs, ok := val.(pcommon.Map); ok {
-			attrs.RemoveIf(func(key string, _ pcommon.Value) bool {
-				return compiledPattern.MatchString(key)
-			})
-		}
+		val.RemoveIf(func(key string, _ pcommon.Value) bool {
+			return compiledPattern.MatchString(key)
+		})
 		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
@@ -31,7 +31,7 @@ func Test_deleteMatchingKeys(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardGetSetter[pcommon.Map]{
+	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -39,7 +39,7 @@ func Test_deleteMatchingKeys(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		target  ottl.Getter[pcommon.Map]
+		target  ottl.PMapGetter[pcommon.Map]
 		pattern string
 		want    func(pcommon.Map)
 	}{
@@ -91,7 +91,7 @@ func Test_deleteMatchingKeys(t *testing.T) {
 
 func Test_deleteMatchingKeys_bad_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -101,13 +101,11 @@ func Test_deleteMatchingKeys_bad_input(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = exprFunc(nil, input)
-	assert.Nil(t, err)
-
-	assert.Equal(t, pcommon.NewValueInt(1), input)
+	assert.Error(t, err)
 }
 
 func Test_deleteMatchingKeys_get_nil(t *testing.T) {
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -115,13 +113,12 @@ func Test_deleteMatchingKeys_get_nil(t *testing.T) {
 
 	exprFunc, err := DeleteMatchingKeys[interface{}](target, "anything")
 	assert.NoError(t, err)
-	result, err := exprFunc(nil, nil)
-	assert.NoError(t, err)
-	assert.Nil(t, result)
+	_, err = exprFunc(nil, nil)
+	assert.Error(t, err)
 }
 
 func Test_deleteMatchingKeys_invalid_pattern(t *testing.T) {
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return nil, nil

--- a/pkg/ottl/ottlfuncs/func_keep_keys.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys.go
@@ -22,7 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func KeepKeys[K any](target ottl.GetSetter[K], keys []string) (ottl.ExprFunc[K], error) {
+func KeepKeys[K any](target ottl.PMapGetter[K], keys []string) (ottl.ExprFunc[K], error) {
 	keySet := make(map[string]struct{}, len(keys))
 	for _, key := range keys {
 		keySet[key] = struct{}{}
@@ -33,18 +33,12 @@ func KeepKeys[K any](target ottl.GetSetter[K], keys []string) (ottl.ExprFunc[K],
 		if err != nil {
 			return nil, err
 		}
-		if val == nil {
-			return nil, nil
-		}
-
-		if attrs, ok := val.(pcommon.Map); ok {
-			attrs.RemoveIf(func(key string, value pcommon.Value) bool {
-				_, ok := keySet[key]
-				return !ok
-			})
-			if attrs.Len() == 0 {
-				attrs.Clear()
-			}
+		val.RemoveIf(func(key string, value pcommon.Value) bool {
+			_, ok := keySet[key]
+			return !ok
+		})
+		if val.Len() == 0 {
+			val.Clear()
 		}
 		return nil, nil
 	}, nil

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -30,19 +30,15 @@ func Test_keepKeys(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardGetSetter[pcommon.Map]{
+	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx pcommon.Map, val interface{}) error {
-			val.(pcommon.Map).CopyTo(tCtx)
-			return nil
 		},
 	}
 
 	tests := []struct {
 		name   string
-		target ottl.GetSetter[pcommon.Map]
+		target ottl.PMapGetter[pcommon.Map]
 		keys   []string
 		want   func(pcommon.Map)
 	}{
@@ -75,12 +71,6 @@ func Test_keepKeys(t *testing.T) {
 			keys:   []string{"no match"},
 			want:   func(expectedMap pcommon.Map) {},
 		},
-		{
-			name:   "input is not a pcommon.Map",
-			target: target,
-			keys:   []string{"no match"},
-			want:   func(expectedMap pcommon.Map) {},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -103,13 +93,9 @@ func Test_keepKeys(t *testing.T) {
 
 func Test_keepKeys_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 
@@ -119,19 +105,13 @@ func Test_keepKeys_bad_input(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = exprFunc(nil, input)
-	assert.Nil(t, err)
-
-	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
+	assert.Error(t, err)
 }
 
 func Test_keepKeys_get_nil(t *testing.T) {
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 
@@ -139,7 +119,6 @@ func Test_keepKeys_get_nil(t *testing.T) {
 
 	exprFunc, err := KeepKeys[interface{}](target, keys)
 	assert.NoError(t, err)
-	result, err := exprFunc(nil, nil)
-	assert.NoError(t, err)
-	assert.Nil(t, result)
+	_, err = exprFunc(nil, nil)
+	assert.Error(t, err)
 }

--- a/pkg/ottl/ottlfuncs/func_limit_test.go
+++ b/pkg/ottl/ottlfuncs/func_limit_test.go
@@ -30,19 +30,15 @@ func Test_limit(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardGetSetter[pcommon.Map]{
+	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx pcommon.Map, val interface{}) error {
-			val.(pcommon.Map).CopyTo(tCtx)
-			return nil
 		},
 	}
 
 	tests := []struct {
 		name   string
-		target ottl.GetSetter[pcommon.Map]
+		target ottl.PMapGetter[pcommon.Map]
 		limit  int64
 		keep   []string
 		want   func(pcommon.Map)
@@ -146,18 +142,18 @@ func Test_limit(t *testing.T) {
 func Test_limit_validation(t *testing.T) {
 	tests := []struct {
 		name   string
-		target ottl.GetSetter[interface{}]
+		target ottl.PMapGetter[interface{}]
 		keep   []string
 		limit  int64
 	}{
 		{
 			name:   "limit less than zero",
-			target: &ottl.StandardGetSetter[interface{}]{},
+			target: &ottl.StandardTypeGetter[interface{}, pcommon.Map]{},
 			limit:  int64(-1),
 		},
 		{
 			name:   "limit less than # of keep attrs",
-			target: &ottl.StandardGetSetter[interface{}]{},
+			target: &ottl.StandardTypeGetter[interface{}, pcommon.Map]{},
 			keep:   []string{"test", "test"},
 			limit:  int64(1),
 		},
@@ -172,39 +168,27 @@ func Test_limit_validation(t *testing.T) {
 
 func Test_limit_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 
 	exprFunc, err := Limit[interface{}](target, 1, []string{})
 	assert.NoError(t, err)
-	result, err := exprFunc(nil, input)
-	assert.NoError(t, err)
-	assert.Nil(t, result)
-	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
+	_, err = exprFunc(nil, input)
+	assert.Error(t, err)
 }
 
 func Test_limit_get_nil(t *testing.T) {
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 
 	exprFunc, err := Limit[interface{}](target, 1, []string{})
 	assert.NoError(t, err)
-	result, err := exprFunc(nil, nil)
-	assert.NoError(t, err)
-	assert.Nil(t, result)
-	assert.Nil(t, result)
+	_, err = exprFunc(nil, nil)
+	assert.Error(t, err)
 }

--- a/pkg/ottl/ottlfuncs/func_merge_maps.go
+++ b/pkg/ottl/ottlfuncs/func_merge_maps.go
@@ -35,50 +35,44 @@ const (
 //	insert: Insert the value from `source` into `target` where the key does not already exist.
 //	update: Update the entry in `target` with the value from `source` where the key does exist
 //	upsert: Performs insert or update. Insert the value from `source` into `target` where the key does not already exist and update the entry in `target` with the value from `source` where the key does exist.
-func MergeMaps[K any](target ottl.Getter[K], source ottl.Getter[K], strategy string) (ottl.ExprFunc[K], error) {
+func MergeMaps[K any](target ottl.PMapGetter[K], source ottl.PMapGetter[K], strategy string) (ottl.ExprFunc[K], error) {
 	if strategy != INSERT && strategy != UPDATE && strategy != UPSERT {
 		return nil, fmt.Errorf("invalid value for strategy, %v, must be 'insert', 'update' or 'upsert'", strategy)
 	}
 
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
-		targetVal, err := target.Get(ctx, tCtx)
+		targetMap, err := target.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
-
-		if targetMap, ok := targetVal.(pcommon.Map); ok {
-			val, err := source.Get(ctx, tCtx)
-			if err != nil {
-				return nil, err
-			}
-
-			if valueMap, ok := val.(pcommon.Map); ok {
-				switch strategy {
-				case INSERT:
-					valueMap.Range(func(k string, v pcommon.Value) bool {
-						if _, ok := targetMap.Get(k); !ok {
-							tv := targetMap.PutEmpty(k)
-							v.CopyTo(tv)
-						}
-						return true
-					})
-				case UPDATE:
-					valueMap.Range(func(k string, v pcommon.Value) bool {
-						if tv, ok := targetMap.Get(k); ok {
-							v.CopyTo(tv)
-						}
-						return true
-					})
-				case UPSERT:
-					valueMap.Range(func(k string, v pcommon.Value) bool {
-						tv := targetMap.PutEmpty(k)
-						v.CopyTo(tv)
-						return true
-					})
-				default:
-					return nil, fmt.Errorf("unknown strategy, %v", strategy)
+		valueMap, err := source.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		switch strategy {
+		case INSERT:
+			valueMap.Range(func(k string, v pcommon.Value) bool {
+				if _, ok := targetMap.Get(k); !ok {
+					tv := targetMap.PutEmpty(k)
+					v.CopyTo(tv)
 				}
-			}
+				return true
+			})
+		case UPDATE:
+			valueMap.Range(func(k string, v pcommon.Value) bool {
+				if tv, ok := targetMap.Get(k); ok {
+					v.CopyTo(tv)
+				}
+				return true
+			})
+		case UPSERT:
+			valueMap.Range(func(k string, v pcommon.Value) bool {
+				tv := targetMap.PutEmpty(k)
+				v.CopyTo(tv)
+				return true
+			})
+		default:
+			return nil, fmt.Errorf("unknown strategy, %v", strategy)
 		}
 		return nil, nil
 	}, nil

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -29,7 +29,7 @@ const (
 	modeValue = "value"
 )
 
-func ReplaceAllPatterns[K any](target ottl.GetSetter[K], mode string, regexPattern string, replacement string) (ottl.ExprFunc[K], error) {
+func ReplaceAllPatterns[K any](target ottl.PMapGetter[K], mode string, regexPattern string, replacement string) (ottl.ExprFunc[K], error) {
 	compiledPattern, err := regexp.Compile(regexPattern)
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to replace_all_patterns is not a valid pattern: %w", err)
@@ -43,16 +43,9 @@ func ReplaceAllPatterns[K any](target ottl.GetSetter[K], mode string, regexPatte
 		if err != nil {
 			return nil, err
 		}
-		if val == nil {
-			return nil, nil
-		}
-		attrs, ok := val.(pcommon.Map)
-		if !ok {
-			return nil, nil
-		}
 		updated := pcommon.NewMap()
-		updated.EnsureCapacity(attrs.Len())
-		attrs.Range(func(key string, originalValue pcommon.Value) bool {
+		updated.EnsureCapacity(val.Len())
+		val.Range(func(key string, originalValue pcommon.Value) bool {
 			switch mode {
 			case modeValue:
 				if compiledPattern.MatchString(originalValue.Str()) {
@@ -71,11 +64,7 @@ func ReplaceAllPatterns[K any](target ottl.GetSetter[K], mode string, regexPatte
 			}
 			return true
 		})
-		err = target.Set(ctx, tCtx, updated)
-		if err != nil {
-			return nil, err
-		}
-
+		updated.CopyTo(val)
 		return nil, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -31,19 +31,15 @@ func Test_replaceAllPatterns(t *testing.T) {
 	input.PutStr("test2", "hello")
 	input.PutStr("test3", "goodbye world1 and world2")
 
-	target := &ottl.StandardGetSetter[pcommon.Map]{
+	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx pcommon.Map, val interface{}) error {
-			val.(pcommon.Map).CopyTo(tCtx)
-			return nil
 		},
 	}
 
 	tests := []struct {
 		name        string
-		target      ottl.GetSetter[pcommon.Map]
+		target      ottl.PMapGetter[pcommon.Map]
 		mode        string
 		pattern     string
 		replacement string
@@ -173,13 +169,9 @@ func Test_replaceAllPatterns(t *testing.T) {
 func Test_replaceAllPatterns_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 
@@ -187,19 +179,13 @@ func Test_replaceAllPatterns_bad_input(t *testing.T) {
 	assert.Nil(t, err)
 
 	_, err = exprFunc(nil, input)
-	assert.Nil(t, err)
-
-	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
+	assert.Error(t, err)
 }
 
 func Test_replaceAllPatterns_get_nil(t *testing.T) {
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 
@@ -207,18 +193,14 @@ func Test_replaceAllPatterns_get_nil(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = exprFunc(nil, nil)
-	assert.Nil(t, err)
+	assert.Error(t, err)
 }
 
 func Test_replaceAllPatterns_invalid_pattern(t *testing.T) {
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return nil, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 
@@ -230,14 +212,10 @@ func Test_replaceAllPatterns_invalid_pattern(t *testing.T) {
 }
 
 func Test_replaceAllPatterns_invalid_model(t *testing.T) {
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return nil, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 

--- a/pkg/ottl/ottlfuncs/func_truncate_all_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all_test.go
@@ -31,19 +31,15 @@ func Test_truncateAll(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardGetSetter[pcommon.Map]{
+	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx pcommon.Map, val interface{}) error {
-			val.(pcommon.Map).CopyTo(tCtx)
-			return nil
 		},
 	}
 
 	tests := []struct {
 		name   string
-		target ottl.GetSetter[pcommon.Map]
+		target ottl.PMapGetter[pcommon.Map]
 		limit  int64
 		want   func(pcommon.Map)
 	}{
@@ -109,47 +105,36 @@ func Test_truncateAll(t *testing.T) {
 }
 
 func Test_truncateAll_validation(t *testing.T) {
-	_, err := TruncateAll[interface{}](&ottl.StandardGetSetter[interface{}]{}, -1)
+	_, err := TruncateAll[interface{}](&ottl.StandardTypeGetter[interface{}, pcommon.Map]{}, -1)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "invalid limit for truncate_all function, -1 cannot be negative")
 }
 
 func Test_truncateAll_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 
 	exprFunc, err := TruncateAll[interface{}](target, 1)
 	assert.NoError(t, err)
 
-	result, err := exprFunc(nil, input)
-	assert.NoError(t, err)
-	assert.Nil(t, result)
-	assert.Equal(t, pcommon.NewValueStr("not a map"), input)
+	_, err = exprFunc(nil, input)
+	assert.Error(t, err)
 }
 
 func Test_truncateAll_get_nil(t *testing.T) {
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
-		},
-		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
-			t.Errorf("nothing should be set in this scenario")
-			return nil
 		},
 	}
 
 	exprFunc, err := TruncateAll[interface{}](target, 1)
 	assert.NoError(t, err)
 
-	result, err := exprFunc(nil, nil)
-	assert.NoError(t, err)
-	assert.Nil(t, result)
+	_, err = exprFunc(nil, nil)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
**Description:**
Adds a new typed getter for getting `pcommon.map` values.  Updates functions that expect a `pcommon.map` to use `PMapGetter`. 

**Link to tracking Issue:** <Issue number if applicable>
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16519

**Testing:** <Describe what testing was performed and which tests were added.>
Updated tests

**Documentation**
Reviewed existing docs