### PR TITLE
[receiver/prometheusreceiver] Add version and name to metrics

### DIFF
--- a/.chloggen/prometheus-version-name-in-metrics.yaml
+++ b/.chloggen/prometheus-version-name-in-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: All receivers are setting receiver name and version when sending data. This change introduces the same behaviour to the prometheus receiver.
+
+# One or more tracking issues related to the change
+issues: [20902]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -42,6 +42,7 @@ import (
 
 const (
 	targetMetricName = "target_info"
+	receiverName     = "otelcol/prometheusreceiver"
 )
 
 type transaction struct {
@@ -211,7 +212,7 @@ func (t *transaction) getMetrics(resource pcommon.Resource) (pmetric.Metrics, er
 	rms := md.ResourceMetrics().AppendEmpty()
 	resource.CopyTo(rms.Resource())
 	ils := rms.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/prometheusreceiver")
+	ils.Scope().SetName(receiverName)
 	ils.Scope().SetVersion(t.buildInfo.Version)
 	metrics := ils.Metrics()
 


### PR DESCRIPTION
**Description:** 
All receivers are setting the receiver name and version generating the data. 
This change introduces the same information to the Prometheus receiver as well.

The different receivers are currently setting both name and version of the receiver. Thanks to metrics.go.tmpl all receivers [do it in the same way](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/8c12b05a911d2e3263ee4302f2a23922b533ef8f/cmd/mdatagen/templates/metrics.go.tmpl#L329):

	ils.Scope().SetName("otelcol/{{ .Name }}")
	ils.Scope().SetVersion(mb.buildInfo.Version)

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20902
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13615

**Testing:** 
The approach is exactly the same as the templated one.
Added unit tests and run a manual tests against our backend:
<img width="867" alt="Screenshot 2023-04-14 at 17 19 41" src="https://user-images.githubusercontent.com/43335750/232085641-005e3c99-a235-41da-a540-201b3b0a3e06.png">
