### PR TITLE
[chore] fix: using replace_all_patterns on logs makes attributes values empty

### DIFF
--- a/.chloggen/fix-func-replace-all-patterns.yaml
+++ b/.chloggen/fix-func-replace-all-patterns.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+ change_type: bug_fix
+
+ # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+ component: transformprocessor
+
+ # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+ note: Fixed a scenario where replace_all_patterns would wipe out non-string values on key name change.
+
+ # One or more tracking issues related to the change
+ issues: [21109]
+
+ # (Optional) One or more lines of additional information to render under the primary note.
+ # These lines will be padded with 2 spaces and then inserted directly into the document.
+ # Use pipe (|) for multiline entries.
+ subtext:

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -52,14 +52,14 @@ func ReplaceAllPatterns[K any](target ottl.PMapGetter[K], mode string, regexPatt
 					updatedString := compiledPattern.ReplaceAllString(originalValue.Str(), replacement)
 					updated.PutStr(key, updatedString)
 				} else {
-					updated.PutStr(key, originalValue.Str())
+					originalValue.CopyTo(updated.PutEmpty(key))
 				}
 			case modeKey:
 				if compiledPattern.MatchString(key) {
 					updatedKey := compiledPattern.ReplaceAllLiteralString(key, replacement)
-					updated.PutStr(updatedKey, originalValue.Str())
+					originalValue.CopyTo(updated.PutEmpty(updatedKey))
 				} else {
-					updated.PutStr(key, originalValue.Str())
+					originalValue.CopyTo(updated.PutEmpty(key))
 				}
 			}
 			return true

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -30,6 +30,9 @@ func Test_replaceAllPatterns(t *testing.T) {
 	input.PutStr("test", "hello world")
 	input.PutStr("test2", "hello")
 	input.PutStr("test3", "goodbye world1 and world2")
+	input.PutInt("test4", 1234)
+	input.PutDouble("test5", 1234)
+	input.PutBool("test6", true)
 
 	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
@@ -55,6 +58,9 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutStr("test", "hello {universe} world")
 				expectedMap.PutStr("test2", "hello {universe}")
 				expectedMap.PutStr("test3", "goodbye world1 and world2")
+				expectedMap.PutInt("test4", 1234)
+				expectedMap.PutDouble("test5", 1234)
+				expectedMap.PutBool("test6", true)
 			},
 		},
 		{
@@ -67,6 +73,9 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutStr("test", "hello world")
 				expectedMap.PutStr("test2", "hello")
 				expectedMap.PutStr("test3", "goodbye world1 and world2")
+				expectedMap.PutInt("test4", 1234)
+				expectedMap.PutDouble("test5", 1234)
+				expectedMap.PutBool("test6", true)
 			},
 		},
 		{
@@ -79,6 +88,9 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutStr("test", "hello **** ")
 				expectedMap.PutStr("test2", "hello")
 				expectedMap.PutStr("test3", "goodbye **** and **** ")
+				expectedMap.PutInt("test4", 1234)
+				expectedMap.PutDouble("test5", 1234)
+				expectedMap.PutBool("test6", true)
 			},
 		},
 		{
@@ -92,6 +104,9 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutStr("test", "hello world")
 				expectedMap.PutStr("foo", "hello")
 				expectedMap.PutStr("test3", "goodbye world1 and world2")
+				expectedMap.PutInt("test4", 1234)
+				expectedMap.PutDouble("test5", 1234)
+				expectedMap.PutBool("test6", true)
 			},
 		},
 		{
@@ -105,6 +120,9 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutStr("test", "hello world")
 				expectedMap.PutStr("test2", "hello")
 				expectedMap.PutStr("test3", "goodbye world1 and world2")
+				expectedMap.PutInt("test4", 1234)
+				expectedMap.PutDouble("test5", 1234)
+				expectedMap.PutBool("test6", true)
 			},
 		},
 		{
@@ -118,6 +136,9 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutStr("test.", "hello world")
 				expectedMap.PutStr("test.2", "hello")
 				expectedMap.PutStr("test.3", "goodbye world1 and world2")
+				expectedMap.PutInt("test.4", 1234)
+				expectedMap.PutDouble("test.5", 1234)
+				expectedMap.PutBool("test.6", true)
 			},
 		},
 		{
@@ -131,6 +152,9 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutStr("test", "hello world")
 				expectedMap.PutStr("test2", "hello")
 				expectedMap.PutStr("test3", "goodbye world-1 and world-2")
+				expectedMap.PutInt("test4", 1234)
+				expectedMap.PutDouble("test5", 1234)
+				expectedMap.PutBool("test6", true)
 			},
 		},
 		{
@@ -144,6 +168,9 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutStr("test", "hello world")
 				expectedMap.PutStr("test2", "hello")
 				expectedMap.PutStr("test3", "goodbye $world-1 and $world-2")
+				expectedMap.PutInt("test4", 1234)
+				expectedMap.PutDouble("test5", 1234)
+				expectedMap.PutBool("test6", true)
 			},
 		},
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21109
replace_all_patterns on logs were getting empty values when attributes values was other than string. This fixes that.

@TylerHelmuth 

Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>