### PR TITLE
Rectifying the histogram configuration parameter

### DIFF
--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -117,7 +117,7 @@ type HistogramConfig struct {
 
 	// SendCountSum states if the export should send .sum and .count metrics for histograms.
 	// The default is false.
-	// Deprecated: [v0.75.0] Use `send_aggregations` (HistogramConfig.SendAggregations) instead.
+	// Deprecated: [v0.75.0] Use `send_aggregation_metrics` (HistogramConfig.SendAggregations) instead.
 	SendCountSum bool `mapstructure:"send_count_sum_metrics"`
 
 	// SendAggregations states if the exporter should send .sum, .count, .min and .max metrics for histograms.

--- a/exporter/datadogexporter/examples/collector.yaml
+++ b/exporter/datadogexporter/examples/collector.yaml
@@ -169,6 +169,7 @@ exporters:
 
       ## @param histograms - custom object - optional
       ## Histograms specific configuration.
+      # histogram: 
         ## @param mode - string - optional - default: distributions
         ## How to report histograms. Valid values are:
         ##
@@ -184,10 +185,10 @@ exporters:
         #
         # send_count_sum_metrics: false
 
-        ## @param send_aggreggations - boolean - optional - default: false
+        ## @param send_aggregation_metrics - boolean - optional - default: false
         ## Whether to report sum, count, min and max as separate histogram metrics.
         #
-        # send_aggreggations: false
+        # send_aggregation_metrics: false
 
 
       ## @param sums - custom object - optional


### PR DESCRIPTION
**Description:**
Fixing Issue [#21157](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21157)

**Testing:** 
Tested the configuration in Kubernetes cluster 
```
datadog:
    api:
      key: xx
      site: datadoghq.com
    metrics:
      resource_attributes_as_tags: true
      histograms:
        send_aggregation_metrics: true
    host_metadata:
      enabled: true
```


**Documentation:**
Corrected the example collector.yaml that was having the incorrect content