### PR TITLE
Fixed an error in the readme of awskinesisexporter

### DIFF
--- a/exporter/awskinesisexporter/README.md
+++ b/exporter/awskinesisexporter/README.md
@@ -21,7 +21,7 @@ The following settings can be optionally configured:
     - `region` (default = us-west-2): the region that the kinesis stream is deployed in
     - `role` (no default): The role to be used in order to send data to the kinesis stream
 - `encoding`
-    - `name` (default = otlp): defines the export type to be used to send to kinesis (available is `otlp_proto`, `otlp_json`, `zipkin_proto`, `zipkin_json`, `jaeger`)
+    - `name` (default = otlp): defines the export type to be used to send to kinesis (available is `otlp_proto`, `otlp_json`, `zipkin_proto`, `zipkin_json`, `jaeger_proto`)
       - **Note** : `otlp_json` is considered experimental and _should not_ be used for production environments. 
     - `compression` (default = none): allows to set the compression type (defaults BestSpeed for all) before forwarding to kinesis (available is `flate`, `gzip`, `zlib` or `none`)
 - `max_records_per_batch` (default = 500, PutRecords limit): The number of records that can be batched together then sent to kinesis.


### PR DESCRIPTION
**Description:** 
In the readme, the encoding that is declared to be supported contains `jaeger`, But the actual supported encoding is `jaeger_proto`
[awskinesisexporter/internal/batch/encode.go#L66](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/315fdf3e571088c855f359b85e79cfd6d3ad9e50/exporter/awskinesisexporter/internal/batch/encode.go#L66)