### PR TITLE
[chore] disable updating go cache for govulncheck

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -126,7 +126,7 @@ jobs:
           go-version: ~1.19.8
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/go/bin

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,7 +79,7 @@ jobs:
           go-version: 1.19
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/go/bin
@@ -147,7 +147,7 @@ jobs:
           go-version: 1.19
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/go/bin
@@ -217,7 +217,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/go/bin
@@ -266,7 +266,7 @@ jobs:
           go-version: 1.19
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/go/bin
@@ -285,7 +285,7 @@ jobs:
           go-version: 1.19
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/go/bin
@@ -309,7 +309,7 @@ jobs:
           go-version: 1.19
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/go/bin
@@ -367,7 +367,7 @@ jobs:
           go-version: 1.19
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/go/bin
@@ -500,7 +500,7 @@ jobs:
           mkdir bin/ dist/
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/go/bin

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: 1.19   
       - name: Cache Go
         id: go-cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             ~/go/bin


### PR DESCRIPTION
There's no need for this job to update the go cache. Likely there are other jobs that should be updated as well, but this job specifically times out at this step.

Fixes #21225 