### PR TITLE
[pkg/ottl] Update grammar to enforce paths terminate with brackets if included.

### DIFF
--- a/.chloggen/ottl-adjust-fields.yaml
+++ b/.chloggen/ottl-adjust-fields.yaml
@@ -2,10 +2,10 @@
 change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: Remove ability to specify identifiers after brackets in a path.
+component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note:
+note: Remove ability to specify identifiers after brackets in a path.
 
 # One or more tracking issues related to the change
 issues: [20528]

--- a/.chloggen/ottl-adjust-fields.yaml
+++ b/.chloggen/ottl-adjust-fields.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: Remove ability to specify identifiers after brackets in a path.
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# One or more tracking issues related to the change
+issues: [20528]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The change has no impact on any of the standard OTTL contexts, transformprocessor, filterprocessor, or routingprocessor.  It is only a breaking change if you have implemented your own context and were taking advantage of dots after bracket indexing.

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -59,7 +59,7 @@ Values are passed as input to an Invocation or are used in a Boolean Expression.
 
 #### Paths
 
-A Path Value is a reference to a telemetry field.  Paths are made up of lowercase identifiers, dots (`.`), and square brackets combined with a string key (`["key"]`).  **The interpretation of a Path is NOT implemented by the OTTL.**  Instead, the user must provide a `PathExpressionParser` that the OTTL can use to interpret paths.  As a result, how the Path parts are used is up to the user.  However, it is recommended, that the parts be used like so:
+A Path Value is a reference to a telemetry field.  Paths are made up of lowercase identifiers separated by dots (`.`), and optionally terminating with square brackets combined with a string key (`["key"]`). Dots (`.`) and lowercase identifiers cannot be included after brackets/keys (`["key"]`).  **The interpretation of a Path is NOT implemented by the OTTL.**  Instead, the user must provide a `PathExpressionParser` that the OTTL can use to interpret paths.  As a result, how the Path parts are used is up to the user.  However, it is recommended, that the parts be used like so:
 
 - Identifiers are used to map to a telemetry field.
 - Dots (`.`) are used to separate nested fields.

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -59,7 +59,7 @@ Values are passed as input to an Invocation or are used in a Boolean Expression.
 
 #### Paths
 
