### PR TITLE
Add pod config hash identifier

### DIFF
--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -91,6 +91,14 @@ func TestLoadConfig(t *testing.T) {
 						Sources: []PodAssociationSourceConfig{
 							{
 								From: "resource_attribute",
+								Name: "k8s.pod.confighash",
+							},
+						},
+					},
+					{
+						Sources: []PodAssociationSourceConfig{
+							{
+								From: "resource_attribute",
 								Name: "host.name",
 							},
 						},

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -438,6 +438,15 @@ func (c *WatchClient) podFromAPI(pod *api_v1.Pod) *Pod {
 		HostNetwork: pod.Spec.HostNetwork,
 		PodUID:      string(pod.UID),
 		StartTime:   pod.Status.StartTime,
+		PodConfigHash: func() string {
+			if len(pod.Annotations) == 0 {
+				return ""
+			}
+			if hash, ok := pod.Annotations[K8sConfigHashAnnotation]; ok {
+				return hash
+			}
+			return ""
+		}(),
 	}
 
 	if c.shouldIgnorePod(pod) {
@@ -489,6 +498,8 @@ func (c *WatchClient) getIdentifiersFromAssoc(pod *Pod) []PodIdentifier {
 				// k8s.pod.ip is set by passthrough mode
 				case K8sIPLabelName:
 					attr = pod.Address
+				case K8sConfigHashName:
+					attr = pod.PodConfigHash
 				default:
 					if v, ok := pod.Attributes[source.Name]; ok {
 						attr = v

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -86,6 +86,9 @@ func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj interfac
 	pod.Name = "podC"
 	pod.Status.PodIP = "2.2.2.2"
 	pod.UID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	pod.Annotations = map[string]string{
+		"kubernetes.io/config.hash": "e19c1283c925b3206685ff522acfe3e6",
+	}
 	handler(pod)
 	assert.Equal(t, 5, len(c.Pods))
 	got = c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "2.2.2.2")]
@@ -93,6 +96,10 @@ func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj interfac
 	assert.Equal(t, "podC", got.Name)
 	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", got.PodUID)
 	got = c.Pods[newPodIdentifier("resource_attribute", "k8s.pod.uid", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")]
+	assert.Equal(t, "2.2.2.2", got.Address)
+	assert.Equal(t, "podC", got.Name)
+	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", got.PodUID)
+	got = c.Pods[newPodIdentifier("resource_attribute", "k8s.pod.confighash", "e19c1283c925b3206685ff522acfe3e6")]
 	assert.Equal(t, "2.2.2.2", got.Address)
 	assert.Equal(t, "podC", got.Name)
 	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", got.PodUID)

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -39,9 +39,12 @@ const (
 	MetadataFromNamespace  = "namespace"
 	PodIdentifierMaxLength = 4
 
-	ResourceSource   = "resource_attribute"
-	ConnectionSource = "connection"
-	K8sIPLabelName   = "k8s.pod.ip"
+	ResourceSource    = "resource_attribute"
+	ConnectionSource  = "connection"
+	K8sIPLabelName    = "k8s.pod.ip"
+	K8sConfigHashName = "k8s.pod.confighash"
+
+	K8sConfigHashAnnotation = "kubernetes.io/config.hash"
 )
 
 // PodIdentifierAttribute represents AssociationSource with matching value for pod
@@ -111,14 +114,15 @@ type APIClientsetProvider func(config k8sconfig.APIConfig) (kubernetes.Interface
 
 // Pod represents a kubernetes pod.
 type Pod struct {
-	Name        string
-	Address     string
-	PodUID      string
-	Attributes  map[string]string
-	StartTime   *metav1.Time
-	Ignore      bool
-	Namespace   string
-	HostNetwork bool
+	Name          string
+	Address       string
+	PodUID        string
+	PodConfigHash string
+	Attributes    map[string]string
+	StartTime     *metav1.Time
+	Ignore        bool
+	Namespace     string
+	HostNetwork   bool
 
 	// Containers is a map of container name to Container struct.
 	Containers map[string]*Container

--- a/processor/k8sattributesprocessor/testdata/config.yaml
+++ b/processor/k8sattributesprocessor/testdata/config.yaml
@@ -62,6 +62,9 @@ k8sattributes/2:
         name: k8s.pod.ip
     - sources:
       - from: resource_attribute
+        name: k8s.pod.confighash
+    - sources:
+      - from: resource_attribute
         name: host.name
     - sources:
       - from: connection


### PR DESCRIPTION
**Description:**
This allows pods to be identified by their config hash.  This is required for static pods where it is impossible to extract the pod UID from the file path

**Link to tracking Issue:** #20231 

**Testing:** Have manually tested that this resolves the issue.  Have added tests equivalent to the Pod UID coverage

**Documentation:** If the owners agree this is a reasonable approach I will add documentation.