### PR TITLE
[receiver/mongodbatlas] Fix disk usage & utilization metrics & drop one duplicate metric definition

### DIFF
--- a/.chloggen/mongodbatlas-disk-metrics.yaml
+++ b/.chloggen/mongodbatlas-disk-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/mongodbatlasreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Disk Usage & Utilization metrics are now being reported correctly.
+
+# One or more tracking issues related to the change
+issues: [21180]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mongodbatlasreceiver/documentation.md
+++ b/receiver/mongodbatlasreceiver/documentation.md
@@ -140,9 +140,9 @@ Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USE
 | ---- | ----------- | ------ |
 | disk_status | Disk measurement type | Str: ``free``, ``used`` |
 
-### mongodbatlas.disk.partition.utilization.average
+### mongodbatlas.disk.partition.usage.average
 
-Disk partition utilization (%)
+Disk partition usage (%)
 
 Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_SPACE_PERCENT_USED
 
@@ -156,9 +156,9 @@ Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_S
 | ---- | ----------- | ------ |
 | disk_status | Disk measurement type | Str: ``free``, ``used`` |
 
-### mongodbatlas.disk.partition.utilization.max
+### mongodbatlas.disk.partition.usage.max
 
-Disk partition utilization (%)
+Disk partition usage (%)
 
 Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PARTITION_SPACE_PERCENT_FREE
 
@@ -171,6 +171,26 @@ Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PAR
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | disk_status | Disk measurement type | Str: ``free``, ``used`` |
+
+### mongodbatlas.disk.partition.utilization.average
+
+The maximum percentage of time during which requests are being issued to and serviced by the partition.
+
+MongoDB Metrics DISK_PARTITION_UTILIZATION
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| 1 | Gauge | Double |
+
+### mongodbatlas.disk.partition.utilization.max
+
+The percentage of time during which requests are being issued to and serviced by the partition.
+
+MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| 1 | Gauge | Double |
 
 ### mongodbatlas.process.asserts
 

--- a/receiver/mongodbatlasreceiver/documentation.md
+++ b/receiver/mongodbatlasreceiver/documentation.md
@@ -174,7 +174,7 @@ Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PAR
 
 ### mongodbatlas.disk.partition.utilization.average
 
-The maximum percentage of time during which requests are being issued to and serviced by the partition.
+The percentage of time during which requests are being issued to and serviced by the partition.
 
 MongoDB Metrics DISK_PARTITION_UTILIZATION
 
@@ -184,7 +184,7 @@ MongoDB Metrics DISK_PARTITION_UTILIZATION
 
 ### mongodbatlas.disk.partition.utilization.max
 
-The percentage of time during which requests are being issued to and serviced by the partition.
+The maximum percentage of time during which requests are being issued to and serviced by the partition.
 
 MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
 

--- a/receiver/mongodbatlasreceiver/documentation.md
+++ b/receiver/mongodbatlasreceiver/documentation.md
@@ -182,12 +182,6 @@ MongoDB Metrics DISK_PARTITION_UTILIZATION
 | ---- | ----------- | ---------- |
 | 1 | Gauge | Double |
 
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| disk_status | Disk measurement type | Str: ``free``, ``used`` |
-
 ### mongodbatlas.disk.partition.utilization.max
 
 Disk partition utilization (%)
@@ -197,12 +191,6 @@ MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | 1 | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| disk_status | Disk measurement type | Str: ``free``, ``used`` |
 
 ### mongodbatlas.process.asserts
 
@@ -513,22 +501,6 @@ Aggregate of MongoDB Metrics DB_INDEX_SIZE_TOTAL, DB_DATA_SIZE_TOTAL_WO_SYSTEM, 
 | ---- | ----------- | ------ |
 | storage_status | Views on database size | Str: ``total``, ``data_size``, ``index_size``, ``data_size_wo_system`` |
 
-### mongodbatlas.process.fts.cpu.usage
-
-Full text search CPU (%)
-
-Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| cpu_state | CPU state | Str: ``kernel``, ``user``, ``nice``, ``iowait``, ``irq``, ``softirq``, ``guest``, ``steal`` |
-
 ### mongodbatlas.process.global_lock
 
 Number and status of locks
@@ -793,7 +765,9 @@ Aggregate of MongoDB Metrics FTS_PROCESS_NORMALIZED_CPU_USER, FTS_PROCESS_NORMAL
 
 ### mongodbatlas.system.fts.cpu.usage
 
-Full-text search (%)
+Full text search CPU (%)
+
+Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -809,7 +783,7 @@ Full-text search (%)
 
 Full text search disk usage
 
-MongoDB Metric FTS_DISK_USAGE
+MongoDB Metric FTS_DISK_USAGE (Documentation incorrectly claims FTS_DISK_UTILIZATION)
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |

--- a/receiver/mongodbatlasreceiver/documentation.md
+++ b/receiver/mongodbatlasreceiver/documentation.md
@@ -140,9 +140,9 @@ Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_FREE, DISK_PARTITION_SPACE_USE
 | ---- | ----------- | ------ |
 | disk_status | Disk measurement type | Str: ``free``, ``used`` |
 
-### mongodbatlas.disk.partition.usage.average
+### mongodbatlas.disk.partition.utilization.average
 
-Disk partition usage (%)
+Disk partition utilization (%)
 
 Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_SPACE_PERCENT_USED
 
@@ -156,9 +156,9 @@ Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_S
 | ---- | ----------- | ------ |
 | disk_status | Disk measurement type | Str: ``free``, ``used`` |
 
-### mongodbatlas.disk.partition.usage.max
+### mongodbatlas.disk.partition.utilization.max
 
-Disk partition usage (%)
+Disk partition utilization (%)
 
 Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PARTITION_SPACE_PERCENT_FREE
 
@@ -171,26 +171,6 @@ Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PAR
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | disk_status | Disk measurement type | Str: ``free``, ``used`` |
-
-### mongodbatlas.disk.partition.utilization.average
-
-Disk partition utilization (%)
-
-MongoDB Metrics DISK_PARTITION_UTILIZATION
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
-
-### mongodbatlas.disk.partition.utilization.max
-
-Disk partition utilization (%)
-
-MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
 
 ### mongodbatlas.process.asserts
 
@@ -501,6 +481,22 @@ Aggregate of MongoDB Metrics DB_INDEX_SIZE_TOTAL, DB_DATA_SIZE_TOTAL_WO_SYSTEM, 
 | ---- | ----------- | ------ |
 | storage_status | Views on database size | Str: ``total``, ``data_size``, ``index_size``, ``data_size_wo_system`` |
 
+### mongodbatlas.process.fts.cpu.usage
+
+Full text search CPU (%)
+
+Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| 1 | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| cpu_state | CPU state | Str: ``kernel``, ``user``, ``nice``, ``iowait``, ``irq``, ``softirq``, ``guest``, ``steal`` |
+
 ### mongodbatlas.process.global_lock
 
 Number and status of locks
@@ -765,9 +761,7 @@ Aggregate of MongoDB Metrics FTS_PROCESS_NORMALIZED_CPU_USER, FTS_PROCESS_NORMAL
 
 ### mongodbatlas.system.fts.cpu.usage
 
-Full text search CPU (%)
-
-Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
+Full-text search (%)
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -783,7 +777,7 @@ Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
 
 Full text search disk usage
 
