### PR TITLE
[processor/resourcedetection] Add a note about missing host.name in GKE workload identity

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -168,6 +168,11 @@ processors:
     * host.id (instance id)
     * host.name (instance name; only when workload identity is disabled)
 
+One known issue is when GKE workload identity is enabled, the GCE metadata endpoints won't be available, thus the GKE resource detector won't be
+able to determine `host.name`. In that case, users are encouraged to set `host.name` from either:
+- `node.name` through the downward API with the `env` detector
+- obtaining the Kubernetes node name from the Kubernetes API (with `k8s.io/client-go`)
+
 #### Google Cloud Run Metadata
 
     * cloud.provider ("gcp")


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add a note about GKE resource detector missing host.name in GKE workload identity. Context: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/10486, https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12355 and https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15716

**Link to tracking Issue:** <Issue number if applicable>
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/15716

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>