### PR TITLE
[receiver/fluentforward] Fix performance degradation 

### DIFF
--- a/.chloggen/ffr-fix-performance.yaml
+++ b/.chloggen/ffr-fix-performance.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: fluentforwardreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed performance issue.
+
+# One or more tracking issues related to the change
+issues: [20721]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/fluentforwardreceiver/collector.go
+++ b/receiver/fluentforwardreceiver/collector.go
@@ -66,9 +66,9 @@ func (c *Collector) processEvents(ctx context.Context) {
 			c.fillBufferUntilChanEmpty(logSlice)
 
 			stats.Record(context.Background(), observ.RecordsGenerated.M(int64(out.LogRecordCount())))
-			ctx = c.obsrecv.StartLogsOp(ctx)
-			err := c.nextConsumer.ConsumeLogs(ctx, out)
-			c.obsrecv.EndLogsOp(ctx, "fluent", out.LogRecordCount(), err)
+			obsCtx := c.obsrecv.StartLogsOp(ctx)
+			err := c.nextConsumer.ConsumeLogs(obsCtx, out)
+			c.obsrecv.EndLogsOp(obsCtx, "fluent", out.LogRecordCount(), err)
 		}
 	}
 }


### PR DESCRIPTION
**Description:** 
Fixes a performance degradation caused by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/18860.  This change ensures the long-lived context is not mutated for each event. See issues for details.

**Link to tracking Issue:**
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19798

**Testing:** 
tested using load balancing tests