### PR TITLE
[receiver/file] enable file receiver

### DIFF
--- a/.chloggen/fr-enable.yaml
+++ b/.chloggen/fr-enable.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: This change enables the file receiver.
+
+# One or more tracking issues related to the change
+issues: [14638]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -126,6 +126,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver v0.77.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.77.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver v0.77.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filereceiver v0.77.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver v0.77.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.77.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.77.0
@@ -333,6 +334,7 @@ replaces:
   - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver => ../../receiver/mongodbreceiver
   - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite => ../../pkg/translator/prometheusremotewrite
   - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver => ../../receiver/filelogreceiver
+  - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filereceiver => ../../receiver/filereceiver
   - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter => ../../exporter/signalfxexporter
   - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/solacereceiver => ../../receiver/solacereceiver
   - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver => ../../receiver/iisreceiver

--- a/cmd/otelcontribcol/components.go
+++ b/cmd/otelcontribcol/components.go
@@ -126,6 +126,7 @@ import (
 	elasticsearchreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver"
 	expvarreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver"
 	filelogreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
+	filereceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filereceiver"
 	filestatsreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver"
 	flinkmetricsreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver"
 	fluentforwardreceiver "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver"
@@ -239,6 +240,7 @@ func components() (otelcol.Factories, error) {
 		expvarreceiver.NewFactory(),
 		filelogreceiver.NewFactory(),
 		filestatsreceiver.NewFactory(),
+		filereceiver.NewFactory(),
 		flinkmetricsreceiver.NewFactory(),
 		fluentforwardreceiver.NewFactory(),
 		googlecloudpubsubreceiver.NewFactory(),

--- a/cmd/otelcontribcol/exporters_test.go
+++ b/cmd/otelcontribcol/exporters_test.go
@@ -85,8 +85,8 @@ func TestDefaultExporters(t *testing.T) {
 	endpoint := testutil.GetAvailableLocalAddress(t)
 
 	tests := []struct {
-		exporter      component.Type
 		getConfigFn   getExporterConfigFn
+		exporter      component.Type
 		skipLifecycle bool
 	}{
 		{

--- a/cmd/otelcontribcol/extensions_test.go
+++ b/cmd/otelcontribcol/extensions_test.go
@@ -60,8 +60,8 @@ func TestDefaultExtensions(t *testing.T) {
 	endpoint := testutil.GetAvailableLocalAddress(t)
 
 	tests := []struct {
-		extension     component.Type
 		getConfigFn   getExtensionConfigFn
+		extension     component.Type
 		skipLifecycle bool
 	}{
 		{

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -115,6 +115,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver v0.77.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver v0.77.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.77.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filereceiver v0.77.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver v0.77.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver v0.77.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.77.0
@@ -946,6 +947,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongo
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite => ../../pkg/translator/prometheusremotewrite
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver => ../../receiver/filelogreceiver
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filereceiver => ../../receiver/filereceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter => ../../exporter/signalfxexporter
 

--- a/cmd/otelcontribcol/processors_test.go
+++ b/cmd/otelcontribcol/processors_test.go
@@ -45,8 +45,8 @@ func TestDefaultProcessors(t *testing.T) {
 	procFactories := allFactories.Processors
 
 	tests := []struct {
-		processor     component.Type
 		getConfigFn   getProcessorConfigFn
+		processor     component.Type
 		skipLifecycle bool
 	}{
 		{

--- a/cmd/otelcontribcol/receivers_test.go
+++ b/cmd/otelcontribcol/receivers_test.go
@@ -58,9 +58,9 @@ func TestDefaultReceivers(t *testing.T) {
 	rcvrFactories := allFactories.Receivers
 
 	tests := []struct {
+		getConfigFn  getReceiverConfigFn
 		receiver     component.Type
 		skipLifecyle bool
-		getConfigFn  getReceiverConfigFn
 	}{
 		{
 			receiver:     "active_directory_ds",
@@ -182,6 +182,10 @@ func TestDefaultReceivers(t *testing.T) {
 				cfg.InputConfig.Include = []string{filepath.Join(t.TempDir(), "*")}
 				return cfg
 			},
+		},
+		{
+			receiver:     "file",
+			skipLifecyle: true, // Requires an existing JSONL file
 		},
 		{
 			receiver: "filestats",

--- a/receiver/filereceiver/receiver.go
+++ b/receiver/filereceiver/receiver.go
@@ -28,9 +28,9 @@ import (
 
 type fileReceiver struct {
 	consumer consumer.Metrics
-	path     string
 	logger   *zap.Logger
 	cancel   context.CancelFunc
+	path     string
 	throttle float64
 }
 

--- a/receiver/filereceiver/receiver_test.go
+++ b/receiver/filereceiver/receiver_test.go
@@ -46,8 +46,8 @@ func TestReceiver(t *testing.T) {
 }
 
 type testConsumer struct {
-	mu       sync.Mutex
 	consumed []pmetric.Metrics
+	mu       sync.Mutex
 }
 
 func (c *testConsumer) Capabilities() consumer.Capabilities {

--- a/receiver/filereceiver/replay_timer.go
+++ b/receiver/filereceiver/replay_timer.go
@@ -23,9 +23,9 @@ import (
 )
 
 type replayTimer struct {
-	prev      pcommon.Timestamp
-	throttle  float64 // set to 1.0 to replay at same speed, 2.0 for half speed, etc.
 	sleepFunc func(ctx context.Context, d time.Duration) error
+	prev      pcommon.Timestamp
+	throttle  float64
 }
 
 func newReplayTimer(throttle float64) *replayTimer {


### PR DESCRIPTION
**Description:** This change enables the file receiver, which is still in development, but can already be used to replay JSON metrics.

**Link to tracking Issue:** #14638

**Testing:** Manually tested in a simple pipeline.

**Documentation:** README had already been added.