### PR TITLE
[exporter/coralogixexporter] Allow setting single endpoint

### DIFF
--- a/.chloggen/coralogix-single-endpoint.yaml
+++ b/.chloggen/coralogix-single-endpoint.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: coralogixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow users to use only single Coralogix endpoint"
+
+# One or more tracking issues related to the change
+issues: [20719]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/coralogixexporter/README.md
+++ b/exporter/coralogixexporter/README.md
@@ -21,6 +21,7 @@ Example configuration:
 exporters:
   coralogix:
     # The Coralogix traces ingress endpoint
+    endpoint: "ingress.coralogix.com:443"
     traces:
       endpoint: "ingress.coralogix.com:443"
     metrics:
@@ -48,26 +49,18 @@ exporters:
     # (Optional) Timeout is the timeout for every attempt to send data to the backend.
     timeout: 30s
 ```
-### Tracing deprecation 
 
-The v0.67 version removed old Jaeger based tracing endpoint in favour of Opentelemetry based one.
+### Coralogix Single Endpoint
 
-To migrate, please remove the old endpoint field, and change the configuration to `traces.endpoint` using the new Tracing endpoint.
+Since v0.76.0 you can specify a single Coralogix endpoint in the configuration file instead of specifying different endpoints for traces, metrics and logs. But you can still specify endpoint per signal type, which allows you to configure gRPC settings per signal type. See [gRPC Configuration Settings documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md) for all available settings. For example:
 
-Old configuration:
-```yaml
-exporters:
-  coralogix:
-    # The Coralogix traces ingress endpoint
-    endpoint: "tracing-ingress.coralogix.com:9443"
 ```
-
-New configuration:
-```yaml
-exporters
-  coralogix:
-    # The Coralogix traces ingress endpoint
     traces:
+      endpoint: "ingress.coralogix.com:443"
+      read_buffer_size: 524288
+    metrics:
+      endpoint: "ingress.coralogix.com:443"
+    logs:
       endpoint: "ingress.coralogix.com:443"
 ```
 
@@ -75,13 +68,27 @@ exporters
 
 Depending on your region, you might need to use a different endpoint. Here are the available Endpoints:
 
-| Region  | Traces Endpoint                          | Metrics Endpoint                     | Logs Endpoint                     |
-|---------|------------------------------------------|------------------------------------- | --------------------------------- |
-| USA1    | `ingress.coralogix.us:443`      | `ingress.coralogix.us:443`      | `ingress.coralogix.us:443`      |
-| APAC1   | `ingress.coralogix.in:443`  | `ingress.coralogix.in:443`      | `ingress.coralogix.in:443`      | 
-| APAC2   | `ingress.coralogixsg.com:443`   | `ingress.coralogixsg.com:443`   | `ingress.coralogixsg.com:443`   |
-| EUROPE1 | `ingress.coralogix.com:443`     | `ingress.coralogix.com:443`     | `ingress.coralogix.com:443`     |
-| EUROPE2 | `ingress.eu2.coralogix.com:443` | `ingress.eu2.coralogix.com:443` | `ingress.eu2.coralogix.com:443` |
+| Region  | Endpoint                        |
+|---------|---------------------------------|
+| USA1    | `ingress.coralogix.us:443`      |
+| APAC1   | `ingress.coralogix.in:443`      |
+| APAC2   | `ingress.coralogixsg.com:443`   |
+| EUROPE1 | `ingress.coralogix.com:443`     |
+| EUROPE2 | `ingress.eu2.coralogix.com:443` |
+
+Additionally, Coralogix supports AWS PrivateLink, which provides private connectivity between virtual private clouds (VPCs), supported AWS services, and your on-premises networks without exposing your traffic to the public internet.
+
+Here are available AWS PrivateLink endpoints:
+
+| Region  | Endpoint                                |
+|---------|-----------------------------------------|
+| USA1    | `ingress.private.coralogix.com:443`     |
+| APAC1   | `ingress.private.coralogix.in:443`       |
+| APAC2   | `ingress.private.coralogixsg.com:443`   |
+| EUROPE1 | `ingress.private.coralogix.com:443`     |
+| EUROPE2 | `ingress.private.eu2.coralogix.com:443` |
+
+Learn more about [AWS PrivateLink in the documentation page](https://coralogix.com/docs/coralogix-amazon-web-services-aws-privatelink-endpoints/).
 
 ### Application and SubSystem attributes
 
@@ -96,12 +103,7 @@ When using OpenTelemetry Collector with [k8sattribute](https://github.com/open-t
 exporters:
   coralogix:
     # The Coralogix traces ingress endpoint
-    traces:
-      endpoint: "ingress.coralogix.com:443"
-    metrics:
-      endpoint: "ingress.coralogix.com:443"
-    logs:
-      endpoint: "ingress.coralogix.com:443"
+    endpoint: "ingress.coralogix.com:443"
     application_name_attributes:
       - "service.namespace"
       - "k8s.namespace.name" 
@@ -137,13 +139,7 @@ You can configure Coralogix Exporter:
 ```yaml
 exporters:
   coralogix:
