### PR TITLE
[receiver/mongodbreceiver] Fix index access count error collection on a replica local database

### DIFF
--- a/.chloggen/mongodb-fix-index-access-on-local-error.yaml
+++ b/.chloggen/mongodb-fix-index-access-on-local-error.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes scraper error `Unauthorized` by not calling index stats on an internal local MongoDB database.
+
+# One or more tracking issues related to the change
+issues: [21114]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mongodbreceiver/scraper.go
+++ b/receiver/mongodbreceiver/scraper.go
@@ -149,6 +149,9 @@ func (s *mongodbScraper) collectTopStats(ctx context.Context, now pcommon.Timest
 }
 
 func (s *mongodbScraper) collectIndexStats(ctx context.Context, now pcommon.Timestamp, databaseName string, collectionName string, errs *scrapererror.ScrapeErrors) {
+	if databaseName == "local" {
+		return
+	}
 	indexStats, err := s.client.IndexStats(ctx, databaseName, collectionName)
 	if err != nil {
 		errs.AddPartial(1, fmt.Errorf("failed to fetch index stats metrics: %w", err))

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_0.yaml
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_0.yaml
@@ -13,15 +13,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: miss
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
-                - asInt: "307"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "310"
                   attributes:
                     - key: type
                       value:
                         stringValue: hit
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
               isMonotonic: true
             unit: '{operations}'
           - description: The number of open cursors maintained for clients.
@@ -30,8 +30,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{cursors}'
           - description: The number of cursors that have timed out.
             name: mongodb.cursor.timeout.count
@@ -39,8 +39,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{cursors}'
           - description: The number of existing databases.
             name: mongodb.database.count
@@ -48,17 +48,17 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{databases}'
           - description: The time the global lock has been held.
             name: mongodb.global_lock.time
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "21008"
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                - asInt: "21940"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
               isMonotonic: true
             unit: ms
           - description: The number of bytes received.
@@ -66,75 +66,75 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4530"
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                - asInt: "4307"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The number of by transmitted.
             name: mongodb.network.io.transmit
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "189752"
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                - asInt: "189538"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The number of requests received by the server.
             name: mongodb.network.request.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "39"
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                - asInt: "37"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{requests}'
           - description: The number of operations executed.
             name: mongodb.operation.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "42"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: command
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: insert
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
-                - asInt: "1"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: update
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: getmore
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "40"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: insert
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "2"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: update
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
               isMonotonic: true
             unit: '{operations}'
           - description: The total number of active sessions.
@@ -143,8 +143,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "19"
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{sessions}'
         scope:
           name: otelcol/mongodbreceiver
@@ -162,44 +162,44 @@ resourceMetrics:
                   attributes:
                     - key: operation
                       value:
-                        stringValue: getmore
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
-                - asInt: "12090"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: command
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
-                - asInt: "30"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "175"
                   attributes:
                     - key: operation
                       value:
                         stringValue: query
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: getmore
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "50467"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
               isMonotonic: true
             unit: ms
         scope:
@@ -222,24 +222,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "3"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: admin
-                    - key: type
-                      value:
-                        stringValue: current
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
                 - asInt: "1"
                   attributes:
                     - key: database
@@ -248,8 +238,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -258,8 +248,18 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "3"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: admin
+                    - key: type
+                      value:
+                        stringValue: current
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -271,8 +271,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -287,8 +287,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -297,8 +297,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -307,8 +307,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{documents}'
           - description: The number of extents.
             name: mongodb.extent.count
@@ -320,8 +320,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{extents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -333,8 +333,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -346,24 +346,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "83886080"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: admin
-                    - key: type
-                      value:
-                        stringValue: resident
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
                 - asInt: "1142947840"
                   attributes:
                     - key: database
@@ -372,8 +362,18 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "83886080"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: admin
+                    - key: type
+                      value:
+                        stringValue: resident
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -385,8 +385,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -398,8 +398,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
               isMonotonic: true
             unit: By
         scope:
@@ -422,8 +422,8 @@ resourceMetrics:
                     - key: collection
                       value:
                         stringValue: system.version
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
@@ -445,8 +445,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
@@ -461,8 +461,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -471,8 +471,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -481,8 +481,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -494,8 +494,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -510,8 +510,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -520,8 +520,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -530,8 +530,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{documents}'
           - description: The number of extents.
             name: mongodb.extent.count
@@ -543,8 +543,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{extents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -556,8 +556,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -569,8 +569,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
@@ -585,8 +585,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "1142947840"
                   attributes:
                     - key: database
@@ -595,8 +595,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -608,8 +608,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -621,8 +621,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
               isMonotonic: true
             unit: By
         scope:
@@ -645,8 +645,8 @@ resourceMetrics:
                     - key: collection
                       value:
                         stringValue: system.sessions
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
@@ -668,24 +668,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: local
-                    - key: type
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -694,8 +684,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -704,8 +694,18 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "1"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: local
+                    - key: type
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -717,8 +717,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -733,8 +733,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -743,8 +743,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -753,8 +753,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{documents}'
           - description: The number of extents.
             name: mongodb.extent.count
@@ -766,8 +766,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{extents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -779,8 +779,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -792,8 +792,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
@@ -808,8 +808,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "1142947840"
                   attributes:
                     - key: database
@@ -818,8 +818,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -831,8 +831,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -844,33 +844,10 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes: []
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: local
-                    - key: collection
-                      value:
-                        stringValue: startup_log
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest
@@ -891,8 +868,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
@@ -907,8 +884,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -917,8 +894,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -927,8 +904,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -940,8 +917,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -956,8 +933,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -966,8 +943,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -976,8 +953,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{documents}'
           - description: The number of extents.
             name: mongodb.extent.count
@@ -989,8 +966,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{extents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -1002,8 +979,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -1015,24 +992,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1142947840"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: testdb
-                    - key: type
-                      value:
-                        stringValue: virtual
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
                 - asInt: "83886080"
                   attributes:
                     - key: database
@@ -1041,8 +1008,18 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
+                - asInt: "1142947840"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: testdb
+                    - key: type
+                      value:
+                        stringValue: virtual
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -1054,8 +1031,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -1067,8 +1044,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
               isMonotonic: true
             unit: By
         scope:
@@ -1091,8 +1068,8 @@ resourceMetrics:
                     - key: collection
                       value:
                         stringValue: orders
-                  startTimeUnixNano: "1680549192047364000"
-                  timeUnixNano: "1680549212050056000"
+                  startTimeUnixNano: "1682299293760630000"
+                  timeUnixNano: "1682299313767754000"
             unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_2.yaml
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_2.yaml
@@ -13,15 +13,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: miss
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "304"
                   attributes:
                     - key: type
                       value:
                         stringValue: hit
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
               isMonotonic: true
             unit: '{operations}'
           - description: The number of open cursors maintained for clients.
@@ -30,8 +30,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{cursors}'
           - description: The number of cursors that have timed out.
             name: mongodb.cursor.timeout.count
@@ -39,8 +39,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{cursors}'
           - description: The number of existing databases.
             name: mongodb.database.count
@@ -48,17 +48,17 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{databases}'
           - description: The time the global lock has been held.
             name: mongodb.global_lock.time
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "20987"
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                - asInt: "21717"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
               isMonotonic: true
             unit: ms
           - description: The number of bytes received.
@@ -66,27 +66,27 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4525"
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                - asInt: "4367"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The number of by transmitted.
             name: mongodb.network.io.transmit
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "205330"
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                - asInt: "204677"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The number of requests received by the server.
             name: mongodb.network.request.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "38"
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                - asInt: "37"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{requests}'
           - description: The number of operations executed.
             name: mongodb.operation.count
@@ -97,44 +97,44 @@ resourceMetrics:
                   attributes:
                     - key: operation
                       value:
+                        stringValue: update
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: getmore
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
-                - asInt: "41"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
+                - asInt: "40"
                   attributes:
                     - key: operation
                       value:
                         stringValue: command
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "1"
                   attributes:
                     - key: operation
                       value:
                         stringValue: query
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: update
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
               isMonotonic: true
             unit: '{operations}'
           - description: The total number of active sessions.
@@ -143,8 +143,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "18"
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{sessions}'
         scope:
           name: otelcol/mongodbreceiver
@@ -163,43 +163,43 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: getmore
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
-                - asInt: "43931"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
+                - asInt: "81138"
                   attributes:
                     - key: operation
                       value:
                         stringValue: command
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
-                - asInt: "56"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
+                - asInt: "90"
                   attributes:
                     - key: operation
                       value:
                         stringValue: query
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
               isMonotonic: true
             unit: ms
         scope:
@@ -222,8 +222,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
@@ -238,8 +238,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -248,8 +248,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -258,8 +258,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -271,8 +271,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -287,8 +287,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -297,8 +297,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -307,8 +307,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{documents}'
           - description: The number of extents.
             name: mongodb.extent.count
@@ -320,8 +320,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{extents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -333,8 +333,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -346,8 +346,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
@@ -362,9 +362,9 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
-                - asInt: "1621098496"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
+                - asInt: "1622147072"
                   attributes:
                     - key: database
                       value:
@@ -372,8 +372,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -385,8 +385,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -398,8 +398,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
               isMonotonic: true
             unit: By
         scope:
@@ -422,8 +422,8 @@ resourceMetrics:
                     - key: collection
                       value:
                         stringValue: system.version
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
@@ -445,8 +445,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
@@ -461,8 +461,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -471,8 +471,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -481,8 +481,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -494,8 +494,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -510,8 +510,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -520,8 +520,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -530,8 +530,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{documents}'
           - description: The number of extents.
             name: mongodb.extent.count
@@ -543,8 +543,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{extents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -556,8 +556,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -569,8 +569,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
@@ -585,9 +585,9 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
-                - asInt: "1621098496"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
+                - asInt: "1622147072"
                   attributes:
                     - key: database
                       value:
@@ -595,8 +595,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -608,8 +608,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -621,8 +621,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
               isMonotonic: true
             unit: By
         scope:
@@ -645,8 +645,8 @@ resourceMetrics:
                     - key: collection
                       value:
                         stringValue: system.sessions
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
@@ -668,24 +668,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: local
-                    - key: type
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -694,8 +684,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -704,8 +694,18 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
+                - asInt: "1"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: local
+                    - key: type
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -717,8 +717,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -732,19 +732,9 @@ resourceMetrics:
                         stringValue: local
                     - key: operation
                       value:
-                        stringValue: insert
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
-                - asInt: "0"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: local
-                    - key: operation
-                      value:
                         stringValue: update
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -753,8 +743,18 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
+                - asInt: "0"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: local
+                    - key: operation
+                      value:
+                        stringValue: insert
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{documents}'
           - description: The number of extents.
             name: mongodb.extent.count
@@ -766,8 +766,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{extents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -779,8 +779,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -792,8 +792,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
@@ -808,9 +808,9 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
-                - asInt: "1621098496"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
+                - asInt: "1622147072"
                   attributes:
                     - key: database
                       value:
@@ -818,8 +818,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -831,8 +831,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -844,33 +844,10 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes: []
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: local
-                    - key: collection
-                      value:
-                        stringValue: startup_log
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest
@@ -891,8 +868,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
@@ -907,8 +884,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -917,8 +894,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -927,8 +904,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -940,8 +917,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -956,8 +933,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -966,8 +943,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -976,8 +953,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{documents}'
           - description: The number of extents.
             name: mongodb.extent.count
@@ -989,8 +966,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{extents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -1002,8 +979,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -1015,8 +992,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
@@ -1031,9 +1008,9 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
-                - asInt: "1621098496"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
+                - asInt: "1622147072"
                   attributes:
                     - key: database
                       value:
@@ -1041,8 +1018,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -1054,8 +1031,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -1067,8 +1044,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
               isMonotonic: true
             unit: By
         scope:
@@ -1091,8 +1068,8 @@ resourceMetrics:
                     - key: collection
                       value:
                         stringValue: orders
-                  startTimeUnixNano: "1680549215728629000"
-                  timeUnixNano: "1680549235731826000"
+                  startTimeUnixNano: "1682299293936556000"
+                  timeUnixNano: "1682299313945635000"
             unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_4.lpu.yaml
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_4.lpu.yaml
@@ -13,15 +13,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: miss
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "287"
                   attributes:
                     - key: type
                       value:
                         stringValue: hit
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
               isMonotonic: true
             unit: '{operations}'
           - description: The number of open cursors maintained for clients.
@@ -30,8 +30,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{cursors}'
           - description: The number of cursors that have timed out.
             name: mongodb.cursor.timeout.count
@@ -39,8 +39,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{cursors}'
           - description: The number of existing databases.
             name: mongodb.database.count
@@ -48,17 +48,17 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{databases}'
           - description: The time the global lock has been held.
             name: mongodb.global_lock.time
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "24279"
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                - asInt: "24319"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
               isMonotonic: true
             unit: ms
           - description: The number of bytes received.
@@ -66,75 +66,75 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "6863"
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                - asInt: "6705"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The number of by transmitted.
             name: mongodb.network.io.transmit
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "265671"
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                - asInt: "265399"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The number of requests received by the server.
             name: mongodb.network.request.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "51"
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                - asInt: "50"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{requests}'
           - description: The number of operations executed.
             name: mongodb.operation.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: getmore
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
-                - asInt: "53"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: command
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
-                - asInt: "1"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: insert
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
                 - asInt: "2"
                   attributes:
                     - key: operation
                       value:
                         stringValue: query
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "1"
                   attributes:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: getmore
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "52"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "1"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: insert
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
               isMonotonic: true
             unit: '{operations}'
           - description: The total number of active sessions.
@@ -143,8 +143,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "15"
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{sessions}'
         scope:
           name: otelcol/mongodbreceiver
@@ -158,48 +158,48 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "152"
+                - asInt: "132"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "104"
                   attributes:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: getmore
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
-                - asInt: "40137"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "12528"
                   attributes:
                     - key: operation
                       value:
                         stringValue: command
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
-                - asInt: "1182"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "1340"
                   attributes:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
-                - asInt: "295"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
               isMonotonic: true
             unit: ms
         scope:
@@ -222,8 +222,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
@@ -238,8 +238,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -248,8 +248,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -258,8 +258,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -271,34 +271,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: admin
-                    - key: operation
-                      value:
-                        stringValue: insert
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
-                - asInt: "1"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: admin
-                    - key: operation
-                      value:
-                        stringValue: update
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -307,8 +287,28 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "1"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: admin
+                    - key: operation
+                      value:
+                        stringValue: insert
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "1"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: admin
+                    - key: operation
+                      value:
+                        stringValue: update
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{documents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -320,8 +320,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -333,15 +333,15 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "108003328"
+                - asInt: "105906176"
                   attributes:
                     - key: database
                       value:
@@ -349,8 +349,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "1563426816"
                   attributes:
                     - key: database
@@ -359,8 +359,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -372,8 +372,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -385,8 +385,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
               isMonotonic: true
             unit: By
         scope:
@@ -409,24 +409,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: config
-                    - key: type
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -435,8 +425,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -445,8 +435,18 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "2"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: config
+                    - key: type
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -458,8 +458,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -474,8 +474,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "1"
                   attributes:
                     - key: database
@@ -484,8 +484,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -494,8 +494,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{documents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -507,8 +507,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -520,15 +520,15 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "108003328"
+                - asInt: "105906176"
                   attributes:
                     - key: database
                       value:
@@ -536,8 +536,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "1563426816"
                   attributes:
                     - key: database
@@ -546,8 +546,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -559,8 +559,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -572,8 +572,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
               isMonotonic: true
             unit: By
         scope:
@@ -596,24 +596,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: local
-                    - key: type
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -622,8 +612,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -632,8 +622,18 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "2"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: local
+                    - key: type
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -645,24 +645,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: local
-                    - key: operation
-                      value:
-                        stringValue: delete
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
                 - asInt: "1"
                   attributes:
                     - key: database
@@ -671,8 +661,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "1"
                   attributes:
                     - key: database
@@ -681,8 +671,18 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "0"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: local
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{documents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -694,8 +694,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -707,15 +707,15 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "108003328"
+                - asInt: "105906176"
                   attributes:
                     - key: database
                       value:
@@ -723,8 +723,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "1563426816"
                   attributes:
                     - key: database
@@ -733,8 +733,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -746,8 +746,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -759,33 +759,10 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes: []
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: local
-                    - key: collection
-                      value:
-                        stringValue: startup_log
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest
@@ -806,24 +783,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "3"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: testdb
-                    - key: type
-                      value:
-                        stringValue: current
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
                 - asInt: "2"
                   attributes:
                     - key: database
@@ -832,8 +799,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -842,8 +809,18 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "3"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: testdb
+                    - key: type
+                      value:
+                        stringValue: current
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -855,8 +832,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -871,8 +848,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "1"
                   attributes:
                     - key: database
@@ -881,8 +858,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -891,8 +868,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{documents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -904,8 +881,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -917,24 +894,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "108003328"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: testdb
-                    - key: type
-                      value:
-                        stringValue: resident
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
                 - asInt: "1563426816"
                   attributes:
                     - key: database
@@ -943,8 +910,18 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
+                - asInt: "105906176"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: testdb
+                    - key: type
+                      value:
+                        stringValue: resident
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -956,8 +933,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -969,8 +946,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
               isMonotonic: true
             unit: By
         scope:
@@ -993,8 +970,8 @@ resourceMetrics:
                     - key: collection
                       value:
                         stringValue: orders
-                  startTimeUnixNano: "1680547602000268000"
-                  timeUnixNano: "1680547622002290000"
+                  startTimeUnixNano: "1682299299024584000"
+                  timeUnixNano: "1682299319031945000"
             unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver

--- a/receiver/mongodbreceiver/testdata/integration/expected.5_0.yaml
+++ b/receiver/mongodbreceiver/testdata/integration/expected.5_0.yaml
@@ -13,15 +13,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: miss
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
-                - asInt: "261"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
+                - asInt: "259"
                   attributes:
                     - key: type
                       value:
                         stringValue: hit
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
               isMonotonic: true
             unit: '{operations}'
           - description: The number of open cursors maintained for clients.
@@ -30,8 +30,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{cursors}'
           - description: The number of cursors that have timed out.
             name: mongodb.cursor.timeout.count
@@ -39,8 +39,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{cursors}'
           - description: The number of existing databases.
             name: mongodb.database.count
@@ -48,17 +48,17 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{databases}'
           - description: The time the global lock has been held.
             name: mongodb.global_lock.time
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "21121"
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                - asInt: "21727"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
               isMonotonic: true
             unit: ms
           - description: The number of bytes received.
@@ -66,75 +66,75 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4664"
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                - asInt: "4506"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The number of by transmitted.
             name: mongodb.network.io.transmit
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "295223"
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                - asInt: "294951"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The number of requests received by the server.
             name: mongodb.network.request.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "38"
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                - asInt: "37"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{requests}'
           - description: The number of operations executed.
             name: mongodb.operation.count
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "40"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: query
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: getmore
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
-                - asInt: "41"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: command
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
               isMonotonic: true
             unit: '{operations}'
           - description: The total number of active sessions.
@@ -143,8 +143,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "15"
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{sessions}'
         scope:
           name: otelcol/mongodbreceiver
@@ -162,44 +162,44 @@ resourceMetrics:
                   attributes:
                     - key: operation
                       value:
-                        stringValue: getmore
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
-                - asInt: "19547"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: command
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: query
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: getmore
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
+                - asInt: "39873"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
               isMonotonic: true
             unit: ms
         scope:
@@ -222,24 +222,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "3"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: admin
-                    - key: type
-                      value:
-                        stringValue: current
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
                 - asInt: "2"
                   attributes:
                     - key: database
@@ -248,8 +238,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -258,8 +248,18 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
+                - asInt: "3"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: admin
+                    - key: type
+                      value:
+                        stringValue: current
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -271,8 +271,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -286,9 +286,19 @@ resourceMetrics:
                         stringValue: admin
                     - key: operation
                       value:
+                        stringValue: insert
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
+                - asInt: "0"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: admin
+                    - key: operation
+                      value:
                         stringValue: update
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -297,18 +307,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
-                - asInt: "0"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: admin
-                    - key: operation
-                      value:
-                        stringValue: insert
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{documents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -320,8 +320,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -333,15 +333,15 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "116391936"
+                - asInt: "114294784"
                   attributes:
                     - key: database
                       value:
@@ -349,8 +349,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "1578106880"
                   attributes:
                     - key: database
@@ -359,8 +359,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -372,8 +372,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -385,8 +385,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: admin
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
               isMonotonic: true
             unit: By
         scope:
@@ -409,8 +409,8 @@ resourceMetrics:
                     - key: collection
                       value:
                         stringValue: system.version
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
@@ -432,8 +432,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
@@ -448,8 +448,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -458,8 +458,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -468,8 +468,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -481,8 +481,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -497,8 +497,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -507,8 +507,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -517,8 +517,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{documents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -530,8 +530,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -543,15 +543,15 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "116391936"
+                - asInt: "114294784"
                   attributes:
                     - key: database
                       value:
@@ -559,8 +559,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "1578106880"
                   attributes:
                     - key: database
@@ -569,8 +569,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -582,8 +582,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -595,8 +595,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: config
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
               isMonotonic: true
             unit: By
         scope:
@@ -619,8 +619,8 @@ resourceMetrics:
                     - key: collection
                       value:
                         stringValue: system.sessions
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
@@ -642,24 +642,14 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "3"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: local
-                    - key: type
-                      value:
-                        stringValue: current
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
                 - asInt: "2"
                   attributes:
                     - key: database
@@ -668,8 +658,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -678,8 +668,18 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
+                - asInt: "3"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: local
+                    - key: type
+                      value:
+                        stringValue: current
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -691,8 +691,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -707,8 +707,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -717,8 +717,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -727,8 +727,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{documents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -740,8 +740,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -753,15 +753,15 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "116391936"
+                - asInt: "114294784"
                   attributes:
                     - key: database
                       value:
@@ -769,8 +769,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "1578106880"
                   attributes:
                     - key: database
@@ -779,8 +779,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -792,8 +792,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -805,33 +805,10 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: local
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes: []
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: local
-                    - key: collection
-                      value:
-                        stringValue: startup_log
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest
@@ -852,8 +829,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{collections}'
           - description: The number of connections.
             name: mongodb.connection.count
@@ -868,8 +845,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "838857"
                   attributes:
                     - key: database
@@ -878,8 +855,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "3"
                   attributes:
                     - key: database
@@ -888,8 +865,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: current
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{connections}'
           - description: The size of the collection. Data compression does not affect this value.
             name: mongodb.data.size
@@ -901,8 +878,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The number of document operations executed.
             name: mongodb.document.operation.count
@@ -917,8 +894,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: insert
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -927,8 +904,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "0"
                   attributes:
                     - key: database
@@ -937,8 +914,8 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{documents}'
           - description: The number of indexes.
             name: mongodb.index.count
@@ -950,8 +927,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{indexes}'
           - description: Sum of the space allocated to all indexes in the database, including free index space.
             name: mongodb.index.size
@@ -963,15 +940,15 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The amount of memory used.
             name: mongodb.memory.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "116391936"
+                - asInt: "114294784"
                   attributes:
                     - key: database
                       value:
@@ -979,8 +956,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: resident
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
                 - asInt: "1578106880"
                   attributes:
                     - key: database
@@ -989,8 +966,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: virtual
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: By
           - description: The number of objects.
             name: mongodb.object.count
@@ -1002,8 +979,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{objects}'
           - description: The total amount of storage allocated to this collection.
             name: mongodb.storage.size
@@ -1015,8 +992,8 @@ resourceMetrics:
                     - key: database
                       value:
                         stringValue: testdb
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
               isMonotonic: true
             unit: By
         scope:
@@ -1039,8 +1016,8 @@ resourceMetrics:
                     - key: collection
                       value:
                         stringValue: orders
-                  startTimeUnixNano: "1680549266563589000"
-                  timeUnixNano: "1680549286566652000"
+                  startTimeUnixNano: "1682299293700121000"
+                  timeUnixNano: "1682299313707434000"
             unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The scraper is reporting a scraper error  `Unauthorized` when trying to collect index stats when the database is `local`. This occurs even when the correct roles are used.

This is for the metric `mongodb.index.access.count` which is `The number of times an index has been accessed.`. This is metric is to help monitor the amount an index has been access on user created indexes, not on internal databases such as the `local` database. The `local` database in MongoDB is used for internal purpose by MongoDB which manages replication, sharding and storage and should not be used directly by users.  Furthermore, the local database is [invisible to replication](https://www.mongodb.com/docs/v6.0/reference/local-database/); collections in the local database are not replicated which is causing errors when attempting to do so.

**Link to tracking Issue:** <Issue number if applicable>
#21114

**Testing:** <Describe what testing was performed and which tests were added.>
Updated integration test so they are not showing no mongodb.index.access.count metric with `local` database being collected.
**Documentation:** <Describe the documentation added.>