### PR TITLE
[chore] [receiver/elasticsearch] Skip flaky integration tests

### DIFF
--- a/receiver/elasticsearchreceiver/integration_test.go
+++ b/receiver/elasticsearchreceiver/integration_test.go
@@ -68,6 +68,7 @@ var (
 func TestElasticsearchIntegration(t *testing.T) {
 	// Starts an elasticsearch docker container
 	t.Run("Running elasticsearch 7.0.0", func(t *testing.T) {
+		t.Skip("Skipping as the test fails intermittently, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19755")
 		t.Parallel()
 		container := getContainer(t, containerRequest7_0_0)
 		defer func() {
@@ -108,6 +109,7 @@ func TestElasticsearchIntegration(t *testing.T) {
 		))
 	})
 	t.Run("Running elasticsearch 7.9.3", func(t *testing.T) {
+		t.Skip("Skipping as the test fails intermittently, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19755")
 		t.Parallel()
 		container := getContainer(t, containerRequest7_9_3)
 		defer func() {


### PR DESCRIPTION
See #19755 