### PR TITLE
processor/k8sattributesprocessor: map containers by ID

### DIFF
--- a/.chloggen/gbbr_container-id.yaml
+++ b/.chloggen/gbbr_container-id.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributesprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow getting k8s.container.name, container.image.name and container.image.tag by container.id.
+
+# One or more tracking issues related to the change
+issues: [19468]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The container.id resource attribute can be set automatically in most SDKs by means of API.

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -59,15 +59,18 @@ You can change this list with `metadata` configuration.
 Not all the attributes are guaranteed to be added. Only attribute names from `metadata` should be used for 
 pod_association's `resource_attribute`, because empty or non-existing values will be ignored.
 
-The following container level attributes require additional attributes to identify a particular container in a pod:
-1. Container spec attributes - will be set only if container identifying attribute `k8s.container.name` is set
-   as a resource attribute (similar to all other attributes, pod has to be identified as well):
+Additional container level attributes can be extracted provided that certain resource attributes are provided:
+
+1. If the `container.id` resource attribute is provided, the following additional attributes will be available:
+   - k8s.container.name
    - container.image.name
    - container.image.tag
-2. Container attributes - in addition to pod identifier and `k8s.container.name` attribute, `k8s.container.restart_count` 
-   resource attribute is needed to get association with a particular container instance, but not required. 
-   If `k8s.container.restart_count` is not set, the latest container instance will be used:
-   - container.id (not added by default, have to be specified in `metadata`)
+2. If the `k8s.container.name` resource attribute is provided, the following additional attributes will be available:
+   - container.image.name
+   - container.image.tag
+3. If the `k8s.container.restart_count` resource attribute is provided, it can be used to associate with a particular container
+   instance. If it's not set, the latest container instance will be used:
+   - container.id (not added by default, has to be specified in `metadata`)
 
 The k8sattributesprocessor can also set resource attributes from k8s labels and annotations of pods and namespaces.
 The config for associating the data passing through the processor (spans, metrics and logs) with specific Pod/Namespace annotations/labels is configured via "annotations"  and "labels" keys.

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -75,8 +75,8 @@ type ExtractConfig struct {
 	//   k8s.daemonset.name, k8s.daemonset.uid,
 	//   k8s.job.name, k8s.job.uid, k8s.cronjob.name,
 	//   k8s.statefulset.name, k8s.statefulset.uid,
-	//   container.image.name, container.image.tag,
-	//   container.id
+	//   k8s.container.name, container.image.name,
+	//   container.image.tag, container.id
 	//
 	// Specifying anything other than these values will result in an error.
 	// By default, the following fields are extracted and added to spans, metrics and logs as attributes:
@@ -86,8 +86,9 @@ type ExtractConfig struct {
 	//  - k8s.namespace.name
 	//  - k8s.node.name
 	//  - k8s.deployment.name (if the pod is controlled by a deployment)
-	//  - container.image.name (requires an additional attribute to be set: k8s.container.name)
-	//  - container.image.tag (requires an additional attribute to be set: k8s.container.name)
+	//  - k8s.container.name (requires an additional attribute to be set: container.id)
+	//  - container.image.name (requires one of the following additional attributes to be set: container.id or k8s.container.name)
+	//  - container.image.tag (requires one of the following additional attributes to be set: container.id or k8s.container.name)
 	Metadata []string `mapstructure:"metadata"`
 
 	// Annotations allows extracting data from pod annotations and record it

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -388,10 +388,7 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 		}
 		return ""
 	}
