### PR TITLE
[pkg/stanza] support flatten resource and attributes

### DIFF
--- a/.chloggen/add-stanza-flatten-resource-and-attribtues.yaml
+++ b/.chloggen/add-stanza-flatten-resource-and-attribtues.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enhancement pkg/stanza/flatten to support resource and attributes
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/add-stanza-flatten-resource-and-attribtues.yaml
+++ b/.chloggen/add-stanza-flatten-resource-and-attribtues.yaml
@@ -8,7 +8,7 @@ component: stanza
 note: Enhancement pkg/stanza/flatten to support resource and attributes
 
 # One or more tracking issues related to the change
-issues: []
+issues: [20448]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/stanza/operator/transformer/flatten/config_test.go
+++ b/pkg/stanza/operator/transformer/flatten/config_test.go
@@ -28,7 +28,7 @@ func TestUnmarshal(t *testing.T) {
 		TestsFile:     filepath.Join(".", "testdata", "config.yaml"),
 		Tests: []operatortest.ConfigUnmarshalTest{
 			{
-				Name: "flatten_one_level",
+				Name: "flatten_body_one_level",
 				Expect: func() *Config {
 					cfg := NewConfig()
 					cfg.Field = entry.NewBodyField("nested")
@@ -37,7 +37,7 @@ func TestUnmarshal(t *testing.T) {
 				ExpectErr: false,
 			},
 			{
-				Name: "flatten_second_level",
+				Name: "flatten_body_second_level",
 				Expect: func() *Config {
 					cfg := NewConfig()
 					cfg.Field = entry.NewBodyField("nested", "secondlevel")
@@ -46,19 +46,37 @@ func TestUnmarshal(t *testing.T) {
 				ExpectErr: false,
 			},
 			{
-				Name: "flatten_resource",
+				Name: "flatten_resource_one_level",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.Field = entry.NewResourceField("secondlevel")
+					cfg.Field = entry.NewResourceField("nested")
 					return cfg
 				}(),
 				ExpectErr: false,
 			},
 			{
-				Name: "flatten_attributes",
+				Name: "flatten_resource_second_level",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.Field = entry.NewAttributeField("secondlevel")
+					cfg.Field = entry.NewResourceField("nested", "secondlevel")
+					return cfg
+				}(),
+				ExpectErr: false,
+			},
+			{
+				Name: "flatten_attributes_one_level",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.Field = entry.NewAttributeField("nested")
+					return cfg
+				}(),
+				ExpectErr: false,
+			},
+			{
+				Name: "flatten_attributes_second_level",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.Field = entry.NewAttributeField("nested", "secondlevel")
 					return cfg
 				}(),
 				ExpectErr: false,

--- a/pkg/stanza/operator/transformer/flatten/config_test.go
+++ b/pkg/stanza/operator/transformer/flatten/config_test.go
@@ -31,9 +31,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "flatten_one_level",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.Field = entry.BodyField{
-						Keys: []string{"nested"},
-					}
+					cfg.Field = entry.NewBodyField("nested")
 					return cfg
 				}(),
 				ExpectErr: false,
@@ -42,9 +40,16 @@ func TestUnmarshal(t *testing.T) {
 				Name: "flatten_second_level",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.Field = entry.BodyField{
-						Keys: []string{"nested", "secondlevel"},
-					}
+					cfg.Field = entry.NewBodyField("nested", "secondlevel")
+					return cfg
+				}(),
+				ExpectErr: false,
+			},
+			{
+				Name: "flatten_resource",
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.Field = entry.NewResourceField("secondlevel")
 					return cfg
 				}(),
 				ExpectErr: false,
@@ -53,12 +58,10 @@ func TestUnmarshal(t *testing.T) {
 				Name: "flatten_attributes",
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.Field = entry.BodyField{
-						Keys: []string{"attributes", "errField"},
-					}
+					cfg.Field = entry.NewAttributeField("secondlevel")
 					return cfg
 				}(),
-				ExpectErr: true,
+				ExpectErr: false,
 			},
 		},
 	}.Run(t)

--- a/pkg/stanza/operator/transformer/flatten/flatten.go
+++ b/pkg/stanza/operator/transformer/flatten/flatten.go
@@ -17,7 +17,6 @@ package flatten // import "github.com/open-telemetry/opentelemetry-collector-con
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"go.uber.org/zap"
 
@@ -48,7 +47,7 @@ func NewConfigWithID(operatorID string) *Config {
 // Config is the configuration of a flatten operator
 type Config struct {
 	helper.TransformerConfig `mapstructure:",squash"`
-	Field                    entry.BodyField `mapstructure:"field"`
+	Field                    entry.Field `mapstructure:"field"`
 }
 
 // Build will build a Flatten operator from the supplied configuration
@@ -58,34 +57,53 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		return nil, err
 	}
 
