### PR TITLE
[exporter/splunkhec] Surface and fix "no data" issue with Splunk HEC exporter, add test towards dropped records case

### DIFF
--- a/.chloggen/past_max_capacity.yaml
+++ b/.chloggen/past_max_capacity.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: splunkhecexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add a test showing what happens if we have a log record that is past what the collector can send.
+note: Do not send data to a Splunk backend if no data is present in the batch. Previously compressed batches would not correctly detect data was not present in the batch.
 
 # One or more tracking issues related to the change
 issues: [20290]

--- a/.chloggen/past_max_capacity.yaml
+++ b/.chloggen/past_max_capacity.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a test showing what happens if we have a log record that is past what the collector can send.
+
+# One or more tracking issues related to the change
+issues: [20290]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/splunkhecexporter/buffer.go
+++ b/exporter/splunkhecexporter/buffer.go
@@ -48,12 +48,14 @@ type bufferState struct {
 	bufFront             *index
 	resource             int
 	library              int
+	containsData         bool
 }
 
 func (b *bufferState) reset() {
 	b.buf.Reset()
 	b.compressionEnabled = false
 	b.writer = &cancellableBytesWriter{innerWriter: b.buf, maxCapacity: b.bufferMaxLen}
+	b.containsData = false
 }
 
 func (b *bufferState) Read(p []byte) (n int, err error) {
@@ -110,11 +112,13 @@ func (b *bufferState) accept(data []byte) (bool, error) {
 			}
 
 		}
+		b.containsData = true
 		return true, nil
 	}
 	if overCapacity {
 		return false, nil
 	}
+	b.containsData = true
 	return true, err
 }
 

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -168,7 +168,7 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, headers
 	}
 
 	// There's some leftover unsent non-profiling data
-	if bufState.buf.Len() > 0 {
+	if bufState.containsData {
 
 		if err := c.postEvents(ctx, bufState, headers); err != nil {
 			return consumererror.NewLogs(err, c.subLogs(ld, bufState.bufFront, profilingBufState.bufFront))
@@ -176,7 +176,7 @@ func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, headers
 	}
 
 	// There's some leftover unsent profiling data
-	if profilingBufState.buf.Len() > 0 {
+	if profilingBufState.containsData {
 		if err := c.postEvents(ctx, profilingBufState, profilingLocalHeaders); err != nil {
 			// Non-profiling bufFront is set to nil because all non-profiling data was flushed successfully above.
 			return consumererror.NewLogs(err, c.subLogs(ld, nil, profilingBufState.bufFront))
@@ -222,7 +222,7 @@ func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice,
 			continue
 		}
 
-		if state.buf.Len() > 0 {
+		if state.containsData {
 			if err := c.postEvents(ctx, state, headers); err != nil {
 				return permanentErrors, err
 			}
@@ -241,7 +241,7 @@ func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice,
 				fmt.Errorf("dropped log event error: event size %d bytes larger than configured max content length %d bytes", len(b), state.bufferMaxLen)))
 			continue
 		}
-		if state.buf.Len() > 0 {
+		if state.containsData {
 			// This means that the current record had overflown the buffer and was not sent
 			state.bufFront = &index{resource: state.resource, library: state.library, record: k}
 		} else {
@@ -296,7 +296,7 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 			continue
 		}
 
-		if state.buf.Len() > 0 {
+		if state.containsData {
 			if err := c.postEvents(ctx, state, headers); err != nil {
 				return permanentErrors, err
 			}
@@ -316,7 +316,7 @@ func (c *client) pushMetricsRecords(ctx context.Context, mds pmetric.ResourceMet
 			continue
 		}
 
-		if state.buf.Len() > 0 {
+		if state.containsData {
 			// This means that the current record had overflown the buffer and was not sent
 			state.bufFront = &index{resource: state.resource, library: state.library, record: k}
 		} else {
@@ -358,7 +358,7 @@ func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSli
 			continue
 		}
 
-		if state.buf.Len() > 0 {
+		if state.containsData {
 			if err = c.postEvents(ctx, state, headers); err != nil {
 				return permanentErrors, err
 			}
@@ -378,7 +378,7 @@ func (c *client) pushTracesData(ctx context.Context, tds ptrace.ResourceSpansSli
 			continue
 		}
 
-		if state.buf.Len() > 0 {
+		if state.containsData {
 			// This means that the current record had overflown the buffer and was not sent
 			state.bufFront = &index{resource: state.resource, library: state.library, record: k}
 		} else {
@@ -417,7 +417,7 @@ func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metric
 	}
 
 	// There's some leftover unsent metrics
-	if bufState.buf.Len() > 0 {
+	if bufState.containsData {
 		if err := c.postEvents(ctx, bufState, headers); err != nil {
 			return consumererror.NewMetrics(err, subMetrics(md, bufState.bufFront))
 		}
@@ -452,7 +452,7 @@ func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, 
 	}
 
 	// There's some leftover unsent traces
-	if bufState.buf.Len() > 0 {
+	if bufState.containsData {
 		if err := c.postEvents(ctx, bufState, headers); err != nil {
 			return consumererror.NewTraces(err, subTraces(td, bufState.bufFront))
 		}


### PR DESCRIPTION
**Description:**
Add a test showing what happens if we have a log record that is past what the collector can send.

**Link to tracking Issue:**
Fixes #20290

**Testing:**
Unit test

**Documentation:**
No changes