### PR TITLE
[receiver/kakfareceiver] add: text unmarshaler support in kafka recei…

### DIFF
--- a/.chloggen/kafka_receiver_text.yaml
+++ b/.chloggen/kafka_receiver_text.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `text` unmarshaler, which will decode the kafka message as text and insert it as the body of a log record.
+
+# One or more tracking issues related to the change
+issues: [20734]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/coreinternal/go.mod
+++ b/internal/coreinternal/go.mod
@@ -14,6 +14,7 @@ require (
 	go.opentelemetry.io/otel v1.15.1
 	go.opentelemetry.io/otel/trace v1.15.1
 	go.uber.org/zap v1.24.0
+	golang.org/x/text v0.9.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -31,7 +32,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
 	google.golang.org/grpc v1.55.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect

--- a/internal/coreinternal/textutils/encoding.go
+++ b/internal/coreinternal/textutils/encoding.go
@@ -1,0 +1,107 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textutils // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/textutils"
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/ianaindex"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+// NewBasicConfig creates a new Encoding config
+func NewEncodingConfig() EncodingConfig {
+	return EncodingConfig{
+		Encoding: "utf-8",
+	}
+}
+
+// EncodingConfig is the configuration of a Encoding helper
+type EncodingConfig struct {
+	Encoding string `mapstructure:"encoding,omitempty"`
+}
+
+// Build will build an Encoding operator.
+func (c EncodingConfig) Build() (Encoding, error) {
+	enc, err := lookupEncoding(c.Encoding)
+	if err != nil {
+		return Encoding{}, err
+	}
+
+	return Encoding{
+		Encoding:     enc,
+		decodeBuffer: make([]byte, 1<<12),
+		decoder:      enc.NewDecoder(),
+	}, nil
+}
+
+type Encoding struct {
+	Encoding     encoding.Encoding
+	decoder      *encoding.Decoder
+	decodeBuffer []byte
+}
+
+// Decode converts the bytes in msgBuf to utf-8 from the configured encoding
+func (e *Encoding) Decode(msgBuf []byte) ([]byte, error) {
+	for {
+		e.decoder.Reset()
+		nDst, _, err := e.decoder.Transform(e.decodeBuffer, msgBuf, true)
+		if err == nil {
+			return e.decodeBuffer[:nDst], nil
+		}
+		if errors.Is(err, transform.ErrShortDst) {
+			e.decodeBuffer = make([]byte, len(e.decodeBuffer)*2)
+			continue
+		}
+		return nil, fmt.Errorf("transform encoding: %w", err)
+	}
+}
+
+var encodingOverrides = map[string]encoding.Encoding{
+	"utf-16":   unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM),
+	"utf16":    unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM),
+	"utf-8":    unicode.UTF8,
+	"utf8":     unicode.UTF8,
+	"ascii":    unicode.UTF8,
+	"us-ascii": unicode.UTF8,
+	"nop":      encoding.Nop,
+	"":         unicode.UTF8,
+}
+
+func lookupEncoding(enc string) (encoding.Encoding, error) {
+	if e, ok := encodingOverrides[strings.ToLower(enc)]; ok {
+		return e, nil
+	}
+	e, err := ianaindex.IANA.Encoding(enc)
+	if err != nil {
+		return nil, fmt.Errorf("unsupported encoding '%s'", enc)
+	}
+	if e == nil {
+		return nil, fmt.Errorf("no charmap defined for encoding '%s'", enc)
+	}
+	return e, nil
+}
+
+func IsNop(enc string) bool {
+	e, err := lookupEncoding(enc)
+	if err != nil {
+		return false
+	}
+	return e == encoding.Nop
+}

--- a/internal/coreinternal/textutils/encoding_test.go
+++ b/internal/coreinternal/textutils/encoding_test.go
@@ -1,0 +1,64 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/korean"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/unicode"
+)
+
+func TestUTF8Encoding(t *testing.T) {
+	tests := []struct {
+		name         string
+		encoding     encoding.Encoding
+		encodingName string
+	}{
+		{
+			name:         "UTF8 encoding",
+			encoding:     unicode.UTF8,
+			encodingName: "utf8",
+		},
+		{
+			name:         "GBK encoding",
+			encoding:     simplifiedchinese.GBK,
+			encodingName: "gbk",
+		},
+		{
+			name:         "SHIFT_JIS encoding",
+			encoding:     japanese.ShiftJIS,
+			encodingName: "shift_jis",
+		},
+		{
+			name:         "EUC-KR encoding",
+			encoding:     korean.EUCKR,
+			encodingName: "euc-kr",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			encCfg := NewEncodingConfig()
+			encCfg.Encoding = test.encodingName
+			enc, err := encCfg.Build()
+			assert.NoError(t, err)
+			assert.Equal(t, test.encoding, enc.Encoding)
+		})
+	}
+}

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -32,6 +32,7 @@ The following settings can be optionally configured:
   - `zipkin_json`: the payload is deserialized into a list of Zipkin V2 JSON spans.
   - `zipkin_thrift`: the payload is deserialized into a list of Zipkin Thrift spans.
   - `raw`: (logs only) the payload's bytes are inserted as the body of a log record.
