### PR TITLE
[exporter/coralogixexporter] Make coralogixexporter default to gzip

### DIFF
--- a/.chloggen/coralogix-gzip.yaml
+++ b/.chloggen/coralogix-gzip.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: coralogixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Change coralogixexporter to default to gzip compression for logs and traces"
+
+# One or more tracking issues related to the change
+issues: [20337]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/coralogixexporter/config_test.go
+++ b/exporter/coralogixexporter/config_test.go
@@ -57,11 +57,12 @@ func TestLoadConfig(t *testing.T) {
 					WriteBufferSize: 512 * 1024,
 				},
 				Logs: configgrpc.GRPCClientSettings{
-					Endpoint: "https://",
+					Endpoint:    "https://",
+					Compression: "gzip",
 				},
 				Traces: configgrpc.GRPCClientSettings{
 					Endpoint:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					Compression: "",
+					Compression: "gzip",
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting:         configtls.TLSSetting{},
 						Insecure:           false,
@@ -74,8 +75,7 @@ func TestLoadConfig(t *testing.T) {
 					BalancerName:    "",
 				},
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
-					Endpoint:    "",
-					Compression: "",
+					Endpoint: "",
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting:         configtls.TLSSetting{},
 						Insecure:           false,
@@ -109,11 +109,12 @@ func TestLoadConfig(t *testing.T) {
 					WriteBufferSize: 512 * 1024,
 				},
 				Logs: configgrpc.GRPCClientSettings{
-					Endpoint: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+					Endpoint:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+					Compression: "gzip",
 				},
 				Traces: configgrpc.GRPCClientSettings{
 					Endpoint:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					Compression: "",
+					Compression: "gzip",
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting:         configtls.TLSSetting{},
 						Insecure:           false,
@@ -128,8 +129,7 @@ func TestLoadConfig(t *testing.T) {
 				AppNameAttributes:   []string{"service.namespace"},
 				SubSystemAttributes: []string{"service.name"},
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
-					Endpoint:    "",
-					Compression: "",
+					Endpoint: "",
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting:         configtls.TLSSetting{},
 						Insecure:           false,

--- a/exporter/coralogixexporter/factory.go
+++ b/exporter/coralogixexporter/factory.go
@@ -43,7 +43,8 @@ func createDefaultConfig() component.Config {
 		TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
 		// Traces GRPC client
 		Traces: configgrpc.GRPCClientSettings{
-			Endpoint: "https://",
+			Endpoint:    "https://",
+			Compression: configcompression.Gzip,
 		},
 		Metrics: configgrpc.GRPCClientSettings{
 			Endpoint: "https://",
@@ -52,7 +53,8 @@ func createDefaultConfig() component.Config {
 			WriteBufferSize: 512 * 1024,
 		},
 		Logs: configgrpc.GRPCClientSettings{
-			Endpoint: "https://",
+			Endpoint:    "https://",
+			Compression: configcompression.Gzip,
 		},
 		PrivateKey: "",
 		AppName:    "",


### PR DESCRIPTION
**Description:** 

Makes coralogixexporter use gzip for logs and traces

**Link to tracking Issue:** #20337 
**Testing:** <Describe what testing was performed and which tests were added.>

- Updated unit tests
- Manually tested the flow.

**Documentation:** <Describe the documentation added.>