### PR TITLE
[chore] improve dependabot update script

### DIFF
--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install zsh
+        run: sudo apt-get update; sudo apt-get install zsh
       - name: Setup Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/scripts/dependabot-pr.sh
+++ b/.github/workflows/scripts/dependabot-pr.sh
@@ -1,4 +1,18 @@
-#!/bin/bash -ex
+#!/bin/zsh -ex
+
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 git config user.name opentelemetrybot
 git config user.email 107717825+opentelemetrybot@users.noreply.github.com
@@ -9,32 +23,34 @@ git checkout -b $PR_NAME
 IFS=$'\n'
 requests=$( gh pr list --search "author:app/dependabot" --limit 1000 --json title --jq '.[].title' | sort )
 message=""
+dirs=(`find . -type f -name "go.mod" -exec dirname {} \; | sort | egrep  '^./'`)
 
-last_updated=""
+declare -A mods
 
 for line in $requests; do
-    if [[ $line != Bump* ]]; then 
+    echo $line
+    if [[ $line != Bump* ]]; then
         continue
     fi
 
     module=$(echo $line | cut -f 2 -d " ")
-    if [[ $module == go.opentelemetry.io/collector* ]]; then
-        continue
-    fi
     version=$(echo $line | cut -f 6 -d " ")
+
+    mods[$module]=$version
     message+=$line
     message+=$'\n'
-    if [[ "$last_updated" == "$module $version" ]]; then
-        continue
-    fi
-    last_updated="$module $version"
-    make for-all CMD="$GITHUB_WORKSPACE/internal/buildscripts/update-dep" MODULE=$module VERSION=v$version
 done
 
-make gotidy
-make genotelcontribcol
-make genoteltestbedcol
-make otelcontribcol
+for module version in ${(kv)mods}; do
+    topdir=`pwd`
+    for dir in $dirs; do
+        echo "checking $dir"
+        cd $dir && if grep -q "$module " go.mod; then go get "$module"@v"$version"; fi
+        cd $topdir
+    done
+done
+
+make gotidy genotelcontribcol genoteltestbedcol otelcontribcol
 
 git add go.sum go.mod
 git add "**/go.sum" "**/go.mod"


### PR DESCRIPTION
This is pulling the updates from the opentelemetry-go-build-tools repo to reduce the amount of time the script takes to execute by reducing the number of times it loops through all the directories.

Pinging @Aneurysm9 as the author of the script used in the other repo.