### PR TITLE
Fixed bug with awskinesisexporter batch’s creation parameters

### DIFF
--- a/.chloggen/fix-awskinesis-batch-records-cap.yaml
+++ b/.chloggen/fix-awskinesis-batch-records-cap.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/awskinesisexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the capacity of records slices in the initialized batch
+
+# One or more tracking issues related to the change
+issues: [20914]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 

--- a/exporter/awskinesisexporter/internal/batch/batch.go
+++ b/exporter/awskinesisexporter/internal/batch/batch.go
@@ -78,7 +78,7 @@ func New(opts ...Option) *Batch {
 		maxBatchSize:  MaxBatchedRecords,
 		maxRecordSize: MaxRecordSize,
 		compression:   compress.NewNoopCompressor(),
-		records:       make([]types.PutRecordsRequestEntry, 0, MaxRecordSize),
+		records:       make([]types.PutRecordsRequestEntry, 0, MaxBatchedRecords),
 	}
 
 	for _, op := range opts {

--- a/exporter/awskinesisexporter/internal/batch/batch_test.go
+++ b/exporter/awskinesisexporter/internal/batch/batch_test.go
@@ -15,12 +15,23 @@
 package batch_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awskinesisexporter/internal/batch"
 )
+
+func TestBatchRecordsCapacity(t *testing.T) {
+	t.Parallel()
+
+	b := batch.New()
+	assert.NotNil(t, b, "Must not be nil")
+
+	recordsCap := reflect.ValueOf(b).Elem().FieldByName("records").Cap()
+	assert.Equal(t, batch.MaxBatchedRecords, recordsCap, "Must have the expected capacity")
+}
 
 func TestBatchingMessages(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
**Description:** 
When a new Batch is created, it's slice capacity for the number of records should be set to the maximum number of records, not the max record size, an error that can cause memory to be allocated frequently.
[awskinesisexporter/internal/batch/batch.go#L76-L82](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/41b5f81343828a37f709acf7788b08eb2c66730e/exporter/awskinesisexporter/internal/batch/batch.go#L76-L82)
[awskinesisexporter/internal/batch/batch.go#L28-L29](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/41b5f81343828a37f709acf7788b08eb2c66730e/exporter/awskinesisexporter/internal/batch/batch.go#L28-L29)

**Link to tracking Issue:**
Fixes #20914 