-MongoDB Metric FTS_DISK_USAGE (Documentation incorrectly claims FTS_DISK_UTILIZATION)
+MongoDB Metric FTS_DISK_USAGE
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |

--- a/receiver/mongodbatlasreceiver/documentation.md
+++ b/receiver/mongodbatlasreceiver/documentation.md
@@ -501,22 +501,6 @@ Aggregate of MongoDB Metrics DB_INDEX_SIZE_TOTAL, DB_DATA_SIZE_TOTAL_WO_SYSTEM, 
 | ---- | ----------- | ------ |
 | storage_status | Views on database size | Str: ``total``, ``data_size``, ``index_size``, ``data_size_wo_system`` |
 
-### mongodbatlas.process.fts.cpu.usage
-
-Full text search CPU (%)
-
-Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| 1 | Gauge | Double |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| cpu_state | CPU state | Str: ``kernel``, ``user``, ``nice``, ``iowait``, ``irq``, ``softirq``, ``guest``, ``steal`` |
-
 ### mongodbatlas.process.global_lock
 
 Number and status of locks
@@ -782,6 +766,8 @@ Aggregate of MongoDB Metrics FTS_PROCESS_NORMALIZED_CPU_USER, FTS_PROCESS_NORMAL
 ### mongodbatlas.system.fts.cpu.usage
 
 Full-text search (%)
