### PR TITLE
[chore] add milestone rotation gh action

### DIFF
--- a/.github/workflows/milestone-add-to-pr.yml
+++ b/.github/workflows/milestone-add-to-pr.yml
@@ -1,5 +1,6 @@
 # This action adds the "next release" milestone to a pull request
-# when it is merged
+# when it is merged. The "next release" milestone is managed
+# by the "Project: Rotate Milestone" action.
 
 name: 'Project: Add PR to Milestone'
 on:

--- a/.github/workflows/milestone-rotate.yml
+++ b/.github/workflows/milestone-rotate.yml
@@ -1,0 +1,38 @@
+# This action updates the "next release" milestone
+# to the latest released version and creates a new milestone
+# named "next release" in its place
+
+name: 'Project: Rotate Milestone'
+on:
+  release:
+    types: [published]
+
+jobs:
+  rotate-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const milestones = await github.rest.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open"
+            })
+            for (const milestone of milestones.data) {
+              if (milestone.title == "next release") {
+                await github.rest.issues.updateMilestone({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  milestone_number: milestone.number,
+                  title: "${{ github.event.release.tag_name }}"
+                });
+                await github.rest.issues.createMilestone({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: "next release"
+                });
+                return
+              }
+            }
+          


### PR DESCRIPTION
This action triggers when a new release is published, updates the next release milestone to the title of the new release and creates a new next release milestone.
