### PR TITLE
[routingprocessor] Instrument the routing processor with non-routed spans/metric points/log records counters (OTel SDK).

### DIFF
--- a/.chloggen/routing-processor.yaml
+++ b/.chloggen/routing-processor.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/routingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Instrument the routing processor with non-routed spans/metricpoints/logrecords counters (OTel SDK).
+
+# One or more tracking issues related to the change
+issues: [21476]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/routingprocessor/factory.go
+++ b/processor/routingprocessor/factory.go
@@ -30,6 +30,15 @@ const (
 	typeStr = "routing"
 	// The stability level of the processor.
 	stability = component.StabilityLevelBeta
+
+	scopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor"
+	nameSep   = "/"
+
+	processorKey             = "processor"
+	metricSep                = "_"
+	nonRoutedSpansKey        = "non_routed_spans"
+	nonRoutedMetricPointsKey = "non_routed_metric_points"
+	nonRoutedLogRecordsKey   = "non_routed_log_records"
 )
 
 // NewFactory creates a factory for the routing processor.
@@ -52,17 +61,17 @@ func createDefaultConfig() component.Config {
 
 func createTracesProcessor(_ context.Context, params processor.CreateSettings, cfg component.Config, nextConsumer consumer.Traces) (processor.Traces, error) {
 	warnIfNotLastInPipeline(nextConsumer, params.Logger)
-	return newTracesProcessor(params.TelemetrySettings, cfg), nil
+	return newTracesProcessor(params.TelemetrySettings, cfg)
 }
 
 func createMetricsProcessor(_ context.Context, params processor.CreateSettings, cfg component.Config, nextConsumer consumer.Metrics) (processor.Metrics, error) {
 	warnIfNotLastInPipeline(nextConsumer, params.Logger)
-	return newMetricProcessor(params.TelemetrySettings, cfg), nil
+	return newMetricProcessor(params.TelemetrySettings, cfg)
 }
 
 func createLogsProcessor(_ context.Context, params processor.CreateSettings, cfg component.Config, nextConsumer consumer.Logs) (processor.Logs, error) {
 	warnIfNotLastInPipeline(nextConsumer, params.Logger)
-	return newLogProcessor(params.TelemetrySettings, cfg), nil
+	return newLogProcessor(params.TelemetrySettings, cfg)
 }
 
 func warnIfNotLastInPipeline(nextConsumer interface{}, logger *zap.Logger) {

--- a/processor/routingprocessor/go.mod
+++ b/processor/routingprocessor/go.mod
@@ -12,6 +12,9 @@ require (
 	go.opentelemetry.io/collector/exporter v0.77.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.77.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0011
+	go.opentelemetry.io/otel v1.15.1
+	go.opentelemetry.io/otel/metric v0.38.1
+	go.opentelemetry.io/otel/trace v1.15.1
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.24.0
 	google.golang.org/grpc v1.55.0
@@ -43,9 +46,6 @@ require (
 	go.opentelemetry.io/collector/featuregate v0.77.0 // indirect
 	go.opentelemetry.io/collector/receiver v0.77.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.41.1 // indirect
-	go.opentelemetry.io/otel v1.15.1 // indirect
-	go.opentelemetry.io/otel/metric v0.38.1 // indirect
-	go.opentelemetry.io/otel/trace v1.15.1 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/exp v0.0.0-20221205204356-47842c84f3db // indirect
 	golang.org/x/net v0.10.0 // indirect

--- a/processor/routingprocessor/logs_test.go
+++ b/processor/routingprocessor/logs_test.go
@@ -23,7 +23,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -38,7 +37,8 @@ func TestLogProcessorCapabilities(t *testing.T) {
 	}
 
 	// test
-	p := newLogProcessor(component.TelemetrySettings{Logger: zap.NewNop()}, config)
+	p, err := newLogProcessor(noopTelemetrySettings, config)
+	require.NoError(t, err)
 	require.NotNil(t, p)
 
 	// verify
@@ -56,7 +56,7 @@ func TestLogs_RoutingWorks_Context(t *testing.T) {
 		},
 	})
 
-	exp := newLogProcessor(component.TelemetrySettings{Logger: zap.NewNop()}, &Config{
+	exp, err := newLogProcessor(noopTelemetrySettings, &Config{
 		FromAttribute:    "X-Tenant",
 		AttributeSource:  contextAttributeSource,
 		DefaultExporters: []string{"otlp"},
@@ -67,6 +67,8 @@ func TestLogs_RoutingWorks_Context(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
+
 	require.NoError(t, exp.Start(context.Background(), host))
 
 	l := plog.NewLogs()
@@ -115,7 +117,7 @@ func TestLogs_RoutingWorks_ResourceAttribute(t *testing.T) {
 		},
 	})
 
-	exp := newLogProcessor(component.TelemetrySettings{Logger: zap.NewNop()}, &Config{
+	exp, err := newLogProcessor(noopTelemetrySettings, &Config{
 		FromAttribute:    "X-Tenant",
 		AttributeSource:  resourceAttributeSource,
 		DefaultExporters: []string{"otlp"},
@@ -126,6 +128,8 @@ func TestLogs_RoutingWorks_ResourceAttribute(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
+
 	require.NoError(t, exp.Start(context.Background(), host))
 
 	t.Run("non default route is properly used", func(t *testing.T) {
@@ -168,7 +172,7 @@ func TestLogs_RoutingWorks_ResourceAttribute_DropsRoutingAttribute(t *testing.T)
 		},
 	})
 
-	exp := newLogProcessor(component.TelemetrySettings{Logger: zap.NewNop()}, &Config{
+	exp, err := newLogProcessor(noopTelemetrySettings, &Config{
 		AttributeSource:              resourceAttributeSource,
 		FromAttribute:                "X-Tenant",
 		DropRoutingResourceAttribute: true,
@@ -180,6 +184,8 @@ func TestLogs_RoutingWorks_ResourceAttribute_DropsRoutingAttribute(t *testing.T)
 			},
 		},
 	})
+	require.NoError(t, err)
+
 	require.NoError(t, exp.Start(context.Background(), host))
 
 	l := plog.NewLogs()
@@ -210,7 +216,7 @@ func TestLogs_AreCorrectlySplitPerResourceAttributeRouting(t *testing.T) {
 		},
 	})
 
-	exp := newLogProcessor(component.TelemetrySettings{Logger: zap.NewNop()}, &Config{
+	exp, err := newLogProcessor(noopTelemetrySettings, &Config{
 		FromAttribute:    "X-Tenant",
 		AttributeSource:  resourceAttributeSource,
 		DefaultExporters: []string{"otlp"},
@@ -221,6 +227,7 @@ func TestLogs_AreCorrectlySplitPerResourceAttributeRouting(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
 
 	l := plog.NewLogs()
 
@@ -264,7 +271,7 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 		},
 	})
 
-	exp := newLogProcessor(component.TelemetrySettings{Logger: zap.NewNop()}, &Config{
+	exp, err := newLogProcessor(noopTelemetrySettings, &Config{
 		DefaultExporters: []string{"otlp"},
 		Table: []RoutingTableItem{
 			{
@@ -277,6 +284,7 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
 
 	require.NoError(t, exp.Start(context.Background(), host))
 

--- a/processor/routingprocessor/router.go
+++ b/processor/routingprocessor/router.go
@@ -47,6 +47,7 @@ func newRouter[E component.Component, K any](
 	defaultExporterIDs []string,
 	settings component.TelemetrySettings,
 	parser ottl.Parser[K],
+
 ) router[E, K] {
 	return router[E, K]{
 		logger: settings.Logger,

--- a/processor/routingprocessor/traces.go
+++ b/processor/routingprocessor/traces.go
@@ -23,6 +23,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
@@ -39,12 +41,26 @@ type tracesProcessor struct {
 
 	extractor extractor
 	router    router[exporter.Traces, ottlspan.TransformContext]
+
+	nonRoutedSpansCounter metric.Int64Counter
 }
 
-func newTracesProcessor(settings component.TelemetrySettings, config component.Config) *tracesProcessor {
+func newTracesProcessor(settings component.TelemetrySettings, config component.Config) (*tracesProcessor, error) {
 	cfg := rewriteRoutingEntriesToOTTL(config.(*Config))
 
-	spanParser, _ := ottlspan.NewParser(common.Functions[ottlspan.TransformContext](), settings)
+	spanParser, err := ottlspan.NewParser(common.Functions[ottlspan.TransformContext](), settings)
+	if err != nil {
+		return nil, err
+	}
+
+	meter := settings.MeterProvider.Meter(scopeName + nameSep + "traces")
+	nonRoutedSpansCounter, err := meter.Int64Counter(
+		typeStr+metricSep+processorKey+metricSep+nonRoutedSpansKey,
+		metric.WithDescription("Number of spans that were not routed to some or all exporters."),
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	return &tracesProcessor{
 		logger: settings.Logger,
@@ -56,7 +72,9 @@ func newTracesProcessor(settings component.TelemetrySettings, config component.C
 			spanParser,
 		),
 		extractor: newExtractor(cfg.FromAttribute, settings.Logger),
-	}
+
+		nonRoutedSpansCounter: nonRoutedSpansCounter,
+	}, nil
 }
 
 func (p *tracesProcessor) Start(_ context.Context, host component.Host) error {
@@ -111,6 +129,7 @@ func (p *tracesProcessor) route(ctx context.Context, t ptrace.Traces) error {
 					return err
 				}
 				p.group("", groups, p.router.defaultExporters, rspans)
+				p.recordNonRoutedResourceSpans(ctx, key, rspans)
 				continue
 			}
 			if !isMatch {
@@ -123,6 +142,7 @@ func (p *tracesProcessor) route(ctx context.Context, t ptrace.Traces) error {
 		if matchCount == 0 {
 			// no route conditions are matched, add resource spans to default exporters group
 			p.group("", groups, p.router.defaultExporters, rspans)
+			p.recordNonRoutedResourceSpans(ctx, "", rspans)
 		}
 	}
 
@@ -144,9 +164,34 @@ func (p *tracesProcessor) group(key string, groups map[string]spanGroup, exporte
 	groups[key] = group
 }
 
+func (p *tracesProcessor) recordNonRoutedResourceSpans(ctx context.Context, routingKey string, rspans ptrace.ResourceSpans) {
+	spanCount := 0
+	ilss := rspans.ScopeSpans()
+	for j := 0; j < ilss.Len(); j++ {
+		spanCount += ilss.At(j).Spans().Len()
+	}
+
+	p.nonRoutedSpansCounter.Add(
+		ctx,
+		int64(spanCount),
+		metric.WithAttributes(
+			attribute.String("routing_key", routingKey),
+		),
+	)
+}
+
 func (p *tracesProcessor) routeForContext(ctx context.Context, t ptrace.Traces) error {
 	value := p.extractor.extractFromContext(ctx)
 	exporters := p.router.getExporters(value)
+	if value == "" { // "" is a  key for default exporters
+		p.nonRoutedSpansCounter.Add(
+			ctx,
+			int64(t.SpanCount()),
+			metric.WithAttributes(
+				attribute.String("routing_key", p.extractor.fromAttr),
+			),
+		)
+	}
 
 	var errs error
 	for _, e := range exporters {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

 Instrument the routing processor with non-routed spans/metric points/log records counters (OTel SDK).
 
The routing entry key is used as a `routing_key` label for the metric. It is quite hard to use the value from routing entry as metrics label value, also for the case with OTTL it might simply not be possible. Also, in the future connector implementation of the routing processor we might use only OTTL routing statements.
 
 **Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>