### PR TITLE
[chore] bump govulncheck timeout

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -116,7 +116,7 @@ jobs:
           fi
   govulncheck:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Works towards https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21225

it looks like it is timing out when it has an error getting the cache:
- [good run](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/4833688164/jobs/8613986583)
- [bad run](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/4833770881/jobs/8614173648)

When the golvulncheck step can't read the cache and has to download all the tools before it runs the check we end up hitting the 5 min timeout.  I don't have an explanation yet for why the cache doesn't work sometimes, but since we want this to pass every time regardless of its access to the cache I vote we bump the timeout in the meantime.  No other step in build-and-test has a dependency on this step so it is ok if it runs a little longer in parallel.