### PR TITLE
[pkg/stanza] fix eventData format for Windows events

### DIFF
--- a/.chloggen/feat_stanza_windowsinput_eventdata-map.yaml
+++ b/.chloggen/feat_stanza_windowsinput_eventdata-map.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix eventData format for Windows events
+
+# One or more tracking issues related to the change
+issues: [20547]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/operator/input/windows/testdata/xmlSample.xml
+++ b/pkg/stanza/operator/input/windows/testdata/xmlSample.xml
@@ -16,7 +16,7 @@
         <Security /> 
     </System> 
     <EventData> 
-        <Data>2022-04-28T19:48:52Z</Data> 
-        <Data>RulesEngine</Data> 
+        <Data Name="Time">2022-04-28T19:48:52Z</Data> 
+        <Data Name="Source">RulesEngine</Data> 
     </EventData> 
 </Event>

--- a/pkg/stanza/operator/input/windows/xml.go
+++ b/pkg/stanza/operator/input/windows/xml.go
@@ -27,22 +27,22 @@ import (
 
 // EventXML is the rendered xml of an event.
 type EventXML struct {
-	EventID          EventID     `xml:"System>EventID"`
-	Provider         Provider    `xml:"System>Provider"`
-	Computer         string      `xml:"System>Computer"`
-	Channel          string      `xml:"System>Channel"`
-	RecordID         uint64      `xml:"System>EventRecordID"`
-	TimeCreated      TimeCreated `xml:"System>TimeCreated"`
-	Message          string      `xml:"RenderingInfo>Message"`
-	RenderedLevel    string      `xml:"RenderingInfo>Level"`
-	Level            string      `xml:"System>Level"`
-	RenderedTask     string      `xml:"RenderingInfo>Task"`
-	Task             string      `xml:"System>Task"`
-	RenderedOpcode   string      `xml:"RenderingInfo>Opcode"`
-	Opcode           string      `xml:"System>Opcode"`
-	RenderedKeywords []string    `xml:"RenderingInfo>Keywords>Keyword"`
-	Keywords         []string    `xml:"System>Keywords"`
-	EventData        []string    `xml:"EventData>Data"`
+	EventID          EventID          `xml:"System>EventID"`
+	Provider         Provider         `xml:"System>Provider"`
+	Computer         string           `xml:"System>Computer"`
+	Channel          string           `xml:"System>Channel"`
+	RecordID         uint64           `xml:"System>EventRecordID"`
+	TimeCreated      TimeCreated      `xml:"System>TimeCreated"`
+	Message          string           `xml:"RenderingInfo>Message"`
+	RenderedLevel    string           `xml:"RenderingInfo>Level"`
+	Level            string           `xml:"System>Level"`
+	RenderedTask     string           `xml:"RenderingInfo>Task"`
+	Task             string           `xml:"System>Task"`
+	RenderedOpcode   string           `xml:"RenderingInfo>Opcode"`
+	Opcode           string           `xml:"System>Opcode"`
+	RenderedKeywords []string         `xml:"RenderingInfo>Keywords>Keyword"`
+	Keywords         []string         `xml:"System>Keywords"`
+	EventData        []EventDataEntry `xml:"EventData>Data"`
 }
 
 // parseTimestamp will parse the timestamp of the event.
@@ -130,7 +130,7 @@ func (e *EventXML) parseBody() map[string]interface{} {
 		"task":        task,
 		"opcode":      opcode,
 		"keywords":    keywords,
-		"event_data":  e.EventData,
+		"event_data":  parseEventData(e.EventData),
 	}
 	if len(details) > 0 {
 		body["details"] = details
@@ -146,6 +146,22 @@ func (e *EventXML) parseMessage() (string, map[string]interface{}) {
 	default:
 		return e.Message, nil
 	}
+}
+
+// parse event data entries into a map[string]interface
+// where the key is the Name attribute, and value is the element value
+// entries without Name are ignored
+// see: https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-datafieldtype-complextype
+func parseEventData(entries []EventDataEntry) map[string]interface{} {
+	outputMap := make(map[string]interface{}, len(entries))
+
+	for _, entry := range entries {
+		if entry.Name != "" {
+			outputMap[entry.Name] = entry.Value
+		}
+	}
+
+	return outputMap
 }
 
 // unmarshalEventXML will unmarshal EventXML from xml bytes.
@@ -173,4 +189,9 @@ type Provider struct {
 	Name            string `xml:"Name,attr"`
 	GUID            string `xml:"Guid,attr"`
 	EventSourceName string `xml:"EventSourceName,attr"`
+}
+
+type EventDataEntry struct {
+	Name  string `xml:"Name,attr"`
+	Value string `xml:",chardata"`
 }

--- a/pkg/stanza/operator/input/windows/xml_test.go
+++ b/pkg/stanza/operator/input/windows/xml_test.go
@@ -88,15 +88,17 @@ func TestParseBody(t *testing.T) {
 		TimeCreated: TimeCreated{
 			SystemTime: "2020-07-30T01:01:01.123456789Z",
 		},
-		Computer:         "computer",
-		Channel:          "application",
-		RecordID:         1,
-		Level:            "Information",
-		Message:          "message",
-		Task:             "task",
-		Opcode:           "opcode",
-		Keywords:         []string{"keyword"},
-		EventData:        []string{"this", "is", "some", "sample", "data"},
+		Computer: "computer",
+		Channel:  "application",
+		RecordID: 1,
+		Level:    "Information",
+		Message:  "message",
+		Task:     "task",
+		Opcode:   "opcode",
+		Keywords: []string{"keyword"},
+		EventData: []EventDataEntry{
+			{Name: "name", Value: "value"}, {Name: "another_name", Value: "another_value"},
+		},
 		RenderedLevel:    "rendered_level",
 		RenderedTask:     "rendered_task",
 		RenderedOpcode:   "rendered_opcode",
@@ -122,7 +124,7 @@ func TestParseBody(t *testing.T) {
 		"task":        "rendered_task",
 		"opcode":      "rendered_opcode",
 		"keywords":    []string{"RenderedKeywords"},
-		"event_data":  []string{"this", "is", "some", "sample", "data"},
+		"event_data":  map[string]interface{}{"name": "value", "another_name": "another_value"},
 	}
 
 	require.Equal(t, expected, xml.parseBody())
@@ -142,15 +144,17 @@ func TestParseNoRendered(t *testing.T) {
 		TimeCreated: TimeCreated{
 			SystemTime: "2020-07-30T01:01:01.123456789Z",
 		},
-		Computer:  "computer",
-		Channel:   "application",
-		RecordID:  1,
-		Level:     "Information",
-		Message:   "message",
-		Task:      "task",
-		Opcode:    "opcode",
-		Keywords:  []string{"keyword"},
-		EventData: []string{"this", "is", "some", "sample", "data"},
+		Computer: "computer",
+		Channel:  "application",
+		RecordID: 1,
+		Level:    "Information",
+		Message:  "message",
+		Task:     "task",
+		Opcode:   "opcode",
+		Keywords: []string{"keyword"},
+		EventData: []EventDataEntry{
+			{Name: "name", Value: "value"}, {Name: "another_name", Value: "another_value"},
+		},
 	}
 
 	expected := map[string]interface{}{
@@ -172,7 +176,7 @@ func TestParseNoRendered(t *testing.T) {
 		"task":        "task",
 		"opcode":      "opcode",
 		"keywords":    []string{"keyword"},
-		"event_data":  []string{"this", "is", "some", "sample", "data"},
+		"event_data":  map[string]interface{}{"name": "value", "another_name": "another_value"},
 	}
 
 	require.Equal(t, expected, xml.parseBody())
@@ -192,15 +196,17 @@ func TestParseBodySecurity(t *testing.T) {
 		TimeCreated: TimeCreated{
 			SystemTime: "2020-07-30T01:01:01.123456789Z",
 		},
-		Computer:         "computer",
-		Channel:          "Security",
-		RecordID:         1,
-		Level:            "Information",
-		Message:          "message",
-		Task:             "task",
-		Opcode:           "opcode",
-		Keywords:         []string{"keyword"},
-		EventData:        []string{"this", "is", "some", "sample", "data"},
+		Computer: "computer",
+		Channel:  "Security",
+		RecordID: 1,
+		Level:    "Information",
+		Message:  "message",
+		Task:     "task",
+		Opcode:   "opcode",
+		Keywords: []string{"keyword"},
+		EventData: []EventDataEntry{
+			{Name: "name", Value: "value"}, {Name: "another_name", Value: "another_value"},
+		},
 		RenderedLevel:    "rendered_level",
 		RenderedTask:     "rendered_task",
 		RenderedOpcode:   "rendered_opcode",
@@ -226,10 +232,33 @@ func TestParseBodySecurity(t *testing.T) {
 		"task":        "rendered_task",
 		"opcode":      "rendered_opcode",
 		"keywords":    []string{"RenderedKeywords"},
-		"event_data":  []string{"this", "is", "some", "sample", "data"},
+		"event_data":  map[string]interface{}{"name": "value", "another_name": "another_value"},
 	}
 
 	require.Equal(t, expected, xml.parseBody())
+}
+
+func TestParseEventData(t *testing.T) {
+	xmlMap := EventXML{
+		EventData: []EventDataEntry{
+			{Name: "name", Value: "value"},
+		},
+	}
+
+	parsed := xmlMap.parseBody()
+	expectedMap := map[string]interface{}{"name": "value"}
+	require.Equal(t, expectedMap, parsed["event_data"])
+
+	xmlMixed := EventXML{
+		EventData: []EventDataEntry{
+			{Name: "name", Value: "value"},
+			{Value: "noname"},
+		},
+	}
+
+	parsed = xmlMixed.parseBody()
+	expectedSlice := map[string]interface{}{"name": "value"}
+	require.Equal(t, expectedSlice, parsed["event_data"])
 }
 
 func TestInvalidUnmarshal(t *testing.T) {
@@ -257,15 +286,18 @@ func TestUnmarshal(t *testing.T) {
 		TimeCreated: TimeCreated{
 			SystemTime: "2022-04-22T10:20:52.3778625Z",
 		},
-		Computer:  "computer",
-		Channel:   "Application",
-		RecordID:  23401,
-		Level:     "4",
-		Message:   "",
-		Task:      "0",
-		Opcode:    "0",
-		EventData: []string{"2022-04-28T19:48:52Z", "RulesEngine"},
-		Keywords:  []string{"0x80000000000000"},
+		Computer: "computer",
+		Channel:  "Application",
+		RecordID: 23401,
+		Level:    "4",
+		Message:  "",
+		Task:     "0",
+		Opcode:   "0",
+		EventData: []EventDataEntry{
+			{Name: "Time", Value: "2022-04-28T19:48:52Z"},
+			{Name: "Source", Value: "RulesEngine"},
+		},
+		Keywords: []string{"0x80000000000000"},
 	}
 
 	require.Equal(t, xml, event)

--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -118,12 +118,7 @@ func TestReadWindowsEventLogger(t *testing.T) {
 	record := records.At(0)
 	body := record.Body().Map().AsRaw()
 
-	strs := []string{"Test log"}
-	test := make([]interface{}, len(strs))
-	for i, s := range strs {
-		test[i] = s
-	}
-	require.Equal(t, test, body["event_data"])
+	require.Equal(t, "Test log", body["message"])
 
 	eventID := body["event_id"]
 	require.NotNil(t, eventID)

--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -78,6 +78,8 @@ func TestCreateWithInvalidInputConfig(t *testing.T) {
 }
 
 func TestReadWindowsEventLogger(t *testing.T) {
+	logMessage := "Test log"
+
 	ctx := context.Background()
 	factory := NewFactory()
 	createSettings := receivertest.NewNopCreateSettings()
@@ -100,7 +102,7 @@ func TestReadWindowsEventLogger(t *testing.T) {
 	require.NoError(t, err)
 	defer logger.Close()
 
-	err = logger.Info(10, "Test log")
+	err = logger.Info(10, logMessage)
 	require.NoError(t, err)
 
 	logsReceived := func() bool {
@@ -118,7 +120,12 @@ func TestReadWindowsEventLogger(t *testing.T) {
 	record := records.At(0)
 	body := record.Body().Map().AsRaw()
 
-	require.Equal(t, "Test log", body["message"])
+	require.Equal(t, logMessage, body["message"])
+
+	eventData := body["event_data"]
+	eventDataMap, ok := eventData.(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, map[string]interface{}{}, eventDataMap)
 
 	eventID := body["event_id"]
 	require.NotNil(t, eventID)


### PR DESCRIPTION
**Description:**
Resubmitting #20548 with the failing `windowseventlogreceiver` test fixed.

I've also changed the event data to be a `map[string]interface{}` instead of a `map[string][string]` - otherwise I'd get a string instead of a map in the receiver, which is something I don't entirely understand the reason for. I assume it has to do with stanza internals?

**Link to tracking Issue:** #20858 

**Testing:**
The changed test is logically more correct now, as what we should really be checking is the event message rather than the data.