### PR TITLE
Modify prometheus receiver validate config logic to fix  file_sd_configs error

### DIFF
--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -111,7 +111,7 @@ func checkTLSConfig(tlsConfig commonconfig.TLSConfig) error {
 func checkSDFile(filename string) error {
 	content, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
-		return nil
+		return err
 	}
 
 	var targetGroups []*targetgroup.Group

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -111,7 +111,8 @@ func checkTLSConfig(tlsConfig commonconfig.TLSConfig) error {
 func checkSDFile(filename string) error {
 	content, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
-		return err
+		fmt.Errorf("SD file %q does not exist", filename)
+		return nil
 	}
 
 	var targetGroups []*targetgroup.Group

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -111,7 +111,6 @@ func checkTLSConfig(tlsConfig commonconfig.TLSConfig) error {
 func checkSDFile(filename string) error {
 	content, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
-		fmt.Errorf("SD file %q does not exist", filename)
 		return nil
 	}
 
@@ -225,9 +224,7 @@ func (cfg *Config) validatePromConfig(promConfig *promconfig.Config) error {
 								return fmt.Errorf("checking SD file %q: %w", file, err)
 							}
 						}
-						continue
 					}
-					return fmt.Errorf("file %q for file_sd in scrape job %q does not exist", file, sc.JobName)
 				}
 			}
 		}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Modify prometheus receiver validate config logic to fix file_sd_configs 'does not exist' error while using ECS Observer.


**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5373

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>