### PR TITLE
[prometheusreceiver] enable reporting of additional metrics

### DIFF
--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
 
-	// ReportExtraMetrics enables reporting of additional metrics for Prometheus client, eg. scrape_body_size_bytes
+	// ReportExtraMetrics enables reporting of additional metrics for Prometheus client like scrape_body_size_bytes
 	ReportExtraMetrics bool `mapstructure:"report_extra_metrics"`
 
 	TargetAllocator *targetAllocator `mapstructure:"target_allocator"`

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -59,6 +59,9 @@ type Config struct {
 	UseStartTimeMetric   bool   `mapstructure:"use_start_time_metric"`
 	StartTimeMetricRegex string `mapstructure:"start_time_metric_regex"`
 
+	// ReportExtraMetrics enables reporting of additional metrics for Prometheus client, eg. scrape_body_size_bytes
+	ReportExtraMetrics bool `mapstructure:"report_extra_metrics"`
+
 	TargetAllocator *targetAllocator `mapstructure:"target_allocator"`
 
 	// ConfigPlaceholder is just an entry to make the configuration pass a check

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -50,6 +50,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, time.Duration(r1.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval), 5*time.Second)
 	assert.Equal(t, r1.UseStartTimeMetric, true)
 	assert.Equal(t, r1.StartTimeMetricRegex, "^(.+_)*process_start_time_seconds$")
+	assert.True(t, r1.ReportExtraMetrics)
 
 	assert.Equal(t, "http://my-targetallocator-service", r1.TargetAllocator.Endpoint)
 	assert.Equal(t, 30*time.Second, r1.TargetAllocator.Interval)

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -281,7 +281,7 @@ func (r *pReceiver) initPrometheusComponents(ctx context.Context, host component
 	if err != nil {
 		return err
 	}
-	r.scrapeManager = scrape.NewManager(&scrape.Options{PassMetadataInContext: true}, logger, store)
+	r.scrapeManager = scrape.NewManager(&scrape.Options{PassMetadataInContext: true, ExtraMetrics: r.cfg.ReportExtraMetrics}, logger, store)
 
 	go func() {
 		// The scrape manager needs to wait for the configuration to be loaded before beginning

--- a/receiver/prometheusreceiver/testdata/config.yaml
+++ b/receiver/prometheusreceiver/testdata/config.yaml
@@ -4,6 +4,7 @@ prometheus/customname:
   buffer_count: 45
   use_start_time_metric: true
   start_time_metric_regex: '^(.+_)*process_start_time_seconds$'
+  report_extra_metrics: true
   target_allocator:
     endpoint: http://my-targetallocator-service
     interval: 30s


### PR DESCRIPTION
Feature: Enable reporting of additional metrics for Prometheus client used in PrometheusReceiver

**Description:** 
Prometheus client has a featureFlag options.ExtraMetrics which reports content size metric ([scrape_body_size_bytes](https://github.com/prometheus/prometheus/blob/main/scrape/scrape.go#L1770)) for successful scrapes and -1 for dropped data. This metric will help us collect data and setup alert for dropped data. However the prometheus receiver does not have a way to enable this feature flag. 

This PR passes the flag to **scrape.NewManager()** to enable reporting of metric - [scrape_body_size_bytes](https://github.com/prometheus/prometheus/blob/main/scrape/scrape.go#L1770)

**Link to tracking Issue:** <Issue number if applicable>
[#21040](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21040)

**Testing:** 
Added check for validating the value set in testdata/config.yaml

