### PR TITLE
[processor/metrictransform]: Preserve metric description while aggregating labels (#14577)

### DIFF
--- a/.chloggen/fix-metrictransform-description.yaml
+++ b/.chloggen/fix-metrictransform-description.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/metricstransform
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Preserve metric description while aggregating labels
+
+# One or more tracking issues related to the change
+issues: [14577]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/metricstransformprocessor/metrics_testcase_builder_test.go
+++ b/processor/metricstransformprocessor/metrics_testcase_builder_test.go
@@ -46,6 +46,11 @@ func metricBuilder(metricType pmetric.MetricType, name string, attrs ...string) 
 	}
 }
 
+func (b builder) addDescription(description string) builder {
+	b.metric.SetDescription(description)
+	return b
+}
+
 func (b builder) addIntDatapoint(start, ts pcommon.Timestamp, val int64, attrValues ...string) builder {
 	dp := b.addNumberDatapoint(start, ts, attrValues)
 	dp.SetIntValue(val)

--- a/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
@@ -453,6 +453,7 @@ func combine(transform internalTransform, metrics pmetric.MetricSlice) pmetric.M
 func copyMetricDetails(from, to pmetric.Metric) {
 	to.SetName(from.Name())
 	to.SetUnit(from.Unit())
+	to.SetDescription(from.Description())
 	switch from.Type() {
 	case pmetric.MetricTypeGauge:
 		to.SetEmptyGauge()

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -245,11 +245,11 @@ var (
 			in: []pmetric.Metric{
 				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
 					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
+					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").addDescription("foobar").build(),
 			},
 			out: []pmetric.Metric{
 				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 4, "label1-value1").build(),
+					addIntDatapoint(1, 2, 4, "label1-value1").addDescription("foobar").build(),
 			},
 		},
 		{


### PR DESCRIPTION

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** #14577 

**Testing:** Updated existing a testcase in unittest to check whether description is set correctly upon aggregation. 

**Documentation:** <Describe the documentation added.>