### PR TITLE
[extension/sigv4authextension] Fix null pointer dereference in sigv4authextension

### DIFF
--- a/.chloggen/fix-null-dereference-in-sigv4authextension.yaml
+++ b/.chloggen/fix-null-dereference-in-sigv4authextension.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: extension/sigv4authextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Don't panic if no credentials provider is set up.
+
+# One or more tracking issues related to the change
+issues: [19796]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/extension/sigv4authextension/signingroundtripper.go
+++ b/extension/sigv4authextension/signingroundtripper.go
@@ -80,6 +80,9 @@ func (si *signingRoundTripper) signRequest(req *http.Request) (*http.Request, er
 
 	// Use user provided service/region if specified, use inferred service/region if not, then sign the request
 	service, region := si.inferServiceAndRegion(req2)
+	if si.credsProvider == nil {
+		return nil, fmt.Errorf("a credentials provider is not set")
+	}
 	creds, err := (*si.credsProvider).Retrieve(req2.Context())
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving credentials: %w", err)

--- a/extension/sigv4authextension/signingroundtripper_test.go
+++ b/extension/sigv4authextension/signingroundtripper_test.go
@@ -50,13 +50,19 @@ func TestRoundTrip(t *testing.T) {
 			"valid_round_tripper",
 			defaultRoundTripper,
 			false,
-			&Config{Region: "region", Service: "service"},
+			&Config{Region: "region", Service: "service", credsProvider: awsCredsProvider},
 		},
 		{
 			"error_round_tripper",
 			errorRoundTripper,
 			true,
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
+			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}, credsProvider: awsCredsProvider},
+		},
+		{
+			"error_invalid_credsProvider",
+			defaultRoundTripper,
+			true,
+			&Config{Region: "region", Service: "service", credsProvider: nil},
 		},
 	}
 
@@ -79,7 +85,6 @@ func TestRoundTrip(t *testing.T) {
 			defer server.Close()
 			serverURL, _ := url.Parse(server.URL)
 
-			testcase.cfg.credsProvider = awsCredsProvider
 			sa := newSigv4Extension(testcase.cfg, awsSDKInfo, zap.NewNop())
 			rt, err := sa.RoundTripper(testcase.rt)
 			assert.NoError(t, err)


### PR DESCRIPTION
Fixing a minor bug where there is a panic if no credentials provider is set up.

I stumbled upon this when porting this extension to the Grafana Agent in [this PR](https://github.com/grafana/agent/pull/3200). I hadn't called `Validate()` (the function which sets up the credentials provider) and got a panic.