### PR TITLE
[chore] update unmaintained components

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -22,6 +22,5 @@ internal/common
 
 ## DEPRECATED components
 
-## UNMANTAINED components
-extension/httpforwarder
+## UNMAINTAINED components
 receiver/dotnetdiagnosticsreceiver

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,7 +83,7 @@ extension/basicauthextension/                            @open-telemetry/collect
 extension/bearertokenauthextension/                      @open-telemetry/collector-contrib-approvers @jpkrohling @pavankrish123
 extension/headerssetterextension/                        @open-telemetry/collector-contrib-approvers @jpkrohling @kovrus
 extension/healthcheckextension/                          @open-telemetry/collector-contrib-approvers @jpkrohling
-extension/httpforwarder                                  @open-telemetry/collector-contrib-approvers @atoulme @rmfitzpatrick
+extension/httpforwarder/                                 @open-telemetry/collector-contrib-approvers @atoulme @rmfitzpatrick
 extension/jaegerremotesampling/                          @open-telemetry/collector-contrib-approvers @jpkrohling @frzifus
 extension/oauth2clientauthextension/                     @open-telemetry/collector-contrib-approvers @pavankrish123 @jpkrohling
 extension/observer/                                      @open-telemetry/collector-contrib-approvers @dmitryax @rmfitzpatrick


### PR DESCRIPTION
Fix typo in heading
Remove httpforwarder extension in unmaintained since it is now maintained again, see #18100 