### PR TITLE
[receiver/mongodbatlas] Ensure mongo atlas metrics are emitted with the correct resource attributes

### DIFF
--- a/.chloggen/mongodbatlas-emit-order.yaml
+++ b/.chloggen/mongodbatlas-emit-order.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/mongodbatlasreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure that Process metrics are emitted with only the correct subset of attributes.
+
+# One or more tracking issues related to the change
+issues: [21155]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mongodbatlasreceiver/receiver.go
+++ b/receiver/mongodbatlasreceiver/receiver.go
@@ -103,25 +103,18 @@ func (s *receiver) poll(ctx context.Context, time timeconstraints) error {
 				return fmt.Errorf("error retrieving MongoDB Atlas processes: %w", err)
 			}
 			for _, process := range processes {
-				if err := s.extractProcessMetrics(
-					ctx,
-					time,
-					org.Name,
-					project,
-					process,
-				); err != nil {
-					return err
+
+				if err := s.extractProcessMetrics(ctx, time, org.Name, project, process); err != nil {
+					return fmt.Errorf("error when polling process metrics from MongoDB Atlas for process %s: %w", process.ID, err)
 				}
-				s.mb.EmitForResource(
-					metadata.WithMongodbAtlasOrgName(org.Name),
-					metadata.WithMongodbAtlasProjectName(project.Name),
-					metadata.WithMongodbAtlasProjectID(project.ID),
-					metadata.WithMongodbAtlasHostName(process.Hostname),
-					metadata.WithMongodbAtlasUserAlias(process.UserAlias),
-					metadata.WithMongodbAtlasProcessPort(strconv.Itoa(process.Port)),
-					metadata.WithMongodbAtlasProcessTypeName(process.TypeName),
-					metadata.WithMongodbAtlasProcessID(process.ID),
-				)
+
+				if err := s.extractProcessDatabaseMetrics(ctx, time, org.Name, project, process); err != nil {
+					return fmt.Errorf("error when polling process database metrics from MongoDB Atlas for process %s: %w", process.ID, err)
+				}
+
+				if err := s.extractProcessDiskMetrics(ctx, time, org.Name, project, process); err != nil {
+					return fmt.Errorf("error when polling process disk metrics from MongoDB Atlas for process %s: %w", process.ID, err)
+				}
 			}
 		}
 	}
@@ -150,13 +143,17 @@ func (s *receiver) extractProcessMetrics(
 		return fmt.Errorf("error when polling process metrics from MongoDB Atlas: %w", err)
 	}
 
-	if err := s.extractProcessDatabaseMetrics(ctx, time, orgName, project, process); err != nil {
-		return fmt.Errorf("error when polling process database metrics from MongoDB Atlas: %w", err)
-	}
+	s.mb.EmitForResource(
+		metadata.WithMongodbAtlasOrgName(orgName),
+		metadata.WithMongodbAtlasProjectName(project.Name),
+		metadata.WithMongodbAtlasProjectID(project.ID),
+		metadata.WithMongodbAtlasHostName(process.Hostname),
+		metadata.WithMongodbAtlasUserAlias(process.UserAlias),
+		metadata.WithMongodbAtlasProcessPort(strconv.Itoa(process.Port)),
+		metadata.WithMongodbAtlasProcessTypeName(process.TypeName),
+		metadata.WithMongodbAtlasProcessID(process.ID),
+	)
 
-	if err := s.extractProcessDiskMetrics(ctx, time, orgName, project, process); err != nil {
-		return fmt.Errorf("error when polling process disk metrics from MongoDB Atlas: %w", err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Ordering of function calls & EmitForResource calls caused Process metrics to usually be emitted under the wrong Resource (with the db.name of the first collected Database)

**Link to tracking Issue:** #21155 

**Testing:** Validated that metrics were no longer emitted incorrectly. This receiver is lacking in metrics tests to enhance for this issue, which should probably be resolved as well.

**Documentation:** None