+
+Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
@@ -65,7 +65,6 @@ type MetricsSettings struct {
 	MongodbatlasProcessDbQueryExecutorScanned             MetricSettings `mapstructure:"mongodbatlas.process.db.query_executor.scanned"`
 	MongodbatlasProcessDbQueryTargetingScannedPerReturned MetricSettings `mapstructure:"mongodbatlas.process.db.query_targeting.scanned_per_returned"`
 	MongodbatlasProcessDbStorage                          MetricSettings `mapstructure:"mongodbatlas.process.db.storage"`
-	MongodbatlasProcessFtsCPUUsage                        MetricSettings `mapstructure:"mongodbatlas.process.fts.cpu.usage"`
 	MongodbatlasProcessGlobalLock                         MetricSettings `mapstructure:"mongodbatlas.process.global_lock"`
 	MongodbatlasProcessIndexBtreeMissRatio                MetricSettings `mapstructure:"mongodbatlas.process.index.btree_miss_ratio"`
 	MongodbatlasProcessIndexCounters                      MetricSettings `mapstructure:"mongodbatlas.process.index.counters"`
@@ -194,9 +193,6 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		MongodbatlasProcessDbStorage: MetricSettings{
-			Enabled: true,
-		},
-		MongodbatlasProcessFtsCPUUsage: MetricSettings{
 			Enabled: true,
 		},
 		MongodbatlasProcessGlobalLock: MetricSettings{
@@ -2697,57 +2693,6 @@ func newMetricMongodbatlasProcessDbStorage(settings MetricSettings) metricMongod
 	return m
 }
 
-type metricMongodbatlasProcessFtsCPUUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills mongodbatlas.process.fts.cpu.usage metric with initial data.
-func (m *metricMongodbatlasProcessFtsCPUUsage) init() {
-	m.data.SetName("mongodbatlas.process.fts.cpu.usage")
-	m.data.SetDescription("Full text search CPU (%)")
-	m.data.SetUnit("1")
-	m.data.SetEmptyGauge()
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricMongodbatlasProcessFtsCPUUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricMongodbatlasProcessFtsCPUUsage) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricMongodbatlasProcessFtsCPUUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricMongodbatlasProcessFtsCPUUsage(settings MetricSettings) metricMongodbatlasProcessFtsCPUUsage {
-	m := metricMongodbatlasProcessFtsCPUUsage{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricMongodbatlasProcessGlobalLock struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -4313,7 +4258,6 @@ type MetricsBuilder struct {
 	metricMongodbatlasProcessDbQueryExecutorScanned             metricMongodbatlasProcessDbQueryExecutorScanned
 	metricMongodbatlasProcessDbQueryTargetingScannedPerReturned metricMongodbatlasProcessDbQueryTargetingScannedPerReturned
 	metricMongodbatlasProcessDbStorage                          metricMongodbatlasProcessDbStorage
-	metricMongodbatlasProcessFtsCPUUsage                        metricMongodbatlasProcessFtsCPUUsage
 	metricMongodbatlasProcessGlobalLock                         metricMongodbatlasProcessGlobalLock
 	metricMongodbatlasProcessIndexBtreeMissRatio                metricMongodbatlasProcessIndexBtreeMissRatio
 	metricMongodbatlasProcessIndexCounters                      metricMongodbatlasProcessIndexCounters
@@ -4408,7 +4352,6 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		metricMongodbatlasProcessDbQueryExecutorScanned:             newMetricMongodbatlasProcessDbQueryExecutorScanned(mbc.Metrics.MongodbatlasProcessDbQueryExecutorScanned),
 		metricMongodbatlasProcessDbQueryTargetingScannedPerReturned: newMetricMongodbatlasProcessDbQueryTargetingScannedPerReturned(mbc.Metrics.MongodbatlasProcessDbQueryTargetingScannedPerReturned),
 		metricMongodbatlasProcessDbStorage:                          newMetricMongodbatlasProcessDbStorage(mbc.Metrics.MongodbatlasProcessDbStorage),
-		metricMongodbatlasProcessFtsCPUUsage:                        newMetricMongodbatlasProcessFtsCPUUsage(mbc.Metrics.MongodbatlasProcessFtsCPUUsage),
 		metricMongodbatlasProcessGlobalLock:                         newMetricMongodbatlasProcessGlobalLock(mbc.Metrics.MongodbatlasProcessGlobalLock),
 		metricMongodbatlasProcessIndexBtreeMissRatio:                newMetricMongodbatlasProcessIndexBtreeMissRatio(mbc.Metrics.MongodbatlasProcessIndexBtreeMissRatio),
 		metricMongodbatlasProcessIndexCounters:                      newMetricMongodbatlasProcessIndexCounters(mbc.Metrics.MongodbatlasProcessIndexCounters),
@@ -4613,7 +4556,6 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricMongodbatlasProcessDbQueryExecutorScanned.emit(ils.Metrics())
 	mb.metricMongodbatlasProcessDbQueryTargetingScannedPerReturned.emit(ils.Metrics())
 	mb.metricMongodbatlasProcessDbStorage.emit(ils.Metrics())
-	mb.metricMongodbatlasProcessFtsCPUUsage.emit(ils.Metrics())
 	mb.metricMongodbatlasProcessGlobalLock.emit(ils.Metrics())
 	mb.metricMongodbatlasProcessIndexBtreeMissRatio.emit(ils.Metrics())
 	mb.metricMongodbatlasProcessIndexCounters.emit(ils.Metrics())
@@ -4822,11 +4764,6 @@ func (mb *MetricsBuilder) RecordMongodbatlasProcessDbQueryTargetingScannedPerRet
 // RecordMongodbatlasProcessDbStorageDataPoint adds a data point to mongodbatlas.process.db.storage metric.
 func (mb *MetricsBuilder) RecordMongodbatlasProcessDbStorageDataPoint(ts pcommon.Timestamp, val float64, storageStatusAttributeValue AttributeStorageStatus) {
 	mb.metricMongodbatlasProcessDbStorage.recordDataPoint(mb.startTime, ts, val, storageStatusAttributeValue.String())
-}
-
-// RecordMongodbatlasProcessFtsCPUUsageDataPoint adds a data point to mongodbatlas.process.fts.cpu.usage metric.
-func (mb *MetricsBuilder) RecordMongodbatlasProcessFtsCPUUsageDataPoint(ts pcommon.Timestamp, val float64, cpuStateAttributeValue AttributeCPUState) {
-	mb.metricMongodbatlasProcessFtsCPUUsage.recordDataPoint(mb.startTime, ts, val, cpuStateAttributeValue.String())
 }
 
 // RecordMongodbatlasProcessGlobalLockDataPoint adds a data point to mongodbatlas.process.global_lock metric.

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
@@ -65,7 +65,6 @@ type MetricsSettings struct {
 	MongodbatlasProcessDbQueryExecutorScanned             MetricSettings `mapstructure:"mongodbatlas.process.db.query_executor.scanned"`
 	MongodbatlasProcessDbQueryTargetingScannedPerReturned MetricSettings `mapstructure:"mongodbatlas.process.db.query_targeting.scanned_per_returned"`
 	MongodbatlasProcessDbStorage                          MetricSettings `mapstructure:"mongodbatlas.process.db.storage"`
-	MongodbatlasProcessFtsCPUUsage                        MetricSettings `mapstructure:"mongodbatlas.process.fts.cpu.usage"`
 	MongodbatlasProcessGlobalLock                         MetricSettings `mapstructure:"mongodbatlas.process.global_lock"`
 	MongodbatlasProcessIndexBtreeMissRatio                MetricSettings `mapstructure:"mongodbatlas.process.index.btree_miss_ratio"`
 	MongodbatlasProcessIndexCounters                      MetricSettings `mapstructure:"mongodbatlas.process.index.counters"`
@@ -194,9 +193,6 @@ func DefaultMetricsSettings() MetricsSettings {
 			Enabled: true,
 		},
 		MongodbatlasProcessDbStorage: MetricSettings{
-			Enabled: true,
-		},
-		MongodbatlasProcessFtsCPUUsage: MetricSettings{
 			Enabled: true,
 		},
 		MongodbatlasProcessGlobalLock: MetricSettings{
@@ -1588,10 +1584,9 @@ func (m *metricMongodbatlasDiskPartitionUtilizationAverage) init() {
 	m.data.SetDescription("Disk partition utilization (%)")
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricMongodbatlasDiskPartitionUtilizationAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskStatusAttributeValue string) {
+func (m *metricMongodbatlasDiskPartitionUtilizationAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -1599,7 +1594,6 @@ func (m *metricMongodbatlasDiskPartitionUtilizationAverage) recordDataPoint(star
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("disk_status", diskStatusAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -1639,10 +1633,9 @@ func (m *metricMongodbatlasDiskPartitionUtilizationMax) init() {
 	m.data.SetDescription("Disk partition utilization (%)")
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricMongodbatlasDiskPartitionUtilizationMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskStatusAttributeValue string) {
+func (m *metricMongodbatlasDiskPartitionUtilizationMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
 	if !m.settings.Enabled {
 		return
 	}
@@ -1650,7 +1643,6 @@ func (m *metricMongodbatlasDiskPartitionUtilizationMax) recordDataPoint(start pc
 	dp.SetStartTimestamp(start)
 	dp.SetTimestamp(ts)
 	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("disk_status", diskStatusAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -2701,57 +2693,6 @@ func newMetricMongodbatlasProcessDbStorage(settings MetricSettings) metricMongod
 	return m
 }
 
-type metricMongodbatlasProcessFtsCPUUsage struct {
-	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
-	capacity int            // max observed number of data points added to the metric.
-}
-
-// init fills mongodbatlas.process.fts.cpu.usage metric with initial data.
-func (m *metricMongodbatlasProcessFtsCPUUsage) init() {
-	m.data.SetName("mongodbatlas.process.fts.cpu.usage")
-	m.data.SetDescription("Full text search CPU (%)")
-	m.data.SetUnit("1")
-	m.data.SetEmptyGauge()
-	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
-}
-
-func (m *metricMongodbatlasProcessFtsCPUUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
-		return
-	}
-	dp := m.data.Gauge().DataPoints().AppendEmpty()
-	dp.SetStartTimestamp(start)
-	dp.SetTimestamp(ts)
-	dp.SetDoubleValue(val)
-	dp.Attributes().PutStr("cpu_state", cpuStateAttributeValue)
-}
-
-// updateCapacity saves max length of data point slices that will be used for the slice capacity.
-func (m *metricMongodbatlasProcessFtsCPUUsage) updateCapacity() {
-	if m.data.Gauge().DataPoints().Len() > m.capacity {
-		m.capacity = m.data.Gauge().DataPoints().Len()
-	}
-}
-
-// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
-func (m *metricMongodbatlasProcessFtsCPUUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
-		m.updateCapacity()
-		m.data.MoveTo(metrics.AppendEmpty())
-		m.init()
-	}
-}
-
-func newMetricMongodbatlasProcessFtsCPUUsage(settings MetricSettings) metricMongodbatlasProcessFtsCPUUsage {
-	m := metricMongodbatlasProcessFtsCPUUsage{settings: settings}
-	if settings.Enabled {
-		m.data = pmetric.NewMetric()
-		m.init()
-	}
-	return m
-}
-
 type metricMongodbatlasProcessGlobalLock struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	settings MetricSettings // metric settings provided by user.
@@ -3718,7 +3659,7 @@ type metricMongodbatlasSystemFtsCPUUsage struct {
 // init fills mongodbatlas.system.fts.cpu.usage metric with initial data.
 func (m *metricMongodbatlasSystemFtsCPUUsage) init() {
 	m.data.SetName("mongodbatlas.system.fts.cpu.usage")
-	m.data.SetDescription("Full-text search (%)")
+	m.data.SetDescription("Full text search CPU (%)")
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
@@ -4317,7 +4258,6 @@ type MetricsBuilder struct {
 	metricMongodbatlasProcessDbQueryExecutorScanned             metricMongodbatlasProcessDbQueryExecutorScanned
 	metricMongodbatlasProcessDbQueryTargetingScannedPerReturned metricMongodbatlasProcessDbQueryTargetingScannedPerReturned
 	metricMongodbatlasProcessDbStorage                          metricMongodbatlasProcessDbStorage
-	metricMongodbatlasProcessFtsCPUUsage                        metricMongodbatlasProcessFtsCPUUsage
 	metricMongodbatlasProcessGlobalLock                         metricMongodbatlasProcessGlobalLock
 	metricMongodbatlasProcessIndexBtreeMissRatio                metricMongodbatlasProcessIndexBtreeMissRatio
 	metricMongodbatlasProcessIndexCounters                      metricMongodbatlasProcessIndexCounters
@@ -4412,7 +4352,6 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		metricMongodbatlasProcessDbQueryExecutorScanned:             newMetricMongodbatlasProcessDbQueryExecutorScanned(mbc.Metrics.MongodbatlasProcessDbQueryExecutorScanned),
 		metricMongodbatlasProcessDbQueryTargetingScannedPerReturned: newMetricMongodbatlasProcessDbQueryTargetingScannedPerReturned(mbc.Metrics.MongodbatlasProcessDbQueryTargetingScannedPerReturned),
 		metricMongodbatlasProcessDbStorage:                          newMetricMongodbatlasProcessDbStorage(mbc.Metrics.MongodbatlasProcessDbStorage),
-		metricMongodbatlasProcessFtsCPUUsage:                        newMetricMongodbatlasProcessFtsCPUUsage(mbc.Metrics.MongodbatlasProcessFtsCPUUsage),
 		metricMongodbatlasProcessGlobalLock:                         newMetricMongodbatlasProcessGlobalLock(mbc.Metrics.MongodbatlasProcessGlobalLock),
 		metricMongodbatlasProcessIndexBtreeMissRatio:                newMetricMongodbatlasProcessIndexBtreeMissRatio(mbc.Metrics.MongodbatlasProcessIndexBtreeMissRatio),
 		metricMongodbatlasProcessIndexCounters:                      newMetricMongodbatlasProcessIndexCounters(mbc.Metrics.MongodbatlasProcessIndexCounters),
@@ -4617,7 +4556,6 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricMongodbatlasProcessDbQueryExecutorScanned.emit(ils.Metrics())
 	mb.metricMongodbatlasProcessDbQueryTargetingScannedPerReturned.emit(ils.Metrics())
 	mb.metricMongodbatlasProcessDbStorage.emit(ils.Metrics())
-	mb.metricMongodbatlasProcessFtsCPUUsage.emit(ils.Metrics())
 	mb.metricMongodbatlasProcessGlobalLock.emit(ils.Metrics())
 	mb.metricMongodbatlasProcessIndexBtreeMissRatio.emit(ils.Metrics())
 	mb.metricMongodbatlasProcessIndexCounters.emit(ils.Metrics())
@@ -4719,13 +4657,13 @@ func (mb *MetricsBuilder) RecordMongodbatlasDiskPartitionUsageMaxDataPoint(ts pc
 }
 
 // RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint adds a data point to mongodbatlas.disk.partition.utilization.average metric.
-func (mb *MetricsBuilder) RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts pcommon.Timestamp, val float64, diskStatusAttributeValue AttributeDiskStatus) {
-	mb.metricMongodbatlasDiskPartitionUtilizationAverage.recordDataPoint(mb.startTime, ts, val, diskStatusAttributeValue.String())
+func (mb *MetricsBuilder) RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricMongodbatlasDiskPartitionUtilizationAverage.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint adds a data point to mongodbatlas.disk.partition.utilization.max metric.
-func (mb *MetricsBuilder) RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts pcommon.Timestamp, val float64, diskStatusAttributeValue AttributeDiskStatus) {
-	mb.metricMongodbatlasDiskPartitionUtilizationMax.recordDataPoint(mb.startTime, ts, val, diskStatusAttributeValue.String())
+func (mb *MetricsBuilder) RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts pcommon.Timestamp, val float64) {
+	mb.metricMongodbatlasDiskPartitionUtilizationMax.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordMongodbatlasProcessAssertsDataPoint adds a data point to mongodbatlas.process.asserts metric.
@@ -4826,11 +4764,6 @@ func (mb *MetricsBuilder) RecordMongodbatlasProcessDbQueryTargetingScannedPerRet
 // RecordMongodbatlasProcessDbStorageDataPoint adds a data point to mongodbatlas.process.db.storage metric.
 func (mb *MetricsBuilder) RecordMongodbatlasProcessDbStorageDataPoint(ts pcommon.Timestamp, val float64, storageStatusAttributeValue AttributeStorageStatus) {
 	mb.metricMongodbatlasProcessDbStorage.recordDataPoint(mb.startTime, ts, val, storageStatusAttributeValue.String())
-}
-
-// RecordMongodbatlasProcessFtsCPUUsageDataPoint adds a data point to mongodbatlas.process.fts.cpu.usage metric.
-func (mb *MetricsBuilder) RecordMongodbatlasProcessFtsCPUUsageDataPoint(ts pcommon.Timestamp, val float64, cpuStateAttributeValue AttributeCPUState) {
-	mb.metricMongodbatlasProcessFtsCPUUsage.recordDataPoint(mb.startTime, ts, val, cpuStateAttributeValue.String())
 }
 
 // RecordMongodbatlasProcessGlobalLockDataPoint adds a data point to mongodbatlas.process.global_lock metric.

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
@@ -1581,7 +1581,7 @@ type metricMongodbatlasDiskPartitionUtilizationAverage struct {
 // init fills mongodbatlas.disk.partition.utilization.average metric with initial data.
 func (m *metricMongodbatlasDiskPartitionUtilizationAverage) init() {
 	m.data.SetName("mongodbatlas.disk.partition.utilization.average")
-	m.data.SetDescription("The maximum percentage of time during which requests are being issued to and serviced by the partition.")
+	m.data.SetDescription("The percentage of time during which requests are being issued to and serviced by the partition.")
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 }
@@ -1630,7 +1630,7 @@ type metricMongodbatlasDiskPartitionUtilizationMax struct {
 // init fills mongodbatlas.disk.partition.utilization.max metric with initial data.
 func (m *metricMongodbatlasDiskPartitionUtilizationMax) init() {
 	m.data.SetName("mongodbatlas.disk.partition.utilization.max")
-	m.data.SetDescription("The percentage of time during which requests are being issued to and serviced by the partition.")
+	m.data.SetDescription("The maximum percentage of time during which requests are being issued to and serviced by the partition.")
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 }

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
@@ -92,11 +92,19 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts, 1, AttributeDiskStatus(1))
+			mb.RecordMongodbatlasDiskPartitionUsageAverageDataPoint(ts, 1, AttributeDiskStatus(1))
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts, 1, AttributeDiskStatus(1))
+			mb.RecordMongodbatlasDiskPartitionUsageMaxDataPoint(ts, 1, AttributeDiskStatus(1))
+
+			defaultMetricsCount++
+			allMetricsCount++
+			mb.RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts, 1)
+
+			defaultMetricsCount++
+			allMetricsCount++
+			mb.RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts, 1)
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -517,36 +525,60 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok := dp.Attributes().Get("disk_status")
 					assert.True(t, ok)
 					assert.Equal(t, "free", attrVal.Str())
+				case "mongodbatlas.disk.partition.usage.average":
+					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.average")
+					validatedMetrics["mongodbatlas.disk.partition.usage.average"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+					assert.Equal(t, "Disk partition usage (%)", ms.At(i).Description())
+					assert.Equal(t, "1", ms.At(i).Unit())
+					dp := ms.At(i).Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.Equal(t, float64(1), dp.DoubleValue())
+					attrVal, ok := dp.Attributes().Get("disk_status")
+					assert.True(t, ok)
+					assert.Equal(t, "free", attrVal.Str())
+				case "mongodbatlas.disk.partition.usage.max":
+					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.max")
+					validatedMetrics["mongodbatlas.disk.partition.usage.max"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+					assert.Equal(t, "Disk partition usage (%)", ms.At(i).Description())
+					assert.Equal(t, "1", ms.At(i).Unit())
+					dp := ms.At(i).Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.Equal(t, float64(1), dp.DoubleValue())
+					attrVal, ok := dp.Attributes().Get("disk_status")
+					assert.True(t, ok)
+					assert.Equal(t, "free", attrVal.Str())
 				case "mongodbatlas.disk.partition.utilization.average":
 					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.utilization.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.utilization.average")
 					validatedMetrics["mongodbatlas.disk.partition.utilization.average"] = true
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition utilization (%)", ms.At(i).Description())
+					assert.Equal(t, "The maximum percentage of time during which requests are being issued to and serviced by the partition.", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.Equal(t, float64(1), dp.DoubleValue())
-					attrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", attrVal.Str())
 				case "mongodbatlas.disk.partition.utilization.max":
 					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.utilization.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.utilization.max")
 					validatedMetrics["mongodbatlas.disk.partition.utilization.max"] = true
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition utilization (%)", ms.At(i).Description())
+					assert.Equal(t, "The percentage of time during which requests are being issued to and serviced by the partition.", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.Equal(t, float64(1), dp.DoubleValue())
-					attrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", attrVal.Str())
 				case "mongodbatlas.process.asserts":
 					assert.False(t, validatedMetrics["mongodbatlas.process.asserts"], "Found a duplicate in the metrics slice: mongodbatlas.process.asserts")
 					validatedMetrics["mongodbatlas.process.asserts"] = true

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
@@ -556,7 +556,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["mongodbatlas.disk.partition.utilization.average"] = true
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The maximum percentage of time during which requests are being issued to and serviced by the partition.", ms.At(i).Description())
+					assert.Equal(t, "The percentage of time during which requests are being issued to and serviced by the partition.", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
@@ -568,7 +568,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["mongodbatlas.disk.partition.utilization.max"] = true
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "The percentage of time during which requests are being issued to and serviced by the partition.", ms.At(i).Description())
+					assert.Equal(t, "The maximum percentage of time during which requests are being issued to and serviced by the partition.", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
@@ -188,10 +188,6 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordMongodbatlasProcessFtsCPUUsageDataPoint(ts, 1, AttributeCPUState(1))
-
-			defaultMetricsCount++
-			allMetricsCount++
 			mb.RecordMongodbatlasProcessGlobalLockDataPoint(ts, 1, AttributeGlobalLockState(1))
 
 			defaultMetricsCount++
@@ -882,21 +878,6 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok := dp.Attributes().Get("storage_status")
 					assert.True(t, ok)
 					assert.Equal(t, "total", attrVal.Str())
-				case "mongodbatlas.process.fts.cpu.usage":
-					assert.False(t, validatedMetrics["mongodbatlas.process.fts.cpu.usage"], "Found a duplicate in the metrics slice: mongodbatlas.process.fts.cpu.usage")
-					validatedMetrics["mongodbatlas.process.fts.cpu.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Full text search CPU (%)", ms.At(i).Description())
-					assert.Equal(t, "1", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.Equal(t, float64(1), dp.DoubleValue())
-					attrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", attrVal.Str())
 				case "mongodbatlas.process.global_lock":
 					assert.False(t, validatedMetrics["mongodbatlas.process.global_lock"], "Found a duplicate in the metrics slice: mongodbatlas.process.global_lock")
 					validatedMetrics["mongodbatlas.process.global_lock"] = true

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
@@ -100,11 +100,11 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts, 1, AttributeDiskStatus(1))
+			mb.RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts, 1)
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts, 1, AttributeDiskStatus(1))
+			mb.RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts, 1)
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -185,10 +185,6 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbStorageDataPoint(ts, 1, AttributeStorageStatus(1))
-
-			defaultMetricsCount++
-			allMetricsCount++
-			mb.RecordMongodbatlasProcessFtsCPUUsageDataPoint(ts, 1, AttributeCPUState(1))
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -567,9 +563,6 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.Equal(t, float64(1), dp.DoubleValue())
-					attrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", attrVal.Str())
 				case "mongodbatlas.disk.partition.utilization.max":
 					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.utilization.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.utilization.max")
 					validatedMetrics["mongodbatlas.disk.partition.utilization.max"] = true
@@ -582,9 +575,6 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.Equal(t, float64(1), dp.DoubleValue())
-					attrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", attrVal.Str())
 				case "mongodbatlas.process.asserts":
 					assert.False(t, validatedMetrics["mongodbatlas.process.asserts"], "Found a duplicate in the metrics slice: mongodbatlas.process.asserts")
 					validatedMetrics["mongodbatlas.process.asserts"] = true
@@ -888,21 +878,6 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok := dp.Attributes().Get("storage_status")
 					assert.True(t, ok)
 					assert.Equal(t, "total", attrVal.Str())
-				case "mongodbatlas.process.fts.cpu.usage":
-					assert.False(t, validatedMetrics["mongodbatlas.process.fts.cpu.usage"], "Found a duplicate in the metrics slice: mongodbatlas.process.fts.cpu.usage")
-					validatedMetrics["mongodbatlas.process.fts.cpu.usage"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Full text search CPU (%)", ms.At(i).Description())
-					assert.Equal(t, "1", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.Equal(t, float64(1), dp.DoubleValue())
-					attrVal, ok := dp.Attributes().Get("cpu_state")
-					assert.True(t, ok)
-					assert.Equal(t, "kernel", attrVal.Str())
 				case "mongodbatlas.process.global_lock":
 					assert.False(t, validatedMetrics["mongodbatlas.process.global_lock"], "Found a duplicate in the metrics slice: mongodbatlas.process.global_lock")
 					validatedMetrics["mongodbatlas.process.global_lock"] = true
@@ -1174,7 +1149,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["mongodbatlas.system.fts.cpu.usage"] = true
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Full-text search (%)", ms.At(i).Description())
+					assert.Equal(t, "Full text search CPU (%)", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
@@ -92,19 +92,11 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordMongodbatlasDiskPartitionUsageAverageDataPoint(ts, 1, AttributeDiskStatus(1))
+			mb.RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts, 1, AttributeDiskStatus(1))
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordMongodbatlasDiskPartitionUsageMaxDataPoint(ts, 1, AttributeDiskStatus(1))
-
-			defaultMetricsCount++
-			allMetricsCount++
-			mb.RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts, 1)
-
-			defaultMetricsCount++
-			allMetricsCount++
-			mb.RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts, 1)
+			mb.RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts, 1, AttributeDiskStatus(1))
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -185,6 +177,10 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMongodbatlasProcessDbStorageDataPoint(ts, 1, AttributeStorageStatus(1))
+
+			defaultMetricsCount++
+			allMetricsCount++
+			mb.RecordMongodbatlasProcessFtsCPUUsageDataPoint(ts, 1, AttributeCPUState(1))
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -521,36 +517,6 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok := dp.Attributes().Get("disk_status")
 					assert.True(t, ok)
 					assert.Equal(t, "free", attrVal.Str())
-				case "mongodbatlas.disk.partition.usage.average":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.average")
-					validatedMetrics["mongodbatlas.disk.partition.usage.average"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition usage (%)", ms.At(i).Description())
-					assert.Equal(t, "1", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.Equal(t, float64(1), dp.DoubleValue())
-					attrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", attrVal.Str())
-				case "mongodbatlas.disk.partition.usage.max":
-					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.usage.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.usage.max")
-					validatedMetrics["mongodbatlas.disk.partition.usage.max"] = true
-					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Disk partition usage (%)", ms.At(i).Description())
-					assert.Equal(t, "1", ms.At(i).Unit())
-					dp := ms.At(i).Gauge().DataPoints().At(0)
-					assert.Equal(t, start, dp.StartTimestamp())
-					assert.Equal(t, ts, dp.Timestamp())
-					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
-					assert.Equal(t, float64(1), dp.DoubleValue())
-					attrVal, ok := dp.Attributes().Get("disk_status")
-					assert.True(t, ok)
-					assert.Equal(t, "free", attrVal.Str())
 				case "mongodbatlas.disk.partition.utilization.average":
 					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.utilization.average"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.utilization.average")
 					validatedMetrics["mongodbatlas.disk.partition.utilization.average"] = true
@@ -563,6 +529,9 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.Equal(t, float64(1), dp.DoubleValue())
+					attrVal, ok := dp.Attributes().Get("disk_status")
+					assert.True(t, ok)
+					assert.Equal(t, "free", attrVal.Str())
 				case "mongodbatlas.disk.partition.utilization.max":
 					assert.False(t, validatedMetrics["mongodbatlas.disk.partition.utilization.max"], "Found a duplicate in the metrics slice: mongodbatlas.disk.partition.utilization.max")
 					validatedMetrics["mongodbatlas.disk.partition.utilization.max"] = true
@@ -575,6 +544,9 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.Equal(t, float64(1), dp.DoubleValue())
+					attrVal, ok := dp.Attributes().Get("disk_status")
+					assert.True(t, ok)
+					assert.Equal(t, "free", attrVal.Str())
 				case "mongodbatlas.process.asserts":
 					assert.False(t, validatedMetrics["mongodbatlas.process.asserts"], "Found a duplicate in the metrics slice: mongodbatlas.process.asserts")
 					validatedMetrics["mongodbatlas.process.asserts"] = true
@@ -878,6 +850,21 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok := dp.Attributes().Get("storage_status")
 					assert.True(t, ok)
 					assert.Equal(t, "total", attrVal.Str())
+				case "mongodbatlas.process.fts.cpu.usage":
+					assert.False(t, validatedMetrics["mongodbatlas.process.fts.cpu.usage"], "Found a duplicate in the metrics slice: mongodbatlas.process.fts.cpu.usage")
+					validatedMetrics["mongodbatlas.process.fts.cpu.usage"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+					assert.Equal(t, "Full text search CPU (%)", ms.At(i).Description())
+					assert.Equal(t, "1", ms.At(i).Unit())
+					dp := ms.At(i).Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.Equal(t, float64(1), dp.DoubleValue())
+					attrVal, ok := dp.Attributes().Get("cpu_state")
+					assert.True(t, ok)
+					assert.Equal(t, "kernel", attrVal.Str())
 				case "mongodbatlas.process.global_lock":
 					assert.False(t, validatedMetrics["mongodbatlas.process.global_lock"], "Found a duplicate in the metrics slice: mongodbatlas.process.global_lock")
 					validatedMetrics["mongodbatlas.process.global_lock"] = true
@@ -1149,7 +1136,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["mongodbatlas.system.fts.cpu.usage"] = true
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Full text search CPU (%)", ms.At(i).Description())
+					assert.Equal(t, "Full-text search (%)", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())

--- a/receiver/mongodbatlasreceiver/internal/metadata/metric_name_mapping.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/metric_name_mapping.go
@@ -772,18 +772,6 @@ func getRecordFunc(metricName string) metricRecordFunc {
 			mb.RecordMongodbatlasDiskPartitionLatencyMaxDataPoint(ts, float64(*dp.Value), AttributeDiskDirectionWrite)
 		}
 
-	// The percentage of time during which requests are being issued to and serviced by the partition.
-	// This includes requests from any process, not just MongoDB processes.
-	case "DISK_PARTITION_UTILIZATION":
-		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
-			mb.RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts, float64(*dp.Value))
-		}
-
-	case "MAX_DISK_PARTITION_UTILIZATION":
-		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
-			mb.RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts, float64(*dp.Value))
-		}
-
 	// Measures the free disk space and used disk space on the disk partition used by MongoDB.
 	case "DISK_PARTITION_SPACE_FREE":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {

--- a/receiver/mongodbatlasreceiver/internal/metadata/metric_name_mapping.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/metric_name_mapping.go
@@ -693,6 +693,12 @@ func getRecordFunc(metricName string) metricRecordFunc {
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
 			mb.RecordMongodbatlasSystemFtsDiskUsedDataPoint(ts, float64(*dp.Value))
 		}
+	// This is the documented field name, but FTS_DISK_USAGE is what is returned from the API.
+	// Placing this here in case the metric naming is fixed in the future.
+	case "FTS_DISK_UTILIZATION":
+		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
+			mb.RecordMongodbatlasSystemFtsDiskUsedDataPoint(ts, float64(*dp.Value))
+		}
 
 	// Percentage of CPU that Atlas Search processes use.
 	case "FTS_PROCESS_CPU_USER":
@@ -745,8 +751,7 @@ func getRecordFunc(metricName string) metricRecordFunc {
 			mb.RecordMongodbatlasDiskPartitionIopsMaxDataPoint(ts, float64(*dp.Value), AttributeDiskDirectionTotal)
 		}
 
-	// The percentage of time during which requests are being issued to and serviced by the partition.
-	// This includes requests from any process, not just MongoDB processes.
+	// Measures latency per operation type of the disk partition used by MongoDB.
 	case "DISK_PARTITION_LATENCY_READ":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
 			mb.RecordMongodbatlasDiskPartitionLatencyAverageDataPoint(ts, float64(*dp.Value), AttributeDiskDirectionRead)
@@ -767,7 +772,19 @@ func getRecordFunc(metricName string) metricRecordFunc {
 			mb.RecordMongodbatlasDiskPartitionLatencyMaxDataPoint(ts, float64(*dp.Value), AttributeDiskDirectionWrite)
 		}
 
-	// Measures latency per operation type of the disk partition used by MongoDB.
+	// The percentage of time during which requests are being issued to and serviced by the partition.
+	// This includes requests from any process, not just MongoDB processes.
+	case "DISK_PARTITION_UTILIZATION":
+		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
+			mb.RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts, float64(*dp.Value))
+		}
+
+	case "MAX_DISK_PARTITION_UTILIZATION":
+		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
+			mb.RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts, float64(*dp.Value))
+		}
+
+	// Measures the free disk space and used disk space on the disk partition used by MongoDB.
 	case "DISK_PARTITION_SPACE_FREE":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
 			mb.RecordMongodbatlasDiskPartitionSpaceAverageDataPoint(ts, float64(*dp.Value), AttributeDiskStatusFree)

--- a/receiver/mongodbatlasreceiver/internal/metadata/metric_name_mapping.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/metric_name_mapping.go
@@ -689,17 +689,12 @@ func getRecordFunc(metricName string) metricRecordFunc {
 		}
 
 	// Disk space, in bytes, that Atlas Search indexes use.
-	case "FTS_DISK_USAGE":
+	// FTS_DISK_UTILIZATION is the documented field name, but FTS_DISK_USAGE is what is returned from the API.
+	// Including both so if the API changes to match the documentation this metric is still collected.
+	case "FTS_DISK_USAGE", "FTS_DISK_UTILIZATION":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
 			mb.RecordMongodbatlasSystemFtsDiskUsedDataPoint(ts, float64(*dp.Value))
 		}
-	// This is the documented field name, but FTS_DISK_USAGE is what is returned from the API.
-	// Placing this here in case the metric naming is fixed in the future.
-	case "FTS_DISK_UTILIZATION":
-		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
-			mb.RecordMongodbatlasSystemFtsDiskUsedDataPoint(ts, float64(*dp.Value))
-		}
-
 	// Percentage of CPU that Atlas Search processes use.
 	case "FTS_PROCESS_CPU_USER":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {

--- a/receiver/mongodbatlasreceiver/internal/metadata/metric_name_mapping.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/metric_name_mapping.go
@@ -772,6 +772,18 @@ func getRecordFunc(metricName string) metricRecordFunc {
 			mb.RecordMongodbatlasDiskPartitionLatencyMaxDataPoint(ts, float64(*dp.Value), AttributeDiskDirectionWrite)
 		}
 
+	// The percentage of time during which requests are being issued to and serviced by the partition.
+	// This includes requests from any process, not just MongoDB processes.
+	case "DISK_PARTITION_UTILIZATION":
+		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
+			mb.RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts, float64(*dp.Value))
+		}
+
+	case "MAX_DISK_PARTITION_UTILIZATION":
+		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
+			mb.RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts, float64(*dp.Value))
+		}
+
 	// Measures the free disk space and used disk space on the disk partition used by MongoDB.
 	case "DISK_PARTITION_SPACE_FREE":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
@@ -795,19 +807,19 @@ func getRecordFunc(metricName string) metricRecordFunc {
 
 	case "DISK_PARTITION_SPACE_PERCENT_FREE":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
-			mb.RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts, float64(*dp.Value), AttributeDiskStatusFree)
+			mb.RecordMongodbatlasDiskPartitionUsageAverageDataPoint(ts, float64(*dp.Value), AttributeDiskStatusFree)
 		}
 	case "MAX_DISK_PARTITION_SPACE_PERCENT_FREE":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
-			mb.RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts, float64(*dp.Value), AttributeDiskStatusFree)
+			mb.RecordMongodbatlasDiskPartitionUsageMaxDataPoint(ts, float64(*dp.Value), AttributeDiskStatusFree)
 		}
 	case "DISK_PARTITION_SPACE_PERCENT_USED":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
