### PR TITLE
[pkg/ottl] Allow StringGetter in slices

### DIFF
--- a/.chloggen/ottl-add-stringgetter-to-slice.yaml
+++ b/.chloggen/ottl-add-stringgetter-to-slice.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where StringGetter was not allowed in a slice as a function param.
+
+# One or more tracking issues related to the change
+issues: [19783]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -125,6 +125,12 @@ func (p *Parser[K]) buildSliceArg(argVal value, argType reflect.Type) (any, erro
 			return nil, err
 		}
 		return arg, nil
+	case strings.HasPrefix(name, "StringGetter"):
+		arg, err := buildSlice[StringGetter[K]](argVal, argType, p.buildArg, name)
+		if err != nil {
+			return nil, err
+		}
+		return arg, nil
 	default:
 		return nil, fmt.Errorf("unsupported slice type '%s' for function", argType.Elem().Name())
 	}

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -488,6 +488,27 @@ func Test_NewFunctionCall(t *testing.T) {
 			want: 9,
 		},
 		{
+			name: "stringgetter slice arg",
+			inv: invocation{
+				Function: "testing_stringgetter_slice",
+				Arguments: []value{
+					{
+						List: &list{
+							Values: []value{
+								{
+									String: ottltest.Strp("test"),
+								},
+								{
+									String: ottltest.Strp("also test"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: 2,
+		},
+		{
 			name: "setter arg",
 			inv: invocation{
 				Function: "testing_setter",
@@ -881,6 +902,12 @@ func functionWithGetterSlice(getters []Getter[interface{}]) (ExprFunc[interface{
 	}, nil
 }
 
+func functionWithStringGetterSlice(getters []Getter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return len(getters), nil
+	}, nil
+}
+
 func functionWithSetter(Setter[interface{}]) (ExprFunc[interface{}], error) {
 	return func(context.Context, interface{}) (interface{}, error) {
 		return "anything", nil
@@ -979,6 +1006,7 @@ func defaultFunctionsForTests() map[string]interface{} {
 	functions["testing_int_slice"] = functionWithIntSlice
 	functions["testing_byte_slice"] = functionWithByteSlice
 	functions["testing_getter_slice"] = functionWithGetterSlice
+	functions["testing_stringgetter_slice"] = functionWithStringGetterSlice
 	functions["testing_setter"] = functionWithSetter
 	functions["testing_getsetter"] = functionWithGetSetter
 	functions["testing_getter"] = functionWithGetter


### PR DESCRIPTION
**Description:** 
Allow StringGetter to be used in slices.

**Link to tracking Issue:** <Issue number if applicable>
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16519

**Testing:** <Describe what testing was performed and which tests were added.>
Updated tests

**Documentation**
Reviewed existing docs