### PR TITLE
Add resource configuration in splunkhecreceiver

### DIFF
--- a/.chloggen/splunkhecreceiver-add-custom-resources.yaml
+++ b/.chloggen/splunkhecreceiver-add-custom-resources.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add a new configuration in splunk hec receiver, which allows injection of custom resource attributes.
+
+# One or more tracking issues related to the change
+issues: [7593]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/splunkhecreceiver/README.md
+++ b/receiver/splunkhecreceiver/README.md
@@ -47,7 +47,8 @@ The following settings are optional:
 * `hec_metadata_to_otel_attrs/sourcetype` (default = 'com.splunk.sourcetype'): Specifies the mapping of the sourcetype field to a specific unified model attribute.
 * `hec_metadata_to_otel_attrs/index` (default = 'com.splunk.index'): Specifies the mapping of the  index field to a specific unified model attribute.
 * `hec_metadata_to_otel_attrs/host` (default = 'host.name'): Specifies the mapping of the host field to a specific unified model attribute.
-Example:
+* `resources` (default: empty map): Specifies a custom map of resource attributes to inject into the events.
+* Example:
 
 ```yaml
 receivers:
@@ -63,6 +64,8 @@ receivers:
       sourcetype: "mysourcetype"
       index: "myindex"
       host: "myhost"
+    resources:
+      customKey: customVal
 ```
 
 The full list of settings exposed for this receiver are documented [here](./config.go)

--- a/receiver/splunkhecreceiver/config.go
+++ b/receiver/splunkhecreceiver/config.go
@@ -31,4 +31,6 @@ type Config struct {
 	HealthPath string `mapstructure:"health_path"`
 	// HecToOtelAttrs creates a mapping from HEC metadata to attributes.
 	HecToOtelAttrs splunk.HecToOtelAttrs `mapstructure:"hec_metadata_to_otel_attrs"`
+	// Resources are the optional metadata to be amended on all resource attributes
+	Resources map[string]interface{} `mapstructure:"resources"`
 }

--- a/receiver/splunkhecreceiver/config_test.go
+++ b/receiver/splunkhecreceiver/config_test.go
@@ -59,6 +59,9 @@ func TestLoadConfig(t *testing.T) {
 					Index:      "myindex",
 					Host:       "myhostfield",
 				},
+				Resources: map[string]interface{}{
+					"strKey": "strValue",
+				},
 			},
 		},
 		{
@@ -84,6 +87,7 @@ func TestLoadConfig(t *testing.T) {
 					Index:      "com.splunk.index",
 					Host:       "host.name",
 				},
+				Resources: map[string]interface{}{},
 			},
 		},
 	}

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -62,6 +62,7 @@ func createDefaultConfig() component.Config {
 		},
 		RawPath:    splunk.DefaultRawPath,
 		HealthPath: splunk.DefaultHealthPath,
+		Resources:  map[string]interface{}{},
 	}
 }
 

--- a/receiver/splunkhecreceiver/testdata/config.yaml
+++ b/receiver/splunkhecreceiver/testdata/config.yaml
@@ -11,6 +11,8 @@ splunk_hec/allsettings:
     sourcetype: "foobar"
     index: "myindex"
     host: "myhostfield"
+  resources:
+    strKey: strValue
 splunk_hec/tls:
   tls:
     cert_file: /test.crt


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This change adds a new configuration in splunkhecreceiver, which allows users to inject custom resources into the events.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21466

**Testing:** <Describe what testing was performed and which tests were added.>
Added unit test for both `handleReq` and `handleReqRaw` path.

**Documentation:** <Describe the documentation added.>
Updated README