### PR TITLE
Fix cri-o log format time layout

### DIFF
--- a/.chloggen/fix-cri-o-log-format-time-layout.yaml
+++ b/.chloggen/fix-cri-o-log-format-time-layout.yaml
@@ -8,7 +8,7 @@ component: otel-collector
 note: Fix cri-o log format time layout 
 
 # One or more tracking issues related to the change
-issues: []
+issues: [23027]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-cri-o-log-format-time-layout.yaml
+++ b/.chloggen/fix-cri-o-log-format-time-layout.yaml
@@ -8,7 +8,7 @@ component: otel-collector
 note: Fix cri-o log format time layout 
 
 # One or more tracking issues related to the change
-issues: [open-telemetry/opentelemetry-helm-charts#718]
+issues: []
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-cri-o-log-format-time-layout.yaml
+++ b/.chloggen/fix-cri-o-log-format-time-layout.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: otel-collector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix cri-o log format time layout 
+
+# One or more tracking issues related to the change
+issues: [open-telemetry/opentelemetry-helm-charts#718]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/examples/kubernetes/otel-collector.yaml
+++ b/examples/kubernetes/otel-collector.yaml
@@ -34,7 +34,7 @@ data:
             timestamp:
               parse_from: attributes.time
               layout_type: gotime
-              layout: '2006-01-02T15:04:05.000000000-07:00'
+              layout: '2006-01-02T15:04:05.999999999Z07:00'
           # Parse CRI-Containerd format
           - type: regex_parser
             id: parser-containerd


### PR DESCRIPTION
See related discussion and PR in https://github.com/open-telemetry/opentelemetry-helm-charts/issues/718

**Description:** <Describe what has changed.>

CRI-O log format uses `RFC3339Nano` standard [defined in golang](https://pkg.go.dev/time#pkg-constants) like this:

```
RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
```

The current definition is different which causes errors when milliseconds different count of chars.

Fixes #23027