### PR TITLE
Update attribute processor's readme

### DIFF
--- a/processor/attributesprocessor/README.md
+++ b/processor/attributesprocessor/README.md
@@ -186,15 +186,15 @@ an option to provide a set of properties of a span, log, or metric record to mat
 if the input data should be included or excluded from the processor. To configure
 this option, under `include` and/or `exclude` at least `match_type` and one of the following
 is required:
-- For spans, one of `services`, `span_names`, `attributes`, `resources`, or `libraries` must be specified
-with a non-empty value for a valid configuration. The `log_bodies`, `log_severity_texts`, `expressions`, `resource_attributes` and
-`metric_names` fields are invalid.
-- For logs, one of `log_bodies`, `log_severity_texts`, `attributes`, `resources`, or `libraries` must be specified with a
-non-empty value for a valid configuration. The `span_names`, `metric_names`, `expressions`, `resource_attributes`,
-and `services` fields are invalid.
+- For spans, one of `services`, `span_names`, `span_kinds`, `attributes`, `resources`, or `libraries` must be specified
+with a non-empty value for a valid configuration. The `log_bodies`, `log_severity_texts`, `log_severity_number`, 
+`resource_attributes` and `metric_names` fields are invalid.
+- For logs, one of `log_bodies`, `log_severity_texts`, `log_severity_number`, `attributes`, `resources`, or `libraries` 
+must be specified with a non-empty value for a valid configuration. The `span_names`, `span_kinds`, `metric_names`, 
+`resource_attributes`, and `services` fields are invalid.
 - For metrics, one of `metric_names`, `resources` must be specified
-with a valid non-empty value for a valid configuration. The `span_names`, `log_bodies`, `log_severity_texts` and
-`services` fields are invalid.
+with a valid non-empty value for a valid configuration. The `span_names`, `span_kinds`, `log_bodies`, `log_severity_texts`,
+`log_severity_number` and `services` fields are invalid.
 
 
 Note: If both `include` and `exclude` are specified, the `include` properties
@@ -223,17 +223,36 @@ attributes:
       # This is an optional field.
       services: [<item1>, ..., <itemN>]
 
-      # resources specify an array of items to match the resources against.
+      # resources specifies a list of resources to match against.
       # A match occurs if the input data resources matches at least one of the items.
-      resources: [<item1>, ..., <itemN>]
+      # This is an optional field.
+      resources:
+          # Key specifies the resource to match against.
+        - key: <key>
+          # Value specifies the exact value to match against.
+          # If not specified, a match occurs if the key is present in the resources.
+          value: {value}
 
-      # libraries specify an array of items to match the implementation library against.
+      # libraries specify a list of items to match the implementation library against.
       # A match occurs if the input data implementation library matches at least one of the items.
+      # This is an optional field.
       libraries: [<item1>, ..., <itemN>]
+          # Name specifies the library to match against.
+        - name: <name>
+          # Version specifies the exact version to match against.
+          # This is an optional field.
+          # If the field is not set, any version will match.
+          # If the field is set to an empty string, only an
+          # empty string version will match.
+          version: {version}
 
       # The span name must match at least one of the items.
       # This is an optional field.
       span_names: [<item1>, ..., <itemN>]
+
+      # The span kind must match at least one of the items.
+      # This is an optional field.
+      span_kinds: [<item1>, ..., <itemN>]
 
       # The log body must match at least one of the items.
       # Currently only string body types are supported.
@@ -243,6 +262,18 @@ attributes:
       # The log severity text must match at least one of the items.
       # This is an optional field.
       log_severity_texts: [<item1>, ..., <itemN>]
+
+      # The log severity number defines how to match against a log record's
+      # SeverityNumber, if defined.
+      # This is an optional field.
+      log_severity_number:
+        # Min is the lowest severity that may be matched.
+        # e.g. if this is plog.SeverityNumberInfo, 
+        # INFO, WARN, ERROR, and FATAL logs will match.
+        min: <int>
+        # MatchUndefined controls whether logs with "undefined" severity matches.
+        # If this is true, entries with undefined severity will match.
+        match_undefined: <bool>
 
       # The metric name must match at least one of the items.
       # This is an optional field.

