### PR TITLE
[chore] add ignore paths to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,15 @@
       "config:base"
     ],
     "schedule": ["every wednesday"],
+    "ignorePaths": [
+      "**/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_0_0",
+      "**/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_16_3",
+      "**/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_9_3",
+      "**/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_0",
+      "**/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_2",
+      "**/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_4.lpu",
+      "**/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.5_0"
+    ],
     "packageRules": [
       {
         "matchManagers": ["dockerfile"],


### PR DESCRIPTION
This is to prevent test dependencies from being updated as its testing specific versions.