-			mb.RecordMongodbatlasDiskPartitionUtilizationAverageDataPoint(ts, float64(*dp.Value), AttributeDiskStatusUsed)
+			mb.RecordMongodbatlasDiskPartitionUsageAverageDataPoint(ts, float64(*dp.Value), AttributeDiskStatusUsed)
 		}
 	case "MAX_DISK_PARTITION_SPACE_PERCENT_USED":
 		return func(mb *MetricsBuilder, dp *mongodbatlas.DataPoints, ts pcommon.Timestamp) {
-			mb.RecordMongodbatlasDiskPartitionUtilizationMaxDataPoint(ts, float64(*dp.Value), AttributeDiskStatusUsed)
+			mb.RecordMongodbatlasDiskPartitionUsageMaxDataPoint(ts, float64(*dp.Value), AttributeDiskStatusUsed)
 		}
 
 	// Process Database Measurements (https://docs.atlas.mongodb.com/reference/api/process-disks-measurements/)

--- a/receiver/mongodbatlasreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbatlasreceiver/internal/metadata/testdata/config.yaml
@@ -65,8 +65,6 @@ all_set:
       enabled: true
     mongodbatlas.process.db.storage:
       enabled: true
-    mongodbatlas.process.fts.cpu.usage:
-      enabled: true
     mongodbatlas.process.global_lock:
       enabled: true
     mongodbatlas.process.index.btree_miss_ratio:
