### PR TITLE
[processor/k8sattributes] Fix image name parsing

### DIFF
--- a/.chloggen/k8s-attrs-fix-image-tag-parsing.yaml
+++ b/.chloggen/k8s-attrs-fix-image-tag-parsing.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/k8sattributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix image name parsing when repository name contains a port number.
+
+# One or more tracking issues related to the change
+issues: [20239]

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -380,12 +380,16 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) map[string
 	if c.Rules.ContainerImageName || c.Rules.ContainerImageTag {
 		for _, spec := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
 			container := &Container{}
-			imageParts := strings.Split(spec.Image, ":")
+			nameTagSep := strings.LastIndex(spec.Image, ":")
 			if c.Rules.ContainerImageName {
-				container.ImageName = imageParts[0]
+				if nameTagSep > 0 {
+					container.ImageName = spec.Image[:nameTagSep]
+				} else {
+					container.ImageName = spec.Image
+				}
 			}
-			if c.Rules.ContainerImageTag && len(imageParts) > 1 {
-				container.ImageTag = imageParts[1]
+			if c.Rules.ContainerImageTag && nameTagSep > 0 {
+				container.ImageTag = spec.Image[nameTagSep+1:]
 			}
 			containers[spec.Name] = container
 		}

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -1040,7 +1040,7 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 				},
 				{
 					Name:  "container2",
-					Image: "test/image2:0.2.0",
+					Image: "example.com:port1/image2:0.2.0",
 				},
 			},
 			InitContainers: []api_v1.Container{
@@ -1102,7 +1102,7 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 			pod: pod,
 			want: map[string]*Container{
 				"container1":     {ImageName: "test/image1"},
-				"container2":     {ImageName: "test/image2"},
+				"container2":     {ImageName: "example.com:port1/image2"},
 				"init_container": {ImageName: "test/init-image"},
 			},
 		},
@@ -1166,7 +1166,7 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 					},
 				},
 				"container2": {
-					ImageName: "test/image2",
+					ImageName: "example.com:port1/image2",
 					ImageTag:  "0.2.0",
 					Statuses: map[int]ContainerStatus{
 						2: {ContainerID: "container2-id-456"},


### PR DESCRIPTION
Fix values of `container.image.name` and `container.image.tag` attributes when repository name contains a port number.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20239