-	switch {
-	case c.Rules.ContainerImageName,
-		c.Rules.ContainerImageTag,
-		c.Rules.ContainerName:
+	if c.Rules.ContainerImageName || c.Rules.ContainerImageTag || c.Rules.ContainerName {
 		for _, spec := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
 			container := &Container{Name: ifRule(c.Rules.ContainerName, spec.Name)}
 			nameTagSep := strings.LastIndex(spec.Image, ":")
@@ -663,12 +660,8 @@ func (c *WatchClient) extractNamespaceLabelsAnnotations() bool {
 }
 
 func needContainerAttributes(rules ExtractionRules) bool {
-	switch {
-	case rules.ContainerImageName,
-		rules.ContainerName,
-		rules.ContainerImageTag,
-		rules.ContainerID:
-		return true
-	}
-	return false
+	return rules.ContainerImageName ||
+		rules.ContainerName ||
+		rules.ContainerImageTag ||
+		rules.ContainerID
 }

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -382,15 +382,15 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 	if !needContainerAttributes(c.Rules) {
 		return containers
 	}
-	ifRule := func(rule bool, v string) string {
-		if rule {
-			return v
+	newContainer := func(name string) *Container {
+		if c.Rules.ContainerName {
+			return &Container{Name: name}
 		}
-		return ""
+		return &Container{}
 	}
 	if c.Rules.ContainerImageName || c.Rules.ContainerImageTag || c.Rules.ContainerName {
 		for _, spec := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
-			container := &Container{Name: ifRule(c.Rules.ContainerName, spec.Name)}
+			container := newContainer(spec.Name)
 			nameTagSep := strings.LastIndex(spec.Image, ":")
 			if c.Rules.ContainerImageName {
 				if nameTagSep > 0 {
@@ -408,7 +408,7 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 	for _, apiStatus := range append(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses...) {
 		container, ok := containers.ByName[apiStatus.Name]
 		if !ok {
-			container = &Container{Name: ifRule(c.Rules.ContainerName, apiStatus.Name)}
+			container = newContainer(apiStatus.Name)
 			containers.ByName[apiStatus.Name] = container
 		}
 		containerID := apiStatus.ContainerID

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -419,7 +419,6 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 		}
 		containers.ByID[containerID] = container
 		if c.Rules.ContainerID {
-			container.ID = containerID
 			if container.Statuses == nil {
 				container.Statuses = map[int]ContainerStatus{}
 			}

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -1144,19 +1144,16 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 			want: PodContainers{
 				ByID: map[string]*Container{
 					"container1-id-123": {
-						ID: "container1-id-123",
 						Statuses: map[int]ContainerStatus{
 							0: {ContainerID: "container1-id-123"},
 						},
 					},
 					"container2-id-456": {
-						ID: "container2-id-456",
 						Statuses: map[int]ContainerStatus{
 							2: {ContainerID: "container2-id-456"},
 						},
 					},
 					"init-container-id-123": {
-						ID: "init-container-id-123",
 						Statuses: map[int]ContainerStatus{
 							0: {ContainerID: "init-container-id-123"},
 						},
@@ -1164,19 +1161,16 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 				},
 				ByName: map[string]*Container{
 					"container1": {
-						ID: "container1-id-123",
 						Statuses: map[int]ContainerStatus{
 							0: {ContainerID: "container1-id-123"},
 						},
 					},
 					"container2": {
-						ID: "container2-id-456",
 						Statuses: map[int]ContainerStatus{
 							2: {ContainerID: "container2-id-456"},
 						},
 					},
 					"init_container": {
-						ID: "init-container-id-123",
 						Statuses: map[int]ContainerStatus{
 							0: {ContainerID: "init-container-id-123"},
 						},
@@ -1195,7 +1189,6 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 			want: PodContainers{
 				ByID: map[string]*Container{
 					"container1-id-123": {
-						ID:        "container1-id-123",
 						ImageName: "test/image1",
 						ImageTag:  "0.1.0",
 						Statuses: map[int]ContainerStatus{
@@ -1203,7 +1196,6 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 						},
 					},
 					"container2-id-456": {
-						ID:        "container2-id-456",
 						ImageName: "example.com:port1/image2",
 						ImageTag:  "0.2.0",
 						Statuses: map[int]ContainerStatus{
@@ -1211,7 +1203,6 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 						},
 					},
 					"init-container-id-123": {
-						ID:        "init-container-id-123",
 						ImageName: "test/init-image",
 						ImageTag:  "1.0.2",
 						Statuses: map[int]ContainerStatus{
@@ -1221,7 +1212,6 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 				},
 				ByName: map[string]*Container{
 					"container1": {
-						ID:        "container1-id-123",
 						ImageName: "test/image1",
 						ImageTag:  "0.1.0",
 						Statuses: map[int]ContainerStatus{
@@ -1229,7 +1219,6 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 						},
 					},
 					"container2": {
-						ID:        "container2-id-456",
 						ImageName: "example.com:port1/image2",
 						ImageTag:  "0.2.0",
 						Statuses: map[int]ContainerStatus{
@@ -1237,7 +1226,6 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 						},
 					},
 					"init_container": {
-						ID:        "init-container-id-123",
 						ImageName: "test/init-image",
 						ImageTag:  "1.0.2",
 						Statuses: map[int]ContainerStatus{

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -1076,7 +1076,7 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 		name  string
 		rules ExtractionRules
 		pod   api_v1.Pod
-		want  map[string]*Container
+		want  PodContainers
 	}{
 		{
 			name: "no-data",
@@ -1086,13 +1086,13 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 				ContainerID:        true,
 			},
 			pod:  api_v1.Pod{},
-			want: map[string]*Container{},
+			want: PodContainers{ByID: map[string]*Container{}, ByName: map[string]*Container{}},
 		},
 		{
 			name:  "no-rules",
 			rules: ExtractionRules{},
 			pod:   pod,
-			want:  map[string]*Container{},
+			want:  PodContainers{ByID: map[string]*Container{}, ByName: map[string]*Container{}},
 		},
 		{
 			name: "image-name-only",
@@ -1100,10 +1100,17 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 				ContainerImageName: true,
 			},
 			pod: pod,
-			want: map[string]*Container{
-				"container1":     {ImageName: "test/image1"},
-				"container2":     {ImageName: "example.com:port1/image2"},
-				"init_container": {ImageName: "test/init-image"},
+			want: PodContainers{
+				ByID: map[string]*Container{
+					"container1-id-123":     {ImageName: "test/image1"},
+					"container2-id-456":     {ImageName: "example.com:port1/image2"},
+					"init-container-id-123": {ImageName: "test/init-image"},
+				},
+				ByName: map[string]*Container{
+					"container1":     {ImageName: "test/image1"},
+					"container2":     {ImageName: "example.com:port1/image2"},
+					"init_container": {ImageName: "test/init-image"},
+				},
 			},
 		},
 		{
@@ -1121,8 +1128,11 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]*Container{
-				"test-container": {ImageName: "test/image"},
+			want: PodContainers{
+				ByID: map[string]*Container{},
+				ByName: map[string]*Container{
+					"test-container": {ImageName: "test/image"},
+				},
 			},
 		},
 		{
@@ -1131,20 +1141,45 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 				ContainerID: true,
 			},
 			pod: pod,
-			want: map[string]*Container{
-				"container1": {
-					Statuses: map[int]ContainerStatus{
-						0: {ContainerID: "container1-id-123"},
+			want: PodContainers{
+				ByID: map[string]*Container{
+					"container1-id-123": {
+						ID: "container1-id-123",
+						Statuses: map[int]ContainerStatus{
+							0: {ContainerID: "container1-id-123"},
+						},
+					},
+					"container2-id-456": {
+						ID: "container2-id-456",
+						Statuses: map[int]ContainerStatus{
+							2: {ContainerID: "container2-id-456"},
+						},
+					},
+					"init-container-id-123": {
+						ID: "init-container-id-123",
+						Statuses: map[int]ContainerStatus{
+							0: {ContainerID: "init-container-id-123"},
+						},
 					},
 				},
-				"container2": {
-					Statuses: map[int]ContainerStatus{
-						2: {ContainerID: "container2-id-456"},
+				ByName: map[string]*Container{
+					"container1": {
+						ID: "container1-id-123",
+						Statuses: map[int]ContainerStatus{
+							0: {ContainerID: "container1-id-123"},
+						},
 					},
-				},
-				"init_container": {
-					Statuses: map[int]ContainerStatus{
-						0: {ContainerID: "init-container-id-123"},
+					"container2": {
+						ID: "container2-id-456",
+						Statuses: map[int]ContainerStatus{
+							2: {ContainerID: "container2-id-456"},
+						},
+					},
+					"init_container": {
+						ID: "init-container-id-123",
+						Statuses: map[int]ContainerStatus{
+							0: {ContainerID: "init-container-id-123"},
+						},
 					},
 				},
 			},
@@ -1157,26 +1192,57 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 				ContainerID:        true,
 			},
 			pod: pod,
-			want: map[string]*Container{
-				"container1": {
-					ImageName: "test/image1",
-					ImageTag:  "0.1.0",
-					Statuses: map[int]ContainerStatus{
-						0: {ContainerID: "container1-id-123"},
+			want: PodContainers{
+				ByID: map[string]*Container{
+					"container1-id-123": {
+						ID:        "container1-id-123",
+						ImageName: "test/image1",
+						ImageTag:  "0.1.0",
+						Statuses: map[int]ContainerStatus{
+							0: {ContainerID: "container1-id-123"},
+						},
+					},
+					"container2-id-456": {
+						ID:        "container2-id-456",
+						ImageName: "example.com:port1/image2",
+						ImageTag:  "0.2.0",
+						Statuses: map[int]ContainerStatus{
+							2: {ContainerID: "container2-id-456"},
+						},
+					},
+					"init-container-id-123": {
+						ID:        "init-container-id-123",
+						ImageName: "test/init-image",
+						ImageTag:  "1.0.2",
+						Statuses: map[int]ContainerStatus{
+							0: {ContainerID: "init-container-id-123"},
+						},
 					},
 				},
-				"container2": {
-					ImageName: "example.com:port1/image2",
-					ImageTag:  "0.2.0",
-					Statuses: map[int]ContainerStatus{
-						2: {ContainerID: "container2-id-456"},
+				ByName: map[string]*Container{
+					"container1": {
+						ID:        "container1-id-123",
+						ImageName: "test/image1",
+						ImageTag:  "0.1.0",
+						Statuses: map[int]ContainerStatus{
+							0: {ContainerID: "container1-id-123"},
+						},
 					},
-				},
-				"init_container": {
-					ImageName: "test/init-image",
-					ImageTag:  "1.0.2",
-					Statuses: map[int]ContainerStatus{
-						0: {ContainerID: "init-container-id-123"},
+					"container2": {
+						ID:        "container2-id-456",
+						ImageName: "example.com:port1/image2",
+						ImageTag:  "0.2.0",
+						Statuses: map[int]ContainerStatus{
+							2: {ContainerID: "container2-id-456"},
+						},
+					},
+					"init_container": {
+						ID:        "init-container-id-123",
+						ImageName: "test/init-image",
+						ImageTag:  "1.0.2",
+						Statuses: map[int]ContainerStatus{
+							0: {ContainerID: "init-container-id-123"},
+						},
 					},
 				},
 			},

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -120,14 +120,24 @@ type Pod struct {
 	Namespace   string
 	HostNetwork bool
 
-	// Containers is a map of container name to Container struct.
-	Containers map[string]*Container
+	// Containers specifies all containers in this pod.
+	Containers PodContainers
 
 	DeletedAt time.Time
 }
 
+// PodContainers specifies a list of pod containers. It is not safe for concurrent use.
+type PodContainers struct {
+	// ByID specifies all containers in a pod by container ID.
+	ByID map[string]*Container
+	// ByName specifies all containers in a pod by container name (k8s.container.name).
+	ByName map[string]*Container
+}
+
 // Container stores resource attributes for a specific container defined by k8s pod spec.
 type Container struct {
+	ID        string
+	Name      string
 	ImageName string
 	ImageTag  string
 
@@ -200,6 +210,7 @@ type ExtractionRules struct {
 	StatefulSetName    bool
 	Node               bool
 	StartTime          bool
+	ContainerName      bool
 	ContainerID        bool
 	ContainerImageName bool
 	ContainerImageTag  bool

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -136,7 +136,6 @@ type PodContainers struct {
 
 // Container stores resource attributes for a specific container defined by k8s pod spec.
 type Container struct {
-	ID        string
 	Name      string
 	ImageName string
 	ImageTag  string

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -99,6 +99,8 @@ func withExtractMetadata(fields ...string) option {
 				p.rules.StatefulSetName = true
 			case conventions.AttributeK8SStatefulSetUID:
 				p.rules.StatefulSetUID = true
+			case conventions.AttributeK8SContainerName:
+				p.rules.ContainerName = true
 			case conventions.AttributeK8SJobName:
 				p.rules.JobName = true
 			case conventions.AttributeK8SJobUID:

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -170,22 +170,18 @@ func (kp *kubernetesprocessor) addContainerAttributes(attrs pcommon.Map, pod *ku
 	default:
 		return
 	}
-	// addIfAbsent reports whether it has added the value v to the resource attribute k.
-	// It is false when v is empty or k is already set.
-	addIfAbsent := func(k, v string) bool {
-		if v == "" {
-			return false
-		}
-		if _, ok := attrs.Get(k); ok {
-			return false
-		}
-		attrs.PutStr(k, v)
-		return true
+	if _, ok := attrs.Get(conventions.AttributeK8SContainerName); !ok && containerSpec.Name != "" {
+		attrs.PutStr(conventions.AttributeK8SContainerName, containerSpec.Name)
 	}
-	addIfAbsent(conventions.AttributeK8SContainerName, containerSpec.Name)
-	addIfAbsent(conventions.AttributeContainerImageName, containerSpec.ImageName)
-	addIfAbsent(conventions.AttributeContainerImageTag, containerSpec.ImageTag)
-	if !addIfAbsent(conventions.AttributeContainerID, containerSpec.ID) {
+	if _, ok := attrs.Get(conventions.AttributeContainerImageName); !ok && containerSpec.ImageName != "" {
+		attrs.PutStr(conventions.AttributeContainerImageName, containerSpec.ImageName)
+	}
+	if _, ok := attrs.Get(conventions.AttributeContainerImageTag); !ok && containerSpec.ImageTag != "" {
+		attrs.PutStr(conventions.AttributeContainerImageTag, containerSpec.ImageTag)
+	}
+	if _, ok := attrs.Get(conventions.AttributeContainerID); !ok && containerSpec.ID != "" {
+		attrs.PutStr(conventions.AttributeContainerID, containerSpec.ID)
+	} else {
 		// attempt to get container ID from restart count
 		runID := -1
 		runIDAttr, ok := attrs.Get(conventions.AttributeK8SContainerRestartCount)

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -171,17 +171,17 @@ func (kp *kubernetesprocessor) addContainerAttributes(attrs pcommon.Map, pod *ku
 		return
 	}
 	if containerSpec.Name != "" {
-		if _, ok := attrs.Get(conventions.AttributeK8SContainerName); !ok {
+		if _, found := attrs.Get(conventions.AttributeK8SContainerName); !found {
 			attrs.PutStr(conventions.AttributeK8SContainerName, containerSpec.Name)
 		}
 	}
 	if containerSpec.ImageName != "" {
-		if _, ok := attrs.Get(conventions.AttributeContainerImageName); !ok {
+		if _, found := attrs.Get(conventions.AttributeContainerImageName); !found {
 			attrs.PutStr(conventions.AttributeContainerImageName, containerSpec.ImageName)
 		}
 	}
 	if containerSpec.ImageTag != "" {
-		if _, ok := attrs.Get(conventions.AttributeContainerImageTag); !ok {
+		if _, found := attrs.Get(conventions.AttributeContainerImageTag); !found {
 			attrs.PutStr(conventions.AttributeContainerImageTag, containerSpec.ImageTag)
 		}
 	}

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -774,7 +774,6 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 					Containers: kube.PodContainers{
 						ByName: map[string]*kube.Container{
 							"app": {
-								ID:        "767dc30d4fece77038e8ec2585a33471944d0b754659af7aa7e101181418f0dd",
 								Name:      "app",
 								ImageName: "test/app",
 								ImageTag:  "1.0.1",
@@ -789,7 +788,6 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 			},
 			wantAttrs: map[string]string{
 				conventions.AttributeK8SPodUID:          "19f651bc-73e4-410f-b3e9-f0241679d3b8",
-				conventions.AttributeContainerID:        "767dc30d4fece77038e8ec2585a33471944d0b754659af7aa7e101181418f0dd",
 				conventions.AttributeK8SContainerName:   "app",
 				conventions.AttributeContainerImageName: "test/app",
 				conventions.AttributeContainerImageTag:  "1.0.1",
@@ -813,7 +811,6 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 					Containers: kube.PodContainers{
 						ByID: map[string]*kube.Container{
 							"767dc30d4fece77038e8ec2585a33471944d0b754659af7aa7e101181418f0dd": {
-								ID:        "767dc30d4fece77038e8ec2585a33471944d0b754659af7aa7e101181418f0dd",
 								Name:      "app",
 								ImageName: "test/app",
 								ImageTag:  "1.0.1",

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -308,6 +308,12 @@ func withContainerName(containerName string) generateResourceFunc {
 	}
 }
 
+func withContainerID(id string) generateResourceFunc {
+	return func(res pcommon.Resource) {
+		res.Attributes().PutStr(conventions.AttributeContainerID, id)
+	}
+}
+
 func withContainerRunID(containerRunID string) generateResourceFunc {
 	return func(res pcommon.Resource) {
 		res.Attributes().PutStr(conventions.AttributeK8SContainerRestartCount, containerRunID)
@@ -751,6 +757,84 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 		wantAttrs    map[string]string
 	}{
 		{
+			name: "all-by-name",
+			op: func(kp *kubernetesprocessor) {
+				kp.podAssociations = []kube.Association{
+					{
+						Name: "k8s.pod.uid",
+						Sources: []kube.AssociationSource{
+							{
+								From: "resource_attribute",
+								Name: "k8s.pod.uid",
+							},
+						},
+					},
+				}
+				kp.kc.(*fakeClient).Pods[newPodIdentifier("resource_attribute", "k8s.pod.uid", "19f651bc-73e4-410f-b3e9-f0241679d3b8")] = &kube.Pod{
+					Containers: kube.PodContainers{
+						ByName: map[string]*kube.Container{
+							"app": {
+								ID:        "767dc30d4fece77038e8ec2585a33471944d0b754659af7aa7e101181418f0dd",
+								Name:      "app",
+								ImageName: "test/app",
+								ImageTag:  "1.0.1",
+							},
+						},
+					},
+				}
+			},
+			resourceGens: []generateResourceFunc{
+				withPodUID("19f651bc-73e4-410f-b3e9-f0241679d3b8"),
+				withContainerName("app"),
+			},
+			wantAttrs: map[string]string{
+				conventions.AttributeK8SPodUID:          "19f651bc-73e4-410f-b3e9-f0241679d3b8",
+				conventions.AttributeContainerID:        "767dc30d4fece77038e8ec2585a33471944d0b754659af7aa7e101181418f0dd",
+				conventions.AttributeK8SContainerName:   "app",
+				conventions.AttributeContainerImageName: "test/app",
+				conventions.AttributeContainerImageTag:  "1.0.1",
+			},
+		},
+		{
+			name: "all-by-id",
+			op: func(kp *kubernetesprocessor) {
+				kp.podAssociations = []kube.Association{
+					{
+						Name: "k8s.pod.uid",
+						Sources: []kube.AssociationSource{
+							{
+								From: "resource_attribute",
+								Name: "k8s.pod.uid",
+							},
+						},
+					},
+				}
+				kp.kc.(*fakeClient).Pods[newPodIdentifier("resource_attribute", "k8s.pod.uid", "19f651bc-73e4-410f-b3e9-f0241679d3b8")] = &kube.Pod{
+					Containers: kube.PodContainers{
+						ByID: map[string]*kube.Container{
+							"767dc30d4fece77038e8ec2585a33471944d0b754659af7aa7e101181418f0dd": {
+								ID:        "767dc30d4fece77038e8ec2585a33471944d0b754659af7aa7e101181418f0dd",
+								Name:      "app",
+								ImageName: "test/app",
+								ImageTag:  "1.0.1",
+							},
+						},
+					},
+				}
+			},
+			resourceGens: []generateResourceFunc{
+				withPodUID("19f651bc-73e4-410f-b3e9-f0241679d3b8"),
+				withContainerID("767dc30d4fece77038e8ec2585a33471944d0b754659af7aa7e101181418f0dd"),
+			},
+			wantAttrs: map[string]string{
+				conventions.AttributeK8SPodUID:          "19f651bc-73e4-410f-b3e9-f0241679d3b8",
+				conventions.AttributeContainerID:        "767dc30d4fece77038e8ec2585a33471944d0b754659af7aa7e101181418f0dd",
+				conventions.AttributeK8SContainerName:   "app",
+				conventions.AttributeContainerImageName: "test/app",
+				conventions.AttributeContainerImageTag:  "1.0.1",
+			},
+		},
+		{
 			name: "image-only",
 			op: func(kp *kubernetesprocessor) {
 				kp.podAssociations = []kube.Association{
@@ -765,10 +849,12 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 					},
 				}
 				kp.kc.(*fakeClient).Pods[newPodIdentifier("resource_attribute", "k8s.pod.uid", "19f651bc-73e4-410f-b3e9-f0241679d3b8")] = &kube.Pod{
-					Containers: map[string]*kube.Container{
-						"app": {
-							ImageName: "test/app",
-							ImageTag:  "1.0.1",
+					Containers: kube.PodContainers{
+						ByName: map[string]*kube.Container{
+							"app": {
+								ImageName: "test/app",
+								ImageTag:  "1.0.1",
+							},
 						},
 					},
 				}
@@ -788,11 +874,13 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 			name: "container-id-only",
 			op: func(kp *kubernetesprocessor) {
 				kp.kc.(*fakeClient).Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")] = &kube.Pod{
-					Containers: map[string]*kube.Container{
-						"app": {
-							Statuses: map[int]kube.ContainerStatus{
-								0: {ContainerID: "fcd58c97330c1dc6615bd520031f6a703a7317cd92adc96013c4dd57daad0b5f"},
-								1: {ContainerID: "6a7f1a598b5dafec9c193f8f8d63f6e5839b8b0acd2fe780f94285e26c05580e"},
+					Containers: kube.PodContainers{
+						ByName: map[string]*kube.Container{
+							"app": {
+								Statuses: map[int]kube.ContainerStatus{
+									0: {ContainerID: "fcd58c97330c1dc6615bd520031f6a703a7317cd92adc96013c4dd57daad0b5f"},
+									1: {ContainerID: "6a7f1a598b5dafec9c193f8f8d63f6e5839b8b0acd2fe780f94285e26c05580e"},
+								},
 							},
 						},
 					},
@@ -814,12 +902,14 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 			name: "container-id-latest",
 			op: func(kp *kubernetesprocessor) {
 				kp.kc.(*fakeClient).Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")] = &kube.Pod{
-					Containers: map[string]*kube.Container{
-						"app": {
-							Statuses: map[int]kube.ContainerStatus{
-								0: {ContainerID: "fcd58c97330c1dc6615bd520031f6a703a7317cd92adc96013c4dd57daad0b5f"},
-								1: {ContainerID: "6a7f1a598b5dafec9c193f8f8d63f6e5839b8b0acd2fe780f94285e26c05580e"},
-								2: {ContainerID: "5ba4e0e5a5eb1f37bc6e7fc76495914400a3ee309d8828d16407e4b3d5410848"},
+					Containers: kube.PodContainers{
+						ByName: map[string]*kube.Container{
+							"app": {
+								Statuses: map[int]kube.ContainerStatus{
+									0: {ContainerID: "fcd58c97330c1dc6615bd520031f6a703a7317cd92adc96013c4dd57daad0b5f"},
+									1: {ContainerID: "6a7f1a598b5dafec9c193f8f8d63f6e5839b8b0acd2fe780f94285e26c05580e"},
+									2: {ContainerID: "5ba4e0e5a5eb1f37bc6e7fc76495914400a3ee309d8828d16407e4b3d5410848"},
+								},
 							},
 						},
 					},
@@ -839,12 +929,14 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 			name: "container-name-mismatch",
 			op: func(kp *kubernetesprocessor) {
 				kp.kc.(*fakeClient).Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")] = &kube.Pod{
-					Containers: map[string]*kube.Container{
-						"app": {
-							ImageName: "test/app",
-							ImageTag:  "1.0.1",
-							Statuses: map[int]kube.ContainerStatus{
-								0: {ContainerID: "fcd58c97330c1dc6615bd520031f6a703a7317cd92adc96013c4dd57daad0b5f"},
+					Containers: kube.PodContainers{
+						ByName: map[string]*kube.Container{
+							"app": {
+								ImageName: "test/app",
+								ImageTag:  "1.0.1",
+								Statuses: map[int]kube.ContainerStatus{
+									0: {ContainerID: "fcd58c97330c1dc6615bd520031f6a703a7317cd92adc96013c4dd57daad0b5f"},
+								},
 							},
 						},
 					},
@@ -865,11 +957,13 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 			name: "container-run-id-mismatch",
 			op: func(kp *kubernetesprocessor) {
 				kp.kc.(*fakeClient).Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")] = &kube.Pod{
-					Containers: map[string]*kube.Container{
-						"app": {
-							ImageName: "test/app",
-							Statuses: map[int]kube.ContainerStatus{
-								0: {ContainerID: "fcd58c97330c1dc6615bd520031f6a703a7317cd92adc96013c4dd57daad0b5f"},
+					Containers: kube.PodContainers{
+						ByName: map[string]*kube.Container{
+							"app": {
+								ImageName: "test/app",
+								Statuses: map[int]kube.ContainerStatus{
+									0: {ContainerID: "fcd58c97330c1dc6615bd520031f6a703a7317cd92adc96013c4dd57daad0b5f"},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
This change allows the user (or SDK) sent [`container.id`](https://github.com/open-telemetry/opentelemetry-go/blob/sdk/v1.14.0/sdk/resource/config.go#L188-L201) to be picked up by the processor and used to identify container attributes. As a result, it is now possible to obtain the `k8s.container.name` attribute (along with the `container.image.{name,tag}` pair) more easily and in line with the SDK API.

Closes #19468 