### PR TITLE
 [exporter/coralogixexporter] Allow setting domain for coralogixexporter

### DIFF
--- a/.chloggen/coralogix-domain.yaml
+++ b/.chloggen/coralogix-domain.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: coralogixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow users to use only Coralogix domain to configure exporter"
+
+# One or more tracking issues related to the change
+issues: [20719]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/coralogixexporter/README.md
+++ b/exporter/coralogixexporter/README.md
@@ -20,14 +20,8 @@ Example configuration:
 ```yaml
 exporters:
   coralogix:
-    # The Coralogix traces ingress endpoint
-    traces:
-      endpoint: "ingress.coralogix.com:443"
-    metrics:
-      endpoint: "ingress.coralogix.com:443"
-    logs:
-      endpoint: "ingress.coralogix.com:443"
-
+    # The Coralogix domain
+    domain: "coralogix.com"
     # Your Coralogix private key is sensitive
     private_key: "xxx"
 
@@ -48,40 +42,56 @@ exporters:
     # (Optional) Timeout is the timeout for every attempt to send data to the backend.
     timeout: 30s
 ```
-### Tracing deprecation 
 
-The v0.67 version removed old Jaeger based tracing endpoint in favour of Opentelemetry based one.
+### v0.76.0 Coralogix Domain 
 
-To migrate, please remove the old endpoint field, and change the configuration to `traces.endpoint` using the new Tracing endpoint.
+Since v0.76.0 you can specify Coralogix domain in the configuration file instead of specifying different endpoints for traces, metrics and logs. For example, the configuration below, can be replaced with domain field:
+
 
 Old configuration:
 ```yaml
 exporters:
   coralogix:
-    # The Coralogix traces ingress endpoint
-    endpoint: "tracing-ingress.coralogix.com:9443"
-```
-
-New configuration:
-```yaml
-exporters
-  coralogix:
-    # The Coralogix traces ingress endpoint
     traces:
+      endpoint: "ingress.coralogix.com:443"
+    metrics:
+      endpoint: "ingress.coralogix.com:443"
+    logs:
       endpoint: "ingress.coralogix.com:443"
 ```
 
-### Coralogix's Endpoints 
+New configuration with domain field:
+```yaml
+exporters:
+  coralogix:
+    domain: "coralogix.com"
+```
+
+### Coralogix's Domain 
 
 Depending on your region, you might need to use a different endpoint. Here are the available Endpoints:
 
