### PR TITLE
[chore] [receiver/solacereceiver] Fixed a few flaky tests in receiver/solacereceiver

### DIFF
--- a/receiver/solacereceiver/receiver_test.go
+++ b/receiver/solacereceiver/receiver_test.go
@@ -352,7 +352,7 @@ func TestReceiverFlowControlDelayedRetry(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			receiver, messagingService, unmarshaller := newReceiver(t)
-			delay := 5 * time.Millisecond
+			delay := 50 * time.Millisecond
 			// Increase delay on windows due to tick granularity
 			// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17197
 			if runtime.GOOS == "windows" {
@@ -461,7 +461,12 @@ func TestReceiverFlowControlDelayedRetryInterrupt(t *testing.T) {
 func TestReceiverFlowControlDelayedRetryMultipleRetries(t *testing.T) {
 	receiver, messagingService, unmarshaller := newReceiver(t)
 	// we won't wait 10 seconds since we will interrupt well before
-	retryInterval := 20 * time.Millisecond
+	retryInterval := 50 * time.Millisecond
+	// Increase delay on windows due to tick granularity
+	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19409
+	if runtime.GOOS == "windows" {
+		retryInterval = 500 * time.Millisecond
+	}
 	var retryCount int64 = 5
 	receiver.config.Flow.DelayedRetry.Delay = retryInterval
 	var err error


### PR DESCRIPTION
Fixes #19409. Also addresses the reopening of #17197 which duplicates #19409

**Description:** Addresses a couple of test failures with two main problems:
1. Addressed an issue where on windows the timer window was too small to get within a scheduling tick. Upped the timeout in this case.
2. Addressed a cache coherency issue with callbacks on mock transports. Replaced callbacks with atomic unsafe.Pointers. 

**Link to tracking Issue:** #19409 

**Testing:** Fixed some flaky tests

**Documentation:** N/A

FYI @dmitryax @djaglowski 