### PR TITLE
[pkg/ottl] Add StringLikeGetter for turning types into string

### DIFF
--- a/.chloggen/ottl-use-stringlikegetter.yaml
+++ b/.chloggen/ottl-use-stringlikegetter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds new StringLikeGetter for converting values to string for use.
+
+# One or more tracking issues related to the change
+issues: [19782]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/ottl-use-stringlikegetter.yaml
+++ b/.chloggen/ottl-use-stringlikegetter.yaml
@@ -13,4 +13,4 @@ issues: [19782]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Concat now converts more types to string instead of ignoring them.  []byte are now converted to string using `hex.EncodeToString(v)`.
+subtext: Concat now converts more types to string instead of ignoring them.  IsMatch now converts []byte to string using `hex.EncodeToString(v)`.

--- a/.chloggen/ottl-use-stringlikegetter.yaml
+++ b/.chloggen/ottl-use-stringlikegetter.yaml
@@ -1,5 +1,5 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: pkg/ottl
@@ -13,4 +13,4 @@ issues: [19782]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: Concat now converts more types to string instead of ignoring them.  []byte are now converted to string using `hex.EncodeToString(v)`.

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -174,7 +174,10 @@ func (g StandardStringLikeGetter[K]) Get(ctx context.Context, tCtx K) (*string, 
 	case pcommon.Value:
 		result = v.AsString()
 	default:
-		return nil, fmt.Errorf("unsupported type: %T", v)
+		result, err = jsoniter.MarshalToString(v)
+		if err != nil {
+			return nil, fmt.Errorf("unsupported type: %T", v)
+		}
 	}
 	return &result, nil
 }

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -16,7 +16,7 @@ package ottl // import "github.com/open-telemetry/opentelemetry-collector-contri
 
 import (
 	"context"
-	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 
@@ -160,7 +160,7 @@ func (g StandardStringLikeGetter[K]) Get(ctx context.Context, tCtx K) (*string, 
 	case float64:
 		result = strconv.FormatFloat(v, 'f', -1, 64)
 	case []byte:
-		result = base64.StdEncoding.EncodeToString(v)
+		result = hex.EncodeToString(v)
 	case pcommon.Map:
 		result, err = jsoniter.MarshalToString(v.AsRaw())
 		if err != nil {

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+
 	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -94,7 +94,9 @@ func (l *listGetter[K]) Get(ctx context.Context, tCtx K) (interface{}, error) {
 	return evaluated, nil
 }
 
+// StringGetter is a Getter that must return a string.
 type StringGetter[K any] interface {
+	// Get retrieves a string value.  If the value is not a string, an error is returned.
 	Get(ctx context.Context, tCtx K) (string, error)
 }
 
@@ -126,7 +128,12 @@ func (g StandardTypeGetter[K, T]) Get(ctx context.Context, tCtx K) (T, error) {
 	return v, nil
 }
 
+// StringLikeGetter is a Getter that returns a string by converting the underlying value to a string if necessary.
 type StringLikeGetter[K any] interface {
+	// Get retrieves a string value.
+	// Unlike `StringGetter`, the expectation is that the underlying value is converted to a string if possible.
+	// If the value cannot be converted to a string, nil and an error are returned.
+	// If the value is nil, nil is returned without an error.
 	Get(ctx context.Context, tCtx K) (*string, error)
 }
 

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"strconv"
-
 	jsoniter "github.com/json-iterator/go"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
@@ -153,12 +151,6 @@ func (g StandardStringLikeGetter[K]) Get(ctx context.Context, tCtx K) (*string, 
 	switch v := val.(type) {
 	case string:
 		result = v
-	case bool:
-		result = strconv.FormatBool(v)
-	case int64:
-		result = strconv.FormatInt(v, 10)
-	case float64:
-		result = strconv.FormatFloat(v, 'f', -1, 64)
 	case []byte:
 		result = hex.EncodeToString(v)
 	case pcommon.Map:

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -428,7 +428,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 					return []byte{0}, nil
 				},
 			},
-			want:  "AA==",
+			want:  "00",
 			valid: true,
 		},
 		{

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -481,11 +481,11 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 			name: "invalid type",
 			getter: StandardStringLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
-					return 1, nil
+					return make(chan int), nil
 				},
 			},
 			valid:            false,
-			expectedErrorMsg: "unsupported type: int",
+			expectedErrorMsg: "unsupported type: chan int",
 		},
 	}
 

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
@@ -365,6 +366,139 @@ func Test_StandardTypeGetter(t *testing.T) {
 			if tt.valid {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, val)
+			} else {
+				assert.EqualError(t, err, tt.expectedErrorMsg)
+			}
+		})
+	}
+}
+
+func Test_StandardStringLikeGetter(t *testing.T) {
+	tests := []struct {
+		name             string
+		getter           StringLikeGetter[interface{}]
+		want             interface{}
+		valid            bool
+		expectedErrorMsg string
+	}{
+		{
+			name: "string type",
+			getter: StandardStringLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "str", nil
+				},
+			},
+			want:  "str",
+			valid: true,
+		},
+		{
+			name: "bool type",
+			getter: StandardStringLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return true, nil
+				},
+			},
+			want:  "true",
+			valid: true,
+		},
+		{
+			name: "int64 type",
+			getter: StandardStringLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return int64(1), nil
+				},
+			},
+			want:  "1",
+			valid: true,
+		},
+		{
+			name: "float64 type",
+			getter: StandardStringLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return 1.1, nil
+				},
+			},
+			want:  "1.1",
+			valid: true,
+		},
+		{
+			name: "byte[] type",
+			getter: StandardStringLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return []byte{0}, nil
+				},
+			},
+			want:  "AA==",
+			valid: true,
+		},
+		{
+			name: "pcommon.map type",
+			getter: StandardStringLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					m := pcommon.NewMap()
+					m.PutStr("test", "passed")
+					return m, nil
+				},
+			},
+			want:  `{"test":"passed"}`,
+			valid: true,
+		},
+		{
+			name: "pcommon.slice type",
+			getter: StandardStringLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					s := pcommon.NewSlice()
+					v := s.AppendEmpty()
+					v.SetStr("test")
+					return s, nil
+				},
+			},
+			want:  `["test"]`,
+			valid: true,
+		},
+		{
+			name: "pcommon.value type",
+			getter: StandardStringLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					v := pcommon.NewValueInt(int64(100))
+					return v, nil
+				},
+			},
+			want:  "100",
+			valid: true,
+		},
+		{
+			name: "nil",
+			getter: StandardStringLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return nil, nil
+				},
+			},
+			want:  nil,
+			valid: true,
+		},
+		{
+			name: "invalid type",
+			getter: StandardStringLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return 1, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "unsupported type: int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := tt.getter.Get(context.Background(), nil)
+			if tt.valid {
+				assert.NoError(t, err)
+				if tt.want == nil {
+					assert.Nil(t, val)
+				} else {
+					assert.Equal(t, tt.want, *val)
+				}
 			} else {
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -139,6 +139,12 @@ func (p *Parser[K]) buildSliceArg(argVal value, argType reflect.Type) (any, erro
 			return nil, err
 		}
 		return arg, nil
+	case strings.HasPrefix(name, "StringLikeGetter"):
+		arg, err := buildSlice[StringLikeGetter[K]](argVal, argType, p.buildArg, name)
+		if err != nil {
+			return nil, err
+		}
+		return arg, nil
 	default:
 		return nil, fmt.Errorf("unsupported slice type '%s' for function", argType.Elem().Name())
 	}
@@ -171,6 +177,12 @@ func (p *Parser[K]) buildArg(argVal value, argType reflect.Type) (any, error) {
 			return nil, err
 		}
 		return StandardTypeGetter[K, string]{Getter: arg.Get}, nil
+	case strings.HasPrefix(name, "StringLikeGetter"):
+		arg, err := p.newGetter(argVal)
+		if err != nil {
+			return nil, err
+		}
+		return StandardStringLikeGetter[K]{Getter: arg.Get}, nil
 	case strings.HasPrefix(name, "IntGetter"):
 		arg, err := p.newGetter(argVal)
 		if err != nil {

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -546,6 +546,29 @@ func Test_NewFunctionCall(t *testing.T) {
 			want: 2,
 		},
 		{
+			name: "stringlikegetter slice arg",
+			inv: invocation{
+				Function: "testing_stringlikegetter_slice",
+				Arguments: []value{
+					{
+						List: &list{
+							Values: []value{
+								{
+									String: ottltest.Strp("test"),
+								},
+								{
+									Literal: &mathExprLiteral{
+										Int: ottltest.Intp(1),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: 2,
+		},
+		{
 			name: "setter arg",
 			inv: invocation{
 				Function: "testing_setter",
@@ -689,6 +712,18 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []value{
 					{
 						String: ottltest.Strp("test"),
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "stringlikegetter arg",
+			inv: invocation{
+				Function: "testing_stringlikegetter",
+				Arguments: []value{
+					{
+						Bool: (*boolean)(ottltest.Boolp(false)),
 					},
 				},
 			},
@@ -971,6 +1006,12 @@ func functionWithPMapGetterSlice(getters []PMapGetter[interface{}]) (ExprFunc[in
 	}, nil
 }
 
+func functionWithStringLikeGetterSlice(getters []StringLikeGetter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return len(getters), nil
+	}, nil
+}
+
 func functionWithSetter(Setter[interface{}]) (ExprFunc[interface{}], error) {
 	return func(context.Context, interface{}) (interface{}, error) {
 		return "anything", nil
@@ -990,6 +1031,12 @@ func functionWithGetter(Getter[interface{}]) (ExprFunc[interface{}], error) {
 }
 
 func functionWithStringGetter(StringGetter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return "anything", nil
+	}, nil
+}
+
+func functionWithStringLikeGetter(StringLikeGetter[interface{}]) (ExprFunc[interface{}], error) {
 	return func(context.Context, interface{}) (interface{}, error) {
 		return "anything", nil
 	}, nil
@@ -1077,10 +1124,12 @@ func defaultFunctionsForTests() map[string]interface{} {
 	functions["testing_getter_slice"] = functionWithGetterSlice
 	functions["testing_stringgetter_slice"] = functionWithStringGetterSlice
 	functions["testing_pmapgetter_slice"] = functionWithPMapGetterSlice
+	functions["testing_stringlikegetter_slice"] = functionWithStringLikeGetterSlice
 	functions["testing_setter"] = functionWithSetter
 	functions["testing_getsetter"] = functionWithGetSetter
 	functions["testing_getter"] = functionWithGetter
 	functions["testing_stringgetter"] = functionWithStringGetter
+	functions["testing_stringlikegetter"] = functionWithStringLikeGetter
 	functions["testing_intgetter"] = functionWithIntGetter
 	functions["testing_pmapgetter"] = functionWithPMapGetter
 	functions["testing_string"] = functionWithString

--- a/pkg/ottl/ottlfuncs/func_concat.go
+++ b/pkg/ottl/ottlfuncs/func_concat.go
@@ -22,7 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func Concat[K any](vals []ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], error) {
+func Concat[K any](vals []ottl.StringLikeGetter[K], delimiter string) (ottl.ExprFunc[K], error) {
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
 		builder := strings.Builder{}
 		for i, rv := range vals {
@@ -30,21 +30,11 @@ func Concat[K any](vals []ottl.Getter[K], delimiter string) (ottl.ExprFunc[K], e
 			if err != nil {
 				return nil, err
 			}
-			switch v := val.(type) {
-			case string:
-				builder.WriteString(v)
-			case []byte:
-				builder.WriteString(fmt.Sprintf("%x", v))
-			case int64:
-				builder.WriteString(fmt.Sprint(v))
-			case float64:
-				builder.WriteString(fmt.Sprint(v))
-			case bool:
-				builder.WriteString(fmt.Sprint(v))
-			case nil:
-				builder.WriteString(fmt.Sprint(v))
+			if val == nil {
+				builder.WriteString(fmt.Sprint(val))
+			} else {
+				builder.WriteString(*val)
 			}
-
 			if i != len(vals)-1 {
 				builder.WriteString(delimiter)
 			}

--- a/pkg/ottl/ottlfuncs/func_concat_test.go
+++ b/pkg/ottl/ottlfuncs/func_concat_test.go
@@ -242,7 +242,7 @@ func Test_concat(t *testing.T) {
 func Test_concat_error(t *testing.T) {
 	target := &ottl.StandardStringLikeGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
-			return []int{1, 2}, nil
+			return make(chan int), nil
 		},
 	}
 	exprFunc, err := Concat[interface{}]([]ottl.StringLikeGetter[interface{}]{target}, "test")

--- a/pkg/ottl/ottlfuncs/func_concat_test.go
+++ b/pkg/ottl/ottlfuncs/func_concat_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -26,13 +27,13 @@ import (
 func Test_concat(t *testing.T) {
 	tests := []struct {
 		name      string
-		vals      []ottl.StandardGetSetter[interface{}]
+		vals      []ottl.StandardStringLikeGetter[interface{}]
 		delimiter string
 		expected  string
 	}{
 		{
 			name: "concat strings",
-			vals: []ottl.StandardGetSetter[interface{}]{
+			vals: []ottl.StandardStringLikeGetter[interface{}]{
 				{
 					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 						return "hello", nil
@@ -49,7 +50,7 @@ func Test_concat(t *testing.T) {
 		},
 		{
 			name: "nil",
-			vals: []ottl.StandardGetSetter[interface{}]{
+			vals: []ottl.StandardStringLikeGetter[interface{}]{
 				{
 					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 						return "hello", nil
@@ -71,7 +72,7 @@ func Test_concat(t *testing.T) {
 		},
 		{
 			name: "integers",
-			vals: []ottl.StandardGetSetter[interface{}]{
+			vals: []ottl.StandardStringLikeGetter[interface{}]{
 				{
 					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 						return "hello", nil
@@ -88,7 +89,7 @@ func Test_concat(t *testing.T) {
 		},
 		{
 			name: "floats",
-			vals: []ottl.StandardGetSetter[interface{}]{
+			vals: []ottl.StandardStringLikeGetter[interface{}]{
 				{
 					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 						return "hello", nil
@@ -105,7 +106,7 @@ func Test_concat(t *testing.T) {
 		},
 		{
 			name: "booleans",
-			vals: []ottl.StandardGetSetter[interface{}]{
+			vals: []ottl.StandardStringLikeGetter[interface{}]{
 				{
 					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 						return "hello", nil
@@ -122,7 +123,7 @@ func Test_concat(t *testing.T) {
 		},
 		{
 			name: "byte slices",
-			vals: []ottl.StandardGetSetter[interface{}]{
+			vals: []ottl.StandardStringLikeGetter[interface{}]{
 				{
 					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 						return []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8}, nil
@@ -133,54 +134,50 @@ func Test_concat(t *testing.T) {
 			expected:  "00000000000000000ed2e63cbe71f5a8",
 		},
 		{
-			name: "non-byte slices",
-			vals: []ottl.StandardGetSetter[interface{}]{
+			name: "pcommon.Slaice",
+			vals: []ottl.StandardStringLikeGetter[interface{}]{
 				{
 					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
-						return []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 0}, nil
+						s := pcommon.NewSlice()
+						_ = s.FromRaw([]any{1, 2})
+						return s, nil
+					},
+				},
+				{
+					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+						s := pcommon.NewSlice()
+						_ = s.FromRaw([]any{3, 4})
+						return s, nil
 					},
 				},
 			},
-			delimiter: "",
-			expected:  "",
+			delimiter: ",",
+			expected:  "[1,2],[3,4]",
 		},
 		{
 			name: "maps",
-			vals: []ottl.StandardGetSetter[interface{}]{
+			vals: []ottl.StandardStringLikeGetter[interface{}]{
 				{
 					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
-						return map[string]string{"key": "value"}, nil
+						m := pcommon.NewMap()
+						m.PutStr("a", "b")
+						return m, nil
+					},
+				},
+				{
+					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+						m := pcommon.NewMap()
+						m.PutStr("c", "d")
+						return m, nil
 					},
 				},
 			},
-			delimiter: "",
-			expected:  "",
-		},
-		{
-			name: "unprintable value in the middle",
-			vals: []ottl.StandardGetSetter[interface{}]{
-				{
-					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
-						return "hello", nil
-					},
-				},
-				{
-					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
-						return map[string]string{"key": "value"}, nil
-					},
-				},
-				{
-					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
-						return "world", nil
-					},
-				},
-			},
-			delimiter: "-",
-			expected:  "hello--world",
+			delimiter: ",",
+			expected:  `{"a":"b"},{"c":"d"}`,
 		},
 		{
 			name: "empty string values",
-			vals: []ottl.StandardGetSetter[interface{}]{
+			vals: []ottl.StandardStringLikeGetter[interface{}]{
 				{
 					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 						return "", nil
@@ -202,7 +199,7 @@ func Test_concat(t *testing.T) {
 		},
 		{
 			name: "single argument",
-			vals: []ottl.StandardGetSetter[interface{}]{
+			vals: []ottl.StandardStringLikeGetter[interface{}]{
 				{
 					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 						return "hello", nil
@@ -214,20 +211,20 @@ func Test_concat(t *testing.T) {
 		},
 		{
 			name:      "no arguments",
-			vals:      []ottl.StandardGetSetter[interface{}]{},
+			vals:      []ottl.StandardStringLikeGetter[interface{}]{},
 			delimiter: "-",
 			expected:  "",
 		},
 		{
 			name:      "no arguments with an empty delimiter",
-			vals:      []ottl.StandardGetSetter[interface{}]{},
+			vals:      []ottl.StandardStringLikeGetter[interface{}]{},
 			delimiter: "",
 			expected:  "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			getters := make([]ottl.Getter[interface{}], len(tt.vals))
+			getters := make([]ottl.StringLikeGetter[interface{}], len(tt.vals))
 
 			for i, val := range tt.vals {
 				getters[i] = val
@@ -240,4 +237,16 @@ func Test_concat(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func Test_concat_error(t *testing.T) {
+	target := &ottl.StandardStringLikeGetter[interface{}]{
+		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+			return []int{1, 2}, nil
+		},
+	}
+	exprFunc, err := Concat[interface{}]([]ottl.StringLikeGetter[interface{}]{target}, "test")
+	assert.NoError(t, err)
+	_, err = exprFunc(context.Background(), nil)
+	assert.Error(t, err)
 }

--- a/pkg/ottl/ottlfuncs/func_concat_test.go
+++ b/pkg/ottl/ottlfuncs/func_concat_test.go
@@ -134,7 +134,7 @@ func Test_concat(t *testing.T) {
 			expected:  "00000000000000000ed2e63cbe71f5a8",
 		},
 		{
-			name: "pcommon.Slaice",
+			name: "pcommon.Slice",
 			vals: []ottl.StandardStringLikeGetter[interface{}]{
 				{
 					Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {

--- a/pkg/ottl/ottlfuncs/func_is_match.go
+++ b/pkg/ottl/ottlfuncs/func_is_match.go
@@ -16,19 +16,13 @@ package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-c
 
 import (
 	"context"
-	"encoding/base64"
-	"errors"
 	"fmt"
 	"regexp"
-	"strconv"
-
-	jsoniter "github.com/json-iterator/go"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func IsMatch[K any](target ottl.Getter[K], pattern string) (ottl.ExprFunc[K], error) {
+func IsMatch[K any](target ottl.StringLikeGetter[K], pattern string) (ottl.ExprFunc[K], error) {
 	compiledPattern, err := regexp.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to IsMatch is not a valid regexp pattern: %w", err)
@@ -41,34 +35,6 @@ func IsMatch[K any](target ottl.Getter[K], pattern string) (ottl.ExprFunc[K], er
 		if val == nil {
 			return false, nil
 		}
-
-		switch v := val.(type) {
-		case string:
-			return compiledPattern.MatchString(v), nil
-		case bool:
-			return compiledPattern.MatchString(strconv.FormatBool(v)), nil
-		case int64:
-			return compiledPattern.MatchString(strconv.FormatInt(v, 10)), nil
-		case float64:
-			return compiledPattern.MatchString(strconv.FormatFloat(v, 'f', -1, 64)), nil
-		case []byte:
-			return compiledPattern.MatchString(base64.StdEncoding.EncodeToString(v)), nil
-		case pcommon.Map:
-			result, err := jsoniter.MarshalToString(v.AsRaw())
-			if err != nil {
-				return nil, err
-			}
-			return compiledPattern.MatchString(result), nil
-		case pcommon.Slice:
-			result, err := jsoniter.MarshalToString(v.AsRaw())
-			if err != nil {
-				return nil, err
-			}
-			return compiledPattern.MatchString(result), nil
-		case pcommon.Value:
-			return compiledPattern.MatchString(v.AsString()), nil
-		default:
-			return nil, errors.New("unsupported type")
-		}
+		return compiledPattern.MatchString(*val), nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_is_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_match_test.go
@@ -28,13 +28,13 @@ import (
 func Test_isMatch(t *testing.T) {
 	tests := []struct {
 		name     string
-		target   ottl.Getter[interface{}]
+		target   ottl.StringLikeGetter[interface{}]
 		pattern  string
 		expected bool
 	}{
 		{
 			name: "replace match true",
-			target: &ottl.StandardGetSetter[interface{}]{
+			target: &ottl.StandardStringLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "hello world", nil
 				},
@@ -44,7 +44,7 @@ func Test_isMatch(t *testing.T) {
 		},
 		{
 			name: "replace match false",
-			target: &ottl.StandardGetSetter[interface{}]{
+			target: &ottl.StandardStringLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "goodbye world", nil
 				},
@@ -54,7 +54,7 @@ func Test_isMatch(t *testing.T) {
 		},
 		{
 			name: "replace match complex",
-			target: &ottl.StandardGetSetter[interface{}]{
+			target: &ottl.StandardStringLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "-12.001", nil
 				},
@@ -64,7 +64,7 @@ func Test_isMatch(t *testing.T) {
 		},
 		{
 			name: "target bool",
-			target: &ottl.StandardGetSetter[interface{}]{
+			target: &ottl.StandardStringLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return true, nil
 				},
@@ -74,7 +74,7 @@ func Test_isMatch(t *testing.T) {
 		},
 		{
 			name: "target int",
-			target: &ottl.StandardGetSetter[interface{}]{
+			target: &ottl.StandardStringLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return int64(1), nil
 				},
@@ -84,7 +84,7 @@ func Test_isMatch(t *testing.T) {
 		},
 		{
 			name: "target float",
-			target: &ottl.StandardGetSetter[interface{}]{
+			target: &ottl.StandardStringLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return 1.1, nil
 				},
@@ -94,7 +94,7 @@ func Test_isMatch(t *testing.T) {
 		},
 		{
 			name: "target pcommon.Value",
-			target: &ottl.StandardGetSetter[interface{}]{
+			target: &ottl.StandardStringLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					v := pcommon.NewValueEmpty()
 					v.SetStr("test")
@@ -106,7 +106,7 @@ func Test_isMatch(t *testing.T) {
 		},
 		{
 			name: "nil target",
-			target: &ottl.StandardGetSetter[interface{}]{
+			target: &ottl.StandardStringLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return nil, nil
 				},
@@ -127,7 +127,7 @@ func Test_isMatch(t *testing.T) {
 }
 
 func Test_isMatch_validation(t *testing.T) {
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardStringLikeGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return "anything", nil
 		},
@@ -137,7 +137,7 @@ func Test_isMatch_validation(t *testing.T) {
 }
 
 func Test_isMatch_error(t *testing.T) {
-	target := &ottl.StandardGetSetter[interface{}]{
+	target := &ottl.StandardStringLikeGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			v := ottl.Path{}
 			return v, nil

--- a/pkg/ottl/ottlfuncs/func_is_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_match_test.go
@@ -139,8 +139,7 @@ func Test_isMatch_validation(t *testing.T) {
 func Test_isMatch_error(t *testing.T) {
 	target := &ottl.StandardStringLikeGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
-			v := ottl.Path{}
-			return v, nil
+			return make(chan int), nil
 		},
 	}
 	exprFunc, err := IsMatch[interface{}](target, "test")


### PR DESCRIPTION
**Description:**
Adds a new typed getter for getting a `string` value from the types of values OTTL knows how to handle.  Updates functions that converted any value to a string to use `StringLikeGetter`. 

**Link to tracking Issue:** <Issue number if applicable>
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16519

**Testing:** <Describe what testing was performed and which tests were added.>
Updated tests

**Documentation**
Reviewed existing docs