### PR TITLE
[receiver/purefa] Some endpoints from purefareceiver were having trouble to scraped.

### DIFF
--- a/.chloggen/fix_purefareceiver_scraper_endpoints.yaml
+++ b/.chloggen/fix_purefareceiver_scraper_endpoints.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/purefareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure that all endpoints beyond volumes and hosts are beeing scraped.
+
+# One or more tracking issues related to the change
+issues: [14886]

--- a/receiver/purefareceiver/internal/scraper.go
+++ b/receiver/purefareceiver/internal/scraper.go
@@ -72,9 +72,6 @@ func (h *scraper) ToPrometheusReceiverConfig(host component.Host, fact receiver.
 		httpConfig := configutil.HTTPClientConfig{}
 		httpConfig.BearerToken = configutil.Secret(bearerToken)
 
-		labels := h.labels
-		labels["fa_array_name"] = model.LabelValue(arr.Address)
-
 		scrapeConfig := &config.ScrapeConfig{
 			HTTPClientConfig: httpConfig,
 			ScrapeInterval:   model.Duration(h.scrapeInterval),
@@ -93,7 +90,7 @@ func (h *scraper) ToPrometheusReceiverConfig(host component.Host, fact receiver.
 						Targets: []model.LabelSet{
 							{model.AddressLabel: model.LabelValue(u.Host)},
 						},
-						Labels: labels,
+						Labels: h.labels,
 					},
 				},
 			},

--- a/receiver/purefareceiver/internal/scraper_test.go
+++ b/receiver/purefareceiver/internal/scraper_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"net/http"
 	"net/http/httptest"
+	"log"
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +45,12 @@ func TestToPrometheusConfig(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Serve mock response for the test
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("Mock response"))
+		_, err := w.Write([]byte("Mock response"))
+		if err != nil {
+			log.Println("Error on the response:", err)
+
+			return
+		}
 	}))
 	defer mockServer.Close()
 

--- a/receiver/purefareceiver/internal/scraper_test.go
+++ b/receiver/purefareceiver/internal/scraper_test.go
@@ -37,7 +37,7 @@ func (m *MockHost) GetExtensions() map[component.ID]component.Component {
 }
 
 func (m *MockHost) GetFactory(kind component.Kind, componentType component.Type) component.Factory {
-    return nil 
+	return nil
 }
 func TestToPrometheusConfig(t *testing.T) {
 
@@ -64,7 +64,7 @@ func TestToPrometheusConfig(t *testing.T) {
 	baExt, err := baFactory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), baCfg)
 	require.NoError(t, err)
 
