### PR TITLE
[receiver/dotnetdiagnostics] add deprecation notice

### DIFF
--- a/.chloggen/codeboten_deprecate-component.yaml
+++ b/.chloggen/codeboten_deprecate-component.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: dotnetdiagnosticsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add deprecation notice
+
+# One or more tracking issues related to the change
+issues: [20740]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/dotnetdiagnosticsreceiver/README.md
+++ b/receiver/dotnetdiagnosticsreceiver/README.md
@@ -2,7 +2,7 @@
 
 | Status                   |                |
 | ------------------------ |----------------|
-| Stability                | [unmaintained] |
+| Stability                | [deprecated] |
 | Supported pipeline types | metrics        |
 | Distributions            | [contrib]      |
 
@@ -112,5 +112,5 @@ https://github.com/dotnet/diagnostics/blob/master/documentation/design-docs/ipc-
 
 https://github.com/Microsoft/perfview/blob/main/src/TraceEvent/EventPipe/EventPipeFormat.md
 
-[unmaintained]: https://github.com/open-telemetry/opentelemetry-collector#unmaintained
+[deprecated]: https://github.com/open-telemetry/opentelemetry-collector#deprecated
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/dotnetdiagnosticsreceiver/factory.go
+++ b/receiver/dotnetdiagnosticsreceiver/factory.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	typeStr   = "dotnet_diagnostics"
-	stability = component.StabilityLevelAlpha
+	stability = component.StabilityLevelDeprecated
 )
 
 func NewFactory() rcvr.Factory {

--- a/receiver/dotnetdiagnosticsreceiver/go.mod
+++ b/receiver/dotnetdiagnosticsreceiver/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: dotnetdiagnostics exporter is deprecated.
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dotnetdiagnosticsreceiver
 
 go 1.19


### PR DESCRIPTION
This component was removed from the distribution after being unmaintained for some time.
