### PR TITLE
[pkg/ottl] Move common function to top-level internal

### DIFF
--- a/pkg/ottl/contexts/internal/ids.go
+++ b/pkg/ottl/contexts/internal/ids.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 
 import (
 	"encoding/hex"

--- a/pkg/ottl/contexts/internal/ids_test.go
+++ b/pkg/ottl/contexts/internal/ids_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon
+package internal
 
 import (
 	"testing"

--- a/pkg/ottl/contexts/internal/metric.go
+++ b/pkg/ottl/contexts/internal/metric.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 
 import (
 	"context"

--- a/pkg/ottl/contexts/internal/metric_test.go
+++ b/pkg/ottl/contexts/internal/metric_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon
+package internal
 
 import (
 	"context"

--- a/pkg/ottl/contexts/internal/resource.go
+++ b/pkg/ottl/contexts/internal/resource.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 
 import (
 	"context"
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
 type ResourceContext interface {
@@ -76,10 +77,10 @@ func accessResourceAttributes[K ResourceContext]() ottl.StandardGetSetter[K] {
 func accessResourceAttributesKey[K ResourceContext](mapKey *string) ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (interface{}, error) {
-			return GetMapValue(tCtx.GetResource().Attributes(), *mapKey), nil
+			return ottlcommon.GetMapValue(tCtx.GetResource().Attributes(), *mapKey), nil
 		},
 		Setter: func(ctx context.Context, tCtx K, val interface{}) error {
-			SetMapValue(tCtx.GetResource().Attributes(), *mapKey, val)
+			ottlcommon.SetMapValue(tCtx.GetResource().Attributes(), *mapKey, val)
 			return nil
 		},
 	}

--- a/pkg/ottl/contexts/internal/resource_test.go
+++ b/pkg/ottl/contexts/internal/resource_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon
+package internal
 
 import (
 	"context"

--- a/pkg/ottl/contexts/internal/scope.go
+++ b/pkg/ottl/contexts/internal/scope.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 
 import (
 	"context"
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
 type InstrumentationScopeContext interface {
@@ -81,10 +82,10 @@ func accessInstrumentationScopeAttributes[K InstrumentationScopeContext]() ottl.
 func accessInstrumentationScopeAttributesKey[K InstrumentationScopeContext](mapKey *string) ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (interface{}, error) {
-			return GetMapValue(tCtx.GetInstrumentationScope().Attributes(), *mapKey), nil
+			return ottlcommon.GetMapValue(tCtx.GetInstrumentationScope().Attributes(), *mapKey), nil
 		},
 		Setter: func(ctx context.Context, tCtx K, val interface{}) error {
-			SetMapValue(tCtx.GetInstrumentationScope().Attributes(), *mapKey, val)
+			ottlcommon.SetMapValue(tCtx.GetInstrumentationScope().Attributes(), *mapKey, val)
 			return nil
 		},
 	}

--- a/pkg/ottl/contexts/internal/scope_test.go
+++ b/pkg/ottl/contexts/internal/scope_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon
+package internal
 
 import (
 	"context"

--- a/pkg/ottl/contexts/internal/span.go
+++ b/pkg/ottl/contexts/internal/span.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 
 import (
 	"context"
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
 type SpanContext interface {
@@ -336,10 +337,10 @@ func accessAttributes[K SpanContext]() ottl.StandardGetSetter[K] {
 func accessAttributesKey[K SpanContext](mapKey *string) ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (interface{}, error) {
-			return GetMapValue(tCtx.GetSpan().Attributes(), *mapKey), nil
+			return ottlcommon.GetMapValue(tCtx.GetSpan().Attributes(), *mapKey), nil
 		},
 		Setter: func(ctx context.Context, tCtx K, val interface{}) error {
-			SetMapValue(tCtx.GetSpan().Attributes(), *mapKey, val)
+			ottlcommon.SetMapValue(tCtx.GetSpan().Attributes(), *mapKey, val)
 			return nil
 		},
 	}

--- a/pkg/ottl/contexts/internal/span_test.go
+++ b/pkg/ottl/contexts/internal/span_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon
+package internal
 
 import (
 	"context"

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -24,11 +24,12 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
-var _ ottlcommon.ResourceContext = TransformContext{}
-var _ ottlcommon.InstrumentationScopeContext = TransformContext{}
+var _ internal.ResourceContext = TransformContext{}
+var _ internal.InstrumentationScopeContext = TransformContext{}
 
 type TransformContext struct {
 	dataPoint            interface{}
@@ -114,7 +115,7 @@ var symbolTable = map[ottl.EnumSymbol]ottl.Enum{
 }
 
 func init() {
-	for k, v := range ottlcommon.MetricSymbolTable {
+	for k, v := range internal.MetricSymbolTable {
 		symbolTable[k] = v
 	}
 }
@@ -145,11 +146,11 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 		}
 		return accessCacheKey(mapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return internal.ResourcePathGetSetter[TransformContext](path[1:])
 	case "instrumentation_scope":
-		return ottlcommon.ScopePathGetSetter[TransformContext](path[1:])
+		return internal.ScopePathGetSetter[TransformContext](path[1:])
 	case "metric":
-		return ottlcommon.MetricPathGetSetter[TransformContext](path[1:])
+		return internal.MetricPathGetSetter[TransformContext](path[1:])
 	case "attributes":
 		mapKey := path[0].MapKey
 		if mapKey == nil {

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -25,11 +25,12 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
-var _ ottlcommon.ResourceContext = TransformContext{}
-var _ ottlcommon.InstrumentationScopeContext = TransformContext{}
+var _ internal.ResourceContext = TransformContext{}
+var _ internal.InstrumentationScopeContext = TransformContext{}
 
 type TransformContext struct {
 	logRecord            plog.LogRecord
@@ -151,9 +152,9 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 		}
 		return accessCacheKey(mapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return internal.ResourcePathGetSetter[TransformContext](path[1:])
 	case "instrumentation_scope":
-		return ottlcommon.ScopePathGetSetter[TransformContext](path[1:])
+		return internal.ScopePathGetSetter[TransformContext](path[1:])
 	case "time_unix_nano":
 		return accessTimeUnixNano(), nil
 	case "observed_time_unix_nano":
@@ -363,7 +364,7 @@ func accessStringTraceID() ottl.StandardGetSetter[TransformContext] {
 		},
 		Setter: func(ctx context.Context, tCtx TransformContext, val interface{}) error {
 			if str, ok := val.(string); ok {
-				id, err := ottlcommon.ParseTraceID(str)
+				id, err := internal.ParseTraceID(str)
 				if err != nil {
 					return err
 				}
@@ -396,7 +397,7 @@ func accessStringSpanID() ottl.StandardGetSetter[TransformContext] {
 		},
 		Setter: func(ctx context.Context, tCtx TransformContext, val interface{}) error {
 			if str, ok := val.(string); ok {
-				id, err := ottlcommon.ParseSpanID(str)
+				id, err := internal.ParseSpanID(str)
 				if err != nil {
 					return err
 				}

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -23,12 +23,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
-var _ ottlcommon.ResourceContext = TransformContext{}
-var _ ottlcommon.InstrumentationScopeContext = TransformContext{}
-var _ ottlcommon.MetricContext = TransformContext{}
+var _ internal.ResourceContext = TransformContext{}
+var _ internal.InstrumentationScopeContext = TransformContext{}
+var _ internal.MetricContext = TransformContext{}
 
 type TransformContext struct {
 	metric               pmetric.Metric
@@ -96,7 +97,7 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
-var symbolTable = ottlcommon.MetricSymbolTable
+var symbolTable = internal.MetricSymbolTable
 
 func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 	if val != nil {
@@ -124,11 +125,11 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 		}
 		return accessCacheKey(mapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return internal.ResourcePathGetSetter[TransformContext](path[1:])
 	case "instrumentation_scope":
-		return ottlcommon.ScopePathGetSetter[TransformContext](path[1:])
+		return internal.ScopePathGetSetter[TransformContext](path[1:])
 	default:
-		return ottlcommon.MetricPathGetSetter[TransformContext](path)
+		return internal.MetricPathGetSetter[TransformContext](path)
 	}
 }
 

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -22,10 +22,11 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
-var _ ottlcommon.ResourceContext = TransformContext{}
+var _ internal.ResourceContext = TransformContext{}
 
 type TransformContext struct {
 	resource pcommon.Resource
@@ -101,7 +102,7 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 		}
 		return accessCacheKey(mapKey), nil
 	default:
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path)
+		return internal.ResourcePathGetSetter[TransformContext](path)
 	}
 }
 

--- a/pkg/ottl/contexts/ottlscope/scope.go
+++ b/pkg/ottl/contexts/ottlscope/scope.go
@@ -22,11 +22,12 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
-var _ ottlcommon.ResourceContext = TransformContext{}
-var _ ottlcommon.InstrumentationScopeContext = TransformContext{}
+var _ internal.ResourceContext = TransformContext{}
+var _ internal.InstrumentationScopeContext = TransformContext{}
 
 type TransformContext struct {
 	instrumentationScope pcommon.InstrumentationScope
@@ -108,9 +109,9 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 		}
 		return accessCacheKey(mapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return internal.ResourcePathGetSetter[TransformContext](path[1:])
 	default:
-		return ottlcommon.ScopePathGetSetter[TransformContext](path)
+		return internal.ScopePathGetSetter[TransformContext](path)
 	}
 }
 

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -23,11 +23,12 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
-var _ ottlcommon.ResourceContext = TransformContext{}
-var _ ottlcommon.InstrumentationScopeContext = TransformContext{}
+var _ internal.ResourceContext = TransformContext{}
+var _ internal.InstrumentationScopeContext = TransformContext{}
 
 type TransformContext struct {
 	span                 ptrace.Span
@@ -97,7 +98,7 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 
 func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 	if val != nil {
-		if enum, ok := ottlcommon.SpanSymbolTable[*val]; ok {
+		if enum, ok := internal.SpanSymbolTable[*val]; ok {
 			return &enum, nil
 		}
 		return nil, fmt.Errorf("enum symbol, %s, not found", *val)
@@ -121,11 +122,11 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 		}
 		return accessCacheKey(mapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return internal.ResourcePathGetSetter[TransformContext](path[1:])
 	case "instrumentation_scope":
-		return ottlcommon.ScopePathGetSetter[TransformContext](path[1:])
+		return internal.ScopePathGetSetter[TransformContext](path[1:])
 	default:
-		return ottlcommon.SpanPathGetSetter[TransformContext](path)
+		return internal.SpanPathGetSetter[TransformContext](path)
 	}
 }
 

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -24,12 +24,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
-var _ ottlcommon.ResourceContext = TransformContext{}
-var _ ottlcommon.InstrumentationScopeContext = TransformContext{}
-var _ ottlcommon.SpanContext = TransformContext{}
+var _ internal.ResourceContext = TransformContext{}
+var _ internal.InstrumentationScopeContext = TransformContext{}
+var _ internal.SpanContext = TransformContext{}
 
 type TransformContext struct {
 	spanEvent            ptrace.SpanEvent
@@ -105,7 +106,7 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 
 func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 	if val != nil {
-		if enum, ok := ottlcommon.SpanSymbolTable[*val]; ok {
+		if enum, ok := internal.SpanSymbolTable[*val]; ok {
 			return &enum, nil
 		}
 		return nil, fmt.Errorf("enum symbol, %s, not found", *val)
@@ -129,11 +130,11 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 		}
 		return accessCacheKey(mapKey), nil
 	case "resource":
-		return ottlcommon.ResourcePathGetSetter[TransformContext](path[1:])
+		return internal.ResourcePathGetSetter[TransformContext](path[1:])
 	case "instrumentation_scope":
-		return ottlcommon.ScopePathGetSetter[TransformContext](path[1:])
+		return internal.ScopePathGetSetter[TransformContext](path[1:])
 	case "span":
-		return ottlcommon.SpanPathGetSetter[TransformContext](path[1:])
+		return internal.SpanPathGetSetter[TransformContext](path[1:])
 	case "time_unix_nano":
 		return accessSpanEventTimeUnixNano(), nil
 	case "name":

--- a/pkg/ottl/internal/ottlcommon/map.go
+++ b/pkg/ottl/internal/ottlcommon/map.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+package ottlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/pkg/ottl/internal/ottlcommon/value.go
+++ b/pkg/ottl/internal/ottlcommon/value.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ottlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal/ottlcommon"
+package ottlcommon // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"


### PR DESCRIPTION
**Description:** 
This PR moves some capabilities from `context/internal` to `internal` so that they can be used as part of complex indexing of converters (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/20754)