### PR TITLE
[exporter/splunkhec] set a default of 10s for idle connection timeout

### DIFF
--- a/.chloggen/allow-to-configure-idle-conn-timeout.yaml
+++ b/.chloggen/allow-to-configure-idle-conn-timeout.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set the default value of the idle connection timeout to 10s, rather than 30s by default
+
+# One or more tracking issues related to the change
+issues: [20543]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -43,6 +43,7 @@ func TestLoadConfig(t *testing.T) {
 	defaultCfg.HTTPClientSettings.Endpoint = "https://splunk:8088/services/collector"
 
 	hundred := 100
+	idleConnTimeout := 10 * time.Second
 
 	tests := []struct {
 		id       component.ID
@@ -80,6 +81,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 					MaxIdleConns:        &hundred,
 					MaxIdleConnsPerHost: &hundred,
+					IdleConnTimeout:     &idleConnTimeout,
 				},
 				RetrySettings: exporterhelper.RetrySettings{
 					Enabled:             true,

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -32,10 +32,11 @@ import (
 
 const (
 	// The value of "type" key in configuration.
-	typeStr              = "splunk_hec"
-	defaultMaxIdleCons   = 100
-	defaultHTTPTimeout   = 10 * time.Second
-	defaultSplunkAppName = "OpenTelemetry Collector Contrib"
+	typeStr                = "splunk_hec"
+	defaultMaxIdleCons     = 100
+	defaultHTTPTimeout     = 10 * time.Second
+	defaultIdleConnTimeout = 10 * time.Second
+	defaultSplunkAppName   = "OpenTelemetry Collector Contrib"
 )
 
 // TODO: Find a place for this to be shared.
@@ -62,11 +63,13 @@ func NewFactory() exporter.Factory {
 
 func createDefaultConfig() component.Config {
 	defaultMaxConns := defaultMaxIdleCons
+	defaultIdleConnTimeout := defaultIdleConnTimeout
 	return &Config{
 		LogDataEnabled:       true,
 		ProfilingDataEnabled: true,
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Timeout:             defaultHTTPTimeout,
+			IdleConnTimeout:     &defaultIdleConnTimeout,
 			MaxIdleConnsPerHost: &defaultMaxConns,
 			MaxIdleConns:        &defaultMaxConns,
 		},


### PR DESCRIPTION
**Description:**
Set the idle connection timeout to 10s by default rather than default 30s.

**Link to tracking Issue:**
Fixes #20543

**Testing:**
Unit tests pass.

**Documentation:**
No documentation impact.