### PR TITLE
[exporter/fileexporter] provide additional documentation for the working setup of the file exporter

### DIFF
--- a/.chloggen/file_exporter_add_document.yaml
+++ b/.chloggen/file_exporter_add_document.yaml
@@ -1,0 +1,15 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: fileexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:  provide additional documentation for the working setup of the file exporter.
+
+# One or more tracking issues related to the change
+issues: [20279]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.

--- a/exporter/fileexporter/README.md
+++ b/exporter/fileexporter/README.md
@@ -18,9 +18,8 @@ Exporter supports the following features：
 Please note that there is no guarantee that exact field names will remain stable.
 This intended for primarily for debugging Collector without setting up backends.
 
-The official [opentelemetry-collector-contrib container](https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags#!) does not have a writable filesystem by default since it's built using the special `from scratch` layer.
-As such, you will need to create a writable directory for the path, potentially by creating writable volumes or creating a custom image.
-
+The official [opentelemetry-collector-contrib container](https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags#!) does not have a writable filesystem by default since it's built on the `scratch` layer.
+As such, you will need to create a writable directory for the path, potentially by mounting writable volumes or creating a custom image.
 ## Configuration options:
 
 The following settings are required:
@@ -96,7 +95,8 @@ exporters:
 
 ## Get Started in an existing cluster
 We will follow the [documentation](https://opentelemetry.io/docs/k8s-operator/) to first install the operator in an existing cluster
-and then create an OpenTelemetry Collector (otelcol) instance, like:
+and then create an OpenTelemetry Collector (otelcol) instance, 
+mounting an additional volume under `/data` under which the file exporter will write `metrics.json`:
 ``` shell
 kubectl apply -f - <<EOF
 apiVersion: opentelemetry.io/v1alpha1

--- a/exporter/fileexporter/README.md
+++ b/exporter/fileexporter/README.md
@@ -18,9 +18,10 @@ Exporter supports the following features：
 Please note that there is no guarantee that exact field names will remain stable.
 This intended for primarily for debugging Collector without setting up backends.
 
-The official [opentelemetry-collector-contrib container](https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags#!) does not have a writable filesystem by default since it's built using the special `from scratch` layer. As such, you will need to create a writable directory for the path, potentially by creating writable volumes or creating a custom image.
+The official [opentelemetry-collector-contrib container](https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags#!) does not have a writable filesystem by default since it's built using the special `from scratch` layer.
+As such, you will need to create a writable directory for the path, potentially by creating writable volumes or creating a custom image.
 
-## Getting Started
+## Configuration options:
 
 The following settings are required:
 
@@ -93,6 +94,43 @@ exporters:
     flush_interval: 5
 ```
 
+## Get Started in an existing cluster
+We will follow the [documentation](https://opentelemetry.io/docs/k8s-operator/) to first install the operator in an existing cluster
+and then create an OpenTelemetry Collector (otelcol) instance, like:
+``` shell
+kubectl apply -f - <<EOF
+apiVersion: opentelemetry.io/v1alpha1
+kind: OpenTelemetryCollector
+metadata:
+  name: fileexporter
+spec:
+  config: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    processors:
+
+    exporters:
+      logging:
+      file:
+        path: /data/metrics.json
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          processors: []
+          exporters: [logging,file]
+  volumes:
+    - name: file
+      emptyDir: {}
+  volumeMounts: 
+    - name: file
+      mountPath: /data
+EOF
+```
 
 [alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]:https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
To address the issue of the official OpenTelemetry collector-contrib container not having a writable filesystem by default due to its construction with a special from scratch layer, users will need to create a writable directory for the file exporter's path. This can potentially be done by creating writable volumes or creating a custom image.

In order to help users better utilize the file exporter, we are working on providing guidance based on the OpenTelemetry operator.

**Link to tracking Issue:** <Issue number if applicable>
#20279

**Testing:** <Describe what testing was performed and which tests were added.>
N/A
**Documentation:** <Describe the documentation added.>
provide additional documentation for the working setup of the file exporter.