### PR TITLE
[exporter/splunkhec] Increase default HEC limits

### DIFF
--- a/.chloggen/increase-default-hec-limits.yaml
+++ b/.chloggen/increase-default-hec-limits.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change the default max content length for the Splunk HEC exporter from 2 MiB to 5 MiB by default.
+
+# One or more tracking issues related to the change
+issues: [20517]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -31,16 +31,15 @@ The following configuration options can also be configured:
 - `ca_file` (no default) Path to the CA cert to verify the server being connected to.
 - `cert_file` (no default) Path to the TLS cert to use for client connections when TLS client auth is required.
 - `key_file` (no default) Path to the TLS key to use for TLS required connections.
-- `max_content_length_logs` (default: 2097152): Maximum log payload size in bytes. Log batches of bigger size will be
-  broken down into several requests. Default value is 2097152 bytes (2 MiB). Maximum allowed value is 838860800
-  (~ 800 MB). Keep in mind that Splunk Observability backend doesn't accept requests bigger than 2 MiB. This
-  configuration value can be raised only if used with Splunk Core/Cloud. When set to 0, it will treat as infinite length and it will create only 1 request per batch.
-- `max_content_length_metrics` (default: 2097152): Maximum metric payload size in bytes. Metric batches of bigger size
-  will be broken down into several requests. Default value is 2097152 bytes (2 MiB). Maximum allowed value is 838860800
-  (~ 800 MB). When set to 0, it will treat as infinite length and it will create only one request per batch.
-- `max_content_length_traces` (default: 2097152): Maximum trace payload size in bytes. Trace batches of bigger size
-  will be broken down into several requests. Default value is 2097152 bytes (2 MiB). Maximum allowed value is 838860800
-  (~ 800 MB). When set to 0, it will treat as infinite length and it will create only one request per batch.
+- `max_content_length_logs` (default: 5242880): Maximum log payload size in bytes. Log batches of bigger size will be
+  broken down into several requests. Default value is 5242880 bytes (5 MiB). Maximum allowed value is 838860800
+  (~ 800 MB). When set to 0, it will treat as infinite length, and it will create only 1 request per batch.
+- `max_content_length_metrics` (default: 5242880): Maximum metric payload size in bytes. Metric batches of bigger size
+  will be broken down into several requests. Default value is 5242880 bytes (5 MiB). Maximum allowed value is 838860800
+  (~ 800 MB). When set to 0, it will treat as infinite length, and it will create only one request per batch.
+- `max_content_length_traces` (default: 5242880): Maximum trace payload size in bytes. Trace batches of bigger size
+  will be broken down into several requests. Default value is 5242880 bytes (5 MiB). Maximum allowed value is 838860800
+  (~ 800 MB). When set to 0, it will treat as infinite length, and it will create only one request per batch.
 - `splunk_app_name` (default: "OpenTelemetry Collector Contrib") App name is used to track telemetry information for Splunk App's using HEC by App name.
 - `splunk_app_version` (default: Current OpenTelemetry Collector Contrib Build Version): App version is used to track telemetry information for Splunk App's using HEC by App version. 
 - `log_data_enabled` (default: true): Specifies whether the log data is exported. Set it to `false` if you want the log 

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -31,9 +31,9 @@ import (
 const (
 	// hecPath is the default HEC path on the Splunk instance.
 	hecPath                          = "services/collector"
-	defaultContentLengthLogsLimit    = 2 * 1024 * 1024
-	defaultContentLengthMetricsLimit = 2 * 1024 * 1024
-	defaultContentLengthTracesLimit  = 2 * 1024 * 1024
+	defaultContentLengthLogsLimit    = 5 * 1024 * 1024
+	defaultContentLengthMetricsLimit = 5 * 1024 * 1024
+	defaultContentLengthTracesLimit  = 5 * 1024 * 1024
 	defaultMaxEventSize              = 5 * 1024 * 1024
 	maxContentLengthLogsLimit        = 800 * 1024 * 1024
 	maxContentLengthMetricsLimit     = 800 * 1024 * 1024

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -66,9 +66,9 @@ func TestLoadConfig(t *testing.T) {
 				ProfilingDataEnabled:    true,
 				ExportRaw:               true,
 				MaxEventSize:            5 * 1024 * 1024,
-				MaxContentLengthLogs:    2 * 1024 * 1024,
-				MaxContentLengthMetrics: 2 * 1024 * 1024,
-				MaxContentLengthTraces:  2 * 1024 * 1024,
+				MaxContentLengthLogs:    5 * 1024 * 1024,
+				MaxContentLengthMetrics: 5 * 1024 * 1024,
+				MaxContentLengthTraces:  5 * 1024 * 1024,
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Timeout:  10 * time.Second,
 					Endpoint: "https://splunk:8088/services/collector",


### PR DESCRIPTION
**Description:** 
Change the default max content length for the Splunk HEC exporter from 2 MiB to 5 MiB by default.

**Link to tracking Issue:**
Fixes #20517

**Testing:**
Unit tests changes.

**Documentation:** 
README changes.