### PR TITLE
added integration test to run on windows

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -93,11 +93,6 @@ jobs:
     if: ${{ github.actor != 'dependatbot'[bot] && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push') }}
     runs-on: windows-latest
     steps:
-      - name: Collect Workflow Telemetry
-        if: always()
-        uses: runforesight/foresight-workflow-kit-action@v1
-        with:
-          api_key: ${{ secrets.FORESIGHT_API_KEY}}
       - name: Checkout Repo
         uses: actions/checkout@v3
       - name: Setup Go
@@ -114,15 +109,4 @@ jobs:
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Run Integration Tests
         run: make integration-tests-with-cover
-      - name: Analyze Test and/or Coverage Results
-        if: always()
-        uses: runforesight/foresight-test-kit-action@v1
-        with:
-          api_key: ${{ secrets.FORESIGHT_API_KEY }}
-          test_framework: golang
-          test_format: test
-          test_path: |
-            ./**/foresight-test-report-integration*.txt
-          coverage_format: golang
-          coverage_path: |
-            ./**/integration-coverage.txt
+      

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -89,6 +89,9 @@ jobs:
             echo "One or more matrix jobs failed."
             false
           fi
+
+  integration_tests_excuted_successfully: false
+
   integration-tests:
     if: ${{ github.actor != 'dependatbot'[bot] && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push') }}
     runs-on: windows-latest
@@ -109,4 +112,9 @@ jobs:
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Run Integration Tests
         run: make integration-tests-with-cover
-      
+        #Set flag to true if integration tests were successful
+        if: ${{ success() }}
+        env:
+          integration_tests_excuted_successfully: true
+      - name: Print flag
+        run: echo "Integration tests executed successfully? ${{ env.integration_tests_excuted_successfully }}"

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -89,3 +89,40 @@ jobs:
             echo "One or more matrix jobs failed."
             false
           fi
+  integration-tests:
+    if: ${{ github.actor != 'dependatbot'[bot] && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push') }}
+    runs-on: windows-latest
+    steps:
+      - name: Collect Workflow Telemetry
+        if: always()
+        uses: runforesight/foresight-workflow-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY}}
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - name: Cache Go
+        id: go-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/bin
+            ~/go/pkg/mod
+          key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+      - name: Run Integration Tests
+        run: make integration-tests-with-cover
+      - name: Analyze Test and/or Coverage Results
+        if: always()
+        uses: runforesight/foresight-test-kit-action@v1
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
+          test_framework: golang
+          test_format: test
+          test_path: |
+            ./**/foresight-test-report-integration*.txt
+          coverage_format: golang
+          coverage_path: |
+            ./**/integration-coverage.txt


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
There is no way to run tests with `//go:build windows && integration` in the CI
I added an integration test job in the `build-and-test-windows.yaml` directory
**Link to tracking Issue:** #18006
