### PR TITLE
[signalfxexporter] disk.utilization and disk.summary_utilization now matches the df command by only counting non-root usage.

### DIFF
--- a/.chloggen/signalfx-exporter-disk.utilization-rule.yaml
+++ b/.chloggen/signalfx-exporter-disk.utilization-rule.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: disk.utilization and disk.summary_utilization now matches the df command by only counting non-root usage.
+      disk.utilization = (used/(used + free)) * 100
+
+# One or more tracking issues related to the change
+issues: [20656]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -214,9 +214,14 @@ translation_rules:
 
 # Translations to derive filesystem metrics
 ## sf_temp.disk.total, required to compute disk.utilization
+## same as df, disk.utilization = (used/(used + free)) * 100 see: https://github.com/shirou/gopsutil/issues/562
 - action: copy_metrics
   mapping:
     system.filesystem.usage: sf_temp.disk.total
+  dimension_key: state
+  dimension_values:
+    used: true
+    free: true
 - action: aggregate_metric
   metric_name: sf_temp.disk.total
   aggregation_method: sum
@@ -224,9 +229,14 @@ translation_rules:
     - state
 
 ## sf_temp.disk.summary_total, required to compute disk.summary_utilization
+## same as df, don't count root fs, ie: total = used + free
 - action: copy_metrics
   mapping:
     system.filesystem.usage: sf_temp.disk.summary_total
+  dimension_key: state
+  dimension_values:
+    used: true
+    free: true
 - action: aggregate_metric
   metric_name: sf_temp.disk.summary_total
   aggregation_method: avg


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The way we calculate `disk.utilization` in our translation rule, is `(used/total) * 100` we do NOT take into consideration the reserved disk space.
This causes user confusion when they look at the % space used displayed by `df `
example:
```
 9.8G  8.3G  953M  90% /var
 ```
the percentage in df is ~~`(total - free)/total * 100` or~~ `(used/(used + free)) * 100` and not `used/total * 100` 

(total - free) will give you used + reserved.

Note:
~~I am not sure if we should do the same for `disk.summary_utilization` or leave it as is?~~
updated `disk.summary_utilization` as well 

Also, this should be fine for windows as free and used are the only 2 metrics available, but if the reviewer can double check
**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
manual testing
**Documentation:** <Describe the documentation added.>