@@ -213,8 +211,6 @@ none_set:
     mongodbatlas.process.db.query_targeting.scanned_per_returned:
       enabled: false
     mongodbatlas.process.db.storage:
-      enabled: false
-    mongodbatlas.process.fts.cpu.usage:
       enabled: false
     mongodbatlas.process.global_lock:
       enabled: false

--- a/receiver/mongodbatlasreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbatlasreceiver/internal/metadata/testdata/config.yaml
@@ -17,6 +17,10 @@ all_set:
       enabled: true
     mongodbatlas.disk.partition.space.max:
       enabled: true
+    mongodbatlas.disk.partition.usage.average:
+      enabled: true
+    mongodbatlas.disk.partition.usage.max:
+      enabled: true
     mongodbatlas.disk.partition.utilization.average:
       enabled: true
     mongodbatlas.disk.partition.utilization.max:
@@ -161,6 +165,10 @@ none_set:
     mongodbatlas.disk.partition.space.average:
       enabled: false
     mongodbatlas.disk.partition.space.max:
+      enabled: false
+    mongodbatlas.disk.partition.usage.average:
+      enabled: false
+    mongodbatlas.disk.partition.usage.max:
       enabled: false
     mongodbatlas.disk.partition.utilization.average:
       enabled: false

--- a/receiver/mongodbatlasreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbatlasreceiver/internal/metadata/testdata/config.yaml
@@ -17,10 +17,6 @@ all_set:
       enabled: true
     mongodbatlas.disk.partition.space.max:
       enabled: true
