### PR TITLE
[receiver/k8scluster] Use newer v2 HorizontalPodAutoscaler for Kubern…

### DIFF
--- a/.chloggen/fix-k8scluster-use-v2-horizontalpodautoscaler.yaml
+++ b/.chloggen/fix-k8scluster-use-v2-horizontalpodautoscaler.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/k8scluste
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use newer v2 HorizontalPodAutoscaler for Kubernetes 1.26
+
+# One or more tracking issues related to the change
+issues: [20480]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: v2beta2 HorizontalPodAutoscaler is no longer available starting in Kubernetes 1.26

--- a/.chloggen/fix-k8scluster-use-v2-horizontalpodautoscaler.yaml
+++ b/.chloggen/fix-k8scluster-use-v2-horizontalpodautoscaler.yaml
@@ -2,7 +2,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: receiver/k8scluste
+component: receiver/k8scluster
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Use newer v2 HorizontalPodAutoscaler for Kubernetes 1.26

--- a/receiver/k8sclusterreceiver/internal/collection/collector.go
+++ b/receiver/k8sclusterreceiver/internal/collection/collector.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -136,8 +137,10 @@ func (dc *DataCollector) SyncMetrics(obj interface{}) {
 		md = ocsToMetrics(cronjob.GetMetrics(o))
 	case *batchv1beta1.CronJob:
 		md = ocsToMetrics(cronjob.GetMetricsBeta(o))
-	case *autoscalingv2beta2.HorizontalPodAutoscaler:
+	case *autoscalingv2.HorizontalPodAutoscaler:
 		md = ocsToMetrics(hpa.GetMetrics(o))
+	case *autoscalingv2beta2.HorizontalPodAutoscaler:
+		md = ocsToMetrics(hpa.GetMetricsBeta(o))
 	case *quotav1.ClusterResourceQuota:
 		md = ocsToMetrics(clusterresourcequota.GetMetrics(o))
 	default:
@@ -175,8 +178,10 @@ func (dc *DataCollector) SyncMetadata(obj interface{}) map[experimentalmetricmet
 		km = cronjob.GetMetadata(o)
 	case *batchv1beta1.CronJob:
 		km = cronjob.GetMetadataBeta(o)
-	case *autoscalingv2beta2.HorizontalPodAutoscaler:
+	case *autoscalingv2.HorizontalPodAutoscaler:
 		km = hpa.GetMetadata(o)
+	case *autoscalingv2beta2.HorizontalPodAutoscaler:
+		km = hpa.GetMetadataBeta(o)
 	}
 
 	return km

--- a/receiver/k8sclusterreceiver/internal/hpa/hpa.go
+++ b/receiver/k8sclusterreceiver/internal/hpa/hpa.go
@@ -21,6 +21,7 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/constants"
@@ -86,7 +87,7 @@ func GetMetrics(hpa *autoscalingv2.HorizontalPodAutoscaler) []*agentmetricspb.Ex
 
 	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			Resource: getResourceForHPA(hpa),
+			Resource: getResourceForHPA(&hpa.ObjectMeta),
 			Metrics:  metrics,
 		},
 	}
@@ -122,30 +123,19 @@ func GetMetricsBeta(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) []*agentmet
 
 	return []*agentmetricspb.ExportMetricsServiceRequest{
 		{
-			Resource: getResourceForHPABeta(hpa),
+			Resource: getResourceForHPA(&hpa.ObjectMeta),
 			Metrics:  metrics,
 		},
 	}
 }
 
-func getResourceForHPA(hpa *autoscalingv2.HorizontalPodAutoscaler) *resourcepb.Resource {
+func getResourceForHPA(om *v1.ObjectMeta) *resourcepb.Resource {
 	return &resourcepb.Resource{
 		Type: constants.K8sType,
 		Labels: map[string]string{
-			constants.K8sKeyHPAUID:                string(hpa.UID),
-			constants.K8sKeyHPAName:               hpa.Name,
-			conventions.AttributeK8SNamespaceName: hpa.Namespace,
-		},
-	}
-}
-
-func getResourceForHPABeta(hpa *autoscalingv2beta2.HorizontalPodAutoscaler) *resourcepb.Resource {
-	return &resourcepb.Resource{
-		Type: constants.K8sType,
-		Labels: map[string]string{
-			constants.K8sKeyHPAUID:                string(hpa.UID),
-			constants.K8sKeyHPAName:               hpa.Name,
-			conventions.AttributeK8SNamespaceName: hpa.Namespace,
+			constants.K8sKeyHPAUID:                string(om.UID),
+			constants.K8sKeyHPAName:               om.Name,
+			conventions.AttributeK8SNamespaceName: om.Namespace,
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/internal/testutils/objects.go
+++ b/receiver/k8sclusterreceiver/internal/testutils/objects.go
@@ -16,6 +16,7 @@ package testutils // import "github.com/open-telemetry/opentelemetry-collector-c
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -24,7 +25,26 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func NewHPA(id string) *autoscalingv2beta2.HorizontalPodAutoscaler {
+func NewHPA(id string) *autoscalingv2.HorizontalPodAutoscaler {
+	minReplicas := int32(2)
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-hpa-" + id,
+			Namespace: "test-namespace",
+			UID:       types.UID("test-hpa-" + id + "-uid"),
+		},
+		Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+			CurrentReplicas: 5,
+			DesiredReplicas: 7,
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			MinReplicas: &minReplicas,
+			MaxReplicas: 10,
+		},
+	}
+}
+
+func NewHPABeta(id string) *autoscalingv2beta2.HorizontalPodAutoscaler {
 	minReplicas := int32(2)
 	return &autoscalingv2beta2.HorizontalPodAutoscaler{
 		ObjectMeta: v1.ObjectMeta{

--- a/receiver/k8sclusterreceiver/receiver_test.go
+++ b/receiver/k8sclusterreceiver/receiver_test.go
@@ -263,6 +263,12 @@ func newFakeClientWithAllResources() *fake.Clientset {
 			},
 		},
 		{
+			GroupVersion: "autoscaling/v2",
+			APIResources: []v1.APIResource{
+				gvkToAPIResource(gvk.HorizontalPodAutoscaler),
+			},
+		},
+		{
 			GroupVersion: "autoscaling/v2beta2",
 			APIResources: []v1.APIResource{
 				gvkToAPIResource(gvk.HorizontalPodAutoscaler),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
With these changes the k8scluster receiver will be able to monitor the deprecated v2beta2 and v2 versions of the HorizontalPodAutoscaler. We need these changes for v2 HPA to properly support Kubernetes 1.26. I left in the v2beta2 support to keep support for other clusters.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20480

**Testing:** 
Tested manually with Kubernetes 1.25. Added a unit test as well.
