### PR TITLE
[internal/filter] Add bridge from filterspan to filterottl

### DIFF
--- a/cmd/oteltestbedcol/go.mod
+++ b/cmd/oteltestbedcol/go.mod
@@ -129,6 +129,7 @@ require (
 	github.com/hashicorp/nomad/api v0.0.0-20230308192510-48e7d70fcd4b // indirect
 	github.com/hashicorp/serf v0.10.1 // indirect
 	github.com/hetznercloud/hcloud-go v1.41.0 // indirect
+	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/influxdata/go-syslog/v3 v3.0.1-0.20210608084020-ac565dc76ba6 // indirect

--- a/cmd/oteltestbedcol/go.sum
+++ b/cmd/oteltestbedcol/go.sum
@@ -1648,6 +1648,7 @@ github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEF
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/hudl/fargo v1.4.0/go.mod h1:9Ai6uvFy5fQNq6VPKtg+Ceq1+eTY4nKUlR2JElEOcDo=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/connector/countconnector/go.mod
+++ b/connector/countconnector/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/iancoleman/strcase v0.2.0 // indirect

--- a/connector/countconnector/go.sum
+++ b/connector/countconnector/go.sum
@@ -72,6 +72,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/internal/filter/filterottl/bridge.go
+++ b/internal/filter/filterottl/bridge.go
@@ -37,13 +37,13 @@ const (
 	attributesStaticStatement         = `attributes["%v"] == %v`
 	resourceAttributesStaticStatement = `resource.attributes["%v"] == %v`
 
-	serviceNameRegexStatement        = `IsMatch(resource.attributes["service.name"], "%v") == true`
-	spanNameRegexStatement           = `IsMatch(name, "%v") == true`
-	spanKindRegexStatement           = `IsMatch(kind, "%v") == true`
-	scopeNameRegexStatement          = `IsMatch(instrumentation_scope.name, "%v") == true`
-	scopeVersionRegexStatement       = `IsMatch(instrumentation_scope.version, "%v") == true`
-	attributesRegexStatement         = `IsMatch(attributes["%v"], "%v") == true`
-	resourceAttributesRegexStatement = `IsMatch(resource.attributes["%v"], "%v") == true`
+	serviceNameRegexStatement        = `IsMatch(resource.attributes["service.name"], "%v")`
+	spanNameRegexStatement           = `IsMatch(name, "%v")`
+	spanKindRegexStatement           = `IsMatch(kind, "%v")`
+	scopeNameRegexStatement          = `IsMatch(instrumentation_scope.name, "%v")`
+	scopeVersionRegexStatement       = `IsMatch(instrumentation_scope.version, "%v")`
+	attributesRegexStatement         = `IsMatch(attributes["%v"], "%v")`
+	resourceAttributesRegexStatement = `IsMatch(resource.attributes["%v"], "%v")`
 )
 
 func NewSpanSkipExprBridge(mc *filterconfig.MatchConfig) (expr.BoolExpr[ottlspan.TransformContext], error) {

--- a/internal/filter/filterottl/bridge.go
+++ b/internal/filter/filterottl/bridge.go
@@ -1,0 +1,168 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filterottl // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterottl"
+
+import (
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/expr"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterconfig"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
+)
+
+const (
+	serviceNameStaticStatement        = `resource.attributes["service.name"] == "%v"`
+	spanNameStaticStatement           = `name == "%v"`
+	spanKindStaticStatement           = `kind == "%v"`
+	scopeNameStaticStatement          = `instrumentation_scope.name == "%v"`
+	scopeVersionStaticStatement       = `instrumentation_scope.version == "%v"`
+	attributesStaticStatement         = `attributes["%v"] == %v`
+	resourceAttributesStaticStatement = `resource.attributes["%v"] == %v`
+
+	serviceNameRegexStatement        = `IsMatch(resource.attributes["service.name"], "%v") == true`
+	spanNameRegexStatement           = `IsMatch(name, "%v") == true`
+	spanKindRegexStatement           = `IsMatch(kind, "%v") == true`
+	scopeNameRegexStatement          = `IsMatch(instrumentation_scope.name, "%v") == true`
+	scopeVersionRegexStatement       = `IsMatch(instrumentation_scope.version, "%v") == true`
+	attributesRegexStatement         = `IsMatch(attributes["%v"], "%v") == true`
+	resourceAttributesRegexStatement = `IsMatch(resource.attributes["%v"], "%v") == true`
+)
+
+func NewSpanSkipExprBridge(mc *filterconfig.MatchConfig) (expr.BoolExpr[ottlspan.TransformContext], error) {
+	statements := make([]string, 0, 2)
+	if mc.Include != nil {
+		statement, err := createStatement(*mc.Include)
+		if err != nil {
+			return nil, err
+		}
+		statements = append(statements, fmt.Sprintf("not (%v)", statement))
+	}
+
+	if mc.Exclude != nil {
+		statement, err := createStatement(*mc.Exclude)
+		if err != nil {
+			return nil, err
+		}
+		statements = append(statements, fmt.Sprintf("(%v)", statement))
+	}
+
+	return NewBoolExprForSpan(statements, StandardSpanFuncs(), ottl.PropagateError, component.TelemetrySettings{Logger: zap.NewNop()})
+}
+
+func createStatement(mp filterconfig.MatchProperties) (string, error) {
+	serviceNameConditions, spanNameConditions, spanKindConditions, scopeNameConditions, scopeVersionConditions, attributeConditions, resourceAttributeConditions, err := createConditions(mp)
+	if err != nil {
+		return "", err
+	}
+	var conditions []string
+	if serviceNameConditions != nil {
+		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(serviceNameConditions, " or ")))
+	}
+	if spanNameConditions != nil {
+		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(spanNameConditions, " or ")))
+	}
+	if spanKindConditions != nil {
+		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(spanKindConditions, " or ")))
+	}
+	if scopeNameConditions != nil {
+		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(scopeNameConditions, " or ")))
+	}
+	if scopeVersionConditions != nil {
+		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(scopeVersionConditions, " or ")))
+	}
+	if attributeConditions != nil {
+		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(attributeConditions, " and ")))
+	}
+	if resourceAttributeConditions != nil {
+		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(resourceAttributeConditions, " and ")))
+	}
+	return strings.Join(conditions, " and "), nil
+}
+
+func createConditions(mp filterconfig.MatchProperties) ([]string, []string, []string, []string, []string, []string, []string, error) {
+	serviceNameStatement, spanNameStatement, spanKindStatement, scopeNameStatement, scopeVersionStatement, attrStatement, resourceAttrStatement, err := createStatementTemplates(mp.MatchType)
+	if err != nil {
+		return nil, nil, nil, nil, nil, nil, nil, err
+	}
+
+	serviceNameConditions := createBasicConditions(serviceNameStatement, mp.Services)
+	spanNameConditions := createBasicConditions(spanNameStatement, mp.SpanNames)
+	spanKindConditions := createBasicConditions(spanKindStatement, mp.SpanKinds)
+	scopeNameConditions, scopeVersionConditions := createLibraryConditions(scopeNameStatement, scopeVersionStatement, mp.Libraries)
+	attributeConditions := createAttributeConditions(attrStatement, mp.Attributes, mp.MatchType)
+	resourceAttributeConditions := createAttributeConditions(resourceAttrStatement, mp.Resources, mp.MatchType)
+
+	return serviceNameConditions, spanNameConditions, spanKindConditions, scopeNameConditions, scopeVersionConditions, attributeConditions, resourceAttributeConditions, nil
+}
+
+func createStatementTemplates(matchType filterset.MatchType) (string, string, string, string, string, string, string, error) {
+	switch matchType {
+	case filterset.Strict:
+		return serviceNameStaticStatement, spanNameStaticStatement, spanKindStaticStatement, scopeNameStaticStatement, scopeVersionStaticStatement, attributesStaticStatement, resourceAttributesStaticStatement, nil
+	case filterset.Regexp:
+		return serviceNameRegexStatement, spanNameRegexStatement, spanKindRegexStatement, scopeNameRegexStatement, scopeVersionRegexStatement, attributesRegexStatement, resourceAttributesRegexStatement, nil
+	default:
+		return "", "", "", "", "", "", "", filterset.NewUnrecognizedMatchTypeError(matchType)
+	}
+}
+
+func createBasicConditions(template string, input []string) []string {
+	var conditions []string
+	for _, serviceName := range input {
+		conditions = append(conditions, fmt.Sprintf(template, serviceName))
+	}
+	return conditions
+}
+
+func createLibraryConditions(nameTemplate string, versionTemplate string, libraries []filterconfig.InstrumentationLibrary) ([]string, []string) {
+	var scopeNameConditions []string
+	var scopeVersionConditions []string
+	for _, scope := range libraries {
+		scopeNameConditions = append(scopeNameConditions, fmt.Sprintf(nameTemplate, scope.Name))
+		if scope.Version != nil {
+			scopeVersionConditions = append(scopeVersionConditions, fmt.Sprintf(versionTemplate, *scope.Version))
+		}
+	}
+	return scopeNameConditions, scopeVersionConditions
+}
+
+func createAttributeConditions(template string, input []filterconfig.Attribute, matchType filterset.MatchType) []string {
+	var attributeConditions []string
+	for _, attribute := range input {
+		var value any
+		if matchType == filterset.Strict {
+			value = convertAttribute(attribute.Value)
+		} else {
+			value = attribute.Key
+		}
+		attributeConditions = append(attributeConditions, fmt.Sprintf(template, attribute.Key, value))
+	}
+	return attributeConditions
+}
+
+func convertAttribute(value any) string {
+	switch val := value.(type) {
+	case string:
+		return fmt.Sprintf(`"%v"`, val)
+	default:
+		return fmt.Sprintf(`%v`, val)
+	}
+}

