### PR TITLE
Added service.name to Datadog to OTel translator

### DIFF
--- a/.chloggen/dd-service-name-fix.yaml
+++ b/.chloggen/dd-service-name-fix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/datadog 
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:  Enabled copying of service.name from Datadog to OTEL Format    
+
+# One or more tracking issues related to the change
+issues: [21210]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/datadogreceiver/translator.go
+++ b/receiver/datadogreceiver/translator.go
@@ -141,7 +141,6 @@ func translateDataDogKeyToOtel(k string) string {
 	case "error.msg":
 		return semconv.AttributeExceptionMessage
 	case "service.name":
-	case "service_name":
 		return semconv.AttributeServiceName
 	default:
 		return k

--- a/receiver/datadogreceiver/translator.go
+++ b/receiver/datadogreceiver/translator.go
@@ -140,6 +140,9 @@ func translateDataDogKeyToOtel(k string) string {
 		return semconv.AttributeExceptionStacktrace
 	case "error.msg":
 		return semconv.AttributeExceptionMessage
+	case "service.name":
+	case "service_name":
+		return semconv.AttributeServiceName
 	default:
 		return k
 	}


### PR DESCRIPTION
**Description:**
Bug: Fixing missing service.name after translation form DD to OTEL

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21210

**Testing:** 
Ran all tests to make sure this doesn't break anything.

**Documentation:** 
None needed