--- a/processor/attributesprocessor/README.md
+++ b/processor/attributesprocessor/README.md
@@ -181,20 +181,19 @@ Metric transform processor specific functionality
 
 ## Include/Exclude Filtering
 
-The [attribute processor](README.md) exposes
-an option to provide a set of properties of a span, log, or metric record to match against to determine
-if the input data should be included or excluded from the processor. To configure
-this option, under `include` and/or `exclude` at least `match_type` and one of the following
-is required:
-- For spans, one of `services`, `span_names`, `span_kinds`, `attributes`, `resources`, or `libraries` must be specified
-with a non-empty value for a valid configuration. The `log_bodies`, `log_severity_texts`, `log_severity_number`, 
-`resource_attributes` and `metric_names` fields are invalid.
-- For logs, one of `log_bodies`, `log_severity_texts`, `log_severity_number`, `attributes`, `resources`, or `libraries` 
-must be specified with a non-empty value for a valid configuration. The `span_names`, `span_kinds`, `metric_names`, 
-`resource_attributes`, and `services` fields are invalid.
-- For metrics, one of `metric_names`, `resources` must be specified
-with a valid non-empty value for a valid configuration. The `span_names`, `span_kinds`, `log_bodies`, `log_severity_texts`,
-`log_severity_number` and `services` fields are invalid.
+The [attribute processor](README.md) exposes an option to provide a set of properties of a span, log 
+or metric record to match against to determine if the input data should be included or excluded from
+the processor. To configure this option, under `include` and/or `exclude` at least `match_type` and 
+one of the following is required:
+- For spans, one of `services`, `span_names`, `span_kinds`, `attributes`, `resources` or `libraries` 
+must be specified with a non-empty value for a valid configuration. The `log_bodies`, `log_severity_texts`, 
+`log_severity_number` and `metric_names` fields are invalid.
+- For logs, one of `log_bodies`, `log_severity_texts`, `log_severity_number`, `attributes`, `resources`
+or `libraries` must be specified with a non-empty value for a valid configuration. The `span_names`, 
+`span_kinds`, `metric_names` and `services` fields are invalid.
+- For metrics, one of `metric_names` or `resources` must be specified with a valid non-empty value for
+a valid configuration. The `span_names`, `span_kinds`, `log_bodies`, `log_severity_texts`, 
+`log_severity_number`, `services`, `attributes` and `libraries` fields are invalid.
 
 
 Note: If both `include` and `exclude` are specified, the `include` properties

--- a/processor/attributesprocessor/testdata/config.yaml
+++ b/processor/attributesprocessor/testdata/config.yaml
@@ -300,7 +300,7 @@ attributes/regexp2:
     match_type: regexp
     attributes:
       # This attribute ('db.statement') must exist in the span and match the regex ('SELECT \* FROM USERS.*') for a match.
-      - {key: env, value: 'SELECT \* FROM USERS.*'}
+      - {key: "db.statement", value: 'SELECT \* FROM USERS.*'}
   actions:
     - key: db.statement
       action: update


### PR DESCRIPTION
While working on a [feature](https://github.com/grafana/agent/pull/3349) for the Grafana Agent, I noticed that the the attribute processor's readme is out of date. This PR changes the following:
* Remove mention of `expressions`. I'm not sure what this is in the first place, and why it is in the .md file.
* Mention `span_kinds` and `log_severity_number`
* Fix the way `resources ` and `libraries ` are described in config.

It seems filtering based on [severity number](https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/14996d1a5953f07b3637560988735b185ff14c35) and [span kinds](https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/e043da8ff3d4a28ed33a11584e625a5404a6049a) was added later, which is why the documentation does not mention them.

I did not add a changelog entry for this PR because it's quite a minor change.