### PR TITLE
[chore]Change X-Ray Segment Exception.ID to be optional

### DIFF
--- a/receiver/awsxrayreceiver/internal/translator/cause.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause.go
@@ -68,8 +68,7 @@ func addCause(seg *awsxray.Segment, span ptrace.Span) {
 			attrs := evt.Attributes()
 			attrs.EnsureCapacity(8)
 
-			// ID is a required field
-			attrs.PutStr(awsxray.AWSXrayExceptionIDAttribute, *excp.ID)
+			addString(excp.ID, awsxray.AWSXrayExceptionIDAttribute, attrs)
 			addString(excp.Message, conventions.AttributeExceptionMessage, attrs)
 			addString(excp.Type, conventions.AttributeExceptionType, attrs)
 			addBool(excp.Remote, awsxray.AWSXrayExceptionRemoteAttribute, attrs)


### PR DESCRIPTION
Exception.ID in X-Ray is designed as a reference for building exception chain. In practice we realized it is not easy to set it in manual instrumentation.  X-Ray will relax the spec, update it to be an optional field.

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>