### PR TITLE
[exporter/loki]. Rename resources to resource field in JSON format

### DIFF
--- a/.chloggen/loki-exporter-rename-resources-field.yaml
+++ b/.chloggen/loki-exporter-rename-resources-field.yaml
@@ -1,11 +1,11 @@
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: 'breaking'
+change_type: 'enhancement'
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: lokitranslator
+component: lokiexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Rename resources field to resource in JSON format to align the name with the opentelemetry log data model specification
+note: Added feature gate flag `exporter.loki.sendWithResourceInJSONFormat`. If enabled, loki exporter sends `resource` instead of `resources` field in JSON format to align the name with the opentelemetry log data model specification
 
 # One or more tracking issues related to the change
 issues: [21161]

--- a/.chloggen/loki-translator-rename-resources-field.yaml
+++ b/.chloggen/loki-translator-rename-resources-field.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'breaking'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: lokitranslator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename resources field to resource in JSON format to align the name with the opentelemetry log data model specification
+
+# One or more tracking issues related to the change
+issues: [21161]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/lokiexporter/config.go
+++ b/exporter/lokiexporter/config.go
@@ -13,9 +13,10 @@ import (
 
 // Config defines configuration for Loki exporter.
 type Config struct {
-	confighttp.HTTPClientSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
-	exporterhelper.QueueSettings  `mapstructure:"sending_queue"`
-	exporterhelper.RetrySettings  `mapstructure:"retry_on_failure"`
+	confighttp.HTTPClientSettings        `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
+	exporterhelper.QueueSettings         `mapstructure:"sending_queue"`
+	exporterhelper.RetrySettings         `mapstructure:"retry_on_failure"`
+	sendResourceFieldInJSONFormatEnabled bool
 }
 
 func (c *Config) Validate() error {

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -44,7 +44,13 @@ func newExporter(config *Config, settings component.TelemetrySettings) *lokiExpo
 }
 
 func (l *lokiExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
-	requests := loki.LogsToLokiRequests(ld)
+	var requests map[string]loki.PushRequest
+
+	if l.config.sendResourceFieldInJSONFormatEnabled {
+		requests = loki.LogsToLokiRequestsWithResourceFieldInJSONFormat(ld)
+	} else {
+		requests = loki.LogsToLokiRequests(ld)
+	}
 
 	var errs error
 	for tenant, request := range requests {

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -21,17 +21,19 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/plog"
 )
 
 func TestPushLogData(t *testing.T) {
 	testCases := []struct {
-		desc          string
-		hints         map[string]interface{}
-		attrs         map[string]interface{}
-		res           map[string]interface{}
-		expectedLabel string
-		expectedLine  string
+		desc                                 string
+		hints                                map[string]interface{}
+		attrs                                map[string]interface{}
+		res                                  map[string]interface{}
+		expectedLabel                        string
+		expectedLine                         string
+		sendResourceFieldInJSONFormatEnabled bool
 	}{
 		{
 			desc: "with attribute to label and regular attribute",
@@ -55,11 +57,31 @@ func TestPushLogData(t *testing.T) {
 				"loki.resource.labels": "host.name",
 			},
 			expectedLabel: `{exporter="OTLP", host_name="guarana"}`,
-			expectedLine:  `{"traceid":"01020304000000000000000000000000","resource":{"region.az":"eu-west-1a"}}`,
+			expectedLine:  `{"traceid":"01020304000000000000000000000000","resources":{"region.az":"eu-west-1a"}}`,
+		},
+		{
+			desc: "with resource to label and regular resource and feature gate flag exporter.loki.sendWithResourceInJSONFormat is set to true",
+			res: map[string]interface{}{
+				"host.name": "guarana",
+				"region.az": "eu-west-1a",
+			},
+			hints: map[string]interface{}{
+				"loki.resource.labels": "host.name",
+			},
+			expectedLabel:                        `{exporter="OTLP", host_name="guarana"}`,
+			expectedLine:                         `{"traceid":"01020304000000000000000000000000","resource":{"region.az":"eu-west-1a"}}`,
+			sendResourceFieldInJSONFormatEnabled: true,
 		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
+			if tC.sendResourceFieldInJSONFormatEnabled {
+				require.NoError(t, featuregate.GlobalRegistry().Set(sendResourceInJSONFormat.ID(), true))
+			}
+			t.Cleanup(func() {
+				require.NoError(t, featuregate.GlobalRegistry().Set(sendResourceInJSONFormat.ID(), false))
+			})
+
 			actualPushRequest := &push.PushRequest{}
 
 			// prepare
@@ -79,6 +101,7 @@ func TestPushLogData(t *testing.T) {
 				HTTPClientSettings: confighttp.HTTPClientSettings{
 					Endpoint: ts.URL,
 				},
+				sendResourceFieldInJSONFormatEnabled: sendResourceInJSONFormat.IsEnabled(),
 			}
 
 			f := NewFactory()

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -55,7 +55,7 @@ func TestPushLogData(t *testing.T) {
 				"loki.resource.labels": "host.name",
 			},
 			expectedLabel: `{exporter="OTLP", host_name="guarana"}`,
-			expectedLine:  `{"traceid":"01020304000000000000000000000000","resources":{"region.az":"eu-west-1a"}}`,
+			expectedLine:  `{"traceid":"01020304000000000000000000000000","resource":{"region.az":"eu-west-1a"}}`,
 		},
 	}
 	for _, tC := range testCases {

--- a/exporter/lokiexporter/factory.go
+++ b/exporter/lokiexporter/factory.go
@@ -14,8 +14,17 @@ import (
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/featuregate"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/metadata"
+)
+
+var sendResourceInJSONFormat = featuregate.GlobalRegistry().MustRegister(
+	"exporter.loki.sendWithResourceInJSONFormat",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterFromVersion("0.77.0"),
+	featuregate.WithRegisterDescription("When enabled, sends 'resource' instead of 'resources' in JSON format"),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21161"),
 )
 
 // NewFactory creates a factory for the legacy Loki exporter.
@@ -36,8 +45,9 @@ func createDefaultConfig() component.Config {
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.
 			WriteBufferSize: 512 * 1024,
 		},
-		RetrySettings: exporterhelper.NewDefaultRetrySettings(),
-		QueueSettings: exporterhelper.NewDefaultQueueSettings(),
+		RetrySettings:                        exporterhelper.NewDefaultRetrySettings(),
+		QueueSettings:                        exporterhelper.NewDefaultQueueSettings(),
+		sendResourceFieldInJSONFormatEnabled: sendResourceInJSONFormat.IsEnabled(),
 	}
 }
 

--- a/exporter/lokiexporter/go.mod
+++ b/exporter/lokiexporter/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.77.0
 	go.opentelemetry.io/collector/consumer v0.77.0
 	go.opentelemetry.io/collector/exporter v0.77.0
+	go.opentelemetry.io/collector/featuregate v0.77.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0011
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.24.0
@@ -52,7 +53,6 @@ require (
 	github.com/prometheus/prometheus v0.43.1 // indirect
 	github.com/rs/cors v1.9.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/featuregate v0.77.0 // indirect
 	go.opentelemetry.io/collector/receiver v0.77.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.77.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.41.1 // indirect

--- a/pkg/translator/loki/convert.go
+++ b/pkg/translator/loki/convert.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	hintAttributes = "loki.attribute.labels"
-	hintResources  = "loki.resource.labels"
+	hintResource   = "loki.resource.labels"
 	hintTenant     = "loki.tenant"
 	hintFormat     = "loki.format"
 )
@@ -39,7 +39,7 @@ func convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs pcommon.Map) model
 		out[model.InstanceLabel] = model.LabelValue(instance)
 	}
 
-	if resourcesToLabel, found := resAttrs.Get(hintResources); found {
+	if resourcesToLabel, found := resAttrs.Get(hintResource); found {
 		labels := convertAttributesToLabels(resAttrs, resourcesToLabel)
 		out = out.Merge(labels)
 	}
@@ -47,7 +47,7 @@ func convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs pcommon.Map) model
 	// get the hint from the log attributes, not from the resource
 	// the value can be a single resource name to use as label
 	// or a slice of string values
-	if resourcesToLabel, found := logAttrs.Get(hintResources); found {
+	if resourcesToLabel, found := logAttrs.Get(hintResource); found {
 		labels := convertAttributesToLabels(resAttrs, resourcesToLabel)
 		out = out.Merge(labels)
 	}
@@ -129,7 +129,7 @@ func parseAttributeNames(attrsToSelect pcommon.Value) []string {
 
 func removeAttributes(attrs pcommon.Map, labels model.LabelSet) {
 	attrs.RemoveIf(func(s string, v pcommon.Value) bool {
-		if s == hintAttributes || s == hintResources || s == hintTenant || s == hintFormat {
+		if s == hintAttributes || s == hintResource || s == hintTenant || s == hintFormat {
 			return true
 		}
 

--- a/pkg/translator/loki/convert_test.go
+++ b/pkg/translator/loki/convert_test.go
@@ -39,7 +39,7 @@ func TestConvertAttributesAndMerge(t *testing.T) {
 		{
 			desc: "selected resource attribute should be included",
 			logAttrs: map[string]interface{}{
-				hintResources: "host.name",
+				hintResource: "host.name",
 			},
 			resAttrs: map[string]interface{}{
 				"host.name": "guarana",
@@ -54,9 +54,9 @@ func TestConvertAttributesAndMerge(t *testing.T) {
 			desc:     "selected attributes from resource attributes should be included",
 			logAttrs: map[string]interface{}{},
 			resAttrs: map[string]interface{}{
-				hintResources: "host.name",
-				"host.name":   "hostname-from-resources",
-				"pod.name":    "should-be-ignored",
+				hintResource: "host.name",
+				"host.name":  "hostname-from-resources",
+				"pod.name":   "should-be-ignored",
 			},
 			expected: model.LabelSet{
 				"exporter":  "OTLP",
@@ -68,7 +68,7 @@ func TestConvertAttributesAndMerge(t *testing.T) {
 			logAttrs: map[string]interface{}{
 				"host.name":    "hostname-from-attributes",
 				hintAttributes: "host.name",
-				hintResources:  "host.name",
+				hintResource:   "host.name",
 			},
 			resAttrs: map[string]interface{}{
 				"host.name": "hostname-from-resources",
@@ -225,7 +225,7 @@ func TestRemoveAttributes(t *testing.T) {
 			desc: "remove hints",
 			attrs: map[string]interface{}{
 				hintAttributes: "some.field",
-				hintResources:  "some.other.field",
+				hintResource:   "some.other.field",
 				hintFormat:     "logfmt",
 				hintTenant:     "some_tenant",
 				"host.name":    "guarana",

--- a/pkg/translator/loki/encode.go
+++ b/pkg/translator/loki/encode.go
@@ -24,7 +24,7 @@ type lokiEntry struct {
 	SpanID               string                 `json:"spanid,omitempty"`
 	Severity             string                 `json:"severity,omitempty"`
 	Attributes           map[string]interface{} `json:"attributes,omitempty"`
-	Resources            map[string]interface{} `json:"resources,omitempty"`
+	Resource             map[string]interface{} `json:"resource,omitempty"`
 	InstrumentationScope *instrumentationScope  `json:"instrumentation_scope,omitempty"`
 }
 
@@ -52,7 +52,7 @@ func Encode(lr plog.LogRecord, res pcommon.Resource, scope pcommon.Instrumentati
 		SpanID:     traceutil.SpanIDToHexOrEmptyString(lr.SpanID()),
 		Severity:   lr.SeverityText(),
 		Attributes: lr.Attributes().AsRaw(),
-		Resources:  res.Attributes().AsRaw(),
+		Resource:   res.Attributes().AsRaw(),
 	}
 
 	scopeName := scope.Name()

--- a/pkg/translator/loki/encode_test.go
+++ b/pkg/translator/loki/encode_test.go
@@ -33,7 +33,7 @@ func exampleLog() (plog.LogRecord, pcommon.Resource, pcommon.InstrumentationScop
 }
 
 func TestEncodeJsonWithStringBody(t *testing.T) {
-	in := `{"body":"Example log","traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resource":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
+	in := `{"body":"Example log","traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resources":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
 	log, resource, scope := exampleLog()
 
 	out, err := Encode(log, resource, scope)
@@ -41,8 +41,17 @@ func TestEncodeJsonWithStringBody(t *testing.T) {
 	assert.Equal(t, in, out)
 }
 
+func TestEncodeJsonWithStringBodyWithResourceField(t *testing.T) {
+	in := `{"body":"Example log","traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resource":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
+	log, resource, scope := exampleLog()
+
+	out, err := EncodeWithResourceField(log, resource, scope)
+	assert.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
 func TestEncodeJsonWithMapBody(t *testing.T) {
-	in := `{"body":{"key1":"value","key2":"value"},"traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resource":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
+	in := `{"body":{"key1":"value","key2":"value"},"traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resources":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
 
 	log, resource, scope := exampleLog()
 	mapVal := pcommon.NewValueMap()
@@ -51,6 +60,20 @@ func TestEncodeJsonWithMapBody(t *testing.T) {
 	mapVal.CopyTo(log.Body())
 
 	out, err := Encode(log, resource, scope)
+	assert.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
+func TestEncodeJsonWithMapBodyWithResourceField(t *testing.T) {
+	in := `{"body":{"key1":"value","key2":"value"},"traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resource":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
+
+	log, resource, scope := exampleLog()
+	mapVal := pcommon.NewValueMap()
+	mapVal.Map().PutStr("key1", "value")
+	mapVal.Map().PutStr("key2", "value")
+	mapVal.CopyTo(log.Body())
+
+	out, err := EncodeWithResourceField(log, resource, scope)
 	assert.NoError(t, err)
 	assert.Equal(t, in, out)
 }

--- a/pkg/translator/loki/encode_test.go
+++ b/pkg/translator/loki/encode_test.go
@@ -33,7 +33,7 @@ func exampleLog() (plog.LogRecord, pcommon.Resource, pcommon.InstrumentationScop
 }
 
 func TestEncodeJsonWithStringBody(t *testing.T) {
-	in := `{"body":"Example log","traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resources":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
+	in := `{"body":"Example log","traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resource":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
 	log, resource, scope := exampleLog()
 
 	out, err := Encode(log, resource, scope)
@@ -42,7 +42,7 @@ func TestEncodeJsonWithStringBody(t *testing.T) {
 }
 
 func TestEncodeJsonWithMapBody(t *testing.T) {
-	in := `{"body":{"key1":"value","key2":"value"},"traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resources":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
+	in := `{"body":{"key1":"value","key2":"value"},"traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resource":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
 
 	log, resource, scope := exampleLog()
 	mapVal := pcommon.NewValueMap()

--- a/pkg/translator/loki/logs_to_loki_test.go
+++ b/pkg/translator/loki/logs_to_loki_test.go
@@ -268,13 +268,13 @@ func TestLogsToLokiRequestWithoutTenant(t *testing.T) {
 				"region.az": "eu-west-1a",
 			},
 			hints: map[string]interface{}{
-				hintResources: "host.name",
+				hintResource: "host.name",
 			},
 			expectedLabel: `{exporter="OTLP", host_name="guarana"}`,
 			expectedLines: []string{
-				`{"traceid":"01000000000000000000000000000000","resources":{"region.az":"eu-west-1a"}}`,
-				`{"traceid":"02000000000000000000000000000000","resources":{"region.az":"eu-west-1a"}}`,
-				`{"traceid":"03000000000000000000000000000000","resources":{"region.az":"eu-west-1a"}}`,
+				`{"traceid":"01000000000000000000000000000000","resource":{"region.az":"eu-west-1a"}}`,
+				`{"traceid":"02000000000000000000000000000000","resource":{"region.az":"eu-west-1a"}}`,
+				`{"traceid":"03000000000000000000000000000000","resource":{"region.az":"eu-west-1a"}}`,
 			},
 		},
 		{
@@ -424,13 +424,13 @@ func TestLogsToLoki(t *testing.T) {
 				"region.az": "eu-west-1a",
 			},
 			hints: map[string]interface{}{
-				hintResources: "host.name",
+				hintResource: "host.name",
 			},
 			expectedLabel: `{exporter="OTLP", host.name="guarana"}`,
 			expectedLines: []string{
-				`{"traceid":"01020304000000000000000000000000","resources":{"region.az":"eu-west-1a"}}`,
-				`{"traceid":"01020304050000000000000000000000","resources":{"region.az":"eu-west-1a"}}`,
-				`{"traceid":"01020304050600000000000000000000","resources":{"region.az":"eu-west-1a"}}`,
+				`{"traceid":"01020304000000000000000000000000","resource":{"region.az":"eu-west-1a"}}`,
+				`{"traceid":"01020304050000000000000000000000","resource":{"region.az":"eu-west-1a"}}`,
+				`{"traceid":"01020304050600000000000000000000","resource":{"region.az":"eu-west-1a"}}`,
 			},
 		},
 		{
@@ -440,8 +440,8 @@ func TestLogsToLoki(t *testing.T) {
 				"region.az": "eu-west-1a",
 			},
 			hints: map[string]interface{}{
-				hintResources: "host.name",
-				hintFormat:    formatLogfmt,
+				hintResource: "host.name",
+				hintFormat:   formatLogfmt,
 			},
 			expectedLabel: `{exporter="OTLP", host.name="guarana"}`,
 			expectedLines: []string{
@@ -663,12 +663,12 @@ func TestLogToLokiEntry(t *testing.T) {
 				"region.az": "eu-west-1a",
 			},
 			hints: map[string]interface{}{
-				hintResources: "host.name",
+				hintResource: "host.name",
 			},
 			expected: &PushEntry{
 				Entry: &push.Entry{
 					Timestamp: time.Unix(0, 1677592916000000000),
-					Line:      `{"resources":{"region.az":"eu-west-1a"}}`,
+					Line:      `{"resource":{"region.az":"eu-west-1a"}}`,
 				},
 				Labels: model.LabelSet{
 					"exporter":  "OTLP",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Lokiexporter sends `resources` field to Loki in JSON format. This name is not following the opentelemetry log data model specification: https://opentelemetry.io/docs/reference/specification/logs/data-model/#field-resource
The field name should be `resource`

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21161
