### PR TITLE
[exporter/azuremonitor] Export metric attributes to Azure Monitor

### DIFF
--- a/.chloggen/export-metric-dimensions.yaml
+++ b/.chloggen/export-metric-dimensions.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure that metric attributes are exported to Azure Monitor
+
+# One or more tracking issues related to the change
+issues: [19407]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/azuremonitorexporter/contracts_utils.go
+++ b/exporter/azuremonitorexporter/contracts_utils.go
@@ -64,3 +64,11 @@ func applyInstrumentationScopeValueToDataProperties(dataProperties map[string]st
 		dataProperties[instrumentationLibraryVersion] = instrumentationScope.Version()
 	}
 }
+
+// Applies attributes as Application Insights properties
+func setAttributesAsProperties(attributeMap pcommon.Map, properties map[string]string) {
+	attributeMap.Range(func(k string, v pcommon.Value) bool {
+		properties[k] = v.AsString()
+		return true
+	})
+}

--- a/exporter/azuremonitorexporter/log_to_envelope.go
+++ b/exporter/azuremonitorexporter/log_to_envelope.go
@@ -107,10 +107,3 @@ func timestampFromLogRecord(lr plog.LogRecord) pcommon.Timestamp {
 
 	return pcommon.NewTimestampFromTime(timeNow())
 }
-
-func setAttributesAsProperties(attributeMap pcommon.Map, properties map[string]string) {
-	attributeMap.Range(func(k string, v pcommon.Value) bool {
-		properties[k] = v.AsString()
-		return true
-	})
-}

--- a/exporter/azuremonitorexporter/metric_to_envelopes.go
+++ b/exporter/azuremonitorexporter/metric_to_envelopes.go
@@ -28,8 +28,9 @@ type metricPacker struct {
 }
 
 type timedMetricDataPoint struct {
-	dataPoint *contracts.DataPoint
-	timestamp pcommon.Timestamp
+	dataPoint  *contracts.DataPoint
+	timestamp  pcommon.Timestamp
+	attributes pcommon.Map
 }
 
 type metricTimedData interface {
@@ -66,6 +67,8 @@ func (packer *metricPacker) MetricToEnvelopes(metric pmetric.Metric, resource pc
 			applyResourcesToDataProperties(metricData.Properties, resourceAttributes)
 			applyInstrumentationScopeValueToDataProperties(metricData.Properties, instrumentationScope)
 			applyCloudTagsToEnvelope(envelope, resourceAttributes)
+
+			setAttributesAsProperties(timedDataPoint.attributes, metricData.Properties)
 
 			packer.sanitize(func() []string { return metricData.Sanitize() })
 			packer.sanitize(func() []string { return envelope.Sanitize() })
@@ -140,9 +143,11 @@ func (m scalarMetric) getTimedDataPoints() []*timedMetricDataPoint {
 		}
 		dataPoint.Count = 1
 		dataPoint.Kind = contracts.Measurement
+		numberDataPoint.Attributes()
 		timedDataPoints[i] = &timedMetricDataPoint{
-			dataPoint: dataPoint,
-			timestamp: numberDataPoint.Timestamp(),
+			dataPoint:  dataPoint,
+			timestamp:  numberDataPoint.Timestamp(),
+			attributes: numberDataPoint.Attributes(),
 		}
 	}
 	return timedDataPoints
@@ -173,8 +178,9 @@ func (m histogramMetric) getTimedDataPoints() []*timedMetricDataPoint {
 		dataPoint.Count = int(histogramDataPoint.Count())
 
 		timedDataPoints[i] = &timedMetricDataPoint{
-			dataPoint: dataPoint,
-			timestamp: histogramDataPoint.Timestamp(),
+			dataPoint:  dataPoint,
+			timestamp:  histogramDataPoint.Timestamp(),
+			attributes: histogramDataPoint.Attributes(),
 		}
 
 	}
@@ -206,8 +212,9 @@ func (m exponentialHistogramMetric) getTimedDataPoints() []*timedMetricDataPoint
 		dataPoint.Count = int(exponentialHistogramDataPoint.Count())
 
 		timedDataPoints[i] = &timedMetricDataPoint{
-			dataPoint: dataPoint,
-			timestamp: exponentialHistogramDataPoint.Timestamp(),
+			dataPoint:  dataPoint,
+			timestamp:  exponentialHistogramDataPoint.Timestamp(),
+			attributes: exponentialHistogramDataPoint.Attributes(),
 		}
 	}
 	return timedDataPoints
