### PR TITLE
[receiver/kafkareceiver] Support configuration of initial offset strategy

### DIFF
--- a/.chloggen/feat_kafkareceiver-initialoffset.yaml
+++ b/.chloggen/feat_kafkareceiver-initialoffset.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/kafkareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support configuration of initial offset strategy to allow consuming form latest or earliest offset
+
+# One or more tracking issues related to the change
+issues: [14976]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -34,6 +34,7 @@ The following settings can be optionally configured:
   - `raw`: (logs only) the payload's bytes are inserted as the body of a log record.
 - `group_id` (default = otel-collector):  The consumer group that receiver will be consuming messages from
 - `client_id` (default = otel-collector): The consumer client ID that receiver will use
+- `initial_offset` (default = latest): The initial offset to use if no offset was previously committed. Must be `latest` or `earliest`.
 - `auth`
   - `plain_text`
     - `username`: The username to use.

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -56,6 +56,9 @@ type Config struct {
 	GroupID string `mapstructure:"group_id"`
 	// The consumer client ID that receiver will use (default "otel-collector")
 	ClientID string `mapstructure:"client_id"`
+	// The initial offset to use if no offset was previously committed.
+	// Must be `latest` or `earliest` (default "latest").
+	InitialOffset string `mapstructure:"initial_offset"`
 
 	// Metadata is the namespace for metadata management properties used by the
 	// Client, and shared by the Producer/Consumer.
@@ -69,6 +72,11 @@ type Config struct {
 	// Controls the way the messages are marked as consumed
 	MessageMarking MessageMarking `mapstructure:"message_marking"`
 }
+
+const (
+	offsetLatest   string = "latest"
+	offsetEarliest string = "earliest"
+)
 
 var _ component.Config = (*Config)(nil)
 

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -43,11 +43,12 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, ""),
 			expected: &Config{
-				Topic:    "spans",
-				Encoding: "otlp_proto",
-				Brokers:  []string{"foo:123", "bar:456"},
-				ClientID: "otel-collector",
-				GroupID:  "otel-collector",
+				Topic:         "spans",
+				Encoding:      "otlp_proto",
+				Brokers:       []string{"foo:123", "bar:456"},
+				ClientID:      "otel-collector",
+				GroupID:       "otel-collector",
+				InitialOffset: "latest",
 				Authentication: kafkaexporter.Authentication{
 					TLS: &configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
@@ -74,11 +75,12 @@ func TestLoadConfig(t *testing.T) {
 
 			id: component.NewIDWithName(metadata.Type, "logs"),
 			expected: &Config{
-				Topic:    "logs",
-				Encoding: "direct",
-				Brokers:  []string{"coffee:123", "foobar:456"},
-				ClientID: "otel-collector",
-				GroupID:  "otel-collector",
+				Topic:         "logs",
+				Encoding:      "direct",
+				Brokers:       []string{"coffee:123", "foobar:456"},
+				ClientID:      "otel-collector",
+				GroupID:       "otel-collector",
+				InitialOffset: "earliest",
 				Authentication: kafkaexporter.Authentication{
 					TLS: &configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -28,11 +28,12 @@ import (
 )
 
 const (
-	defaultTopic    = "otlp_spans"
-	defaultEncoding = "otlp_proto"
-	defaultBroker   = "localhost:9092"
-	defaultClientID = "otel-collector"
-	defaultGroupID  = defaultClientID
+	defaultTopic         = "otlp_spans"
+	defaultEncoding      = "otlp_proto"
+	defaultBroker        = "localhost:9092"
+	defaultClientID      = "otel-collector"
+	defaultGroupID       = defaultClientID
+	defaultInitialOffset = offsetLatest
 
 	// default from sarama.NewConfig()
 	defaultMetadataRetryMax = 3
@@ -100,11 +101,12 @@ func NewFactory(options ...FactoryOption) receiver.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Topic:    defaultTopic,
-		Encoding: defaultEncoding,
-		Brokers:  []string{defaultBroker},
-		ClientID: defaultClientID,
-		GroupID:  defaultGroupID,
+		Topic:         defaultTopic,
+		Encoding:      defaultEncoding,
+		Brokers:       []string{defaultBroker},
+		ClientID:      defaultClientID,
+		GroupID:       defaultGroupID,
+		InitialOffset: defaultInitialOffset,
 		Metadata: kafkaexporter.Metadata{
 			Full: defaultMetadataFull,
 			Retry: kafkaexporter.MetadataRetry{

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -35,6 +35,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, defaultTopic, cfg.Topic)
 	assert.Equal(t, defaultGroupID, cfg.GroupID)
 	assert.Equal(t, defaultClientID, cfg.ClientID)
+	assert.Equal(t, defaultInitialOffset, cfg.InitialOffset)
 }
 
 func TestCreateTracesReceiver(t *testing.T) {

--- a/receiver/kafkareceiver/testdata/config.yaml
+++ b/receiver/kafkareceiver/testdata/config.yaml
@@ -22,6 +22,7 @@ kafka/logs:
     - "foobar:456"
   client_id: otel-collector
   group_id: otel-collector
+  initial_offset: earliest
   auth:
     tls:
       ca_file: ca.pem


### PR DESCRIPTION
**Description:** Added the ability to configure the initial offset strategy to allow consuming form latest or earliest offset.

**Link to tracking Issue:** #14976

**Testing:** Unit tests to check configuration, e.g. that "latest" is still the default, and mapping to Sarama offset.

**Documentation:** Added documentation of new "initial_offset" configuration attribute.