### PR TITLE
[chore] Make prometheus tests pass with the new library

### DIFF
--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -278,7 +278,8 @@ func TestCollectMetricsLabelSanitize(t *testing.T) {
 
 	for m := range ch {
 		require.Contains(t, m.Desc().String(), "fqName: \"test_space_test_metric\"")
-		require.Contains(t, m.Desc().String(), "variableLabels: [label_1 label_2]")
+		require.Contains(t, m.Desc().String(), "label_1")
+		require.Contains(t, m.Desc().String(), "label_2")
 
 		pbMetric := io_prometheus_client.Metric{}
 		require.NoError(t, m.Write(&pbMetric))
@@ -458,7 +459,7 @@ func TestCollectMetrics(t *testing.T) {
 						continue
 					}
 
-					require.Contains(t, m.Desc().String(), "variableLabels: [label_1 label_2 job instance]")
+					require.Regexp(t, `variableLabels: \[.*label_1.+label_2.+job.+instance.*\]`, m.Desc().String())
 
 					pbMetric := io_prometheus_client.Metric{}
 					require.NoError(t, m.Write(&pbMetric))
@@ -558,7 +559,8 @@ func TestAccumulateHistograms(t *testing.T) {
 				for m := range ch {
 					n++
 					require.Contains(t, m.Desc().String(), "fqName: \"test_metric\"")
-					require.Contains(t, m.Desc().String(), "variableLabels: [label_1 label_2]")
+					require.Contains(t, m.Desc().String(), "label_1")
+					require.Contains(t, m.Desc().String(), "label_2")
 
 					pbMetric := io_prometheus_client.Metric{}
 					require.NoError(t, m.Write(&pbMetric))
@@ -660,7 +662,8 @@ func TestAccumulateSummary(t *testing.T) {
 				for m := range ch {
 					n++
 					require.Contains(t, m.Desc().String(), "fqName: \"test_metric\"")
-					require.Contains(t, m.Desc().String(), "variableLabels: [label_1 label_2]")
+					require.Contains(t, m.Desc().String(), "label_1")
+					require.Contains(t, m.Desc().String(), "label_2")
 
 					pbMetric := io_prometheus_client.Metric{}
 					require.NoError(t, m.Write(&pbMetric))


### PR DESCRIPTION
After https://github.com/prometheus/client_golang/pull/1151 the tests are failing with:

```
--- FAIL: TestAccumulateSummary (0.00s)
    --- FAIL: TestAccumulateSummary/Summary_with_single_point/WithTimestamp (0.00s)
        collector_test.go:663: 
            	Error Trace:	/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/exporter/prometheusexporter/collector_test.go:663
            	Error:      	"Desc{fqName: \"test_metric\", help: \"test description\", constLabels: {}, variableLabels: [{label_1 <nil>} {label_2 <nil>}]}" does not contain "variableLabels: [label_1 label_2]"
            	Test:       	TestAccumulateSummary/Summary_with_single_point/WithTimestamp
    --- FAIL: TestAccumulateSummary/Summary_with_single_point (0.00s)
        collector_test.go:663: 
            	Error Trace:	/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/exporter/prometheusexporter/collector_test.go:663
            	Error:      	"Desc{fqName: \"test_metric\", help: \"test description\", constLabels: {}, variableLabels: [{label_1 <nil>} {label_2 <nil>}]}" does not contain "variableLabels: [label_1 label_2]"
            	Test:       	TestAccumulateSummary/Summary_with_single_point
```