### PR TITLE
signalfxexporter: add missing idle system.cpu.time default exclusion

### DIFF
--- a/.chloggen/sfxexporterexcludeidle.yaml
+++ b/.chloggen/sfxexporterexcludeidle.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes undesired default reporting of per-core system.cpu.time for idle states.
+
+# One or more tracking issues related to the change
+issues: [20354]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/signalfxexporter/internal/translation/default_metrics.go
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.go
@@ -49,7 +49,7 @@ exclude_metrics:
 # CPU Metrics.
 - metric_name: system.cpu.time
   dimensions:
-    state: [interrupt, nice, softirq, steal, system, user, wait]
+    state: [idle, interrupt, nice, softirq, steal, system, user, wait]
 
 - metric_name: cpu.idle
   dimensions:


### PR DESCRIPTION
**Description:**
Fixing a bug - These changes add the `idle` state for `system.cpu.time` to the default exclusion rules that are preventing it from being excluded like all others.

**Testing:**
Added a default cpu metrics test.