@@ -236,8 +243,9 @@ func (m summaryMetric) getTimedDataPoints() []*timedMetricDataPoint {
 		dataPoint.Count = int(summaryDataPoint.Count())
 
 		timedDataPoints[i] = &timedMetricDataPoint{
-			dataPoint: dataPoint,
-			timestamp: summaryDataPoint.Timestamp(),
+			dataPoint:  dataPoint,
+			timestamp:  summaryDataPoint.Timestamp(),
+			attributes: summaryDataPoint.Attributes(),
 		}
 
 	}

--- a/exporter/azuremonitorexporter/metric_to_envelopes.go
+++ b/exporter/azuremonitorexporter/metric_to_envelopes.go
@@ -143,7 +143,6 @@ func (m scalarMetric) getTimedDataPoints() []*timedMetricDataPoint {
 		}
 		dataPoint.Count = 1
 		dataPoint.Kind = contracts.Measurement
-		numberDataPoint.Attributes()
 		timedDataPoints[i] = &timedMetricDataPoint{
 			dataPoint:  dataPoint,
 			timestamp:  numberDataPoint.Timestamp(),

--- a/exporter/azuremonitorexporter/metricexporter_test.go
+++ b/exporter/azuremonitorexporter/metricexporter_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 )
@@ -137,6 +138,12 @@ func getDataPoint(t testing.TB, metric pmetric.Metric) *contracts.DataPoint {
 	dataPoint := metricData.Metrics[0]
 	require.NotNil(t, dataPoint)
 
+	actualProperties := metricData.Properties
+	require.Equal(t, "10", actualProperties["int_attribute"])
+	require.Equal(t, "str_value", actualProperties["str_attribute"])
+	require.Equal(t, "true", actualProperties["bool_attribute"])
+	require.Equal(t, "1.2", actualProperties["double_attribute"])
+
 	return dataPoint
 }
 
@@ -202,6 +209,7 @@ func getTestGaugeMetric(modify func(pmetric.NumberDataPoint)) pmetric.Metric {
 	metric.SetEmptyGauge()
 	datapoints := metric.Gauge().DataPoints()
 	datapoint := datapoints.AppendEmpty()
+	setDefaultTestAttributes(datapoint.Attributes())
 	modify(datapoint)
 	return metric
 }
@@ -224,6 +232,7 @@ func getTestSumMetric(modify func(pmetric.NumberDataPoint)) pmetric.Metric {
 	metric.SetEmptySum()
 	datapoints := metric.Sum().DataPoints()
 	datapoint := datapoints.AppendEmpty()
+	setDefaultTestAttributes(datapoint.Attributes())
 	modify(datapoint)
 	return metric
 }
@@ -238,6 +247,7 @@ func getTestHistogramMetric() pmetric.Metric {
 	datapoint.SetCount(3)
 	datapoint.SetMin(0)
 	datapoint.SetMax(2)
+	setDefaultTestAttributes(datapoint.Attributes())
 	return metric
 }
 
@@ -251,6 +261,7 @@ func getTestExponentialHistogramMetric() pmetric.Metric {
 	datapoint.SetCount(4)
 	datapoint.SetMin(1)
 	datapoint.SetMax(3)
+	setDefaultTestAttributes(datapoint.Attributes())
 	return metric
 }
 
@@ -262,5 +273,13 @@ func getTestSummaryMetric() pmetric.Metric {
 	datapoint := datapoints.AppendEmpty()
 	datapoint.SetSum(5)
 	datapoint.SetCount(5)
+	setDefaultTestAttributes(datapoint.Attributes())
 	return metric
+}
+
+func setDefaultTestAttributes(attributeMap pcommon.Map) {
+	attributeMap.PutInt("int_attribute", 10)
+	attributeMap.PutStr("str_attribute", "str_value")
+	attributeMap.PutBool("bool_attribute", true)
+	attributeMap.PutDouble("double_attribute", 1.2)
 }


### PR DESCRIPTION
**Description:**

As of now, no attributes (dimensions) from the metrics timeseries model are exported to Application Insights. This PR ensures that for all metric points, attributes are present as `customDimensions` in Application Insights.

**Link to tracking Issue:**

Fixes #19407

**Testing:**

Automated tests ensure that metric attributes (dimensions) are exported to the properties on the Application Insights contract.

**Documentation:**

No documentation added.