### PR TITLE
[receiver/dockerstats] Fix ToMetricLabels behaviour

### DIFF
--- a/.chloggen/fix_dockerstats_to_metric_label_loop.yaml
+++ b/.chloggen/fix_dockerstats_to_metric_label_loop.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: dockerstats
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Only one label/envVar was added even if multiple ones were specified by ContainerLabelsToMetricLabels or EnvVarsToMetricLabels
+
+# One or more tracking issues related to the change
+issues: [21113]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/dockerstatsreceiver/receiver.go
+++ b/receiver/dockerstatsreceiver/receiver.go
@@ -138,6 +138,7 @@ func (r *receiver) recordContainerStats(now pcommon.Timestamp, containerStats *d
 		metadata.WithContainerName(strings.TrimPrefix(container.Name, "/")))
 
 	for k, label := range r.config.EnvVarsToMetricLabels {
+		label := label
 		if v := container.EnvMap[k]; v != "" {
 			resourceMetricsOptions = append(resourceMetricsOptions, func(ras metadata.ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 				rm.Resource().Attributes().PutStr(label, v)
@@ -145,6 +146,7 @@ func (r *receiver) recordContainerStats(now pcommon.Timestamp, containerStats *d
 		}
 	}
 	for k, label := range r.config.ContainerLabelsToMetricLabels {
+		label := label
 		if v := container.Config.Labels[k]; v != "" {
 			resourceMetricsOptions = append(resourceMetricsOptions, func(ras metadata.ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 				rm.Resource().Attributes().PutStr(label, v)

--- a/receiver/dockerstatsreceiver/receiver_test.go
+++ b/receiver/dockerstatsreceiver/receiver_test.go
@@ -205,8 +205,14 @@ func TestScrapeV2(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			cfg := createDefaultConfig().(*Config)
 			cfg.Endpoint = tc.mockDockerEngine.URL
-			cfg.EnvVarsToMetricLabels = map[string]string{"ENV_VAR": "env-var-metric-label"}
-			cfg.ContainerLabelsToMetricLabels = map[string]string{"container.label": "container-metric-label"}
+			cfg.EnvVarsToMetricLabels = map[string]string{
+				"ENV_VAR":   "env-var-metric-label",
+				"ENV_VAR_2": "env-var-metric-label-2",
+			}
+			cfg.ContainerLabelsToMetricLabels = map[string]string{
+				"container.label":   "container-metric-label",
+				"container.label.2": "container-metric-label-2",
+			}
 			cfg.MetricsBuilderConfig.Metrics = allMetricsEnabled
 
 			receiver := newReceiver(receivertest.NewNopCreateSettings(), cfg)

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container/container.json
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container/container.json
@@ -12,6 +12,7 @@
     "Entrypoint": null,
     "Env": [
       "ENV_VAR=env-var",
+      "ENV_VAR_2=env-var-2",
       "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     ],
     "ExposedPorts": {
@@ -20,7 +21,8 @@
     "Hostname": "10b703fb312b",
     "Image": "ubuntu",
     "Labels": {
-      "container.label": "container-label"
+      "container.label": "container-label",
+      "container.label.2": "container-label-2"
     },
     "OnBuild": null,
     "OpenStdin": true,

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container/containers.json
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container/containers.json
@@ -9,7 +9,8 @@
     "Image": "ubuntu",
     "ImageID": "sha256:825d55fb6340083b06e69e02e823a02918f3ffb575ed2a87026d4645a7fd9e1b",
     "Labels": {
-      "container.label": "container-label"
+      "container.label": "container-label",
+      "container.label.2": "container-label-2"
     },
     "Mounts": [],
     "Names": [

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
@@ -19,9 +19,15 @@ resourceMetrics:
         - key: env-var-metric-label
           value:
             stringValue: env-var
+        - key: env-var-metric-label-2
+          value:
+            stringValue: env-var-2
         - key: container-metric-label
           value:
             stringValue: container-label
+        - key: container-metric-label-2
+          value:
+            stringValue: container-label-2
     schemaUrl: https://opentelemetry.io/schemas/1.6.1
     scopeMetrics:
       - metrics:


### PR DESCRIPTION
**Description:** 
Only one label/envVar was added even if multiple ones were specified
by ContainerLabelsToMetricLabels or EnvVarsToMetricLabels.
Adding a local variable shadowing the loop one solves the issue.

Without such fix the `label` variable assumes the value of the last element computed in the loop.

More details can be find reading https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21113

**Link to tracking Issue:** 
Fix https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21113

**Testing:** 
The tests that were already existing have been updated to cover the broken use-case
