### PR TITLE
[exporter/splunkhec] handle overCapacity error better when we are trying to complete a gzip buffer

### DIFF
--- a/.chloggen/over-capacity-issue.yaml
+++ b/.chloggen/over-capacity-issue.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make sure to not return an error if we are over capacity, just return that we cannot accept the event.
+
+# One or more tracking issues related to the change
+issues: [20481]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/splunkhecexporter/buffer.go
+++ b/exporter/splunkhecexporter/buffer.go
@@ -102,6 +102,10 @@ func (b *bufferState) accept(data []byte) (bool, error) {
 		// if the byte writer was over capacity, try to write the new entry in the zip writer:
 		if overCapacity {
 			if _, err2 := zipWriter.Write(data); err2 != nil {
+				overCapacity2 := errors.Is(err2, errOverCapacity)
+				if overCapacity2 {
+					return false, nil
+				}
 				return false, err2
 			}
 


### PR DESCRIPTION
**Description:** 
Make sure to not return an error if we are over capacity, just return that we cannot accept the event.

**Link to tracking Issue:**
Fixes #20481

**Testing:**
Will add tests.

**Documentation:**
