### PR TITLE
[exporter/instana] Preserve resource attributes in spans

### DIFF
--- a/.chloggen/instana-exporter-preserve-resources.yaml
+++ b/.chloggen/instana-exporter-preserve-resources.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: instanaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Preserve resource attributes in converted spans
+
+# One or more tracking issues related to the change
+issues: [20454]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/instanaexporter/internal/converter/model/span.go
+++ b/exporter/instanaexporter/internal/converter/model/span.go
@@ -62,6 +62,7 @@ type OTelSpanData struct {
 	Operation      string            `json:"operation"`
 	TraceState     string            `json:"trace_state,omitempty"`
 	Tags           map[string]string `json:"tags,omitempty"`
+	Resource       map[string]string `json:"resource,omitempty"`
 }
 
 type Span struct {
@@ -92,7 +93,8 @@ func ConvertPDataSpanToInstanaSpan(fromS FromS, otelSpan ptrace.Span, serviceNam
 		Timestamp:      uint64(otelSpan.StartTimestamp()) / uint64(time.Millisecond),
 		Duration:       (uint64(otelSpan.EndTimestamp()) - uint64(otelSpan.StartTimestamp())) / uint64(time.Millisecond),
 		Data: OTelSpanData{
-			Tags: make(map[string]string),
+			Tags:     make(map[string]string),
+			Resource: make(map[string]string),
 		},
 		From: &fromS,
 	}
@@ -125,6 +127,12 @@ func ConvertPDataSpanToInstanaSpan(fromS FromS, otelSpan ptrace.Span, serviceNam
 
 	otelSpan.Attributes().Range(func(k string, v pcommon.Value) bool {
 		instanaSpan.Data.Tags[k] = v.AsString()
+
+		return true
+	})
+
+	attributes.Range(func(k string, v pcommon.Value) bool {
+		instanaSpan.Data.Resource[k] = v.AsString()
 
 		return true
 	})

--- a/exporter/instanaexporter/internal/converter/span_converter_test.go
+++ b/exporter/instanaexporter/internal/converter/span_converter_test.go
@@ -127,6 +127,20 @@ func validateInstanaSpanBasics(sp model.Span, t *testing.T) {
 	if sp.Duration <= 0 {
 		t.Errorf("expected duration to be provided but received %v", sp.Duration)
 	}
+
+	if sp.Data.ServiceName != "myservice" {
+		t.Errorf("expected span name to be 'myservice' but received '%v'", sp.Data.ServiceName)
+	}
+
+	if len(sp.Data.Resource) == 0 {
+		t.Error("expected resource block not to be empty")
+	}
+
+	if sp.Data.Resource[conventions.AttributeServiceName] != sp.Data.ServiceName {
+		t.Errorf("expected resource block to contain same name (%v) as span.Name (%v)",
+			sp.Data.Resource[conventions.AttributeServiceName], sp.Data.ServiceName)
+	}
+
 }
 
 func validateBundle(jsonData []byte, t *testing.T, fn func(model.Span, *testing.T)) {


### PR DESCRIPTION
**Description:** 
Currently the instana exporter does not preserve the resource attributes when converting otel spans to instana spans. This results in instana not properly correlating infrastructure to the opentelemetry traces - as [described in the instana docs](https://www.ibm.com/docs/en/instana-observability/current?topic=apis-opentelemetry#analyzing-opentelemetry-calls). To also support possible future mappings in instana, I think it is a good idea to convert all resource attributes and keep them in the instana spans.

**Link to tracking Issue:** 
#20454 

**Testing:** 
Added proper unit tests for the new span informations.

**Documentation:**