### PR TITLE
[pkg/stanza] Fix issue where partial fingerprint could be matched to additional files

### DIFF
--- a/.chloggen/pkg-stanza-fix-stale-fingerprint.yaml
+++ b/.chloggen/pkg-stanza-fix-stale-fingerprint.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix issue where first few lines of a file could be ignored when another file had recently contained the same beginning.
+
+# One or more tracking issues related to the change
+issues: [20745]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -294,6 +294,9 @@ func (m *Manager) findFingerprintMatch(fp *Fingerprint) (*Reader, bool) {
 	for i := len(m.knownFiles) - 1; i >= 0; i-- {
 		oldReader := m.knownFiles[i]
 		if fp.StartsWith(oldReader.Fingerprint) {
+			// Remove the old reader from the list of known files. We will
+			// add it back in saveCurrent if it is still alive.
+			m.knownFiles = append(m.knownFiles[:i], m.knownFiles[i+1:]...)
 			return oldReader, true
 		}
 	}

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -1511,3 +1511,38 @@ func TestHeaderPersistanceInHeader(t *testing.T) {
 	require.NoError(t, op2.Stop())
 
 }
+
+func TestStalePartialFingerprintDiscarded(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	cfg := NewConfig().includeDir(tempDir)
+	cfg.FingerprintSize = 18
+	cfg.StartAt = "beginning"
+	operator, emitCalls := buildTestManager(t, cfg)
+	operator.persister = testutil.NewMockPersister("test")
+
+	// Both of they will be include
+	file1 := openTempWithPattern(t, tempDir, "*.log1")
+	file2 := openTempWithPattern(t, tempDir, "*.log2")
+
+	// Two same fingerprint file , and smaller than  config size
+	content := "aaaaaaaaaaa"
+	writeString(t, file1, content+"\n")
+	writeString(t, file2, content+"\n")
+	operator.poll(context.Background())
+	// one file will be exclude, ingest only one content
+	waitForToken(t, emitCalls, []byte(content))
+	expectNoTokens(t, emitCalls)
+	operator.wg.Wait()
+
+	// keep append data to file1 and file2
+	newContent := "bbbbbbbbbbbb"
+	newContent1 := "ddd"
+	writeString(t, file1, newContent1+"\n")
+	writeString(t, file2, newContent+"\n")
+	operator.poll(context.Background())
+	// We should have updated the offset for one of the files, so the second file should now
+	// be ingested from the beginning
+	waitForTokens(t, emitCalls, [][]byte{[]byte(content), []byte(newContent1), []byte(newContent)})
+	operator.wg.Wait()
+}


### PR DESCRIPTION
**Description:**

When a file is read before its length reaches the fingerprint size, we capture the contents of the file as a partial fingerprint. When additional data is written to the file, we begin reading from the previously known length, and ultimately create a new fingerprint and offset. However, we were not discarding the first known offset. The effect of this was that, for a brief period of time (about 3 poll cycles), if a new file was found that also started with the same partial fingerprint, we would begin reading the file from the end of the partial fingerprint.

**Link to tracking Issue:**

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20745

**Testing:**

Used test written by @maokitty in #20745