### PR TITLE
[chore] Bump govulncheck timeout (again)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -116,7 +116,7 @@ jobs:
           fi
   govulncheck:
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 30
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
**Description:**
Add more bandaids by bumping the govulncheck timeout to 30 mins to align with other timeout checks in the repo.  Addresses failures like https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/4863477148/jobs/8671240402 where 8 mins wasn't long enough.

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21225