### PR TITLE
[chore] add status type metadata use in zipkin exporter

### DIFF
--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -26,6 +26,8 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter/internal/metadata"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -43,11 +45,11 @@ func TestLoadConfig(t *testing.T) {
 		expected component.Config
 	}{
 		{
-			id:       component.NewIDWithName(typeStr, ""),
+			id:       component.NewIDWithName(metadata.Type, ""),
 			expected: defaultCfg,
 		},
 		{
-			id: component.NewIDWithName(typeStr, "2"),
+			id: component.NewIDWithName(metadata.Type, "2"),
 			expected: &Config{
 				RetrySettings: exporterhelper.RetrySettings{
 					Enabled:             true,

--- a/exporter/zipkinexporter/factory.go
+++ b/exporter/zipkinexporter/factory.go
@@ -28,9 +28,6 @@ import (
 )
 
 const (
-	// The value of "type" key in configuration.
-	typeStr = "zipkin"
-
 	defaultTimeout = time.Second * 5
 
 	defaultFormat = "json"
@@ -41,7 +38,7 @@ const (
 // NewFactory creates a factory for Zipkin exporter.
 func NewFactory() exporter.Factory {
 	return exporter.NewFactory(
-		typeStr,
+		metadata.Type,
 		createDefaultConfig,
 		exporter.WithTraces(createTracesExporter, metadata.Stability))
 }

--- a/exporter/zipkinexporter/internal/metadata/generated_status.go
+++ b/exporter/zipkinexporter/internal/metadata/generated_status.go
@@ -7,6 +7,6 @@ import (
 )
 
 const (
-	Type      = "zipkinexporter"
+	Type      = "zipkin"
 	Stability = component.StabilityLevelBeta
 )

--- a/exporter/zipkinexporter/metadata.yaml
+++ b/exporter/zipkinexporter/metadata.yaml
@@ -1,4 +1,4 @@
-type: zipkinexporter
+type: zipkin
 
 status:
   class: exporter


### PR DESCRIPTION
Use metadata.Type instead of typeStr in zipkin exporter.