-    # The Coralogix traces ingress endpoint
-    traces:
-      endpoint: "ingress.coralogix.com:443"
-    metrics:
-      endpoint: "ingress.coralogix.com:443"
-    logs:
-      endpoint: "ingress.coralogix.com:443"
+    endpoint: "ingress.coralogix.com:443"
     application_name_attributes:
       - "env" 
     subsystem_name_attributes:
@@ -186,13 +182,7 @@ You can configure Coralogix Exporter:
 ```yaml
 exporters:
   coralogix:
-    # The Coralogix traces ingress endpoint
-    traces:
-      endpoint: "ingress.coralogix.com:443"
-    metrics:
-      endpoint: "ingress.coralogix.com:443"
-    logs:
-      endpoint: "ingress.coralogix.com:443"
+    endpoint: "ingress.coralogix.com:443"
     application_name_attributes:
       - "ec2.tag.name" 
     subsystem_name_attributes:
@@ -213,13 +203,7 @@ Then you can use the custom Resource attribute in Coralogix exporter:
 ```yaml
 exporters:
   coralogix:
-    # The Coralogix traces ingress endpoint
-    traces:
-      endpoint: "ingress.coralogix.com:443"
-    metrics:
-      endpoint: "ingress.coralogix.com:443"
-    logs:
-      endpoint: "ingress.coralogix.com:443"
+    endpoint: "ingress.coralogix.com:443"
     application_name_attributes:
       - "applicationName" 
     subsystem_name_attributes:

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -38,10 +38,9 @@ type Config struct {
 	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
 	exporterhelper.TimeoutSettings `mapstructure:",squash"`
 
-	// Deprecated: [v0.60.0] Coralogix jaeger based trace endpoint
-	// will be removed in the next version
-	// Please use OTLP endpoint using traces.endpoint
+	// Coralogix single endpoint for logs, trace and metrics
 	configgrpc.GRPCClientSettings `mapstructure:",squash"`
+
 	// Coralogix traces ingress endpoint
 	Traces configgrpc.GRPCClientSettings `mapstructure:"traces"`
 
@@ -77,7 +76,7 @@ func (c *Config) Validate() error {
 		isEmpty(c.Traces.Endpoint) &&
 		isEmpty(c.Metrics.Endpoint) &&
 		isEmpty(c.Logs.Endpoint) {
-		return fmt.Errorf("`traces.endpoint` or `metrics.endpoint` or `logs.endpoint` not specified, please fix the configuration file")
+		return fmt.Errorf("`endpoint` or `traces.endpoint` or `metrics.endpoint` or `logs.endpoint` not specified, please fix the configuration file")
 	}
 	if c.PrivateKey == "" {
 		return fmt.Errorf("`privateKey` not specified, please fix the configuration file")

--- a/exporter/coralogixexporter/factory.go
+++ b/exporter/coralogixexporter/factory.go
@@ -41,6 +41,10 @@ func createDefaultConfig() component.Config {
 		QueueSettings:   exporterhelper.NewDefaultQueueSettings(),
 		RetrySettings:   exporterhelper.NewDefaultRetrySettings(),
 		TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
+		GRPCClientSettings: configgrpc.GRPCClientSettings{
+			Endpoint:    "https://",
+			Compression: configcompression.Gzip,
+		},
 		// Traces GRPC client
 		Traces: configgrpc.GRPCClientSettings{
 			Endpoint:    "https://",

--- a/exporter/coralogixexporter/factory_test.go
+++ b/exporter/coralogixexporter/factory_test.go
@@ -55,10 +55,32 @@ func TestCreateMetricsExporter(t *testing.T) {
 	require.NotNil(t, oexp)
 }
 
+func TestCreateMetricsExporterWithSingleEndpoint(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
+
+	set := exportertest.NewNopCreateSettings()
+	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
+	require.Nil(t, err)
+	require.NotNil(t, oexp)
+}
+
 func TestCreateLogsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.Logs.Endpoint = testutil.GetAvailableLocalAddress(t)
+
+	set := exportertest.NewNopCreateSettings()
+	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
+	require.Nil(t, err)
+	require.NotNil(t, oexp)
+}
+
+func TestCreateLogsExporterWithSingleEndpoint(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Endpoint = testutil.GetAvailableLocalAddress(t)
 
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
@@ -167,6 +189,28 @@ func TestCreateTracesExporter(t *testing.T) {
 				},
 			},
 			mustFailOnStart: true,
+		},
+		{
+			name: "UseEnpdoint",
+			config: Config{
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Endpoint: endpoint,
+					TLSSetting: configtls.TLSClientSetting{
+						Insecure: false,
+					},
+				},
+			},
+		},
+		{
+			name: "UseSingleEndpoint",
+			config: Config{
+				GRPCClientSettings: configgrpc.GRPCClientSettings{
+					Endpoint: endpoint,
+					TLSSetting: configtls.TLSClientSetting{
+						Insecure: false,
+					},
+				},
+			},
 		},
 	}
 

--- a/exporter/coralogixexporter/logs_client.go
+++ b/exporter/coralogixexporter/logs_client.go
@@ -32,8 +32,8 @@ import (
 func newLogsExporter(cfg component.Config, set exp.CreateSettings) (*logsExporter, error) {
 	oCfg := cfg.(*Config)
 
-	if oCfg.Logs.Endpoint == "" || oCfg.Logs.Endpoint == "https://" || oCfg.Logs.Endpoint == "http://" {
-		return nil, errors.New("coralogix exporter config requires `logs.endpoint` configuration")
+	if isEmpty(oCfg.Endpoint) && isEmpty(oCfg.Logs.Endpoint) {
+		return nil, errors.New("coralogix exporter config requires `endpoint` or `logs.endpoint` configuration")
 	}
 	userAgent := fmt.Sprintf("%s/%s (%s/%s)",
 		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
@@ -56,8 +56,15 @@ type logsExporter struct {
 }
 
 func (e *logsExporter) start(ctx context.Context, host component.Host) (err error) {
-	if e.clientConn, err = e.config.Logs.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
-		return err
+	switch {
+	case !isEmpty(e.config.Logs.Endpoint):
+		if e.clientConn, err = e.config.Logs.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
+			return err
+		}
+	case !isEmpty(e.config.Endpoint):
+		if e.clientConn, err = e.config.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
+			return err
+		}
 	}
 
 	e.logExporter = plogotlp.NewGRPCClient(e.clientConn)

--- a/exporter/coralogixexporter/metrics_client.go
+++ b/exporter/coralogixexporter/metrics_client.go
@@ -38,8 +38,8 @@ import (
 func newMetricsExporter(cfg component.Config, set exp.CreateSettings) (*exporter, error) {
 	oCfg := cfg.(*Config)
 
-	if oCfg.Metrics.Endpoint == "" || oCfg.Metrics.Endpoint == "https://" || oCfg.Metrics.Endpoint == "http://" {
-		return nil, errors.New("coralogix exporter config requires `metrics.endpoint` configuration")
+	if isEmpty(oCfg.Endpoint) && isEmpty(oCfg.Metrics.Endpoint) {
+		return nil, errors.New("coralogix exporter config requires `endpoint` or `metrics.endpoint` configuration")
 	}
 	userAgent := fmt.Sprintf("%s/%s (%s/%s)",
 		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
@@ -62,8 +62,16 @@ type exporter struct {
 }
 
 func (e *exporter) start(ctx context.Context, host component.Host) (err error) {
-	if e.clientConn, err = e.config.Metrics.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
-		return err
+
+	switch {
+	case !isEmpty(e.config.Metrics.Endpoint):
+		if e.clientConn, err = e.config.Metrics.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
+			return err
+		}
+	case !isEmpty(e.config.Endpoint):
+		if e.clientConn, err = e.config.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
+			return err
+		}
 	}
 
 	e.metricExporter = pmetricotlp.NewGRPCClient(e.clientConn)

--- a/exporter/coralogixexporter/testdata/config.yaml
+++ b/exporter/coralogixexporter/testdata/config.yaml
@@ -31,3 +31,14 @@ coralogix/all:
   application_name: "APP_NAME"
   subsystem_name: "SUBSYSTEM_NAME"
   timeout: 5s
+
+coralogix/singleendpoint:
+  endpoint: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  application_name_attributes:
+    - "service.namespace"
+  subsystem_name_attributes:
+    - "service.name"
+  private_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  application_name: "APP_NAME"
+  subsystem_name: "SUBSYSTEM_NAME"
+  timeout: 5s

--- a/exporter/coralogixexporter/traces_client.go
+++ b/exporter/coralogixexporter/traces_client.go
@@ -49,8 +49,8 @@ func newTracesExporter(cfg component.Config, set exp.CreateSettings) (*tracesExp
 		return nil, fmt.Errorf("invalid config exporter, expect type: %T, got: %T", &Config{}, cfg)
 	}
 
-	if oCfg.Traces.Endpoint == "" || oCfg.Traces.Endpoint == "https://" || oCfg.Traces.Endpoint == "http://" {
-		return nil, errors.New("coralogix exporter config requires `Traces.endpoint` configuration")
+	if isEmpty(oCfg.Endpoint) && isEmpty(oCfg.Traces.Endpoint) {
+		return nil, errors.New("coralogix exporter config requires `endpoint` or `Traces.endpoint` configuration")
 	}
 	userAgent := fmt.Sprintf("%s/%s (%s/%s)",
 		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
@@ -59,8 +59,16 @@ func newTracesExporter(cfg component.Config, set exp.CreateSettings) (*tracesExp
 }
 
 func (e *tracesExporter) start(ctx context.Context, host component.Host) (err error) {
-	if e.clientConn, err = e.config.Traces.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
-		return err
+
+	switch {
+	case !isEmpty(e.config.Traces.Endpoint):
+		if e.clientConn, err = e.config.Traces.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
+			return err
+		}
+	case !isEmpty(e.config.Endpoint):
+		if e.clientConn, err = e.config.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
+			return err
+		}
 	}
 
 	e.traceExporter = ptraceotlp.NewGRPCClient(e.clientConn)


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Allow setting single endpoint for logs, metrics and traces in coralogixexporter.

Old way of setting configuration still works. So this is not a breaking change.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.--> 

**Link to tracking Issue:** <Issue number if applicable> https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20719

**Testing:** <Describe what testing was performed and which tests were added.>

- added unit tests
- tested manually

**Documentation:** <Describe the documentation added.>

- updated docs