-    mongodbatlas.disk.partition.usage.average:
-      enabled: true
-    mongodbatlas.disk.partition.usage.max:
-      enabled: true
     mongodbatlas.disk.partition.utilization.average:
       enabled: true
     mongodbatlas.disk.partition.utilization.max:
@@ -64,6 +60,8 @@ all_set:
     mongodbatlas.process.db.query_targeting.scanned_per_returned:
       enabled: true
     mongodbatlas.process.db.storage:
+      enabled: true
+    mongodbatlas.process.fts.cpu.usage:
       enabled: true
     mongodbatlas.process.global_lock:
       enabled: true
@@ -164,10 +162,6 @@ none_set:
       enabled: false
     mongodbatlas.disk.partition.space.max:
       enabled: false
-    mongodbatlas.disk.partition.usage.average:
-      enabled: false
-    mongodbatlas.disk.partition.usage.max:
-      enabled: false
     mongodbatlas.disk.partition.utilization.average:
       enabled: false
     mongodbatlas.disk.partition.utilization.max:
@@ -211,6 +205,8 @@ none_set:
     mongodbatlas.process.db.query_targeting.scanned_per_returned:
       enabled: false
     mongodbatlas.process.db.storage:
+      enabled: false
+    mongodbatlas.process.fts.cpu.usage:
       enabled: false
     mongodbatlas.process.global_lock:
       enabled: false

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -344,14 +344,6 @@ metrics:
     attributes: [document_status]
     gauge:
       value_type: double
