### PR TITLE
[receiver/mongodbatlasreceiver] Do not emit empty logs collections

### DIFF
--- a/.chloggen/mongodbatlas-emit-less.yaml
+++ b/.chloggen/mongodbatlas-emit-less.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/mongodbatlasreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reduce the likelihood that mongodbatlas log receivers will emit empty logs, causing unnecessary events to propagate through a pipeline.
+
+# One or more tracking issues related to the change
+issues: [14170]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mongodbatlasreceiver/logs.go
+++ b/receiver/mongodbatlasreceiver/logs.go
@@ -223,7 +223,13 @@ func (s *logsReceiver) getHostAuditLogs(groupID, hostname, logName string) ([]mo
 func (s *logsReceiver) collectLogs(pc ProjectContext, hostname, logName, clusterName, clusterMajorVersion string) {
 	logs, err := s.getHostLogs(pc.Project.ID, hostname, logName, clusterMajorVersion)
 	if err != nil && !errors.Is(err, io.EOF) {
-		s.log.Warn("Failed to retrieve logs from: "+logName, zap.Error(err))
+		s.log.Warn("Failed to retrieve host logs", zap.Error(err), zap.String("log", logName))
+		return
+	}
+
+	if len(logs) == 0 {
+		s.log.Warn("Attempted to retrieve host logs but received 0 logs", zap.Error(err), zap.String("log", logName))
+		return
 	}
 
 	plog := mongodbEventToLogData(s.log,
@@ -247,7 +253,13 @@ func (s *logsReceiver) collectAuditLogs(pc ProjectContext, hostname, logName, cl
 	)
 
 	if err != nil && !errors.Is(err, io.EOF) {
-		s.log.Warn("Failed to retrieve audit logs: "+logName, zap.Error(err))
+		s.log.Warn("Failed to retrieve audit logs", zap.Error(err), zap.String("log", logName))
+		return
+	}
+
+	if len(logs) == 0 {
+		s.log.Warn("Attempted to retrieve audit logs but received 0 logs", zap.Error(err), zap.String("log", logName))
+		return
 	}
 
 	plog, err := mongodbAuditEventToLogData(s.log,
@@ -259,6 +271,7 @@ func (s *logsReceiver) collectAuditLogs(pc ProjectContext, hostname, logName, cl
 		clusterMajorVersion)
 	if err != nil {
 		s.log.Warn("Failed to translate audit logs: "+logName, zap.Error(err))
+		return
 	}
 
 	err = s.consumer.ConsumeLogs(context.Background(), plog)


### PR DESCRIPTION
**Description:** Reduce the likelihood that mongodbatlas log receivers will emit empty logs, causing unnecessary events to propagate through a pipeline.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14170
