### PR TITLE
[receiver/prometheusreceiver] Fix TestStalenessMarkersEndToEnd

### DIFF
--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -119,7 +119,7 @@ receivers:
     config:
       scrape_configs:
         - job_name: 'test'
-          scrape_interval: 2ms
+          scrape_interval: 100ms
           static_configs:
             - targets: [%q]
 


### PR DESCRIPTION
A too-low `scrape_interval` was forcing the `scrape_timeout` to be too low causing a context deadline exceeded in some environments.


In my local machine `TestStalenessMarkersEndToEnd` test kept failing. I investigated and the root cause was a context deadline exceeded due to a 2ms timeout. Even if it was not set due to [this logic](https://github.com/prometheus/prometheus/blob/136b48855a974ce16e3bf591f1452d41d55eefa9/config/config.go#L561) the `scrape_timeout` is equal to the `scrape_interval`, in this case, 2ms:
```
	if c.ScrapeTimeout == 0 {
		if defaultTimeout > c.ScrapeInterval {
			c.ScrapeTimeout = c.ScrapeInterval
		} else {
			c.ScrapeTimeout = defaultTimeout
		}
	}
```

 - Possibly related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6243
 - Let me know if we can skip the changelog.