### PR TITLE
[exporter/datadog] Reduce log level of retriable errors to Debug level

### DIFF
--- a/.chloggen/datadog-reduce-error-logs.yaml
+++ b/.chloggen/datadog-reduce-error-logs.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reduce log level of retriable errors to Debug level
+
+# One or more tracking issues related to the change
+issues: [20755]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/datadogexporter/internal/clientutil/retrier.go
+++ b/exporter/datadogexporter/internal/clientutil/retrier.go
@@ -80,8 +80,8 @@ func (r *Retrier) DoWithRetries(ctx context.Context, fn func(context.Context) er
 		}
 
 		backoffDelayStr := backoffDelay.String()
-		r.logger.Info(
-			"Request failed with retriable errors. Will retry the request after interval.",
+		r.logger.Debug(
+			"Request failed with retriable errors. Will retry the request after interval. (You can safely discard this log if requests eventually go through.)",
 			zap.Error(err),
 			zap.String("interval", backoffDelayStr),
 			zap.Int64("retry attempts", retryNum),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
 Reduce log level of retriable errors to Debug level. Also update the log message.

**Link to tracking Issue:** <Issue number if applicable>
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20755.

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>