--- a/internal/filter/filterottl/bridge.go
+++ b/internal/filter/filterottl/bridge.go
@@ -61,7 +61,7 @@ func NewSpanSkipExprBridge(mc *filterconfig.MatchConfig) (expr.BoolExpr[ottlspan
 		if err != nil {
 			return nil, err
 		}
-		statements = append(statements, fmt.Sprintf("(%v)", statement))
+		statements = append(statements, fmt.Sprintf("%v", statement))
 	}
 
 	return NewBoolExprForSpan(statements, StandardSpanFuncs(), ottl.PropagateError, component.TelemetrySettings{Logger: zap.NewNop()})
@@ -73,26 +73,52 @@ func createStatement(mp filterconfig.MatchProperties) (string, error) {
 		return "", err
 	}
 	var conditions []string
+	var format string
 	if serviceNameConditions != nil {
-		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(serviceNameConditions, " or ")))
+		if len(serviceNameConditions) > 1 {
+			format = "(%v)"
+		} else {
+			format = "%v"
+		}
+		conditions = append(conditions, fmt.Sprintf(format, strings.Join(serviceNameConditions, " or ")))
 	}
 	if spanNameConditions != nil {
-		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(spanNameConditions, " or ")))
+		if len(spanNameConditions) > 1 {
+			format = "(%v)"
+		} else {
+			format = "%v"
+		}
+		conditions = append(conditions, fmt.Sprintf(format, strings.Join(spanNameConditions, " or ")))
 	}
 	if spanKindConditions != nil {
-		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(spanKindConditions, " or ")))
+		if len(spanKindConditions) > 1 {
+			format = "(%v)"
+		} else {
+			format = "%v"
+		}
+		conditions = append(conditions, fmt.Sprintf(format, strings.Join(spanKindConditions, " or ")))
 	}
 	if scopeNameConditions != nil {
-		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(scopeNameConditions, " or ")))
+		if len(scopeNameConditions) > 1 {
+			format = "(%v)"
+		} else {
+			format = "%v"
+		}
+		conditions = append(conditions, fmt.Sprintf(format, strings.Join(scopeNameConditions, " or ")))
 	}
 	if scopeVersionConditions != nil {
-		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(scopeVersionConditions, " or ")))
+		if len(scopeVersionConditions) > 1 {
+			format = "(%v)"
+		} else {
+			format = "%v"
+		}
+		conditions = append(conditions, fmt.Sprintf(format, strings.Join(scopeVersionConditions, " or ")))
 	}
 	if attributeConditions != nil {
-		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(attributeConditions, " and ")))
+		conditions = append(conditions, fmt.Sprintf("%v", strings.Join(attributeConditions, " and ")))
 	}
 	if resourceAttributeConditions != nil {
-		conditions = append(conditions, fmt.Sprintf("(%v)", strings.Join(resourceAttributeConditions, " and ")))
+		conditions = append(conditions, fmt.Sprintf("%v", strings.Join(resourceAttributeConditions, " and ")))
 	}
 	return strings.Join(conditions, " and "), nil
 }

