### PR TITLE
[chore] use pull_request_target instead

### DIFF
--- a/.github/workflows/milestone-add-to-pr.yml
+++ b/.github/workflows/milestone-add-to-pr.yml
@@ -3,13 +3,9 @@
 
 name: 'Project: Add PR to Milestone'
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
-
-permissions:
-  contents: read
-  pull-requests: write
 
 jobs:
   update-pr:


### PR DESCRIPTION
This solves the permissions issues of pull requests on remote forks.