### PR TITLE
[exporter/splunkhec] Implement maxEventSize on exporter side

### DIFF
--- a/.chloggen/max_event_size.yaml
+++ b/.chloggen/max_event_size.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Apply a new config `maxEventSize` on our events, it would break down the events based on this. This basically implements HEC's `maxEventSize` on our exporter. It is implemented on uncompressed data.
+
+# One or more tracking issues related to the change
+issues: [20290]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -221,7 +221,6 @@ func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice,
 		if accept {
 			continue
 		}
-		// fmt.Println(accept, len(b))
 
 		if state.containsData {
 			if err := c.postEvents(ctx, state, headers); err != nil {
@@ -242,7 +241,6 @@ func (c *client) pushLogRecords(ctx context.Context, lds plog.ResourceLogsSlice,
 				fmt.Errorf("dropped log event error: event size %d bytes larger than configured max content length %d bytes", len(b), state.bufferMaxLen)))
 			continue
 		}
-		// fmt.Println(accept, len(b), state.rawLength)
 		if state.containsData {
 			// This means that the current record had overflown the buffer and was not sent
 			state.bufFront = &index{resource: state.resource, library: state.library, record: k}

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -36,6 +36,7 @@ const (
 	maxContentLengthLogsLimit        = 800 * 1024 * 1024
 	maxContentLengthMetricsLimit     = 800 * 1024 * 1024
 	maxContentLengthTracesLimit      = 800 * 1024 * 1024
+	defaultMaxEventSize              = 5 * 1024 * 1024
 )
 
 // OtelToHecFields defines the mapping of attributes to HEC fields
@@ -89,6 +90,10 @@ type Config struct {
 	// Maximum trace payload size in bytes. Default value is 2097152 bytes (2MiB).
 	// Maximum allowed value is 838860800 (~ 800 MB).
 	MaxContentLengthTraces uint `mapstructure:"max_content_length_traces"`
+
+	// Maximum payload size, raw uncompressed. Default value is 5242880 bytes (5MiB).
+	// Maximum allowed value is 838860800 (~ 800 MB).
+	MaxEventSize uint `mapstructure:"max_event_size"`
 
 	// App name is used to track telemetry information for Splunk App's using HEC by App name. Defaults to "OpenTelemetry Collector Contrib".
 	SplunkAppName string `mapstructure:"splunk_app_name"`

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -33,10 +33,11 @@ const (
 	defaultContentLengthLogsLimit    = 2 * 1024 * 1024
 	defaultContentLengthMetricsLimit = 2 * 1024 * 1024
 	defaultContentLengthTracesLimit  = 2 * 1024 * 1024
+	defaultMaxEventSize              = 5 * 1024 * 1024
 	maxContentLengthLogsLimit        = 800 * 1024 * 1024
 	maxContentLengthMetricsLimit     = 800 * 1024 * 1024
 	maxContentLengthTracesLimit      = 800 * 1024 * 1024
-	defaultMaxEventSize              = 5 * 1024 * 1024
+	maxMaxEventSize                  = 800 * 1024 * 1024
 )
 
 // OtelToHecFields defines the mapping of attributes to HEC fields
@@ -158,6 +159,11 @@ func (cfg *Config) Validate() error {
 	if cfg.MaxContentLengthTraces > maxContentLengthTracesLimit {
 		return fmt.Errorf(`requires "max_content_length_traces" <= %d`, maxContentLengthTracesLimit)
 	}
+
+	if cfg.MaxEventSize > maxMaxEventSize {
+		return fmt.Errorf(`requires "max_event_size" <= %d`, maxMaxEventSize)
+	}
+
 	if err := cfg.QueueSettings.Validate(); err != nil {
 		return fmt.Errorf("sending_queue settings has invalid configuration: %w", err)
 	}

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -64,6 +64,7 @@ func TestLoadConfig(t *testing.T) {
 				LogDataEnabled:          true,
 				ProfilingDataEnabled:    true,
 				ExportRaw:               true,
+				MaxEventSize:            5 * 1024 * 1024,
 				MaxContentLengthLogs:    2 * 1024 * 1024,
 				MaxContentLengthMetrics: 2 * 1024 * 1024,
 				MaxContentLengthTraces:  2 * 1024 * 1024,
@@ -187,6 +188,17 @@ func TestConfig_Validate(t *testing.T) {
 				return cfg
 			}(),
 			wantErr: "requires \"max_content_length_traces\" <= 838860800",
+		},
+		{
+			name: "max default event-size",
+			cfg: func() *Config {
+				cfg := createDefaultConfig().(*Config)
+				cfg.HTTPClientSettings.Endpoint = "http://foo_bar.com"
+				cfg.MaxEventSize = maxMaxEventSize + 1
+				cfg.Token = "foo"
+				return cfg
+			}(),
+			wantErr: "requires \"max_event_size\" <= 838860800",
 		},
 	}
 

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -77,6 +77,7 @@ func createDefaultConfig() component.Config {
 		MaxContentLengthLogs:    defaultContentLengthLogsLimit,
 		MaxContentLengthMetrics: defaultContentLengthMetricsLimit,
 		MaxContentLengthTraces:  defaultContentLengthTracesLimit,
+		MaxEventSize:            defaultMaxEventSize,
 		HecToOtelAttrs: splunk.HecToOtelAttrs{
 			Source:     splunk.DefaultSourceLabel,
 			SourceType: splunk.DefaultSourceTypeLabel,


### PR DESCRIPTION
**Description:** 
Added a new config to apply the maxEventSize on our data.

- ***It applies this limit on uncompressed data***

**Link to tracking Issue:** [18066](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18066)

**Testing:** Relevant test cases added

**Documentation:** <Describe the documentation added.>