### PR TITLE
Fix the "no data" error returned by HEC with compression enabled

### DIFF
--- a/.chloggen/fix-gzip-empty-bug.yaml
+++ b/.chloggen/fix-gzip-empty-bug.yaml
@@ -8,7 +8,7 @@ component: splunkhecexporter
 note: Add a check for gzip buffer before sending it to HEC
 
 # One or more tracking issues related to the change
-issues: [https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20290]
+issues: [20290]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-gzip-empty-bug.yaml
+++ b/.chloggen/fix-gzip-empty-bug.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: While sending empty data to Splunk with compression enabled, the gzip buffer will be at least 18 bytes (10-byte header + 0-byte payload + 8-byte footer), even if uncompressed data is of 0 bytes.
+HEC will return with '{\\\"text\\\":\\\"No data\\\",\\\"code\\\":5}'' if uncompressed data of 0 bytes is gzipped before sending to HEC. 
+The current check in the overall buffer, regardless of compression. So we need to add another check if compression is enabled.
+
+
+# One or more tracking issues related to the change
+issues: [https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20290]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/fix-gzip-empty-bug.yaml
+++ b/.chloggen/fix-gzip-empty-bug.yaml
@@ -5,10 +5,7 @@ change_type: bug_fix
 component: splunkhecexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: While sending empty data to Splunk with compression enabled, the gzip buffer will be at least 18 bytes (10-byte header + 0-byte payload + 8-byte footer), even if uncompressed data is of 0 bytes.
-HEC will return with '{\\\"text\\\":\\\"No data\\\",\\\"code\\\":5}'' if uncompressed data of 0 bytes is gzipped before sending to HEC. 
-The current check in the overall buffer, regardless of compression. So we need to add another check if compression is enabled.
-
+note: Add a check for gzip buffer before sending it to HEC
 
 # One or more tracking issues related to the change
 issues: [https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20290]
@@ -16,4 +13,6 @@ issues: [https://github.com/open-telemetry/opentelemetry-collector-contrib/issue
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: While sending empty data to Splunk with compression enabled, the gzip buffer will be at least 18 bytes (10-byte header + 0-byte payload + 8-byte footer), even if uncompressed data is of 0 bytes. |
+HEC will return with '{\\\"text\\\":\\\"No data\\\",\\\"code\\\":5}'' if uncompressed data of 0 bytes is gzipped before sending to HEC. |
+The current check in the overall buffer, regardless of compression. So we need to add another check if compression is enabled.

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -120,9 +120,8 @@ func isBufferEmpty(bufState *bufferState) bool {
 		// Splunk will return "No data" and reply_code=5 if it is empty.
 		_, err1 := io.CopyN(io.Discard, r, 1)
 		return errors.Is(err1, io.EOF)
-	} else {
-		return bufState.buf.Len() <= 0
 	}
+	return bufState.buf.Len() <= 0
 }
 
 // pushLogDataInBatches sends batches of Splunk events in JSON format.


### PR DESCRIPTION
**Description:** While sending empty data to Splunk with compression enabled, the gzip buffer will be at least 18 bytes (10-byte header + 0-byte payload + 8-byte footer), even if uncompressed data is of 0 bytes.
HEC will return with `{\\\"text\\\":\\\"No data\\\",\\\"code\\\":5}` if uncompressed data of 0 bytes is gzipped before sending to HEC.

**Link to tracking Issue:** [#20290](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20290)