-A Path Value is a reference to a telemetry field.  Paths are made up of lowercase identifiers separated by dots (`.`), and optionally terminating with square brackets combined with a string key (`["key"]`). Dots (`.`) and lowercase identifiers cannot be included after brackets/keys (`["key"]`).  **The interpretation of a Path is NOT implemented by the OTTL.**  Instead, the user must provide a `PathExpressionParser` that the OTTL can use to interpret paths.  As a result, how the Path parts are used is up to the user.  However, it is recommended, that the parts be used like so:
+A Path Value is a reference to a telemetry field.  Paths are made up of lowercase identifiers separated by dots (`.`), optionally terminating with square brackets combined with a string key (`["key"]`). Dots (`.`) and lowercase identifiers cannot be used after brackets/keys (`["key"]`).  **The interpretation of a Path is NOT implemented by the OTTL.**  Instead, the user must provide a `PathExpressionParser` that the OTTL can use to interpret paths.  As a result, how the Path parts are used is up to the user.  However, it is recommended, that the parts be used like so:
 
 - Identifiers are used to map to a telemetry field.
 - Dots (`.`) are used to separate nested fields.

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -55,7 +55,7 @@ Values are passed as input to an Invocation or are used in a Boolean Expression.
 - [Literals](#literals)
 - [Enums](#enums)
 - [Converters](#converters)
-- [Math Expressions](#math_expressions)
+- [Math Expressions](#math-expressions)
 
 #### Paths
 
@@ -66,7 +66,7 @@ A Path Value is a reference to a telemetry field.  Paths are made up of lowercas
 - Square brackets and keys (`["key"]`) are used to access values within maps.
 
 When accessing a map's value, if the given key does not exist, `nil` will be returned.
-This can be used to check for the presence of a key within a map within a [Boolean Expression](#boolean_expressions).
+This can be used to check for the presence of a key within a map within a [Boolean Expression](#boolean-expressions).
 
 Example Paths
 - `name`

--- a/pkg/ottl/boolean_value_test.go
+++ b/pkg/ottl/boolean_value_test.go
@@ -38,10 +38,8 @@ func valueFor(x any) value {
 			// if the string is NAME construct a path of "name".
 			val.Literal = &mathExprLiteral{
 				Path: &Path{
-					Fields: []Field{
-						{
-							Name: "name",
-						},
+					Fields: []string{
+						"name",
 					},
 				},
 			}

--- a/pkg/ottl/contexts/internal/ottlcommon/metric.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/metric.go
@@ -39,11 +39,11 @@ var MetricSymbolTable = map[ottl.EnumSymbol]ottl.Enum{
 	"METRIC_DATA_TYPE_SUMMARY":               ottl.Enum(pmetric.MetricTypeSummary),
 }
 
-func MetricPathGetSetter[K MetricContext](path []ottl.Field) (ottl.GetSetter[K], error) {
-	if len(path) == 0 {
+func MetricPathGetSetter[K MetricContext](path ottl.Path) (ottl.GetSetter[K], error) {
+	if len(path.Fields) == 0 {
 		return accessMetric[K](), nil
 	}
-	switch path[0].Name {
+	switch path.Fields[0] {
 	case "name":
 		return accessName[K](), nil
 	case "description":

--- a/pkg/ottl/contexts/internal/ottlcommon/metric_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/metric_test.go
@@ -37,17 +37,15 @@ func Test_MetricPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		fields   []string
 		orig     interface{}
 		newVal   interface{}
 		modified func(metric pmetric.Metric)
 	}{
 		{
 			name: "metric name",
-			path: []ottl.Field{
-				{
-					Name: "name",
-				},
+			fields: []string{
+				"name",
 			},
 			orig:   "name",
 			newVal: "new name",
@@ -57,10 +55,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric description",
-			path: []ottl.Field{
-				{
-					Name: "description",
-				},
+			fields: []string{
+				"description",
 			},
 			orig:   "description",
 			newVal: "new description",
@@ -70,10 +66,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric unit",
-			path: []ottl.Field{
-				{
-					Name: "unit",
-				},
+			fields: []string{
+				"unit",
 			},
 			orig:   "unit",
 			newVal: "new unit",
@@ -83,10 +77,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric type",
-			path: []ottl.Field{
-				{
-					Name: "type",
-				},
+			fields: []string{
+				"type",
 			},
 			orig:   int64(pmetric.MetricTypeSum),
 			newVal: int64(pmetric.MetricTypeSum),
@@ -95,10 +87,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric aggregation_temporality",
-			path: []ottl.Field{
-				{
-					Name: "aggregation_temporality",
-				},
+			fields: []string{
+				"aggregation_temporality",
 			},
 			orig:   int64(2),
 			newVal: int64(1),
@@ -108,10 +98,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric is_monotonic",
-			path: []ottl.Field{
-				{
-					Name: "is_monotonic",
-				},
+			fields: []string{
+				"is_monotonic",
 			},
 			orig:   true,
 			newVal: false,
@@ -121,10 +109,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric data points",
-			path: []ottl.Field{
-				{
-					Name: "data_points",
-				},
+			fields: []string{
+				"data_points",
 			},
 			orig:   refMetric.Sum().DataPoints(),
 			newVal: newDataPoints,
@@ -135,7 +121,7 @@ func Test_MetricPathGetSetter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := MetricPathGetSetter[*metricContext](tt.path)
+			accessor, err := MetricPathGetSetter[*metricContext](ottl.Path{Fields: tt.fields})
 			assert.NoError(t, err)
 
 			metric := createMetricTelemetry()

--- a/pkg/ottl/contexts/internal/ottlcommon/resource.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/resource.go
@@ -27,17 +27,16 @@ type ResourceContext interface {
 	GetResource() pcommon.Resource
 }
 
-func ResourcePathGetSetter[K ResourceContext](path []ottl.Field) (ottl.GetSetter[K], error) {
-	if len(path) == 0 {
+func ResourcePathGetSetter[K ResourceContext](path ottl.Path) (ottl.GetSetter[K], error) {
+	if len(path.Fields) == 0 {
 		return accessResource[K](), nil
 	}
-	switch path[0].Name {
+	switch path.Fields[0] {
 	case "attributes":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessResourceAttributes[K](), nil
 		}
-		return accessResourceAttributesKey[K](mapKey), nil
+		return accessResourceAttributesKey[K](path.MapKey), nil
 	case "dropped_attributes_count":
 		return accessResourceDroppedAttributesCount[K](), nil
 	}

--- a/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/resource_test.go
@@ -33,14 +33,14 @@ func TestResourcePathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(resource pcommon.Resource)
 	}{
 		{
 			name:   "resource",
-			path:   []ottl.Field{},
+			path:   ottl.Path{},
 			orig:   refResource,
 			newVal: pcommon.NewResource(),
 			modified: func(resource pcommon.Resource) {
@@ -49,9 +49,9 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refResource.Attributes(),
@@ -62,11 +62,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -76,11 +76,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -90,11 +90,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -104,11 +104,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   1.2,
 			newVal: 2.4,
@@ -118,11 +118,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -132,11 +132,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array empty",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_empty"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_empty"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refResource.Attributes().Get("arr_empty")
@@ -149,11 +149,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refResource.Attributes().Get("arr_str")
@@ -166,11 +166,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refResource.Attributes().Get("arr_bool")
@@ -183,11 +183,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refResource.Attributes().Get("arr_int")
@@ -200,11 +200,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refResource.Attributes().Get("arr_float")
@@ -217,11 +217,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refResource.Attributes().Get("arr_bytes")
@@ -234,9 +234,9 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
+			path: ottl.Path{
+				Fields: []string{
+					"dropped_attributes_count",
 				},
 			},
 			orig:   int64(10),

--- a/pkg/ottl/contexts/internal/ottlcommon/scope.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/scope.go
@@ -27,22 +27,21 @@ type InstrumentationScopeContext interface {
 	GetInstrumentationScope() pcommon.InstrumentationScope
 }
 
-func ScopePathGetSetter[K InstrumentationScopeContext](path []ottl.Field) (ottl.GetSetter[K], error) {
-	if len(path) == 0 {
+func ScopePathGetSetter[K InstrumentationScopeContext](path ottl.Path) (ottl.GetSetter[K], error) {
+	if len(path.Fields) == 0 {
 		return accessInstrumentationScope[K](), nil
 	}
 
-	switch path[0].Name {
+	switch path.Fields[0] {
 	case "name":
 		return accessInstrumentationScopeName[K](), nil
 	case "version":
 		return accessInstrumentationScopeVersion[K](), nil
 	case "attributes":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessInstrumentationScopeAttributes[K](), nil
 		}
-		return accessInstrumentationScopeAttributesKey[K](mapKey), nil
+		return accessInstrumentationScopeAttributesKey[K](path.MapKey), nil
 	case "dropped_attributes_count":
 		return accessInstrumentationScopeDroppedAttributesCount[K](), nil
 	}

--- a/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/scope_test.go
@@ -32,14 +32,14 @@ func TestScopePathGetSetter(t *testing.T) {
 	newAttrs.PutStr("hello", "world")
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(is pcommon.InstrumentationScope)
 	}{
 		{
 			name:   "instrumentation_scope",
-			path:   []ottl.Field{},
+			path:   ottl.Path{},
 			orig:   refIS,
 			newVal: pcommon.NewInstrumentationScope(),
 			modified: func(is pcommon.InstrumentationScope) {
@@ -48,9 +48,9 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope name",
-			path: []ottl.Field{
-				{
-					Name: "name",
+			path: ottl.Path{
+				Fields: []string{
+					"name",
 				},
 			},
 			orig:   refIS.Name(),
@@ -61,9 +61,9 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope version",
-			path: []ottl.Field{
-				{
-					Name: "version",
+			path: ottl.Path{
+				Fields: []string{
+					"version",
 				},
 			},
 			orig:   refIS.Version(),
@@ -74,9 +74,9 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refIS.Attributes(),
@@ -85,13 +85,14 @@ func TestScopePathGetSetter(t *testing.T) {
 				newAttrs.CopyTo(is.Attributes())
 			},
 		},
+
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -100,25 +101,12 @@ func TestScopePathGetSetter(t *testing.T) {
 			},
 		},
 		{
-			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
-				},
-			},
-			orig:   int64(10),
-			newVal: int64(20),
-			modified: func(is pcommon.InstrumentationScope) {
-				is.SetDroppedAttributesCount(20)
-			},
-		},
-		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -128,11 +116,11 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -142,11 +130,11 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   1.2,
 			newVal: 2.4,
@@ -156,11 +144,11 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -170,11 +158,11 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array empty",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_empty"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_empty"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refIS.Attributes().Get("arr_empty")
@@ -187,11 +175,11 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refIS.Attributes().Get("arr_str")
@@ -199,17 +187,16 @@ func TestScopePathGetSetter(t *testing.T) {
 			}(),
 			newVal: []string{"new"},
 			modified: func(is pcommon.InstrumentationScope) {
-				newArr := is.Attributes().PutEmptySlice("arr_str")
-				newArr.AppendEmpty().SetStr("new")
+				is.Attributes().PutEmptySlice("arr_str").AppendEmpty().SetStr("new")
 			},
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refIS.Attributes().Get("arr_bool")
@@ -217,17 +204,16 @@ func TestScopePathGetSetter(t *testing.T) {
 			}(),
 			newVal: []bool{false},
 			modified: func(is pcommon.InstrumentationScope) {
-				newArr := is.Attributes().PutEmptySlice("arr_bool")
-				newArr.AppendEmpty().SetBool(false)
+				is.Attributes().PutEmptySlice("arr_bool").AppendEmpty().SetBool(false)
 			},
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refIS.Attributes().Get("arr_int")
@@ -235,17 +221,16 @@ func TestScopePathGetSetter(t *testing.T) {
 			}(),
 			newVal: []int64{20},
 			modified: func(is pcommon.InstrumentationScope) {
-				newArr := is.Attributes().PutEmptySlice("arr_int")
-				newArr.AppendEmpty().SetInt(20)
+				is.Attributes().PutEmptySlice("arr_int").AppendEmpty().SetInt(20)
 			},
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refIS.Attributes().Get("arr_float")
@@ -253,17 +238,16 @@ func TestScopePathGetSetter(t *testing.T) {
 			}(),
 			newVal: []float64{2.0},
 			modified: func(is pcommon.InstrumentationScope) {
-				newArr := is.Attributes().PutEmptySlice("arr_float")
-				newArr.AppendEmpty().SetDouble(2.0)
+				is.Attributes().PutEmptySlice("arr_float").AppendEmpty().SetDouble(2.0)
 			},
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refIS.Attributes().Get("arr_bytes")
@@ -271,8 +255,7 @@ func TestScopePathGetSetter(t *testing.T) {
 			}(),
 			newVal: [][]byte{{9, 6, 4}},
 			modified: func(is pcommon.InstrumentationScope) {
-				newArr := is.Attributes().PutEmptySlice("arr_bytes")
-				newArr.AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
+				is.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
 			},
 		},
 	}

--- a/pkg/ottl/contexts/internal/ottlcommon/span.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/span.go
@@ -43,37 +43,36 @@ var SpanSymbolTable = map[ottl.EnumSymbol]ottl.Enum{
 	"STATUS_CODE_ERROR":     ottl.Enum(ptrace.StatusCodeError),
 }
 
-func SpanPathGetSetter[K SpanContext](path []ottl.Field) (ottl.GetSetter[K], error) {
-	if len(path) == 0 {
+func SpanPathGetSetter[K SpanContext](path ottl.Path) (ottl.GetSetter[K], error) {
+	if len(path.Fields) == 0 {
 		return accessSpan[K](), nil
 	}
 
-	switch path[0].Name {
+	switch path.Fields[0] {
 	case "trace_id":
-		if len(path) == 1 {
+		if len(path.Fields) == 1 {
 			return accessTraceID[K](), nil
 		}
-		if path[1].Name == "string" {
+		if path.Fields[1] == "string" {
 			return accessStringTraceID[K](), nil
 		}
 	case "span_id":
-		if len(path) == 1 {
+		if len(path.Fields) == 1 {
 			return accessSpanID[K](), nil
 		}
-		if path[1].Name == "string" {
+		if path.Fields[1] == "string" {
 			return accessStringSpanID[K](), nil
 		}
 	case "trace_state":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessTraceState[K](), nil
 		}
-		return accessTraceStateKey[K](mapKey), nil
+		return accessTraceStateKey[K](path.MapKey), nil
 	case "parent_span_id":
-		if len(path) == 1 {
+		if len(path.Fields) == 1 {
 			return accessParentSpanID[K](), nil
 		}
-		if path[1].Name == "string" {
+		if path.Fields[1] == "string" {
 			return accessStringParentSpanID[K](), nil
 		}
 	case "name":
@@ -85,11 +84,10 @@ func SpanPathGetSetter[K SpanContext](path []ottl.Field) (ottl.GetSetter[K], err
 	case "end_time_unix_nano":
 		return accessEndTimeUnixNano[K](), nil
 	case "attributes":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessAttributes[K](), nil
 		}
-		return accessAttributesKey[K](mapKey), nil
+		return accessAttributesKey[K](path.MapKey), nil
 	case "dropped_attributes_count":
 		return accessSpanDroppedAttributesCount[K](), nil
 	case "events":
@@ -101,10 +99,10 @@ func SpanPathGetSetter[K SpanContext](path []ottl.Field) (ottl.GetSetter[K], err
 	case "dropped_links_count":
 		return accessDroppedLinksCount[K](), nil
 	case "status":
-		if len(path) == 1 {
+		if len(path.Fields) == 1 {
 			return accessStatus[K](), nil
 		}
-		switch path[1].Name {
+		switch path.Fields[1] {
 		case "code":
 			return accessStatusCode[K](), nil
 		case "message":

--- a/pkg/ottl/contexts/internal/ottlcommon/span_test.go
+++ b/pkg/ottl/contexts/internal/ottlcommon/span_test.go
@@ -52,16 +52,16 @@ func TestSpanPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(span ptrace.Span)
 	}{
 		{
 			name: "trace_id",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
+			path: ottl.Path{
+				Fields: []string{
+					"trace_id",
 				},
 			},
 			orig:   pcommon.TraceID(traceID),
@@ -72,9 +72,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
+			path: ottl.Path{
+				Fields: []string{
+					"span_id",
 				},
 			},
 			orig:   pcommon.SpanID(spanID),
@@ -85,12 +85,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id string",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
-				},
-				{
-					Name: "string",
+			path: ottl.Path{
+				Fields: []string{
+					"trace_id",
+					"string",
 				},
 			},
 			orig:   hex.EncodeToString(traceID[:]),
@@ -101,12 +99,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id string",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
-				},
-				{
-					Name: "string",
+			path: ottl.Path{
+				Fields: []string{
+					"span_id",
+					"string",
 				},
 			},
 			orig:   hex.EncodeToString(spanID[:]),
@@ -117,9 +113,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_state",
-			path: []ottl.Field{
-				{
-					Name: "trace_state",
+			path: ottl.Path{
+				Fields: []string{
+					"trace_state",
 				},
 			},
 			orig:   "key1=val1,key2=val2",
@@ -130,11 +126,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_state key",
-			path: []ottl.Field{
-				{
-					Name:   "trace_state",
-					MapKey: ottltest.Strp("key1"),
+			path: ottl.Path{
+				Fields: []string{
+					"trace_state",
 				},
+				MapKey: ottltest.Strp("key1"),
 			},
 			orig:   "val1",
 			newVal: "newVal",
@@ -144,9 +140,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "parent_span_id",
-			path: []ottl.Field{
-				{
-					Name: "parent_span_id",
+			path: ottl.Path{
+				Fields: []string{
+					"parent_span_id",
 				},
 			},
 			orig:   pcommon.SpanID(spanID2),
@@ -157,12 +153,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "parent_span_id string",
-			path: []ottl.Field{
-				{
-					Name: "parent_span_id",
-				},
-				{
-					Name: "string",
+			path: ottl.Path{
+				Fields: []string{
+					"parent_span_id",
+					"string",
 				},
 			},
 			orig:   hex.EncodeToString(spanID2[:]),
@@ -173,9 +167,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "name",
-			path: []ottl.Field{
-				{
-					Name: "name",
+			path: ottl.Path{
+				Fields: []string{
+					"name",
 				},
 			},
 			orig:   "bear",
@@ -186,9 +180,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "kind",
-			path: []ottl.Field{
-				{
-					Name: "kind",
+			path: ottl.Path{
+				Fields: []string{
+					"kind",
 				},
 			},
 			orig:   int64(2),
@@ -199,9 +193,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"start_time_unix_nano",
 				},
 			},
 			orig:   int64(100_000_000),
@@ -212,9 +206,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "end_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "end_time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"end_time_unix_nano",
 				},
 			},
 			orig:   int64(500_000_000),
@@ -225,9 +219,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refSpan.Attributes(),
@@ -238,11 +232,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -252,11 +246,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -266,11 +260,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -280,11 +274,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
@@ -294,11 +288,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -308,11 +302,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array empty",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_empty"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_empty"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpan.Attributes().Get("arr_empty")
@@ -325,11 +319,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpan.Attributes().Get("arr_str")
@@ -342,11 +336,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpan.Attributes().Get("arr_bool")
@@ -359,11 +353,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpan.Attributes().Get("arr_int")
@@ -376,11 +370,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpan.Attributes().Get("arr_float")
@@ -393,11 +387,11 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpan.Attributes().Get("arr_bytes")
@@ -410,9 +404,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
+			path: ottl.Path{
+				Fields: []string{
+					"dropped_attributes_count",
 				},
 			},
 			orig:   int64(10),
@@ -423,9 +417,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "events",
-			path: []ottl.Field{
-				{
-					Name: "events",
+			path: ottl.Path{
+				Fields: []string{
+					"events",
 				},
 			},
 			orig:   refSpan.Events(),
@@ -439,9 +433,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_events_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_events_count",
+			path: ottl.Path{
+				Fields: []string{
+					"dropped_events_count",
 				},
 			},
 			orig:   int64(20),
@@ -452,9 +446,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "links",
-			path: []ottl.Field{
-				{
-					Name: "links",
+			path: ottl.Path{
+				Fields: []string{
+					"links",
 				},
 			},
 			orig:   refSpan.Links(),
@@ -468,9 +462,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_links_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_links_count",
+			path: ottl.Path{
+				Fields: []string{
+					"dropped_links_count",
 				},
 			},
 			orig:   int64(30),
@@ -481,9 +475,9 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status",
-			path: []ottl.Field{
-				{
-					Name: "status",
+			path: ottl.Path{
+				Fields: []string{
+					"status",
 				},
 			},
 			orig:   refSpan.Status(),
@@ -494,12 +488,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status code",
-			path: []ottl.Field{
-				{
-					Name: "status",
-				},
-				{
-					Name: "code",
+			path: ottl.Path{
+				Fields: []string{
+					"status",
+					"code",
 				},
 			},
 			orig:   int64(ptrace.StatusCodeOk),
@@ -510,12 +502,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status message",
-			path: []ottl.Field{
-				{
-					Name: "status",
-				},
-				{
-					Name: "message",
+			path: ottl.Path{
+				Fields: []string{
+					"status",
+					"message",
 				},
 			},
 			orig:   "good span",

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -131,31 +131,29 @@ func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 
 func parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
 	if val != nil && len(val.Fields) > 0 {
-		return newPathGetSetter(val.Fields)
+		return newPathGetSetter(*val)
 	}
 	return nil, fmt.Errorf("bad path %v", val)
 }
 
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
-	switch path[0].Name {
+func newPathGetSetter(path ottl.Path) (ottl.GetSetter[TransformContext], error) {
+	switch path.Fields[0] {
 	case "cache":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessCache(), nil
 		}
-		return accessCacheKey(mapKey), nil
+		return accessCacheKey(path.MapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return ottlcommon.ResourcePathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	case "instrumentation_scope":
-		return ottlcommon.ScopePathGetSetter[TransformContext](path[1:])
+		return ottlcommon.ScopePathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	case "metric":
-		return ottlcommon.MetricPathGetSetter[TransformContext](path[1:])
+		return ottlcommon.MetricPathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	case "attributes":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessAttributes(), nil
 		}
-		return accessAttributesKey(mapKey), nil
+		return accessAttributesKey(path.MapKey), nil
 	case "start_time_unix_nano":
 		return accessStartTimeUnixNano(), nil
 	case "time_unix_nano":
@@ -181,20 +179,20 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 	case "zero_count":
 		return accessZeroCount(), nil
 	case "positive":
-		if len(path) == 1 {
+		if len(path.Fields) == 1 {
 			return accessPositive(), nil
 		}
-		switch path[1].Name {
+		switch path.Fields[1] {
 		case "offset":
 			return accessPositiveOffset(), nil
 		case "bucket_counts":
 			return accessPositiveBucketCounts(), nil
 		}
 	case "negative":
-		if len(path) == 1 {
+		if len(path.Fields) == 1 {
 			return accessNegative(), nil
 		}
-		switch path[1].Name {
+		switch path.Fields[1] {
 		case "offset":
 			return accessNegativeOffset(), nil
 		case "bucket_counts":

--- a/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
@@ -33,7 +33,7 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		path      []ottl.Field
+		path      ottl.Path
 		orig      interface{}
 		newVal    interface{}
 		modified  func(cache pcommon.Map)
@@ -42,9 +42,9 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
 			},
 			orig:   pcommon.NewMap(),
@@ -55,11 +55,11 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name:   "cache",
-					MapKey: ottltest.Strp("temp"),
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
+				MapKey: ottltest.Strp("temp"),
 			},
 			orig:   nil,
 			newVal: "new value",
@@ -108,7 +108,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		path      []ottl.Field
+		path      ottl.Path
 		orig      interface{}
 		newVal    interface{}
 		modified  func(pmetric.NumberDataPoint)
@@ -116,9 +116,9 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"start_time_unix_nano",
 				},
 			},
 			orig:   int64(100_000_000),
@@ -129,9 +129,9 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"time_unix_nano",
 				},
 			},
 			orig:   int64(500_000_000),
@@ -142,9 +142,9 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "value_double",
-			path: []ottl.Field{
-				{
-					Name: "value_double",
+			path: ottl.Path{
+				Fields: []string{
+					"value_double",
 				},
 			},
 			orig:   1.1,
@@ -156,9 +156,9 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "value_int",
-			path: []ottl.Field{
-				{
-					Name: "value_int",
+			path: ottl.Path{
+				Fields: []string{
+					"value_int",
 				},
 			},
 			orig:   int64(1),
@@ -169,9 +169,9 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: []ottl.Field{
-				{
-					Name: "flags",
+			path: ottl.Path{
+				Fields: []string{
+					"flags",
 				},
 			},
 			orig:   int64(0),
@@ -182,9 +182,9 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "exemplars",
-			path: []ottl.Field{
-				{
-					Name: "exemplars",
+			path: ottl.Path{
+				Fields: []string{
+					"exemplars",
 				},
 			},
 			orig:   refNumberDataPoint.Exemplars(),
@@ -195,9 +195,9 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refNumberDataPoint.Attributes(),
@@ -208,11 +208,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -222,11 +222,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -236,11 +236,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -250,11 +250,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
@@ -264,11 +264,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -278,11 +278,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refNumberDataPoint.Attributes().Get("arr_str")
@@ -295,11 +295,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refNumberDataPoint.Attributes().Get("arr_bool")
@@ -312,11 +312,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refNumberDataPoint.Attributes().Get("arr_int")
@@ -329,11 +329,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refNumberDataPoint.Attributes().Get("arr_float")
@@ -346,11 +346,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refNumberDataPoint.Attributes().Get("arr_bytes")
@@ -363,11 +363,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("pMap"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("pMap"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refNumberDataPoint.Attributes().Get("pMap")
@@ -382,11 +382,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]interface{}",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("map"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("map"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refNumberDataPoint.Attributes().Get("map")
@@ -458,16 +458,16 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(pmetric.HistogramDataPoint)
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"start_time_unix_nano",
 				},
 			},
 			orig:   int64(100_000_000),
@@ -478,9 +478,9 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"time_unix_nano",
 				},
 			},
 			orig:   int64(500_000_000),
@@ -491,9 +491,9 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: []ottl.Field{
-				{
-					Name: "flags",
+			path: ottl.Path{
+				Fields: []string{
+					"flags",
 				},
 			},
 			orig:   int64(0),
@@ -504,9 +504,9 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "count",
-			path: []ottl.Field{
-				{
-					Name: "count",
+			path: ottl.Path{
+				Fields: []string{
+					"count",
 				},
 			},
 			orig:   int64(2),
@@ -517,9 +517,9 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "sum",
-			path: []ottl.Field{
-				{
-					Name: "sum",
+			path: ottl.Path{
+				Fields: []string{
+					"sum",
 				},
 			},
 			orig:   10.1,
@@ -530,9 +530,9 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "bucket_counts",
-			path: []ottl.Field{
-				{
-					Name: "bucket_counts",
+			path: ottl.Path{
+				Fields: []string{
+					"bucket_counts",
 				},
 			},
 			orig:   []uint64{1, 1},
@@ -543,9 +543,9 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "explicit_bounds",
-			path: []ottl.Field{
-				{
-					Name: "explicit_bounds",
+			path: ottl.Path{
+				Fields: []string{
+					"explicit_bounds",
 				},
 			},
 			orig:   []float64{1, 2},
@@ -556,9 +556,9 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "exemplars",
-			path: []ottl.Field{
-				{
-					Name: "exemplars",
+			path: ottl.Path{
+				Fields: []string{
+					"exemplars",
 				},
 			},
 			orig:   refHistogramDataPoint.Exemplars(),
@@ -569,9 +569,9 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refHistogramDataPoint.Attributes(),
@@ -582,11 +582,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -596,11 +596,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -610,11 +610,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -624,11 +624,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
@@ -638,11 +638,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -652,11 +652,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refHistogramDataPoint.Attributes().Get("arr_str")
@@ -669,11 +669,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refHistogramDataPoint.Attributes().Get("arr_bool")
@@ -686,11 +686,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refHistogramDataPoint.Attributes().Get("arr_int")
@@ -703,11 +703,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refHistogramDataPoint.Attributes().Get("arr_float")
@@ -720,11 +720,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refHistogramDataPoint.Attributes().Get("arr_bytes")
@@ -737,11 +737,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("pMap"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("pMap"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refHistogramDataPoint.Attributes().Get("pMap")
@@ -756,11 +756,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]interface{}",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("map"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("map"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refHistogramDataPoint.Attributes().Get("map")
@@ -838,16 +838,16 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(pmetric.ExponentialHistogramDataPoint)
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"start_time_unix_nano",
 				},
 			},
 			orig:   int64(100_000_000),
@@ -858,9 +858,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"time_unix_nano",
 				},
 			},
 			orig:   int64(500_000_000),
@@ -871,9 +871,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: []ottl.Field{
-				{
-					Name: "flags",
+			path: ottl.Path{
+				Fields: []string{
+					"flags",
 				},
 			},
 			orig:   int64(0),
@@ -884,9 +884,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "count",
-			path: []ottl.Field{
-				{
-					Name: "count",
+			path: ottl.Path{
+				Fields: []string{
+					"count",
 				},
 			},
 			orig:   int64(2),
@@ -897,9 +897,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "sum",
-			path: []ottl.Field{
-				{
-					Name: "sum",
+			path: ottl.Path{
+				Fields: []string{
+					"sum",
 				},
 			},
 			orig:   10.1,
@@ -910,9 +910,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "scale",
-			path: []ottl.Field{
-				{
-					Name: "scale",
+			path: ottl.Path{
+				Fields: []string{
+					"scale",
 				},
 			},
 			orig:   int64(1),
@@ -923,9 +923,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "zero_count",
-			path: []ottl.Field{
-				{
-					Name: "zero_count",
+			path: ottl.Path{
+				Fields: []string{
+					"zero_count",
 				},
 			},
 			orig:   int64(1),
@@ -936,9 +936,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "positive",
-			path: []ottl.Field{
-				{
-					Name: "positive",
+			path: ottl.Path{
+				Fields: []string{
+					"positive",
 				},
 			},
 			orig:   refExpoHistogramDataPoint.Positive(),
@@ -949,12 +949,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "positive offset",
-			path: []ottl.Field{
-				{
-					Name: "positive",
-				},
-				{
-					Name: "offset",
+			path: ottl.Path{
+				Fields: []string{
+					"positive",
+					"offset",
 				},
 			},
 			orig:   int64(1),
@@ -965,12 +963,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "positive bucket_counts",
-			path: []ottl.Field{
-				{
-					Name: "positive",
-				},
-				{
-					Name: "bucket_counts",
+			path: ottl.Path{
+				Fields: []string{
+					"positive",
+					"bucket_counts",
 				},
 			},
 			orig:   []uint64{1, 1},
@@ -981,9 +977,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "negative",
-			path: []ottl.Field{
-				{
-					Name: "negative",
+			path: ottl.Path{
+				Fields: []string{
+					"negative",
 				},
 			},
 			orig:   refExpoHistogramDataPoint.Negative(),
@@ -994,12 +990,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "negative offset",
-			path: []ottl.Field{
-				{
-					Name: "negative",
-				},
-				{
-					Name: "offset",
+			path: ottl.Path{
+				Fields: []string{
+					"negative",
+					"offset",
 				},
 			},
 			orig:   int64(1),
@@ -1010,12 +1004,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "negative bucket_counts",
-			path: []ottl.Field{
-				{
-					Name: "negative",
-				},
-				{
-					Name: "bucket_counts",
+			path: ottl.Path{
+				Fields: []string{
+					"negative",
+					"bucket_counts",
 				},
 			},
 			orig:   []uint64{1, 1},
@@ -1026,9 +1018,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "exemplars",
-			path: []ottl.Field{
-				{
-					Name: "exemplars",
+			path: ottl.Path{
+				Fields: []string{
+					"exemplars",
 				},
 			},
 			orig:   refExpoHistogramDataPoint.Exemplars(),
@@ -1039,9 +1031,9 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refExpoHistogramDataPoint.Attributes(),
@@ -1052,11 +1044,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -1066,11 +1058,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -1080,11 +1072,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -1094,11 +1086,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   1.2,
 			newVal: 2.4,
@@ -1108,11 +1100,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -1122,11 +1114,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refExpoHistogramDataPoint.Attributes().Get("arr_str")
@@ -1139,11 +1131,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refExpoHistogramDataPoint.Attributes().Get("arr_bool")
@@ -1156,11 +1148,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refExpoHistogramDataPoint.Attributes().Get("arr_int")
@@ -1173,11 +1165,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refExpoHistogramDataPoint.Attributes().Get("arr_float")
@@ -1190,11 +1182,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refExpoHistogramDataPoint.Attributes().Get("arr_bytes")
@@ -1207,11 +1199,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("pMap"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("pMap"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refExpoHistogramDataPoint.Attributes().Get("pMap")
@@ -1226,11 +1218,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]interface{}",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("map"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("map"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refExpoHistogramDataPoint.Attributes().Get("map")
@@ -1309,16 +1301,16 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(pmetric.SummaryDataPoint)
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"start_time_unix_nano",
 				},
 			},
 			orig:   int64(100_000_000),
@@ -1329,9 +1321,9 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"time_unix_nano",
 				},
 			},
 			orig:   int64(500_000_000),
@@ -1342,9 +1334,9 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: []ottl.Field{
-				{
-					Name: "flags",
+			path: ottl.Path{
+				Fields: []string{
+					"flags",
 				},
 			},
 			orig:   int64(0),
@@ -1355,9 +1347,9 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "count",
-			path: []ottl.Field{
-				{
-					Name: "count",
+			path: ottl.Path{
+				Fields: []string{
+					"count",
 				},
 			},
 			orig:   int64(2),
@@ -1368,9 +1360,9 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "sum",
-			path: []ottl.Field{
-				{
-					Name: "sum",
+			path: ottl.Path{
+				Fields: []string{
+					"sum",
 				},
 			},
 			orig:   10.1,
@@ -1381,9 +1373,9 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "quantile_values",
-			path: []ottl.Field{
-				{
-					Name: "quantile_values",
+			path: ottl.Path{
+				Fields: []string{
+					"quantile_values",
 				},
 			},
 			orig:   refSummaryDataPoint.QuantileValues(),
@@ -1394,9 +1386,9 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refSummaryDataPoint.Attributes(),
@@ -1407,11 +1399,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -1421,11 +1413,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -1435,11 +1427,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -1449,11 +1441,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   1.2,
 			newVal: 2.4,
@@ -1463,11 +1455,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -1477,11 +1469,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSummaryDataPoint.Attributes().Get("arr_str")
@@ -1494,11 +1486,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSummaryDataPoint.Attributes().Get("arr_bool")
@@ -1511,11 +1503,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSummaryDataPoint.Attributes().Get("arr_int")
@@ -1528,11 +1520,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSummaryDataPoint.Attributes().Get("arr_float")
@@ -1545,11 +1537,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSummaryDataPoint.Attributes().Get("arr_bytes")
@@ -1562,11 +1554,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("pMap"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("pMap"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refSummaryDataPoint.Attributes().Get("pMap")
@@ -1581,11 +1573,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]interface{}",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("map"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("map"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refSummaryDataPoint.Attributes().Get("map")
@@ -1679,16 +1671,16 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(metric pmetric.Metric)
 	}{
 		{
 			name: "metric",
-			path: []ottl.Field{
-				{
-					Name: "metric",
+			path: ottl.Path{
+				Fields: []string{
+					"metric",
 				},
 			},
 			orig:   refMetric,
@@ -1699,12 +1691,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric name",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "name",
+			path: ottl.Path{
+				Fields: []string{
+					"metric",
+					"name",
 				},
 			},
 			orig:   "name",
@@ -1715,12 +1705,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric description",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "description",
+			path: ottl.Path{
+				Fields: []string{
+					"metric",
+					"description",
 				},
 			},
 			orig:   "description",
@@ -1731,12 +1719,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric unit",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "unit",
+			path: ottl.Path{
+				Fields: []string{
+					"metric",
+					"unit",
 				},
 			},
 			orig:   "unit",
@@ -1747,12 +1733,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric type",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "type",
+			path: ottl.Path{
+				Fields: []string{
+					"metric",
+					"type",
 				},
 			},
 			orig:   int64(pmetric.MetricTypeSum),
@@ -1762,12 +1746,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric aggregation_temporality",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "aggregation_temporality",
+			path: ottl.Path{
+				Fields: []string{
+					"metric",
+					"aggregation_temporality",
 				},
 			},
 			orig:   int64(2),
@@ -1778,12 +1760,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric is_monotonic",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "is_monotonic",
+			path: ottl.Path{
+				Fields: []string{
+					"metric",
+					"is_monotonic",
 				},
 			},
 			orig:   true,

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -137,23 +137,22 @@ func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 
 func parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
 	if val != nil && len(val.Fields) > 0 {
-		return newPathGetSetter(val.Fields)
+		return newPathGetSetter(*val)
 	}
 	return nil, fmt.Errorf("bad path %v", val)
 }
 
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
-	switch path[0].Name {
+func newPathGetSetter(path ottl.Path) (ottl.GetSetter[TransformContext], error) {
+	switch path.Fields[0] {
 	case "cache":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessCache(), nil
 		}
-		return accessCacheKey(mapKey), nil
+		return accessCacheKey(path.MapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return ottlcommon.ResourcePathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	case "instrumentation_scope":
-		return ottlcommon.ScopePathGetSetter[TransformContext](path[1:])
+		return ottlcommon.ScopePathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	case "time_unix_nano":
 		return accessTimeUnixNano(), nil
 	case "observed_time_unix_nano":
@@ -165,27 +164,26 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 	case "body":
 		return accessBody(), nil
 	case "attributes":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessAttributes(), nil
 		}
-		return accessAttributesKey(mapKey), nil
+		return accessAttributesKey(path.MapKey), nil
 	case "dropped_attributes_count":
 		return accessDroppedAttributesCount(), nil
 	case "flags":
 		return accessFlags(), nil
 	case "trace_id":
-		if len(path) == 1 {
+		if len(path.Fields) == 1 {
 			return accessTraceID(), nil
 		}
-		if path[1].Name == "string" {
+		if path.Fields[1] == "string" {
 			return accessStringTraceID(), nil
 		}
 	case "span_id":
-		if len(path) == 1 {
+		if len(path.Fields) == 1 {
 			return accessSpanID(), nil
 		}
-		if path[1].Name == "string" {
+		if path.Fields[1] == "string" {
 			return accessStringSpanID(), nil
 		}
 	}

--- a/pkg/ottl/contexts/ottllog/log_test.go
+++ b/pkg/ottl/contexts/ottllog/log_test.go
@@ -55,16 +55,16 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map)
 	}{
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"time_unix_nano",
 				},
 			},
 			orig:   int64(100_000_000),
@@ -75,9 +75,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "observed_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "observed_time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"observed_time_unix_nano",
 				},
 			},
 			orig:   int64(500_000_000),
@@ -88,9 +88,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "severity_number",
-			path: []ottl.Field{
-				{
-					Name: "severity_number",
+			path: ottl.Path{
+				Fields: []string{
+					"severity_number",
 				},
 			},
 			orig:   int64(plog.SeverityNumberFatal),
@@ -101,9 +101,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "severity_text",
-			path: []ottl.Field{
-				{
-					Name: "severity_text",
+			path: ottl.Path{
+				Fields: []string{
+					"severity_text",
 				},
 			},
 			orig:   "blue screen of death",
@@ -114,9 +114,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "body",
-			path: []ottl.Field{
-				{
-					Name: "body",
+			path: ottl.Path{
+				Fields: []string{
+					"body",
 				},
 			},
 			orig:   "body",
@@ -127,9 +127,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: []ottl.Field{
-				{
-					Name: "flags",
+			path: ottl.Path{
+				Fields: []string{
+					"flags",
 				},
 			},
 			orig:   int64(4),
@@ -140,9 +140,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
+			path: ottl.Path{
+				Fields: []string{
+					"trace_id",
 				},
 			},
 			orig:   pcommon.TraceID(traceID),
@@ -153,9 +153,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
+			path: ottl.Path{
+				Fields: []string{
+					"span_id",
 				},
 			},
 			orig:   pcommon.SpanID(spanID),
@@ -166,12 +166,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id string",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
-				},
-				{
-					Name: "string",
+			path: ottl.Path{
+				Fields: []string{
+					"trace_id",
+					"string",
 				},
 			},
 			orig:   hex.EncodeToString(traceID[:]),
@@ -182,12 +180,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id string",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
-				},
-				{
-					Name: "string",
+			path: ottl.Path{
+				Fields: []string{
+					"span_id",
+					"string",
 				},
 			},
 			orig:   hex.EncodeToString(spanID[:]),
@@ -198,9 +194,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
 			},
 			orig:   pcommon.NewMap(),
@@ -211,11 +207,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name:   "cache",
-					MapKey: ottltest.Strp("temp"),
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
+				MapKey: ottltest.Strp("temp"),
 			},
 			orig:   nil,
 			newVal: "new value",
@@ -225,9 +221,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refLog.Attributes(),
@@ -238,11 +234,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -252,11 +248,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -266,11 +262,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -280,11 +276,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
@@ -294,11 +290,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -308,11 +304,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refLog.Attributes().Get("arr_str")
@@ -325,11 +321,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refLog.Attributes().Get("arr_bool")
@@ -342,11 +338,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refLog.Attributes().Get("arr_int")
@@ -359,11 +355,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refLog.Attributes().Get("arr_float")
@@ -376,11 +372,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refLog.Attributes().Get("arr_bytes")
@@ -393,11 +389,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("pMap"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("pMap"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refLog.Attributes().Get("pMap")
@@ -412,11 +408,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]interface{}",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("map"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("map"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refLog.Attributes().Get("map")
@@ -431,9 +427,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
+			path: ottl.Path{
+				Fields: []string{
+					"dropped_attributes_count",
 				},
 			},
 			orig:   int64(10),
@@ -444,9 +440,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope",
-			path: []ottl.Field{
-				{
-					Name: "instrumentation_scope",
+			path: ottl.Path{
+				Fields: []string{
+					"instrumentation_scope",
 				},
 			},
 			orig:   refIS,
@@ -457,9 +453,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "resource",
-			path: []ottl.Field{
-				{
-					Name: "resource",
+			path: ottl.Path{
+				Fields: []string{
+					"resource",
 				},
 			},
 			orig:   refResource,

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -110,23 +110,22 @@ func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 
 func parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
 	if val != nil && len(val.Fields) > 0 {
-		return newPathGetSetter(val.Fields)
+		return newPathGetSetter(*val)
 	}
 	return nil, fmt.Errorf("bad path %v", val)
 }
 
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
-	switch path[0].Name {
+func newPathGetSetter(path ottl.Path) (ottl.GetSetter[TransformContext], error) {
+	switch path.Fields[0] {
 	case "cache":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessCache(), nil
 		}
-		return accessCacheKey(mapKey), nil
+		return accessCacheKey(path.MapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return ottlcommon.ResourcePathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	case "instrumentation_scope":
-		return ottlcommon.ScopePathGetSetter[TransformContext](path[1:])
+		return ottlcommon.ScopePathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	default:
 		return ottlcommon.MetricPathGetSetter[TransformContext](path)
 	}

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -42,16 +42,16 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(metric pmetric.Metric, cache pcommon.Map)
 	}{
 		{
 			name: "metric name",
-			path: []ottl.Field{
-				{
-					Name: "name",
+			path: ottl.Path{
+				Fields: []string{
+					"name",
 				},
 			},
 			orig:   "name",
@@ -62,9 +62,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric description",
-			path: []ottl.Field{
-				{
-					Name: "description",
+			path: ottl.Path{
+				Fields: []string{
+					"description",
 				},
 			},
 			orig:   "description",
@@ -75,9 +75,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric unit",
-			path: []ottl.Field{
-				{
-					Name: "unit",
+			path: ottl.Path{
+				Fields: []string{
+					"unit",
 				},
 			},
 			orig:   "unit",
@@ -88,9 +88,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric type",
-			path: []ottl.Field{
-				{
-					Name: "type",
+			path: ottl.Path{
+				Fields: []string{
+					"type",
 				},
 			},
 			orig:   int64(pmetric.MetricTypeSum),
@@ -100,9 +100,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric aggregation_temporality",
-			path: []ottl.Field{
-				{
-					Name: "aggregation_temporality",
+			path: ottl.Path{
+				Fields: []string{
+					"aggregation_temporality",
 				},
 			},
 			orig:   int64(2),
@@ -113,9 +113,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric is_monotonic",
-			path: []ottl.Field{
-				{
-					Name: "is_monotonic",
+			path: ottl.Path{
+				Fields: []string{
+					"is_monotonic",
 				},
 			},
 			orig:   true,
@@ -126,9 +126,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric data points",
-			path: []ottl.Field{
-				{
-					Name: "data_points",
+			path: ottl.Path{
+				Fields: []string{
+					"data_points",
 				},
 			},
 			orig:   refMetric.Sum().DataPoints(),
@@ -139,9 +139,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
 			},
 			orig:   pcommon.NewMap(),
@@ -152,11 +152,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name:   "cache",
-					MapKey: ottltest.Strp("temp"),
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
+				MapKey: ottltest.Strp("temp"),
 			},
 			orig:   nil,
 			newVal: "new value",

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -87,19 +87,18 @@ func parseEnum(_ *ottl.EnumSymbol) (*ottl.Enum, error) {
 
 func parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
 	if val != nil && len(val.Fields) > 0 {
-		return newPathGetSetter(val.Fields)
+		return newPathGetSetter(*val)
 	}
 	return nil, fmt.Errorf("bad path %v", val)
 }
 
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
-	switch path[0].Name {
+func newPathGetSetter(path ottl.Path) (ottl.GetSetter[TransformContext], error) {
+	switch path.Fields[0] {
 	case "cache":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessCache(), nil
 		}
-		return accessCacheKey(mapKey), nil
+		return accessCacheKey(path.MapKey), nil
 	default:
 		return ottlcommon.ResourcePathGetSetter[TransformContext](path)
 	}

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -45,16 +45,16 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(resource pcommon.Resource, cache pcommon.Map)
 	}{
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
 			},
 			orig:   pcommon.NewMap(),
@@ -65,11 +65,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name:   "cache",
-					MapKey: ottltest.Strp("temp"),
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
+				MapKey: ottltest.Strp("temp"),
 			},
 			orig:   nil,
 			newVal: "new value",
@@ -79,9 +79,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refResource.Attributes(),
@@ -92,11 +92,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -106,11 +106,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -120,11 +120,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -134,11 +134,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
@@ -148,11 +148,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -162,11 +162,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refResource.Attributes().Get("arr_str")
@@ -179,11 +179,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refResource.Attributes().Get("arr_bool")
@@ -196,11 +196,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refResource.Attributes().Get("arr_int")
@@ -213,11 +213,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refResource.Attributes().Get("arr_float")
@@ -230,11 +230,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refResource.Attributes().Get("arr_bytes")
@@ -247,11 +247,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("pMap"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("pMap"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refResource.Attributes().Get("pMap")
@@ -266,11 +266,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes mpa[string]interface",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("map"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("map"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refResource.Attributes().Get("map")
@@ -285,9 +285,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
+			path: ottl.Path{
+				Fields: []string{
+					"dropped_attributes_count",
 				},
 			},
 			orig:   int64(10),

--- a/pkg/ottl/contexts/ottlscope/scope.go
+++ b/pkg/ottl/contexts/ottlscope/scope.go
@@ -94,21 +94,20 @@ func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 
 func parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
 	if val != nil && len(val.Fields) > 0 {
-		return newPathGetSetter(val.Fields)
+		return newPathGetSetter(*val)
 	}
 	return nil, fmt.Errorf("bad path %v", val)
 }
 
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
-	switch path[0].Name {
+func newPathGetSetter(path ottl.Path) (ottl.GetSetter[TransformContext], error) {
+	switch path.Fields[0] {
 	case "cache":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessCache(), nil
 		}
-		return accessCacheKey(mapKey), nil
+		return accessCacheKey(path.MapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return ottlcommon.ResourcePathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	default:
 		return ottlcommon.ScopePathGetSetter[TransformContext](path)
 	}

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -45,16 +45,16 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map)
 	}{
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
 			},
 			orig:   pcommon.NewMap(),
@@ -65,11 +65,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name:   "cache",
-					MapKey: ottltest.Strp("temp"),
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
+				MapKey: ottltest.Strp("temp"),
 			},
 			orig:   nil,
 			newVal: "new value",
@@ -79,9 +79,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refIS.Attributes(),
@@ -92,11 +92,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -106,11 +106,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -120,11 +120,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -134,11 +134,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
@@ -148,11 +148,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -162,11 +162,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refIS.Attributes().Get("arr_str")
@@ -179,11 +179,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refIS.Attributes().Get("arr_bool")
@@ -196,11 +196,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refIS.Attributes().Get("arr_int")
@@ -213,11 +213,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refIS.Attributes().Get("arr_float")
@@ -230,11 +230,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refIS.Attributes().Get("arr_bytes")
@@ -247,11 +247,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("pMap"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("pMap"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refIS.Attributes().Get("pMap")
@@ -266,11 +266,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]interface{}",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("map"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("map"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refIS.Attributes().Get("map")
@@ -285,9 +285,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
+			path: ottl.Path{
+				Fields: []string{
+					"dropped_attributes_count",
 				},
 			},
 			orig:   int64(10),
@@ -298,9 +298,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "name",
-			path: []ottl.Field{
-				{
-					Name: "name",
+			path: ottl.Path{
+				Fields: []string{
+					"name",
 				},
 			},
 			orig:   refIS.Name(),
@@ -311,9 +311,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "version",
-			path: []ottl.Field{
-				{
-					Name: "version",
+			path: ottl.Path{
+				Fields: []string{
+					"version",
 				},
 			},
 			orig:   refIS.Version(),
@@ -324,9 +324,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "resource",
-			path: []ottl.Field{
-				{
-					Name: "resource",
+			path: ottl.Path{
+				Fields: []string{
+					"resource",
 				},
 			},
 			orig:   refResource,

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -107,23 +107,22 @@ func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 
 func parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
 	if val != nil && len(val.Fields) > 0 {
-		return newPathGetSetter(val.Fields)
+		return newPathGetSetter(*val)
 	}
 	return nil, fmt.Errorf("bad path %v", val)
 }
 
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
-	switch path[0].Name {
+func newPathGetSetter(path ottl.Path) (ottl.GetSetter[TransformContext], error) {
+	switch path.Fields[0] {
 	case "cache":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessCache(), nil
 		}
-		return accessCacheKey(mapKey), nil
+		return accessCacheKey(path.MapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return ottlcommon.ResourcePathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	case "instrumentation_scope":
-		return ottlcommon.ScopePathGetSetter[TransformContext](path[1:])
+		return ottlcommon.ScopePathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	default:
 		return ottlcommon.SpanPathGetSetter[TransformContext](path)
 	}

--- a/pkg/ottl/contexts/ottlspan/span_test.go
+++ b/pkg/ottl/contexts/ottlspan/span_test.go
@@ -64,16 +64,16 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map)
 	}{
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
 			},
 			orig:   pcommon.NewMap(),
@@ -84,11 +84,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name:   "cache",
-					MapKey: ottltest.Strp("temp"),
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
+				MapKey: ottltest.Strp("temp"),
 			},
 			orig:   nil,
 			newVal: "new value",
@@ -98,9 +98,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
+			path: ottl.Path{
+				Fields: []string{
+					"trace_id",
 				},
 			},
 			orig:   pcommon.TraceID(traceID),
@@ -111,9 +111,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
+			path: ottl.Path{
+				Fields: []string{
+					"span_id",
 				},
 			},
 			orig:   pcommon.SpanID(spanID),
@@ -124,12 +124,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id string",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
-				},
-				{
-					Name: "string",
+			path: ottl.Path{
+				Fields: []string{
+					"trace_id",
+					"string",
 				},
 			},
 			orig:   hex.EncodeToString(traceID[:]),
@@ -140,12 +138,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id string",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
-				},
-				{
-					Name: "string",
+			path: ottl.Path{
+				Fields: []string{
+					"span_id",
+					"string",
 				},
 			},
 			orig:   hex.EncodeToString(spanID[:]),
@@ -156,9 +152,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_state",
-			path: []ottl.Field{
-				{
-					Name: "trace_state",
+			path: ottl.Path{
+				Fields: []string{
+					"trace_state",
 				},
 			},
 			orig:   "key1=val1,key2=val2",
@@ -169,11 +165,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_state key",
-			path: []ottl.Field{
-				{
-					Name:   "trace_state",
-					MapKey: ottltest.Strp("key1"),
+			path: ottl.Path{
+				Fields: []string{
+					"trace_state",
 				},
+				MapKey: ottltest.Strp("key1"),
 			},
 			orig:   "val1",
 			newVal: "newVal",
@@ -183,9 +179,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "parent_span_id",
-			path: []ottl.Field{
-				{
-					Name: "parent_span_id",
+			path: ottl.Path{
+				Fields: []string{
+					"parent_span_id",
 				},
 			},
 			orig:   pcommon.SpanID(spanID2),
@@ -196,9 +192,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "name",
-			path: []ottl.Field{
-				{
-					Name: "name",
+			path: ottl.Path{
+				Fields: []string{
+					"name",
 				},
 			},
 			orig:   "bear",
@@ -209,9 +205,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "kind",
-			path: []ottl.Field{
-				{
-					Name: "kind",
+			path: ottl.Path{
+				Fields: []string{
+					"kind",
 				},
 			},
 			orig:   int64(2),
@@ -222,9 +218,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"start_time_unix_nano",
 				},
 			},
 			orig:   int64(100_000_000),
@@ -235,9 +231,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "end_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "end_time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"end_time_unix_nano",
 				},
 			},
 			orig:   int64(500_000_000),
@@ -248,9 +244,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refSpan.Attributes(),
@@ -261,11 +257,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -275,11 +271,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -289,11 +285,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -303,11 +299,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
@@ -317,11 +313,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -331,11 +327,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpan.Attributes().Get("arr_str")
@@ -348,11 +344,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpan.Attributes().Get("arr_bool")
@@ -365,11 +361,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpan.Attributes().Get("arr_int")
@@ -382,11 +378,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpan.Attributes().Get("arr_float")
@@ -399,11 +395,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpan.Attributes().Get("arr_bytes")
@@ -416,11 +412,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("pMap"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("pMap"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refSpan.Attributes().Get("pMap")
@@ -435,11 +431,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]interface{}",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("map"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("map"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refSpan.Attributes().Get("map")
@@ -454,9 +450,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
+			path: ottl.Path{
+				Fields: []string{
+					"dropped_attributes_count",
 				},
 			},
 			orig:   int64(10),
@@ -467,9 +463,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "events",
-			path: []ottl.Field{
-				{
-					Name: "events",
+			path: ottl.Path{
+				Fields: []string{
+					"events",
 				},
 			},
 			orig:   refSpan.Events(),
@@ -483,9 +479,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_events_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_events_count",
+			path: ottl.Path{
+				Fields: []string{
+					"dropped_events_count",
 				},
 			},
 			orig:   int64(20),
@@ -496,9 +492,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "links",
-			path: []ottl.Field{
-				{
-					Name: "links",
+			path: ottl.Path{
+				Fields: []string{
+					"links",
 				},
 			},
 			orig:   refSpan.Links(),
@@ -512,9 +508,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_links_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_links_count",
+			path: ottl.Path{
+				Fields: []string{
+					"dropped_links_count",
 				},
 			},
 			orig:   int64(30),
@@ -525,9 +521,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status",
-			path: []ottl.Field{
-				{
-					Name: "status",
+			path: ottl.Path{
+				Fields: []string{
+					"status",
 				},
 			},
 			orig:   refSpan.Status(),
@@ -538,12 +534,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status code",
-			path: []ottl.Field{
-				{
-					Name: "status",
-				},
-				{
-					Name: "code",
+			path: ottl.Path{
+				Fields: []string{
+					"status",
+					"code",
 				},
 			},
 			orig:   int64(ptrace.StatusCodeOk),
@@ -554,12 +548,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status message",
-			path: []ottl.Field{
-				{
-					Name: "status",
-				},
-				{
-					Name: "message",
+			path: ottl.Path{
+				Fields: []string{
+					"status",
+					"message",
 				},
 			},
 			orig:   "good span",
@@ -570,9 +562,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope",
-			path: []ottl.Field{
-				{
-					Name: "instrumentation_scope",
+			path: ottl.Path{
+				Fields: []string{
+					"instrumentation_scope",
 				},
 			},
 			orig:   refIS,
@@ -583,9 +575,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "resource",
-			path: []ottl.Field{
-				{
-					Name: "resource",
+			path: ottl.Path{
+				Fields: []string{
+					"resource",
 				},
 			},
 			orig:   refResource,

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -115,35 +115,33 @@ func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 
 func parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
 	if val != nil && len(val.Fields) > 0 {
-		return newPathGetSetter(val.Fields)
+		return newPathGetSetter(*val)
 	}
 	return nil, fmt.Errorf("bad path %v", val)
 }
 
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
-	switch path[0].Name {
+func newPathGetSetter(path ottl.Path) (ottl.GetSetter[TransformContext], error) {
+	switch path.Fields[0] {
 	case "cache":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessCache(), nil
 		}
-		return accessCacheKey(mapKey), nil
+		return accessCacheKey(path.MapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return ottlcommon.ResourcePathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	case "instrumentation_scope":
-		return ottlcommon.ScopePathGetSetter[TransformContext](path[1:])
+		return ottlcommon.ScopePathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	case "span":
-		return ottlcommon.SpanPathGetSetter[TransformContext](path[1:])
+		return ottlcommon.SpanPathGetSetter[TransformContext](ottl.Path{Fields: path.Fields[1:], MapKey: path.MapKey})
 	case "time_unix_nano":
 		return accessSpanEventTimeUnixNano(), nil
 	case "name":
 		return accessSpanEventName(), nil
 	case "attributes":
-		mapKey := path[0].MapKey
-		if mapKey == nil {
+		if path.MapKey == nil {
 			return accessSpanEventAttributes(), nil
 		}
-		return accessSpanEventAttributesKey(mapKey), nil
+		return accessSpanEventAttributesKey(path.MapKey), nil
 	case "dropped_attributes_count":
 		return accessSpanEventDroppedAttributeCount(), nil
 	}

--- a/pkg/ottl/contexts/ottlspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events_test.go
@@ -60,16 +60,16 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path
 		orig     interface{}
 		newVal   interface{}
 		modified func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map)
 	}{
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
 			},
 			orig:   pcommon.NewMap(),
@@ -80,11 +80,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name:   "cache",
-					MapKey: ottltest.Strp("temp"),
+			path: ottl.Path{
+				Fields: []string{
+					"cache",
 				},
+				MapKey: ottltest.Strp("temp"),
 			},
 			orig:   nil,
 			newVal: "new value",
@@ -94,9 +94,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "name",
-			path: []ottl.Field{
-				{
-					Name: "name",
+			path: ottl.Path{
+				Fields: []string{
+					"name",
 				},
 			},
 			orig:   "bear",
@@ -107,9 +107,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
+			path: ottl.Path{
+				Fields: []string{
+					"time_unix_nano",
 				},
 			},
 			orig:   int64(100_000_000),
@@ -120,9 +120,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
 			},
 			orig:   refSpanEvent.Attributes(),
@@ -133,11 +133,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("str"),
 			},
 			orig:   "val",
 			newVal: "newVal",
@@ -147,11 +147,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bool"),
 			},
 			orig:   true,
 			newVal: false,
@@ -161,11 +161,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("int"),
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -175,11 +175,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("double"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("double"),
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
@@ -189,11 +189,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("bytes"),
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
@@ -203,11 +203,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_str"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_str"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpanEvent.Attributes().Get("arr_str")
@@ -220,11 +220,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bool"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bool"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpanEvent.Attributes().Get("arr_bool")
@@ -237,11 +237,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_int"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_int"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpanEvent.Attributes().Get("arr_int")
@@ -254,11 +254,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_float"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_float"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpanEvent.Attributes().Get("arr_float")
@@ -271,11 +271,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("arr_bytes"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("arr_bytes"),
 			},
 			orig: func() pcommon.Slice {
 				val, _ := refSpanEvent.Attributes().Get("arr_bytes")
@@ -288,11 +288,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("pMap"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("pMap"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refSpanEvent.Attributes().Get("pMap")
@@ -307,11 +307,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]interface{}",
-			path: []ottl.Field{
-				{
-					Name:   "attributes",
-					MapKey: ottltest.Strp("map"),
+			path: ottl.Path{
+				Fields: []string{
+					"attributes",
 				},
+				MapKey: ottltest.Strp("map"),
 			},
 			orig: func() pcommon.Map {
 				val, _ := refSpanEvent.Attributes().Get("map")
@@ -326,9 +326,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
+			path: ottl.Path{
+				Fields: []string{
+					"dropped_attributes_count",
 				},
 			},
 			orig:   int64(10),
@@ -339,9 +339,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope",
-			path: []ottl.Field{
-				{
-					Name: "instrumentation_scope",
+			path: ottl.Path{
+				Fields: []string{
+					"instrumentation_scope",
 				},
 			},
 			orig:   refIS,
@@ -352,9 +352,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "resource",
-			path: []ottl.Field{
-				{
-					Name: "resource",
+			path: ottl.Path{
+				Fields: []string{
+					"resource",
 				},
 			},
 			orig:   refResource,
@@ -365,9 +365,9 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span",
-			path: []ottl.Field{
-				{
-					Name: "span",
+			path: ottl.Path{
+				Fields: []string{
+					"span",
 				},
 			},
 			orig:   refSpan,

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -89,10 +89,8 @@ func Test_newGetter(t *testing.T) {
 			val: value{
 				Literal: &mathExprLiteral{
 					Path: &Path{
-						Fields: []Field{
-							{
-								Name: "name",
-							},
+						Fields: []string{
+							"name",
 						},
 					},
 				},
@@ -222,10 +220,8 @@ func Test_newGetter(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "name",
-										},
+									Fields: []string{
+										"name",
 									},
 								},
 							},

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -90,10 +90,8 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 					{
 						Literal: &mathExprLiteral{
 							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
-									},
+								Fields: []string{
+									"name",
 								},
 							},
 						},
@@ -112,10 +110,8 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 					{
 						Literal: &mathExprLiteral{
 							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
-									},
+								Fields: []string{
+									"name",
 								},
 							},
 						},
@@ -391,10 +387,8 @@ func Test_NewFunctionCall(t *testing.T) {
 								{
 									Literal: &mathExprLiteral{
 										Path: &Path{
-											Fields: []Field{
-												{
-													Name: "name",
-												},
+											Fields: []string{
+												"name",
 											},
 										},
 									},
@@ -468,10 +462,8 @@ func Test_NewFunctionCall(t *testing.T) {
 												{
 													Literal: &mathExprLiteral{
 														Path: &Path{
-															Fields: []Field{
-																{
-																	Name: "name",
-																},
+															Fields: []string{
+																"name",
 															},
 														},
 													},
@@ -519,10 +511,8 @@ func Test_NewFunctionCall(t *testing.T) {
 								{
 									Literal: &mathExprLiteral{
 										Path: &Path{
-											Fields: []Field{
-												{
-													Name: "name",
-												},
+											Fields: []string{
+												"name",
 											},
 										},
 									},
@@ -530,10 +520,8 @@ func Test_NewFunctionCall(t *testing.T) {
 								{
 									Literal: &mathExprLiteral{
 										Path: &Path{
-											Fields: []Field{
-												{
-													Name: "name",
-												},
+											Fields: []string{
+												"name",
 											},
 										},
 									},
@@ -576,10 +564,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Literal: &mathExprLiteral{
 							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
-									},
+								Fields: []string{
+									"name",
 								},
 							},
 						},
@@ -596,10 +582,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Literal: &mathExprLiteral{
 							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
-									},
+								Fields: []string{
+									"name",
 								},
 							},
 						},
@@ -616,10 +600,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Literal: &mathExprLiteral{
 							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
-									},
+								Fields: []string{
+									"name",
 								},
 							},
 						},
@@ -670,10 +652,8 @@ func Test_NewFunctionCall(t *testing.T) {
 								{
 									Literal: &mathExprLiteral{
 										Path: &Path{
-											Fields: []Field{
-												{
-													Name: "name",
-												},
+											Fields: []string{
+												"name",
 											},
 										},
 									},
@@ -686,10 +666,8 @@ func Test_NewFunctionCall(t *testing.T) {
 												{
 													Literal: &mathExprLiteral{
 														Path: &Path{
-															Fields: []Field{
-																{
-																	Name: "name",
-																},
+															Fields: []string{
+																"name",
 															},
 														},
 													},
@@ -751,10 +729,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Literal: &mathExprLiteral{
 							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
-									},
+								Fields: []string{
+									"name",
 								},
 							},
 						},
@@ -835,10 +811,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Literal: &mathExprLiteral{
 							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
-									},
+								Fields: []string{
+									"name",
 								},
 							},
 						},

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -239,7 +239,7 @@ func (v *value) checkForCustomError() error {
 	return nil
 }
 
-// Path represents a telemetry path mathExpression.
+// Path represents telemetry on the underlying signal.  What identifiers are allowed and value is returned is based on the context being used.
 type Path struct {
 	Fields []string `parser:"@Lowercase ( '.' @Lowercase )*"`
 	MapKey *string  `parser:"( '[' @String ']' )?"`

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -241,13 +241,8 @@ func (v *value) checkForCustomError() error {
 
 // Path represents a telemetry path mathExpression.
 type Path struct {
-	Fields []Field `parser:"@@ ( '.' @@ )*"`
-}
-
-// Field is an item within a Path.
-type Field struct {
-	Name   string  `parser:"@Lowercase"`
-	MapKey *string `parser:"( '[' @String ']' )?"`
+	Fields []string `parser:"@Lowercase ( '.' @Lowercase )*"`
+	MapKey *string  `parser:"( '[' @String ']' )?"`
 }
 
 type list struct {

--- a/pkg/ottl/math_test.go
+++ b/pkg/ottl/math_test.go
@@ -25,21 +25,21 @@ import (
 )
 
 func mathParsePath(val *Path) (GetSetter[interface{}], error) {
-	if val != nil && len(val.Fields) > 0 && val.Fields[0].Name == "one" {
+	if val != nil && len(val.Fields) > 0 && val.Fields[0] == "one" {
 		return &StandardGetSetter[interface{}]{
 			Getter: func(context.Context, interface{}) (interface{}, error) {
 				return int64(1), nil
 			},
 		}, nil
 	}
-	if val != nil && len(val.Fields) > 0 && val.Fields[0].Name == "two" {
+	if val != nil && len(val.Fields) > 0 && val.Fields[0] == "two" {
 		return &StandardGetSetter[interface{}]{
 			Getter: func(context.Context, interface{}) (interface{}, error) {
 				return int64(2), nil
 			},
 		}, nil
 	}
-	if val != nil && len(val.Fields) > 0 && val.Fields[0].Name == "three" && val.Fields[1].Name == "one" {
+	if val != nil && len(val.Fields) > 0 && val.Fields[0] == "three" && val.Fields[1] == "one" {
 		return &StandardGetSetter[interface{}]{
 			Getter: func(context.Context, interface{}) (interface{}, error) {
 				return 3.1, nil

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -105,13 +105,9 @@ func Test_parse(t *testing.T) {
 										{
 											Literal: &mathExprLiteral{
 												Path: &Path{
-													Fields: []Field{
-														{
-															Name: "bear",
-														},
-														{
-															Name: "honey",
-														},
+													Fields: []string{
+														"bear",
+														"honey",
 													},
 												},
 											},
@@ -127,7 +123,7 @@ func Test_parse(t *testing.T) {
 		},
 		{
 			name:      "complex path",
-			statement: `set(foo.attributes["bar"].cat, "dog")`,
+			statement: `set(foo.attributes["bar"], "dog")`,
 			expected: &parsedStatement{
 				Invocation: invocation{
 					Function: "set",
@@ -135,18 +131,11 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "foo",
-										},
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("bar"),
-										},
-										{
-											Name: "cat",
-										},
+									Fields: []string{
+										"foo",
+										"attributes",
 									},
+									MapKey: ottltest.Strp("bar"),
 								},
 							},
 						},
@@ -160,7 +149,7 @@ func Test_parse(t *testing.T) {
 		},
 		{
 			name:      "where == clause",
-			statement: `set(foo.attributes["bar"].cat, "dog") where name == "fido"`,
+			statement: `set(foo.attributes["bar"], "dog") where name == "fido"`,
 			expected: &parsedStatement{
 				Invocation: invocation{
 					Function: "set",
@@ -168,18 +157,11 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "foo",
-										},
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("bar"),
-										},
-										{
-											Name: "cat",
-										},
+									Fields: []string{
+										"foo",
+										"attributes",
 									},
+									MapKey: ottltest.Strp("bar"),
 								},
 							},
 						},
@@ -195,10 +177,8 @@ func Test_parse(t *testing.T) {
 								Left: value{
 									Literal: &mathExprLiteral{
 										Path: &Path{
-											Fields: []Field{
-												{
-													Name: "name",
-												},
+											Fields: []string{
+												"name",
 											},
 										},
 									},
@@ -215,7 +195,7 @@ func Test_parse(t *testing.T) {
 		},
 		{
 			name:      "where != clause",
-			statement: `set(foo.attributes["bar"].cat, "dog") where name != "fido"`,
+			statement: `set(foo.attributes["bar"], "dog") where name != "fido"`,
 			expected: &parsedStatement{
 				Invocation: invocation{
 					Function: "set",
@@ -223,18 +203,11 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "foo",
-										},
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("bar"),
-										},
-										{
-											Name: "cat",
-										},
+									Fields: []string{
+										"foo",
+										"attributes",
 									},
+									MapKey: ottltest.Strp("bar"),
 								},
 							},
 						},
@@ -250,10 +223,8 @@ func Test_parse(t *testing.T) {
 								Left: value{
 									Literal: &mathExprLiteral{
 										Path: &Path{
-											Fields: []Field{
-												{
-													Name: "name",
-												},
+											Fields: []string{
+												"name",
 											},
 										},
 									},
@@ -270,7 +241,7 @@ func Test_parse(t *testing.T) {
 		},
 		{
 			name:      "ignore extra spaces",
-			statement: `set  ( foo.attributes[ "bar"].cat,   "dog")   where name=="fido"`,
+			statement: `set  ( foo.attributes[ "bar"],   "dog")   where name=="fido"`,
 			expected: &parsedStatement{
 				Invocation: invocation{
 					Function: "set",
@@ -278,18 +249,11 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "foo",
-										},
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("bar"),
-										},
-										{
-											Name: "cat",
-										},
+									Fields: []string{
+										"foo",
+										"attributes",
 									},
+									MapKey: ottltest.Strp("bar"),
 								},
 							},
 						},
@@ -305,10 +269,8 @@ func Test_parse(t *testing.T) {
 								Left: value{
 									Literal: &mathExprLiteral{
 										Path: &Path{
-											Fields: []Field{
-												{
-													Name: "name",
-												},
+											Fields: []string{
+												"name",
 											},
 										},
 									},
@@ -384,12 +346,10 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("bytes"),
-										},
+									Fields: []string{
+										"attributes",
 									},
+									MapKey: ottltest.Strp("bytes"),
 								},
 							},
 						},
@@ -411,12 +371,10 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("test"),
-										},
+									Fields: []string{
+										"attributes",
 									},
+									MapKey: ottltest.Strp("test"),
 								},
 							},
 						},
@@ -438,12 +396,10 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("test"),
-										},
+									Fields: []string{
+										"attributes",
 									},
+									MapKey: ottltest.Strp("test"),
 								},
 							},
 						},
@@ -465,12 +421,10 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("test"),
-										},
+									Fields: []string{
+										"attributes",
 									},
+									MapKey: ottltest.Strp("test"),
 								},
 							},
 						},
@@ -494,12 +448,10 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("test"),
-										},
+									Fields: []string{
+										"attributes",
 									},
+									MapKey: ottltest.Strp("test"),
 								},
 							},
 						},
@@ -527,12 +479,10 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("test"),
-										},
+									Fields: []string{
+										"attributes",
 									},
+									MapKey: ottltest.Strp("test"),
 								},
 							},
 						},
@@ -563,12 +513,10 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("test"),
-										},
+									Fields: []string{
+										"attributes",
 									},
+									MapKey: ottltest.Strp("test"),
 								},
 							},
 						},
@@ -624,12 +572,10 @@ func Test_parse(t *testing.T) {
 									{
 										Literal: &mathExprLiteral{
 											Path: &Path{
-												Fields: []Field{
-													{
-														Name:   "attributes",
-														MapKey: ottltest.Strp("test"),
-													},
+												Fields: []string{
+													"attributes",
 												},
+												MapKey: ottltest.Strp("test"),
 											},
 										},
 									},
@@ -651,12 +597,10 @@ func Test_parse(t *testing.T) {
 						{
 							Literal: &mathExprLiteral{
 								Path: &Path{
-									Fields: []Field{
-										{
-											Name:   "attributes",
-											MapKey: ottltest.Strp("test"),
-										},
+									Fields: []string{
+										"attributes",
 									},
+									MapKey: ottltest.Strp("test"),
 								},
 							},
 						},
@@ -729,10 +673,8 @@ func Test_parse(t *testing.T) {
 											Left: &mathValue{
 												Literal: &mathExprLiteral{
 													Path: &Path{
-														Fields: []Field{
-															{
-																Name: "three",
-															},
+														Fields: []string{
+															"three",
 														},
 													},
 												},
@@ -770,7 +712,7 @@ func Test_parse(t *testing.T) {
 }
 
 func testParsePath(val *Path) (GetSetter[interface{}], error) {
-	if val != nil && len(val.Fields) > 0 && val.Fields[0].Name == "name" {
+	if val != nil && len(val.Fields) > 0 && val.Fields[0] == "name" {
 		return &StandardGetSetter[interface{}]{
 			Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 				return tCtx, nil
@@ -794,10 +736,8 @@ func setNameTest(b *booleanExpression) *parsedStatement {
 				{
 					Literal: &mathExprLiteral{
 						Path: &Path{
-							Fields: []Field{
-								{
-									Name: "name",
-								},
+							Fields: []string{
+								"name",
 							},
 						},
 					},
@@ -993,10 +933,8 @@ func Test_parseWhere(t *testing.T) {
 							Left: value{
 								Literal: &mathExprLiteral{
 									Path: &Path{
-										Fields: []Field{
-											{
-												Name: "name",
-											},
+										Fields: []string{
+											"name",
 										},
 									},
 								},
@@ -1015,10 +953,8 @@ func Test_parseWhere(t *testing.T) {
 									Left: value{
 										Literal: &mathExprLiteral{
 											Path: &Path{
-												Fields: []Field{
-													{
-														Name: "name",
-													},
+												Fields: []string{
+													"name",
 												},
 											},
 										},
@@ -1043,10 +979,8 @@ func Test_parseWhere(t *testing.T) {
 							Left: value{
 								Literal: &mathExprLiteral{
 									Path: &Path{
-										Fields: []Field{
-											{
-												Name: "name",
-											},
+										Fields: []string{
+											"name",
 										},
 									},
 								},
@@ -1067,10 +1001,8 @@ func Test_parseWhere(t *testing.T) {
 									Left: value{
 										Literal: &mathExprLiteral{
 											Path: &Path{
-												Fields: []Field{
-													{
-														Name: "name",
-													},
+												Fields: []string{
+													"name",
 												},
 											},
 										},
@@ -1115,10 +1047,8 @@ func Test_parseWhere(t *testing.T) {
 							Left: value{
 								Literal: &mathExprLiteral{
 									Path: &Path{
-										Fields: []Field{
-											{
-												Name: "name",
-											},
+										Fields: []string{
+											"name",
 										},
 									},
 								},
@@ -1227,7 +1157,7 @@ func Test_parseStatement(t *testing.T) {
 		{`set() where 1 == int()`, true},
 		{`set() where true and 1 == int() `, true},
 		{`set() where false or 1 == int() `, true},
-		{`set(foo.attributes["bar"].cat, "dog")`, false},
+		{`set(foo.attributes["bar"], "dog")`, false},
 		{`set(foo.attributes["animal"], "dog") where animal == "cat"`, false},
 		{`test() where service == "pinger" or foo.attributes["endpoint"] == "/x/alive"`, false},
 		{`test() where service == "pinger" or foo.attributes["verb"] == "GET" and foo.attributes["endpoint"] == "/x/alive"`, false},


### PR DESCRIPTION
**Description:** 
This PR updates the OTTL grammar to disallow the user of `.` or lowercase identifiers after `[]`.  This means that statements like `attributes["cat"].name` will no longer be valid.  

These types of paths are not implemented by any standard OTTL context and go against OTTL's pattern of not reaching "downward" into other contexts.  By removing this existing capability we bring the grammar in line with its goals and open up the possibility for more complex indexing in the future.

This PR has an absurd number of changes due to all the tests that were impacted.  The actual grammar change is in grammar.go.  Changes to the context were to adjust to new grammar structure.

**Link to tracking Issue:**
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16811

**Testing:** 
Updated lots and lots of tests

**Documentation:**
Updated docs.