### PR TITLE
[exporter/coralogix] Document multiple teams usage

### DIFF
--- a/exporter/coralogixexporter/README.md
+++ b/exporter/coralogixexporter/README.md
@@ -256,7 +256,6 @@ service:
       receivers: [prometheus]
       processors: [filter/teamB]
       exporters: [coralogix/teamB]
-
 ```
 
 ### Need help?

--- a/exporter/coralogixexporter/README.md
+++ b/exporter/coralogixexporter/README.md
@@ -211,6 +211,54 @@ exporters:
       - "host.name"
 ```
 
+### Exporting to multiple teams based on attributes
+You can export the signals based on your business logic (attributes) to different Coralogix teams. To achieve this, you'll need to use the [`filter`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/filterprocessor/README.md) processor and setup one pipeline per team. You can setup your `filter` processors as following (example with metrics):
+```
+processors:  
+  filter/teamA:
+    metrics:
+      datapoint:
+          - 'attributes["your_label"] != "teamA"'
+  filter/teamB:
+    metrics:
+      datapoint:
+          - 'attributes["your_label"] != "teamB"'
+```
+
+This configuration ensures separate processor per each team. Any data points without an attribute for a particular team will be dropped from exporting. 
+
+Secondly, set up an individual exporter per each team:
+```
+exporters:
+  coralogix/teamA:
+    metrics:
+      endpoint: "otel-metrics.coralogix.com:443"
+    private_key: <private_key_for_teamA>
+    application_name: "MyBusinessEnvironment"
+    subsystem_name: "MyBusinessSystem"
+  coralogix/teamB:
+    metrics:
+      endpoint: "otel-metrics.coralogix.com:443"
+    private_key: <private_key_for_teamB>
+    application_name: "MyBusinessEnvironment"
+    subsystem_name: "MyBusinessSystem"
+```
+
+Finally, join each processor and exporter (and any other components you wish) in the pipelines. Here is an example with a Prometheus receiver:
+```
+service:
+  pipelines:
+    metrics/1:
+      receivers: [prometheus]
+      processors: [filter/teamA]
+      exporters: [coralogix/teamA]
+    metrics/2:
+      receivers: [prometheus]
+      processors: [filter/teamB]
+      exporters: [coralogix/teamB]
+
+```
+
 ### Need help?
 
 Our world-class customer success team is available 24/7 to walk you through the setup for this exporter and answer any questions that may come up.


### PR DESCRIPTION
**Description:** Update documentation with regards to sending data to multiple teams in Coralogix.

**Link to tracking Issue:** N/A

**Testing:** N/A

**Documentation:** Added documentation on how users can configure Coralogix exporter with multiple teams in the backend.