-	host := &MockHost{	
+	host := &MockHost{
 		Extensions: map[component.ID]component.Component{
 			component.NewIDWithName("bearertokenauth", "array01"): baExt,
 		},
@@ -82,7 +82,7 @@ func TestToPrometheusConfig(t *testing.T) {
 	}
 
 	scraper := NewScraper(context.Background(), "hosts", endpoint, cfgs, interval, model.LabelSet{})
-	
+
 	// test
 	scCfgs, err := scraper.ToPrometheusReceiverConfig(host, prFactory)
 

--- a/receiver/purefareceiver/internal/scraper_test.go
+++ b/receiver/purefareceiver/internal/scraper_test.go
@@ -5,11 +5,11 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"context"
-	"testing"
-	"time"
+	"log"
 	"net/http"
 	"net/http/httptest"
-	"log"
+	"testing"
+	"time"
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"

--- a/receiver/purefareceiver/receiver.go
+++ b/receiver/purefareceiver/receiver.go
@@ -40,7 +40,14 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 
 	commomLabel := model.LabelSet{
 		"deployment.environment": model.LabelValue(r.cfg.Env),
-		"host":                   model.LabelValue(r.cfg.Endpoint),
+		"host.name":                   model.LabelValue(r.cfg.Endpoint),
+	}
+
+	// Extracting deployment.environment from commonLabel
+	deploymentEnv := commomLabel["deployment.environment"]
+
+	labelSet := model.LabelSet{
+		"deployment.environment": deploymentEnv,
 	}
 
 	arrScraper := internal.NewScraper(ctx, internal.ScraperTypeArray, r.cfg.Endpoint, r.cfg.Array, r.cfg.Settings.ReloadIntervals.Array, commomLabel)
@@ -50,7 +57,7 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 		return err
 	}
 
-	hostScraper := internal.NewScraper(ctx, internal.ScraperTypeHosts, r.cfg.Endpoint, r.cfg.Hosts, r.cfg.Settings.ReloadIntervals.Hosts, model.LabelSet{})
+	hostScraper := internal.NewScraper(ctx, internal.ScraperTypeHosts, r.cfg.Endpoint, r.cfg.Hosts, r.cfg.Settings.ReloadIntervals.Hosts, labelSet)
 	if scCfgs, err := hostScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {
@@ -71,7 +78,7 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 		return err
 	}
 
-	volumesScraper := internal.NewScraper(ctx, internal.ScraperTypeVolumes, r.cfg.Endpoint, r.cfg.Volumes, r.cfg.Settings.ReloadIntervals.Volumes, model.LabelSet{})
+	volumesScraper := internal.NewScraper(ctx, internal.ScraperTypeVolumes, r.cfg.Endpoint, r.cfg.Volumes, r.cfg.Settings.ReloadIntervals.Volumes, labelSet)
 	if scCfgs, err := volumesScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {

--- a/receiver/purefareceiver/receiver.go
+++ b/receiver/purefareceiver/receiver.go
@@ -39,9 +39,8 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 	scrapeCfgs := []*config.ScrapeConfig{}
 
 	commomLabel := model.LabelSet{
-		"env":           model.LabelValue(r.cfg.Env),
-		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
-		"host":          model.LabelValue(r.cfg.Endpoint),
+		"env":  model.LabelValue(r.cfg.Env),
+		"host": model.LabelValue(r.cfg.Endpoint),
 	}
 
 	arrScraper := internal.NewScraper(ctx, internal.ScraperTypeArray, r.cfg.Endpoint, r.cfg.Array, r.cfg.Settings.ReloadIntervals.Array, commomLabel)
@@ -51,7 +50,7 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 		return err
 	}
 
-	hostScraper := internal.NewScraper(ctx, internal.ScraperTypeHosts, r.cfg.Endpoint, r.cfg.Hosts, r.cfg.Settings.ReloadIntervals.Hosts, commomLabel)
+	hostScraper := internal.NewScraper(ctx, internal.ScraperTypeHosts, r.cfg.Endpoint, r.cfg.Hosts, r.cfg.Settings.ReloadIntervals.Hosts, model.LabelSet{})
 	if scCfgs, err := hostScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {
@@ -72,7 +71,7 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 		return err
 	}
 
-	volumesScraper := internal.NewScraper(ctx, internal.ScraperTypeVolumes, r.cfg.Endpoint, r.cfg.Volumes, r.cfg.Settings.ReloadIntervals.Volumes, commomLabel)
+	volumesScraper := internal.NewScraper(ctx, internal.ScraperTypeVolumes, r.cfg.Endpoint, r.cfg.Volumes, r.cfg.Settings.ReloadIntervals.Volumes, model.LabelSet{})
 	if scCfgs, err := volumesScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {

--- a/receiver/purefareceiver/receiver.go
+++ b/receiver/purefareceiver/receiver.go
@@ -39,8 +39,8 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 	scrapeCfgs := []*config.ScrapeConfig{}
 
 	commomLabel := model.LabelSet{
-		"env":  model.LabelValue(r.cfg.Env),
-		"host": model.LabelValue(r.cfg.Endpoint),
+		"deployment.environment": model.LabelValue(r.cfg.Env),
+		"host":                   model.LabelValue(r.cfg.Endpoint),
 	}
 
 	arrScraper := internal.NewScraper(ctx, internal.ScraperTypeArray, r.cfg.Endpoint, r.cfg.Array, r.cfg.Settings.ReloadIntervals.Array, commomLabel)

--- a/receiver/purefareceiver/receiver.go
+++ b/receiver/purefareceiver/receiver.go
@@ -40,7 +40,7 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 
 	commomLabel := model.LabelSet{
 		"deployment.environment": model.LabelValue(r.cfg.Env),
-		"host.name":                   model.LabelValue(r.cfg.Endpoint),
+		"host.name":              model.LabelValue(r.cfg.Endpoint),
 	}
 
 	// Extracting deployment.environment from commonLabel

--- a/receiver/purefareceiver/receiver.go
+++ b/receiver/purefareceiver/receiver.go
@@ -39,8 +39,9 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 	scrapeCfgs := []*config.ScrapeConfig{}
 
 	commomLabel := model.LabelSet{
-		"deployment.environment": model.LabelValue(r.cfg.Env),
-		"host.name":              model.LabelValue(r.cfg.Endpoint),
+		"env":           model.LabelValue(r.cfg.Env),
+		"fa_array_name": model.LabelValue(r.cfg.Endpoint),
+		"host":          model.LabelValue(r.cfg.Endpoint),
 	}
 
 	arrScraper := internal.NewScraper(ctx, internal.ScraperTypeArray, r.cfg.Endpoint, r.cfg.Array, r.cfg.Settings.ReloadIntervals.Array, commomLabel)
@@ -71,7 +72,7 @@ func (r *purefaReceiver) Start(ctx context.Context, compHost component.Host) err
 		return err
 	}
 
-	volumesScraper := internal.NewScraper(ctx, internal.ScraperTypeVolumes, r.cfg.Endpoint, r.cfg.Volumes, r.cfg.Settings.ReloadIntervals.Volumes, model.LabelSet{})
+	volumesScraper := internal.NewScraper(ctx, internal.ScraperTypeVolumes, r.cfg.Endpoint, r.cfg.Volumes, r.cfg.Settings.ReloadIntervals.Volumes, commomLabel)
 	if scCfgs, err := volumesScraper.ToPrometheusReceiverConfig(compHost, fact); err == nil {
 		scrapeCfgs = append(scrapeCfgs, scCfgs...)
 	} else {


### PR DESCRIPTION
**Description:**
Some endpoints from Pure Flash Array Receiver were not being scraped: **array**, **pods**, and **directories**.
The reason for that could be caused by a missing pattern insertion on the **volumes** scraper endpoint. This snippet code comes to fix this.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14886

**Testing:**
The validation test must be made by the default configs on config.yaml that is present on README.md.

**Documentation:**
Present on README