### PR TITLE
[Bug Fix]: To allow usage of awss3exporter

### DIFF
--- a/cmd/otelcontribcol/components.go
+++ b/cmd/otelcontribcol/components.go
@@ -45,6 +45,7 @@ import (
 	jaegerexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerexporter"
 	jaegerthrifthttpexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/jaegerthrifthttpexporter"
 	kafkaexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
+	awss3exporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter"
 	loadbalancingexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
 	logicmonitorexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logicmonitorexporter"
 	logzioexporter "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter"
@@ -316,6 +317,7 @@ func components() (otelcol.Factories, error) {
 		jaegerexporter.NewFactory(),
 		jaegerthrifthttpexporter.NewFactory(),
 		kafkaexporter.NewFactory(),
+		awss3exporter.NewFactory(),
 		loadbalancingexporter.NewFactory(),
 		logicmonitorexporter.NewFactory(),
 		logzioexporter.NewFactory(),


### PR DESCRIPTION

**Description:** <Describe what has changed.>
To fix the error while using awss3 exporter:
 

> * error decoding 'exporters': unknown type: "awss3" for id: "awss3" (valid values: 
[alibabacloud_logservice clickhouse googlemanagedprometheus instana jaeger pulsar sapm f5cloud loadbalancing sumologic otlp azuremonitor datadog elasticsearch influxdb mezmo skywalking awscloudwatchlogs awsemf dynatrace googlecloud tanzuobservability tencentcloud_logservice logicmonitor opencensus signalfx splunk_hec googlecloudpubsub loki prometheusremotewrite otlphttp azuredataexplorer carbon file jaeger_thrift logzio kafka prometheus sentry zipkin logging awskinesis awsxray coralogix])

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>