### PR TITLE
[resourcedetectionprocessor] Update README for AWS detector when instance is part of AWS Parallel Cluster

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -236,6 +236,8 @@ processors:
 
 If you are using a proxy server on your EC2 instance, it's important that you exempt requests for instance metadata as [described in the AWS cli user guide](https://github.com/awsdocs/aws-cli-user-guide/blob/a2393582590b64bd2a1d9978af15b350e1f9eb8e/doc_source/cli-configure-proxy.md#using-a-proxy-on-amazon-ec2-instances). Failing to do so can result in proxied or missing instance data.
 
+If the instance is part of AWS ParallelCluster and the detector is failing to connect to the metadata server, check the iptable and make sure the chain `PARALLELCLUSTER_IMDS` contains a rule that allows OTEL user to access `169.254.169.254/32`
+
 ### Amazon ECS
 
 Queries the [Task Metadata Endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html) (TMDE) to record information about the current ECS Task. Only TMDE V4 and V3 are supported.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Was debugging an issue where OTEL was failing to connect to the AWS metadata server, whereas manual curl was working.
However, running the curl command as the user running the OTEL process failed
```
su -s /bin/bash -c 'curl http://169.254.169.254/latest/meta-data/instance-id' <otel_user>
```
it turns out the EC2 instance in question is a node in a "parallel cluster" and AWS is adding an IPtable rule to block access to the metadata server and only allow it for root and 2 other users.
```
-A PARALLELCLUSTER_IMDS -d 169.254.169.254/32 -m owner --uid-owner 0 -j ACCEPT
-A PARALLELCLUSTER_IMDS -d 169.254.169.254/32 -m owner --uid-owner 400 -j ACCEPT
-A PARALLELCLUSTER_IMDS -d 169.254.169.254/32 -m owner --uid-owner 1000 -j ACCEPT
-A PARALLELCLUSTER_IMDS -d 169.254.169.254/32 -j REJECT --reject-with icmp-port-unreachable
```

https://github.com/aws/aws-parallelcluster-cookbook/blame/develop/cookbooks/aws-parallelcluster-config/files/default/imds/imds-access.sh#L105

Adding a rule to `PARALLELCLUSTER_IMDS` to allow <otel_user> access to the metadata server fixed the issue.

This PR improves the readme and cover this use case
**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
README updated