--- a/internal/filter/filterottl/bridge.go
+++ b/internal/filter/filterottl/bridge.go
@@ -1,16 +1,5 @@
 // Copyright The OpenTelemetry Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//       http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package filterottl // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterottl"
 
@@ -31,7 +20,7 @@ import (
 const (
 	serviceNameStaticStatement        = `resource.attributes["service.name"] == "%v"`
 	spanNameStaticStatement           = `name == "%v"`
-	spanKindStaticStatement           = `kind == "%v"`
+	spanKindStaticStatement           = `kind.deprecated_string == "%v"`
 	scopeNameStaticStatement          = `instrumentation_scope.name == "%v"`
 	scopeVersionStaticStatement       = `instrumentation_scope.version == "%v"`
 	attributesStaticStatement         = `attributes["%v"] == %v`
@@ -39,7 +28,7 @@ const (
 
 	serviceNameRegexStatement        = `IsMatch(resource.attributes["service.name"], "%v")`
 	spanNameRegexStatement           = `IsMatch(name, "%v")`
-	spanKindRegexStatement           = `IsMatch(kind, "%v")`
+	spanKindRegexStatement           = `IsMatch(kind.deprecated_string, "%v")`
 	scopeNameRegexStatement          = `IsMatch(instrumentation_scope.name, "%v")`
 	scopeVersionRegexStatement       = `IsMatch(instrumentation_scope.version, "%v")`
 	attributesRegexStatement         = `IsMatch(attributes["%v"], "%v")`
@@ -177,7 +166,7 @@ func createAttributeConditions(template string, input []filterconfig.Attribute, 
 		if matchType == filterset.Strict {
 			value = convertAttribute(attribute.Value)
 		} else {
-			value = attribute.Key
+			value = attribute.Value
 		}
 		attributeConditions = append(attributeConditions, fmt.Sprintf(template, attribute.Key, value))
 	}

--- a/internal/filter/filterspan/filterspan.go
+++ b/internal/filter/filterspan/filterspan.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 
@@ -19,11 +20,36 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 )
 
+var useOTTLBridge = featuregate.GlobalRegistry().MustRegister(
+	"filter.filterspan.useOTTLBridge",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, filterspan will convert filterspan configuration to OTTL and use filterottl evaluation"),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18642"),
+)
+
 // NewSkipExpr creates a BoolExpr that on evaluation returns true if a span should NOT be processed or kept.
 // The logic determining if a span should be processed is based on include and exclude settings.
 // Include properties are checked before exclude settings are checked.
 func NewSkipExpr(mp *filterconfig.MatchConfig) (expr.BoolExpr[ottlspan.TransformContext], error) {
-	return filterottl.NewSpanSkipExprBridge(mp)
+	if useOTTLBridge.IsEnabled() {
+		return filterottl.NewSpanSkipExprBridge(mp)
+	}
+	var matchers []expr.BoolExpr[ottlspan.TransformContext]
+	inclExpr, err := newExpr(mp.Include)
+	if err != nil {
+		return nil, err
+	}
+	if inclExpr != nil {
+		matchers = append(matchers, expr.Not(inclExpr))
+	}
+	exclExpr, err := newExpr(mp.Exclude)
+	if err != nil {
+		return nil, err
+	}
+	if exclExpr != nil {
+		matchers = append(matchers, exclExpr)
+	}
+	return expr.Or(matchers...), nil
 }
 
 // propertiesMatcher allows matching a span against various span properties.

--- a/internal/filter/filterspan/filterspan.go
+++ b/internal/filter/filterspan/filterspan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/expr"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filtermatcher"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspan"
 )