-	if strings.Contains(c.Field.String(), "attributes") || strings.Contains(c.Field.String(), "resource") {
-		return nil, fmt.Errorf("flatten: field cannot be a resource or attribute")
+	if e, ok := c.Field.FieldInterface.(entry.BodyField); ok {
+		return &Transformer[entry.BodyField]{
+			TransformerOperator: transformerOperator,
+			Field:               e,
+		}, nil
 	}
 
-	return &Transformer{
-		TransformerOperator: transformerOperator,
-		Field:               c.Field,
-	}, nil
+	if e, ok := c.Field.FieldInterface.(entry.ResourceField); ok {
+		return &Transformer[entry.ResourceField]{
+			TransformerOperator: transformerOperator,
+			Field:               e,
+		}, nil
+	}
+
+	if e, ok := c.Field.FieldInterface.(entry.AttributeField); ok {
+		return &Transformer[entry.AttributeField]{
+			TransformerOperator: transformerOperator,
+			Field:               e,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("invalid field type: %T", c.Field.FieldInterface)
 }
 
-// Transformer flattens an object in the body field
-type Transformer struct {
+// Transformer flattens an object in the entry field
+type Transformer[T interface {
+	entry.BodyField | entry.ResourceField | entry.AttributeField
+	entry.FieldInterface
+	Parent() T
+	Child(string) T
+}] struct {
 	helper.TransformerOperator
-	Field entry.BodyField
+	Field T
 }
 
 // Process will process an entry with a flatten transformation.
-func (p *Transformer) Process(ctx context.Context, entry *entry.Entry) error {
+func (p *Transformer[T]) Process(ctx context.Context, entry *entry.Entry) error {
 	return p.ProcessWith(ctx, entry, p.Transform)
 }
 
 // Transform will apply the flatten operation to an entry
-func (p *Transformer) Transform(entry *entry.Entry) error {
+func (p *Transformer[T]) Transform(entry *entry.Entry) error {
 	parent := p.Field.Parent()
 	val, ok := entry.Delete(p.Field)
 	if !ok {
 		// The field doesn't exist, so ignore it
-		return fmt.Errorf("apply flatten: field %s does not exist on body", p.Field)
+		return fmt.Errorf("apply flatten: field %s does not exist on entry", p.Field)
 	}
 
 	valMap, ok := val.(map[string]interface{})

--- a/pkg/stanza/operator/transformer/flatten/testdata/config.yaml
+++ b/pkg/stanza/operator/transformer/flatten/testdata/config.yaml
@@ -1,6 +1,9 @@
 flatten_attributes:
   type: flatten
-  field: attributes.errField
+  field: attributes.secondlevel
+flatten_resource:
+  type: flatten
+  field: resource.secondlevel
 flatten_one_level:
   type: flatten
   field: body.nested

--- a/pkg/stanza/operator/transformer/flatten/testdata/config.yaml
+++ b/pkg/stanza/operator/transformer/flatten/testdata/config.yaml
@@ -1,12 +1,18 @@
-flatten_attributes:
-  type: flatten
-  field: attributes.secondlevel
-flatten_resource:
-  type: flatten
-  field: resource.secondlevel
-flatten_one_level:
+flatten_body_one_level:
   type: flatten
   field: body.nested
-flatten_second_level:
+flatten_body_second_level:
   type: flatten
   field: body.nested.secondlevel
+flatten_resource_one_level:
+  type: flatten
+  field: resource.nested
+flatten_resource_second_level:
+  type: flatten
+  field: resource.nested.secondlevel
+flatten_attributes_one_level:
+  type: flatten
+  field: attributes.nested
+flatten_attributes_second_level:
+  type: flatten
+  field: attributes.nested.secondlevel


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

`stanza/flatten` only support `entry.BodyField`. Consider this situation

There are some dynamic tags in body, move them into resource, and finally flatten

```yaml
- type: move
  from: body.tags
  to: resource.tags
  if: "body.tags != nil"
```

<table>
<tr><td> Input Entry</td> <td> Output Entry </td></tr>
<tr>
<td>

```json
{
  "body": {
    "time": "2023-03-03T15:03:22.507+0800 222222",
    "tags": {
      "foo1": "bar1",
      "foo2": "bar2",
      "foo3": "bar3"
    }
  },
  "resource": {}
}
```

</td>
<td>

```json
{
  "body": {
    "time": "2023-03-03T15:03:22.507+0800 222222"
  },
  "resource": {
    "tags": {
      "foo1": "bar1",
      "foo2": "bar2",
      "foo3": "bar3"
    }
  }
}
```

</td>
</tr>
</table>


```yaml
- type: flatten
  field: resource.tags
  if: "resource.tags != nil"
```

<table>
<tr><td> Input Entry</td> <td> Output Entry </td></tr>
<tr>
<td>

```json
{
  "body": {
    "time": "2023-03-03T15:03:22.507+0800 222222"
  },
  "resource": {
    "tags": {
      "foo1": "bar1",
      "foo2": "bar2",
      "foo3": "bar3"
    }
  }
}
```

</td>
<td>

```json
{
  "body": {
    "time": "2023-03-03T15:03:22.507+0800 222222"
  },
  "resource": {
    "foo1": "bar1",
    "foo2": "bar2",
    "foo3": "bar3"
  }
}
```

</td>
</tr>
</table>

This is my first time to use generics, any suggestions are helpful.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>



**Documentation:** <Describe the documentation added.>