### PR TITLE
[chore] use metadata type on signalfxreceiver

### DIFF
--- a/receiver/signalfxreceiver/config_test.go
+++ b/receiver/signalfxreceiver/config_test.go
@@ -26,6 +26,7 @@ import (
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver/internal/metadata"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -39,11 +40,11 @@ func TestLoadConfig(t *testing.T) {
 		expected component.Config
 	}{
 		{
-			id:       component.NewIDWithName(typeStr, ""),
+			id:       component.NewIDWithName(metadata.Type, ""),
 			expected: createDefaultConfig(),
 		},
 		{
-			id: component.NewIDWithName(typeStr, "allsettings"),
+			id: component.NewIDWithName(metadata.Type, "allsettings"),
 			expected: &Config{
 				HTTPServerSettings: confighttp.HTTPServerSettings{
 					Endpoint: "localhost:9943",
@@ -54,7 +55,7 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
-			id: component.NewIDWithName(typeStr, "tls"),
+			id: component.NewIDWithName(metadata.Type, "tls"),
 			expected: &Config{
 				HTTPServerSettings: confighttp.HTTPServerSettings{
 					Endpoint: ":9943",

--- a/receiver/signalfxreceiver/factory.go
+++ b/receiver/signalfxreceiver/factory.go
@@ -32,8 +32,6 @@ import (
 // This file implements factory for SignalFx receiver.
 
 const (
-	// The value of "type" key in configuration.
-	typeStr = "signalfx"
 
 	// Default endpoints to bind to.
 	defaultEndpoint = ":9943"
@@ -42,7 +40,7 @@ const (
 // NewFactory creates a factory for SignalFx receiver.
 func NewFactory() receiver.Factory {
 	return receiver.NewFactory(
-		typeStr,
+		metadata.Type,
 		createDefaultConfig,
 		receiver.WithMetrics(createMetricsReceiver, metadata.Stability),
 		receiver.WithLogs(createLogsReceiver, metadata.Stability))

--- a/receiver/signalfxreceiver/internal/metadata/generated_status.go
+++ b/receiver/signalfxreceiver/internal/metadata/generated_status.go
@@ -7,6 +7,6 @@ import (
 )
 
 const (
-	Type      = "signalfxreceiver"
+	Type      = "signalfx"
 	Stability = component.StabilityLevelBeta
 )

--- a/receiver/signalfxreceiver/metadata.yaml
+++ b/receiver/signalfxreceiver/metadata.yaml
@@ -1,4 +1,4 @@
-type: signalfxreceiver
+type: signalfx
 
 status:
   class: receiver

--- a/receiver/signalfxreceiver/receiver.go
+++ b/receiver/signalfxreceiver/receiver.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver/internal/metadata"
 )
 
 const (
@@ -245,7 +246,7 @@ func (r *sfxReceiver) handleDatapointReq(resp http.ResponseWriter, req *http.Req
 	}
 
 	if len(msg.Datapoints) == 0 {
-		r.obsrecv.EndMetricsOp(ctx, typeStr, 0, nil)
+		r.obsrecv.EndMetricsOp(ctx, metadata.Type, 0, nil)
 		_, _ = resp.Write(okRespBody)
 		return
 	}
@@ -266,7 +267,7 @@ func (r *sfxReceiver) handleDatapointReq(resp http.ResponseWriter, req *http.Req
 	}
 
 	err = r.metricsConsumer.ConsumeMetrics(ctx, md)
-	r.obsrecv.EndMetricsOp(ctx, typeStr, len(msg.Datapoints), err)
+	r.obsrecv.EndMetricsOp(ctx, metadata.Type, len(msg.Datapoints), err)
 
 	r.writeResponse(ctx, resp, err)
 }
@@ -291,7 +292,7 @@ func (r *sfxReceiver) handleEventReq(resp http.ResponseWriter, req *http.Request
 	}
 
 	if len(msg.Events) == 0 {
-		r.obsrecv.EndMetricsOp(ctx, typeStr, 0, nil)
+		r.obsrecv.EndMetricsOp(ctx, metadata.Type, 0, nil)
 		_, _ = resp.Write(okRespBody)
 		return
 	}
@@ -310,7 +311,7 @@ func (r *sfxReceiver) handleEventReq(resp http.ResponseWriter, req *http.Request
 	err := r.logsConsumer.ConsumeLogs(ctx, ld)
 	r.obsrecv.EndMetricsOp(
 		ctx,
-		typeStr,
+		metadata.Type,
 		len(msg.Events),
 		err)
 


### PR DESCRIPTION
Use the type field defined in metadata.yaml in factory.go.