@@ -22,22 +23,7 @@ import (
 // The logic determining if a span should be processed is based on include and exclude settings.
 // Include properties are checked before exclude settings are checked.
 func NewSkipExpr(mp *filterconfig.MatchConfig) (expr.BoolExpr[ottlspan.TransformContext], error) {
-	var matchers []expr.BoolExpr[ottlspan.TransformContext]
-	inclExpr, err := newExpr(mp.Include)
-	if err != nil {
-		return nil, err
-	}
-	if inclExpr != nil {
-		matchers = append(matchers, expr.Not(inclExpr))
-	}
-	exclExpr, err := newExpr(mp.Exclude)
-	if err != nil {
-		return nil, err
-	}
-	if exclExpr != nil {
-		matchers = append(matchers, exclExpr)
-	}
-	return expr.Or(matchers...), nil
+	return filterottl.NewSpanSkipExprBridge(mp)
 }
 
 // propertiesMatcher allows matching a span against various span properties.

--- a/internal/filter/go.mod
+++ b/internal/filter/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/collector/component v0.78.2
 	go.opentelemetry.io/collector/confmap v0.78.2
+	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0012
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0012
 	go.opentelemetry.io/collector/semconv v0.78.2
 	go.uber.org/zap v1.24.0
@@ -34,7 +35,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector v0.78.2 // indirect
-	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0012 // indirect
 	go.opentelemetry.io/otel v1.15.1 // indirect
 	go.opentelemetry.io/otel/metric v0.38.1 // indirect
 	go.opentelemetry.io/otel/trace v1.15.1 // indirect

--- a/internal/filter/go.mod
+++ b/internal/filter/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.78.2
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0012
 	go.opentelemetry.io/collector/semconv v0.78.2
+	go.uber.org/zap v1.24.0
 )
 
 require (
@@ -39,7 +40,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.15.1 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect

--- a/processor/attributesprocessor/go.mod
+++ b/processor/attributesprocessor/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect

--- a/processor/attributesprocessor/go.mod
+++ b/processor/attributesprocessor/go.mod
@@ -22,9 +22,11 @@ require (
 	github.com/antonmedv/expr v1.12.5 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/processor/attributesprocessor/go.sum
+++ b/processor/attributesprocessor/go.sum
@@ -109,6 +109,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.13.0/go.mod h1:ZlVrynguJKcYr54zGaDbaL3fOvKC9m72FhPvA8T35KQ=

--- a/processor/attributesprocessor/go.sum
+++ b/processor/attributesprocessor/go.sum
@@ -67,6 +67,8 @@ github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -146,6 +148,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/processor/spanprocessor/go.mod
+++ b/processor/spanprocessor/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect

--- a/processor/spanprocessor/go.mod
+++ b/processor/spanprocessor/go.mod
@@ -20,9 +20,11 @@ require (
 	github.com/alecthomas/participle/v2 v2.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/processor/spanprocessor/go.sum
+++ b/processor/spanprocessor/go.sum
@@ -65,6 +65,8 @@ github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -144,6 +146,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=

--- a/processor/spanprocessor/go.sum
+++ b/processor/spanprocessor/go.sum
@@ -107,6 +107,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.13.0/go.mod h1:ZlVrynguJKcYr54zGaDbaL3fOvKC9m72FhPvA8T35KQ=


### PR DESCRIPTION
**Description:**
This PR adds a bridge between `filterspan.NewSkipExpr` and `filterottl.NewBoolExprForSpan` behind a feature gate.  With the feature gate enabled, any component using `filterspan.NewSkipExpr` will start using OTTL behind the scenes.

**Link to tracking Issue:**
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18643 
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18642

**Testing:**
Before adding the feature gate, all unit tests from any component using filterspan are were testing this bridge.