-  mongodbatlas.process.fts.cpu.usage:
-    enabled: true
-    description: Full text search CPU (%)
-    extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
-    unit: 1
-    attributes: [cpu_state]
-    gauge:
-      value_type: double
   mongodbatlas.process.global_lock:
     enabled: true
     description: Number and status of locks
@@ -626,7 +618,6 @@ metrics:
     description: Disk partition utilization (%)
     extended_documentation: MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
     unit: 1
-    attributes: [disk_status]
     gauge:
       value_type: double
   mongodbatlas.disk.partition.utilization.average:
@@ -634,7 +625,6 @@ metrics:
     description: Disk partition utilization (%)
     extended_documentation: MongoDB Metrics DISK_PARTITION_UTILIZATION
     unit: 1
-    attributes: [disk_status]
     gauge:
       value_type: double
   mongodbatlas.disk.partition.latency.max:
@@ -698,13 +688,14 @@ metrics:
   mongodbatlas.system.fts.disk.used:
     enabled: true
     description: Full text search disk usage
-    extended_documentation: MongoDB Metric FTS_DISK_USAGE
+    extended_documentation: MongoDB Metric FTS_DISK_USAGE (Documentation incorrectly claims FTS_DISK_UTILIZATION)
     unit: By
     gauge:
       value_type: double
   mongodbatlas.system.fts.cpu.usage:
     enabled: true