+  - `text`: (logs only) the payload are decoded as text and inserted as the body of a log record. By default, it uses UTF-8 to decode. You can use `text_<ENCODING>`, like `text_utf-8`, `text_shift_jis`, etc., to customize this behavior.
 - `group_id` (default = otel-collector):  The consumer group that receiver will be consuming messages from
 - `client_id` (default = otel-collector): The consumer client ID that receiver will use
 - `initial_offset` (default = latest): The initial offset to use if no offset was previously committed. Must be `latest` or `earliest`.

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -17,6 +17,7 @@ package kafkareceiver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -39,6 +40,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/textutils"
 )
 
 func TestNewTracesReceiver_version_err(t *testing.T) {
@@ -806,6 +808,147 @@ func TestLogsConsumerGroupHandler_error_nextConsumer(t *testing.T) {
 	groupClaim.messageChan <- &sarama.ConsumerMessage{Value: bts}
 	close(groupClaim.messageChan)
 	wg.Wait()
+}
+
+// Test unmarshaler for different charsets and encodings.
+func TestLogsConsumerGroupHandler_unmarshal_text(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		enc  string
+	}{
+		{
+			name: "unmarshal test for Englist (ASCII characters) with text_utf8",
+			text: "ASCII characters test",
+			enc:  "utf8",
+		},
+		{
+			name: "unmarshal test for unicode with text_utf8",
+			text: "UTF8 测试 測試 テスト 테스트 ☺️",
+			enc:  "utf8",
+		},
+		{
+			name: "unmarshal test for Simplified Chinese with text_gbk",
+			text: "GBK 简体中文解码测试",
+			enc:  "gbk",
+		},
+		{
+			name: "unmarshal test for Japanese with text_shift_jis",
+			text: "Shift_JIS 日本のデコードテスト",
+			enc:  "shift_jis",
+		},
+		{
+			name: "unmarshal test for Korean with text_euc-kr",
+			text: "EUC-KR 한국 디코딩 테스트",
+			enc:  "euc-kr",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			obsrecv, err := obsreport.NewReceiver(obsreport.ReceiverSettings{ReceiverCreateSettings: receivertest.NewNopCreateSettings()})
+			require.NoError(t, err)
+			unmarshaler := newTextLogsUnmarshaler()
+			unmarshaler, err = unmarshaler.WithEnc(test.enc)
+			require.NoError(t, err)
+			sink := &consumertest.LogsSink{}
+			c := logsConsumerGroupHandler{
+				unmarshaler:  unmarshaler,
+				logger:       zap.NewNop(),
+				ready:        make(chan bool),
+				nextConsumer: sink,
+				obsrecv:      obsrecv,
+			}
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			groupClaim := &testConsumerGroupClaim{
+				messageChan: make(chan *sarama.ConsumerMessage),
+			}
+			go func() {
+				err = c.ConsumeClaim(testConsumerGroupSession{ctx: context.Background()}, groupClaim)
+				assert.NoError(t, err)
+				wg.Done()
+			}()
+			encCfg := textutils.NewEncodingConfig()
+			encCfg.Encoding = test.enc
+			enc, err := encCfg.Build()
+			require.NoError(t, err)
+			encoder := enc.Encoding.NewEncoder()
+			encoded, err := encoder.Bytes([]byte(test.text))
+			require.NoError(t, err)
+			t1 := time.Now()
+			groupClaim.messageChan <- &sarama.ConsumerMessage{Value: encoded}
+			close(groupClaim.messageChan)
+			wg.Wait()
+			require.Equal(t, sink.LogRecordCount(), 1)
+			log := sink.AllLogs()[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+			assert.Equal(t, log.Body().Str(), test.text)
+			assert.LessOrEqual(t, t1, log.ObservedTimestamp().AsTime())
+			assert.LessOrEqual(t, log.ObservedTimestamp().AsTime(), time.Now())
+		})
+	}
+}
+
+func TestGetLogsUnmarshaler_encoding_text(t *testing.T) {
+	tests := []struct {
+		name     string
+		encoding string
+	}{
+		{
+			name:     "default text encoding",
+			encoding: "text",
+		},
+		{
+			name:     "utf-8 text encoding",
+			encoding: "text_utf-8",
+		},
+		{
+			name:     "gbk text encoding",
+			encoding: "text_gbk",
+		},
+		{
+			name:     "shift_jis text encoding, which contains an underline",
+			encoding: "text_shift_jis",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := getLogsUnmarshaler(test.encoding, defaultLogsUnmarshalers())
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestGetLogsUnmarshaler_encoding_text_error(t *testing.T) {
+	tests := []struct {
+		name     string
+		encoding string
+	}{
+		{
+			name:     "text encoding has typo",
+			encoding: "text_uft-8",
+		},
+		{
+			name:     "text encoding is a random string",
+			encoding: "text_vnbqgoba156",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := getLogsUnmarshaler(test.encoding, defaultLogsUnmarshalers())
+			assert.ErrorContains(t, err, fmt.Sprintf("unsupported encoding '%v'", test.encoding[5:]))
+		})
+	}
+}
+
+func TestCreateLogsReceiver_encoding_text_error(t *testing.T) {
+	cfg := Config{
+		Encoding: "text_uft-8",
+	}
+	_, err := newLogsReceiver(cfg, receivertest.NewNopCreateSettings(), defaultLogsUnmarshalers(), consumertest.NewNop())
+	// encoding error comes first
+	assert.Error(t, err, "unsupported encoding")
 }
 
 func TestToSaramaInitialOffset_earliest(t *testing.T) {

--- a/receiver/kafkareceiver/text_unmarshaler.go
+++ b/receiver/kafkareceiver/text_unmarshaler.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
+import (
+	"errors"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/textutils"
+)
+
+type textLogsUnmarshaler struct {
+	enc *textutils.Encoding
+}
+
+func newTextLogsUnmarshaler() LogsUnmarshalerWithEnc {
+	return &textLogsUnmarshaler{}
+}
+
+func (r *textLogsUnmarshaler) Unmarshal(buf []byte) (plog.Logs, error) {
+	if r.enc == nil {
+		return plog.Logs{}, errors.New("encoding not set")
+	}
+	p := plog.NewLogs()
+	decoded, err := r.enc.Decode(buf)
+	if err != nil {
+		return p, err
+	}
+
+	l := p.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	l.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+	l.Body().SetStr(string(decoded))
+	return p, nil
+}
+
+func (r *textLogsUnmarshaler) Encoding() string {
+	return "text"
+}
+
+func (r *textLogsUnmarshaler) WithEnc(encodingName string) (LogsUnmarshalerWithEnc, error) {
+	var err error
+	encCfg := textutils.NewEncodingConfig()
+	encCfg.Encoding = encodingName
+	enc, err := encCfg.Build()
+	if err != nil {
+		return nil, err
+	}
+	return &textLogsUnmarshaler{
+		enc: &enc,
+	}, nil
+}

--- a/receiver/kafkareceiver/text_unmarshaler_test.go
+++ b/receiver/kafkareceiver/text_unmarshaler_test.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafkareceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTextUnmarshaler(t *testing.T) {
+	t.Parallel()
+	um := newTextLogsUnmarshaler()
+	assert.Equal(t, "text", um.Encoding())
+}
+
+func TestTextUnmarshalerWithEnc(t *testing.T) {
+	t.Parallel()
+	um := newTextLogsUnmarshaler()
+	um2 := um
+	assert.EqualValues(t, um, um2)
+
+	um, err := um.WithEnc("utf8")
+	require.NoError(t, err)
+	um2, err = um2.WithEnc("gbk")
+	require.NoError(t, err)
+	assert.NotEqualValues(t, um, um2)
+
+	um2, err = um2.WithEnc("utf8")
+	require.NoError(t, err)
+	assert.EqualValues(t, um, um2)
+}

--- a/receiver/kafkareceiver/unmarshaler.go
+++ b/receiver/kafkareceiver/unmarshaler.go
@@ -50,6 +50,13 @@ type LogsUnmarshaler interface {
 	Encoding() string
 }
 
+type LogsUnmarshalerWithEnc interface {
+	LogsUnmarshaler
+
+	// WithEnc sets the character encoding (UTF-8, GBK, etc.) of the unmarshaler.
+	WithEnc(string) (LogsUnmarshalerWithEnc, error)
+}
+
 // defaultTracesUnmarshalers returns map of supported encodings with TracesUnmarshaler.
 func defaultTracesUnmarshalers() map[string]TracesUnmarshaler {
 	otlpPb := newPdataTracesUnmarshaler(&ptrace.ProtoUnmarshaler{}, defaultEncoding)
@@ -78,8 +85,10 @@ func defaultMetricsUnmarshalers() map[string]MetricsUnmarshaler {
 func defaultLogsUnmarshalers() map[string]LogsUnmarshaler {
 	otlpPb := newPdataLogsUnmarshaler(&plog.ProtoUnmarshaler{}, defaultEncoding)
 	raw := newRawLogsUnmarshaler()
+	text := newTextLogsUnmarshaler()
 	return map[string]LogsUnmarshaler{
 		otlpPb.Encoding(): otlpPb,
 		raw.Encoding():    raw,
+		text.Encoding():   text,
 	}
 }

--- a/receiver/kafkareceiver/unmarshaler_test.go
+++ b/receiver/kafkareceiver/unmarshaler_test.go
@@ -60,6 +60,7 @@ func TestDefaultLogsUnMarshaler(t *testing.T) {
 	expectedEncodings := []string{
 		"otlp_proto",
 		"raw",
+		"text",
 	}
 	marshalers := defaultLogsUnmarshalers()
 	assert.Equal(t, len(expectedEncodings), len(marshalers))


### PR DESCRIPTION
Description:

Add `text` unmarshaler, which will decode the kafka message as text and insert it as the body of a log record.

Link to tracking Issue:

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20734