### PR TITLE
[receiver/mongodbatlas] Change default collection interval to 3 minutes

### DIFF
--- a/.chloggen/mongodbatlas-collection-interval-default-change.yaml
+++ b/.chloggen/mongodbatlas-collection-interval-default-change.yaml
@@ -13,4 +13,4 @@ issues: [18032]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Some metrics were returning null with smaller windows
+subtext: Default collection interval is now 3 minutes.

--- a/.chloggen/mongodbatlas-collection-interval-default-change.yaml
+++ b/.chloggen/mongodbatlas-collection-interval-default-change.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: mongodbatlasreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fixes issue where default collection interval of 1 minute was not properly collecting all metrics.
+note: Fix issue where default collection interval of 1 minute was too short to collect several metrics.
 
 # One or more tracking issues related to the change
 issues: [18032]

--- a/.chloggen/mongodbatlas-collection-interval-default-change.yaml
+++ b/.chloggen/mongodbatlas-collection-interval-default-change.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbatlasreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes issue where default collection interval of 1 minute was not properly collecting all metrics.
+
+# One or more tracking issues related to the change
+issues: [18032]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Some metrics were returning null with smaller windows

--- a/receiver/mongodbatlasreceiver/README.md
+++ b/receiver/mongodbatlasreceiver/README.md
@@ -24,6 +24,7 @@ MongoDB Atlas [Documentation](https://www.mongodb.com/docs/atlas/reference/api/l
 - `public_key` (required for metrics, logs, or alerts in `poll` mode)
 - `private_key` (required for metrics, logs, or alerts in `poll` mode)
 - `granularity` (default `PT1M` - See [MongoDB Atlas Documentation](https://docs.atlas.mongodb.com/reference/api/process-measurements/))
+- `collection_interval` (default `3m`) This receiver collects metrics on an interval. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
 - `storage` (optional) The component ID of a storage extension which can be used when polling for `alerts` or `events` . The storage extension prevents duplication of data after a collector restart by remembering which data were previously collected.
 - `retry_on_failure`
   - `enabled` (default true)

--- a/receiver/mongodbatlasreceiver/factory.go
+++ b/receiver/mongodbatlasreceiver/factory.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -99,7 +100,7 @@ func createCombinedLogReceiver(
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{
+	c := &Config{
 		ScraperControllerSettings: scraperhelper.NewDefaultScraperControllerSettings(typeStr),
 		Granularity:               defaultGranularity,
 		RetrySettings:             exporterhelper.NewDefaultRetrySettings(),
@@ -116,4 +117,8 @@ func createDefaultConfig() component.Config {
 			Projects: []*ProjectConfig{},
 		},
 	}
+	// reset default of 1 minute to be 3 minutes in order to avoid null values for some metrics that do not publish
+	// more frequently
+	c.ScraperControllerSettings.CollectionInterval = 3 * time.Minute
+	return c
 }

--- a/receiver/mongodbatlasreceiver/receiver_test.go
+++ b/receiver/mongodbatlasreceiver/receiver_test.go
@@ -28,6 +28,7 @@ import (
 func TestDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
+	require.Equal(t, cfg.(*Config).ScraperControllerSettings.CollectionInterval, 3*time.Minute)
 	recv, err := createMetricsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, recv, "receiver creation failed")


### PR DESCRIPTION
**Description:** Changes default `collection_interval` to be 3 minutes 

**Link to tracking Issue:** Resolves #18032

**Testing:** Added simple test

**Documentation:** List the parameter as modifiable in the README.md documentation