-| Region  | Traces Endpoint                          | Metrics Endpoint                     | Logs Endpoint                     |
-|---------|------------------------------------------|------------------------------------- | --------------------------------- |
-| USA1    | `ingress.coralogix.us:443`      | `ingress.coralogix.us:443`      | `ingress.coralogix.us:443`      |
-| APAC1   | `ingress.coralogix.in:443`  | `ingress.coralogix.in:443`      | `ingress.coralogix.in:443`      | 
-| APAC2   | `ingress.coralogixsg.com:443`   | `ingress.coralogixsg.com:443`   | `ingress.coralogixsg.com:443`   |
-| EUROPE1 | `ingress.coralogix.com:443`     | `ingress.coralogix.com:443`     | `ingress.coralogix.com:443`     |
-| EUROPE2 | `ingress.eu2.coralogix.com:443` | `ingress.eu2.coralogix.com:443` | `ingress.eu2.coralogix.com:443` |
+| Region  | Domain                        |
+|---------|---------------------------------|
+| USA1    | `coralogix.us`      |
+| APAC1   | `coralogix.in`      |
+| APAC2   | `coralogixsg.com`   |
+| EUROPE1 | `coralogix.com`     |
+| EUROPE2 | `eu2.coralogix.com` |
+
+Additionally, Coralogix supports AWS PrivateLink, which provides private connectivity between virtual private clouds (VPCs), supported AWS services, and your on-premises networks without exposing your traffic to the public internet.
+
+Here are available AWS PrivateLink domains:
+
+| Region  | Domain                      |
+|---------|-----------------------------|
+| USA1    | `private.coralogix.com`     |
+| APAC1   | `private.coralogix.in`      |
+| APAC2   | `private.coralogixsg.com`   |
+| EUROPE1 | `private.coralogix.com`     |
+| EUROPE2 | `private.eu2.coralogix.com` |
+
+Learn more about [AWS PrivateLink in the documentation page](https://coralogix.com/docs/coralogix-amazon-web-services-aws-privatelink-endpoints/).
 
 ### Application and SubSystem attributes
 
@@ -95,13 +105,7 @@ When using OpenTelemetry Collector with [k8sattribute](https://github.com/open-t
 ```yaml
 exporters:
   coralogix:
-    # The Coralogix traces ingress endpoint
-    traces:
-      endpoint: "ingress.coralogix.com:443"
-    metrics:
-      endpoint: "ingress.coralogix.com:443"
-    logs:
-      endpoint: "ingress.coralogix.com:443"
+    domain: "coralogix.com"
     application_name_attributes:
       - "service.namespace"
       - "k8s.namespace.name" 
@@ -137,13 +141,7 @@ You can configure Coralogix Exporter:
 ```yaml
 exporters:
   coralogix:
-    # The Coralogix traces ingress endpoint
-    traces:
-      endpoint: "ingress.coralogix.com:443"
-    metrics:
-      endpoint: "ingress.coralogix.com:443"
-    logs:
-      endpoint: "ingress.coralogix.com:443"
+    domain: "coralogix.com"
     application_name_attributes:
       - "env" 
     subsystem_name_attributes:
@@ -186,13 +184,7 @@ You can configure Coralogix Exporter:
 ```yaml
 exporters:
   coralogix:
-    # The Coralogix traces ingress endpoint
-    traces:
-      endpoint: "ingress.coralogix.com:443"
-    metrics:
-      endpoint: "ingress.coralogix.com:443"
-    logs:
-      endpoint: "ingress.coralogix.com:443"
+    domain: "coralogix.com"
     application_name_attributes:
       - "ec2.tag.name" 
     subsystem_name_attributes:
@@ -213,13 +205,7 @@ Then you can use the custom Resource attribute in Coralogix exporter:
 ```yaml
 exporters:
   coralogix:
-    # The Coralogix traces ingress endpoint
-    traces:
-      endpoint: "ingress.coralogix.com:443"
-    metrics:
-      endpoint: "ingress.coralogix.com:443"
-    logs:
-      endpoint: "ingress.coralogix.com:443"
+    domain: "coralogix.com"
     application_name_attributes:
       - "applicationName" 
     subsystem_name_attributes:

--- a/exporter/coralogixexporter/README.md
+++ b/exporter/coralogixexporter/README.md
@@ -47,7 +47,6 @@ exporters:
 
 Since v0.76.0 you can specify Coralogix domain in the configuration file instead of specifying different endpoints for traces, metrics and logs. For example, the configuration below, can be replaced with domain field:
 
-
 Old configuration:
 ```yaml
 exporters:
@@ -69,7 +68,7 @@ exporters:
 
 ### Coralogix's Domain 
 
-Depending on your region, you might need to use a different endpoint. Here are the available Endpoints:
+Depending on your region, you might need to use a different domains. Here are the available domains:
 
 | Region  | Domain                        |
 |---------|---------------------------------|

--- a/exporter/coralogixexporter/README.md
+++ b/exporter/coralogixexporter/README.md
@@ -68,7 +68,7 @@ exporters:
 
 ### Coralogix's Domain 
 
-Depending on your region, you might need to use a different domains. Here are the available domains:
+Depending on your region, you might need to use a different domain. Here are the available domains:
 
 | Region  | Domain                        |
 |---------|---------------------------------|

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -86,10 +86,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("`domain` or `traces.endpoint` or `metrics.endpoint` or `logs.endpoint` not specified, please fix the configuration")
 	}
 	if c.PrivateKey == "" {
-		return fmt.Errorf("`privateKey` not specified, please fix the configuration file")
+		return fmt.Errorf("`privateKey` not specified, please fix the configuration")
 	}
 	if c.AppName == "" {
-		return fmt.Errorf("`appName` not specified, please fix the configuration file")
+		return fmt.Errorf("`appName` not specified, please fix the configuration")
 	}
 
 	// check if headers exists

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -83,7 +83,7 @@ func (c *Config) Validate() error {
 		isEmpty(c.Traces.Endpoint) &&
 		isEmpty(c.Metrics.Endpoint) &&
 		isEmpty(c.Logs.Endpoint) {
-		return fmt.Errorf("`domain` or `traces.endpoint` or `metrics.endpoint` or `logs.endpoint` not specified, please fix the configuration file")
+		return fmt.Errorf("`domain` or `traces.endpoint` or `metrics.endpoint` or `logs.endpoint` not specified, please fix the configuration")
 	}
 	if c.PrivateKey == "" {
 		return fmt.Errorf("`privateKey` not specified, please fix the configuration file")

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -38,10 +38,16 @@ type Config struct {
 	exporterhelper.RetrySettings   `mapstructure:"retry_on_failure"`
 	exporterhelper.TimeoutSettings `mapstructure:",squash"`
 
+	// Coralogix domain
+	Domain string `mapstructure:"domain"`
+	// GRPC Settings used with Domain
+	DomainSettings configgrpc.GRPCClientSettings `mapstructure:"domain_settings"`
+
 	// Deprecated: [v0.60.0] Coralogix jaeger based trace endpoint
 	// will be removed in the next version
 	// Please use OTLP endpoint using traces.endpoint
 	configgrpc.GRPCClientSettings `mapstructure:",squash"`
+
 	// Coralogix traces ingress endpoint
 	Traces configgrpc.GRPCClientSettings `mapstructure:"traces"`
 
@@ -73,11 +79,11 @@ func isEmpty(endpoint string) bool {
 }
 func (c *Config) Validate() error {
 	// validate that at least one endpoint is set up correctly
-	if isEmpty(c.Endpoint) &&
+	if isEmpty(c.Domain) &&
 		isEmpty(c.Traces.Endpoint) &&
 		isEmpty(c.Metrics.Endpoint) &&
 		isEmpty(c.Logs.Endpoint) {
-		return fmt.Errorf("`traces.endpoint` or `metrics.endpoint` or `logs.endpoint` not specified, please fix the configuration file")
+		return fmt.Errorf("`domain` or `traces.endpoint` or `metrics.endpoint` or `logs.endpoint` not specified, please fix the configuration file")
 	}
 	if c.PrivateKey == "" {
 		return fmt.Errorf("`privateKey` not specified, please fix the configuration file")
@@ -122,4 +128,10 @@ func (c *Config) getMetadataFromResource(res pcommon.Resource) (appName, subsyst
 	}
 
 	return appName, subsystem
+}
+
+func (c *Config) getDomainGrpcSettings() *configgrpc.GRPCClientSettings {
+	settings := c.DomainSettings
+	settings.Endpoint = fmt.Sprintf("ingress.%s:443", c.Domain)
+	return &settings
 }

--- a/exporter/coralogixexporter/config_test.go
+++ b/exporter/coralogixexporter/config_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
@@ -51,18 +52,21 @@ func TestLoadConfig(t *testing.T) {
 				// Deprecated: [v0.47.0] SubSystem will remove in the next version
 				SubSystem:       "SUBSYSTEM_NAME",
 				TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
+				DomainSettings: configgrpc.GRPCClientSettings{
+					Compression: configcompression.Gzip,
+				},
 				Metrics: configgrpc.GRPCClientSettings{
 					Endpoint:        "https://",
-					Compression:     "gzip",
+					Compression:     configcompression.Gzip,
 					WriteBufferSize: 512 * 1024,
 				},
 				Logs: configgrpc.GRPCClientSettings{
 					Endpoint:    "https://",
-					Compression: "gzip",
+					Compression: configcompression.Gzip,
 				},
 				Traces: configgrpc.GRPCClientSettings{
 					Endpoint:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					Compression: "gzip",
+					Compression: configcompression.Gzip,
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting:         configtls.TLSSetting{},
 						Insecure:           false,
@@ -75,7 +79,7 @@ func TestLoadConfig(t *testing.T) {
 					BalancerName:    "",
 				},
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
-					Endpoint: "",
+					Endpoint: "https://",
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting:         configtls.TLSSetting{},
 						Insecure:           false,
@@ -103,18 +107,21 @@ func TestLoadConfig(t *testing.T) {
 				// Deprecated: [v0.47.0] SubSystem will remove in the next version
 				SubSystem:       "SUBSYSTEM_NAME",
 				TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
+				DomainSettings: configgrpc.GRPCClientSettings{
+					Compression: configcompression.Gzip,
+				},
 				Metrics: configgrpc.GRPCClientSettings{
 					Endpoint:        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					Compression:     "gzip",
+					Compression:     configcompression.Gzip,
 					WriteBufferSize: 512 * 1024,
 				},
 				Logs: configgrpc.GRPCClientSettings{
 					Endpoint:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					Compression: "gzip",
+					Compression: configcompression.Gzip,
 				},
 				Traces: configgrpc.GRPCClientSettings{
 					Endpoint:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					Compression: "gzip",
+					Compression: configcompression.Gzip,
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting:         configtls.TLSSetting{},
 						Insecure:           false,
@@ -129,7 +136,7 @@ func TestLoadConfig(t *testing.T) {
 				AppNameAttributes:   []string{"service.namespace"},
 				SubSystemAttributes: []string{"service.name"},
 				GRPCClientSettings: configgrpc.GRPCClientSettings{
-					Endpoint: "",
+					Endpoint: "https://",
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting:         configtls.TLSSetting{},
 						Insecure:           false,
@@ -217,4 +224,31 @@ func TestLogsExporter(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, me, "failed to create logs exporter")
 	require.NoError(t, me.start(context.Background(), componenttest.NewNopHost()))
+}
+
+func TestDomainWithAllExporters(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	sub, err := cm.Sub(component.NewIDWithName(typeStr, "domain").String())
+	require.NoError(t, err)
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
+
+	params := exportertest.NewNopCreateSettings()
+	te, err := newTracesExporter(cfg, params)
+	assert.NoError(t, err)
+	assert.NotNil(t, te, "failed to create trace exporter")
+	assert.NoError(t, te.start(context.Background(), componenttest.NewNopHost()))
+
+	me, err := newMetricsExporter(cfg, params)
+	require.NoError(t, err)
+	require.NotNil(t, me, "failed to create metrics exporter")
+	require.NoError(t, me.start(context.Background(), componenttest.NewNopHost()))
+
+	le, err := newLogsExporter(cfg, params)
+	require.NoError(t, err)
+	require.NotNil(t, le, "failed to create logs exporter")
+	require.NoError(t, le.start(context.Background(), componenttest.NewNopHost()))
 }

--- a/exporter/coralogixexporter/config_test.go
+++ b/exporter/coralogixexporter/config_test.go
@@ -252,3 +252,30 @@ func TestDomainWithAllExporters(t *testing.T) {
 	require.NotNil(t, le, "failed to create logs exporter")
 	require.NoError(t, le.start(context.Background(), componenttest.NewNopHost()))
 }
+
+func TestEndpoindsAndDomainWithAllExporters(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+
+	sub, err := cm.Sub(component.NewIDWithName(typeStr, "domain_endoints").String())
+	require.NoError(t, err)
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
+
+	params := exportertest.NewNopCreateSettings()
+	te, err := newTracesExporter(cfg, params)
+	assert.NoError(t, err)
+	assert.NotNil(t, te, "failed to create trace exporter")
+	assert.NoError(t, te.start(context.Background(), componenttest.NewNopHost()))
+
+	me, err := newMetricsExporter(cfg, params)
+	require.NoError(t, err)
+	require.NotNil(t, me, "failed to create metrics exporter")
+	require.NoError(t, me.start(context.Background(), componenttest.NewNopHost()))
+
+	le, err := newLogsExporter(cfg, params)
+	require.NoError(t, err)
+	require.NotNil(t, le, "failed to create logs exporter")
+	require.NoError(t, le.start(context.Background(), componenttest.NewNopHost()))
+}

--- a/exporter/coralogixexporter/factory.go
+++ b/exporter/coralogixexporter/factory.go
@@ -41,6 +41,12 @@ func createDefaultConfig() component.Config {
 		QueueSettings:   exporterhelper.NewDefaultQueueSettings(),
 		RetrySettings:   exporterhelper.NewDefaultRetrySettings(),
 		TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
+		DomainSettings: configgrpc.GRPCClientSettings{
+			Compression: configcompression.Gzip,
+		},
+		GRPCClientSettings: configgrpc.GRPCClientSettings{
+			Endpoint: "https://",
+		},
 		// Traces GRPC client
 		Traces: configgrpc.GRPCClientSettings{
 			Endpoint:    "https://",

--- a/exporter/coralogixexporter/factory_test.go
+++ b/exporter/coralogixexporter/factory_test.go
@@ -55,11 +55,32 @@ func TestCreateMetricsExporter(t *testing.T) {
 	require.NotNil(t, oexp)
 }
 
+func TestCreateMetricsExporterWithDomain(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Domain = "localhost"
+
+	set := exportertest.NewNopCreateSettings()
+	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
+	require.Nil(t, err)
+	require.NotNil(t, oexp)
+}
+
 func TestCreateLogsExporter(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
 	cfg.Logs.Endpoint = testutil.GetAvailableLocalAddress(t)
 
+	set := exportertest.NewNopCreateSettings()
+	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
+	require.Nil(t, err)
+	require.NotNil(t, oexp)
+}
+
+func TestCreateLogsExporterWithDomain(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Domain = "localhost"
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
 	require.Nil(t, err)
@@ -167,6 +188,17 @@ func TestCreateTracesExporter(t *testing.T) {
 				},
 			},
 			mustFailOnStart: true,
+		},
+		{
+			name: "UseDomain",
+			config: Config{
+				Domain: "localhost",
+				DomainSettings: configgrpc.GRPCClientSettings{
+					TLSSetting: configtls.TLSClientSetting{
+						Insecure: false,
+					},
+				},
+			},
 		},
 	}
 

--- a/exporter/coralogixexporter/factory_test.go
+++ b/exporter/coralogixexporter/factory_test.go
@@ -228,3 +228,27 @@ func TestCreateTracesExporter(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateLogsExporterWithDomainAndEndpoint(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig().(*Config)
+	cfg.Domain = "	bad domain"
+
+	cfg.Logs.Endpoint = testutil.GetAvailableLocalAddress(t)
+
+	set := exportertest.NewNopCreateSettings()
+	consumer, err := factory.CreateLogsExporter(context.Background(), set, cfg)
+	require.Nil(t, err)
+	require.NotNil(t, consumer)
+
+	err = consumer.Start(context.Background(), componenttest.NewNopHost())
+	assert.NoError(t, err)
+
+	err = consumer.Shutdown(context.Background())
+	if err != nil {
+		// Since the endpoint of OTLP exporter doesn't actually exist,
+		// exporter may already stop because it cannot connect.
+		assert.Equal(t, err.Error(), "rpc error: code = Canceled desc = grpc: the client connection is closing")
+	}
+
+}

--- a/exporter/coralogixexporter/logs_client.go
+++ b/exporter/coralogixexporter/logs_client.go
@@ -32,8 +32,8 @@ import (
 func newLogsExporter(cfg component.Config, set exp.CreateSettings) (*logsExporter, error) {
 	oCfg := cfg.(*Config)
 
-	if oCfg.Logs.Endpoint == "" || oCfg.Logs.Endpoint == "https://" || oCfg.Logs.Endpoint == "http://" {
-		return nil, errors.New("coralogix exporter config requires `logs.endpoint` configuration")
+	if isEmpty(oCfg.Domain) && isEmpty(oCfg.Logs.Endpoint) {
+		return nil, errors.New("coralogix exporter config requires `domain` or `logs.endpoint` configuration")
 	}
 	userAgent := fmt.Sprintf("%s/%s (%s/%s)",
 		set.BuildInfo.Description, set.BuildInfo.Version, runtime.GOOS, runtime.GOARCH)
@@ -56,8 +56,16 @@ type logsExporter struct {
 }
 
 func (e *logsExporter) start(ctx context.Context, host component.Host) (err error) {
-	if e.clientConn, err = e.config.Logs.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
-		return err
+	switch {
+	case !isEmpty(e.config.Logs.Endpoint):
+		if e.clientConn, err = e.config.Logs.ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
+			return err
+		}
+	case !isEmpty(e.config.Domain):
+		if e.clientConn, err = e.config.getDomainGrpcSettings().ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
+			return err
+		}
+
 	}
 
 	e.logExporter = plogotlp.NewGRPCClient(e.clientConn)

--- a/exporter/coralogixexporter/logs_client.go
+++ b/exporter/coralogixexporter/logs_client.go
@@ -62,10 +62,10 @@ func (e *logsExporter) start(ctx context.Context, host component.Host) (err erro
 			return err
 		}
 	case !isEmpty(e.config.Domain):
+
 		if e.clientConn, err = e.config.getDomainGrpcSettings().ToClientConn(ctx, host, e.settings, grpc.WithUserAgent(e.userAgent)); err != nil {
 			return err
 		}
-
 	}
 
 	e.logExporter = plogotlp.NewGRPCClient(e.clientConn)

--- a/exporter/coralogixexporter/testdata/config.yaml
+++ b/exporter/coralogixexporter/testdata/config.yaml
@@ -16,13 +16,23 @@ coralogix/trace:
   timeout: 5s
 
 coralogix/all:
-  # endpoint: "http://localhost:8000"
   traces:
     endpoint: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   metrics:
     endpoint: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   logs:
     endpoint: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  application_name_attributes:
+    - "service.namespace"
+  subsystem_name_attributes:
+    - "service.name"
+  private_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  application_name: "APP_NAME"
+  subsystem_name: "SUBSYSTEM_NAME"
+  timeout: 5s
+
+coralogix/domain:
+  domain: "coralogix.com"
   application_name_attributes:
     - "service.namespace"
   subsystem_name_attributes:

--- a/exporter/coralogixexporter/testdata/config.yaml
+++ b/exporter/coralogixexporter/testdata/config.yaml
@@ -41,3 +41,20 @@ coralogix/domain:
   application_name: "APP_NAME"
   subsystem_name: "SUBSYSTEM_NAME"
   timeout: 5s
+
+coralogix/domain_endoints:
+  domain: "coralogix.com"
+  traces:
+    endpoint: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  metrics:
+    endpoint: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  logs:
+    endpoint: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  application_name_attributes:
+    - "service.namespace"
+  subsystem_name_attributes:
+    - "service.name"
+  private_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  application_name: "APP_NAME"
+  subsystem_name: "SUBSYSTEM_NAME"
+  timeout: 5s


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Allow setting domain for coralogixexporter instead of multiple endpoints for signal type.

Old way of configuring is still there and works, takes priority over new configuration.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20719

Incidentally made a git rebase issue in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/20743, which caused a lot of approves and noise, so opening a new PR for clean slate.

@TylerHelmuth  / @atoulme and @nicolastakashi would appreciate if you could take another look :bow: 


**Testing:** 

- tested manually
- added unit tests

**Documentation:** <Describe the documentation added.>

- Updated docs