-    description: Full-text search (%)
+    description: Full text search CPU (%)
+    extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
     unit: 1
     attributes: [cpu_state]
     gauge:

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -605,20 +605,34 @@ metrics:
     attributes: [disk_direction]
     gauge:
       value_type: double
-  mongodbatlas.disk.partition.utilization.max:
+  mongodbatlas.disk.partition.usage.max:
     enabled: true
-    description: Disk partition utilization (%)
+    description: Disk partition usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PARTITION_SPACE_PERCENT_FREE
     unit: 1
     attributes: [disk_status]
     gauge:
       value_type: double
-  mongodbatlas.disk.partition.utilization.average:
+  mongodbatlas.disk.partition.usage.average:
     enabled: true
-    description: Disk partition utilization (%)
+    description: Disk partition usage (%)
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_SPACE_PERCENT_USED
     unit: 1
     attributes: [disk_status]
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.utilization.max:
+    enabled: true
+    description: The percentage of time during which requests are being issued to and serviced by the partition.
+    extended_documentation: MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
+    unit: 1
+    gauge:
+      value_type: double
+  mongodbatlas.disk.partition.utilization.average:
+    enabled: true
+    description: The maximum percentage of time during which requests are being issued to and serviced by the partition.
+    extended_documentation: MongoDB Metrics DISK_PARTITION_UTILIZATION
+    unit: 1
     gauge:
       value_type: double
   mongodbatlas.disk.partition.latency.max:

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -615,14 +615,14 @@ metrics:
       value_type: double
   mongodbatlas.disk.partition.utilization.max:
     enabled: true
-    description: The percentage of time during which requests are being issued to and serviced by the partition.
+    description: The maximum percentage of time during which requests are being issued to and serviced by the partition.
     extended_documentation: MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
     unit: 1
     gauge:
       value_type: double
   mongodbatlas.disk.partition.utilization.average:
     enabled: true
-    description: The maximum percentage of time during which requests are being issued to and serviced by the partition.
+    description: The percentage of time during which requests are being issued to and serviced by the partition.
     extended_documentation: MongoDB Metrics DISK_PARTITION_UTILIZATION
     unit: 1
     gauge:

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -344,14 +344,6 @@ metrics:
     attributes: [document_status]
     gauge:
       value_type: double
-  mongodbatlas.process.fts.cpu.usage:
-    enabled: true
-    description: Full text search CPU (%)
-    extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
-    unit: 1
-    attributes: [cpu_state]
-    gauge:
-      value_type: double
   mongodbatlas.process.global_lock:
     enabled: true
     description: Number and status of locks
@@ -703,6 +695,7 @@ metrics:
   mongodbatlas.system.fts.cpu.usage:
     enabled: true
     description: Full-text search (%)
+    extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
     unit: 1
     attributes: [cpu_state]
     gauge:

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -344,6 +344,14 @@ metrics:
     attributes: [document_status]
     gauge:
       value_type: double
+  mongodbatlas.process.fts.cpu.usage:
+    enabled: true
+    description: Full text search CPU (%)
+    extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
+    unit: 1
+    attributes: [cpu_state]
+    gauge:
+      value_type: double
   mongodbatlas.process.global_lock:
     enabled: true
     description: Number and status of locks
@@ -597,34 +605,20 @@ metrics:
     attributes: [disk_direction]
     gauge:
       value_type: double
-  mongodbatlas.disk.partition.usage.max:
+  mongodbatlas.disk.partition.utilization.max:
     enabled: true
-    description: Disk partition usage (%)
+    description: Disk partition utilization (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PARTITION_SPACE_PERCENT_FREE
     unit: 1
     attributes: [disk_status]
     gauge:
       value_type: double
-  mongodbatlas.disk.partition.usage.average:
-    enabled: true
-    description: Disk partition usage (%)
-    extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_SPACE_PERCENT_USED
-    unit: 1
-    attributes: [disk_status]
-    gauge:
-      value_type: double
-  mongodbatlas.disk.partition.utilization.max:
-    enabled: true
-    description: Disk partition utilization (%)
-    extended_documentation: MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
-    unit: 1
-    gauge:
-      value_type: double
   mongodbatlas.disk.partition.utilization.average:
     enabled: true
     description: Disk partition utilization (%)
-    extended_documentation: MongoDB Metrics DISK_PARTITION_UTILIZATION
+    extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_SPACE_PERCENT_USED
     unit: 1
+    attributes: [disk_status]
     gauge:
       value_type: double
   mongodbatlas.disk.partition.latency.max:
@@ -688,14 +682,13 @@ metrics:
   mongodbatlas.system.fts.disk.used:
     enabled: true
     description: Full text search disk usage
-    extended_documentation: MongoDB Metric FTS_DISK_USAGE (Documentation incorrectly claims FTS_DISK_UTILIZATION)
+    extended_documentation: MongoDB Metric FTS_DISK_USAGE
     unit: By
     gauge:
       value_type: double
   mongodbatlas.system.fts.cpu.usage:
     enabled: true
-    description: Full text search CPU (%)
-    extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
+    description: Full-text search (%)
     unit: 1
     attributes: [cpu_state]
     gauge:


### PR DESCRIPTION
**Description:** Disk Usage (percentage of space used) metrics are being reported under the Disk Utilization (percent of time partition was in use) metric for MongoDB Atlas Disk Partitions. The Disk Utilization metrics are not being collected.

Also removed a duplicated metric definition (process.fts.cpu.usage was a duplicate of system.fts.cpu.usage and of the two, only system.fts.cpu.usage was being collected)

See documentation https://www.mongodb.com/docs/atlas/reference/api/process-disks-measurements/#measurement-values

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21180

**Testing:** Validated that metrics were collected as expected.

**Documentation:** Documentation auto-generated.