### PR TITLE
Make sure the k8scluster receiver is watching for hpa v2

### DIFF
--- a/.chloggen/fix-k8sclusterreceiver-hpav2.yaml
+++ b/.chloggen/fix-k8sclusterreceiver-hpav2.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/k8scluster
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make sure the k8scluster receiver is watching for v2 and v2beta2 HorizontalPodAutoscalers for Kubernetes 1.26
+
+# One or more tracking issues related to the change
+issues: [20480]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/k8sclusterreceiver/internal/gvk/gvk.go
+++ b/receiver/k8sclusterreceiver/internal/gvk/gvk.go
@@ -18,19 +18,20 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 
 // Kubernetes group version kinds
 var (
-	Pod                     = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
-	Node                    = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}
-	Namespace               = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
-	ReplicationController   = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ReplicationController"}
-	ResourceQuota           = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ResourceQuota"}
-	Service                 = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
-	DaemonSet               = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}
-	Deployment              = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
-	ReplicaSet              = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}
-	StatefulSet             = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
-	Job                     = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
-	CronJob                 = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}
-	CronJobBeta             = schema.GroupVersionKind{Group: "batch", Version: "v1beta1", Kind: "CronJob"}
-	HorizontalPodAutoscaler = schema.GroupVersionKind{Group: "autoscaling", Version: "v2beta2", Kind: "HorizontalPodAutoscaler"}
-	ClusterResourceQuota    = schema.GroupVersionKind{Group: "quota", Version: "v1", Kind: "ClusterResourceQuota"}
+	Pod                         = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
+	Node                        = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}
+	Namespace                   = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
+	ReplicationController       = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ReplicationController"}
+	ResourceQuota               = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ResourceQuota"}
+	Service                     = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
+	DaemonSet                   = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}
+	Deployment                  = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	ReplicaSet                  = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"}
+	StatefulSet                 = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSet"}
+	Job                         = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
+	CronJob                     = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "CronJob"}
+	CronJobBeta                 = schema.GroupVersionKind{Group: "batch", Version: "v1beta1", Kind: "CronJob"}
+	HorizontalPodAutoscaler     = schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"}
+	HorizontalPodAutoscalerBeta = schema.GroupVersionKind{Group: "autoscaling", Version: "v2beta2", Kind: "HorizontalPodAutoscaler"}
+	ClusterResourceQuota        = schema.GroupVersionKind{Group: "quota", Version: "v1", Kind: "ClusterResourceQuota"}
 )

--- a/receiver/k8sclusterreceiver/receiver_test.go
+++ b/receiver/k8sclusterreceiver/receiver_test.go
@@ -271,7 +271,7 @@ func newFakeClientWithAllResources() *fake.Clientset {
 		{
 			GroupVersion: "autoscaling/v2beta2",
 			APIResources: []v1.APIResource{
-				gvkToAPIResource(gvk.HorizontalPodAutoscaler),
+				gvkToAPIResource(gvk.HorizontalPodAutoscalerBeta),
 			},
 		},
 	}

--- a/receiver/k8sclusterreceiver/watcher.go
+++ b/receiver/k8sclusterreceiver/watcher.go
@@ -119,7 +119,7 @@ func (rw *resourceWatcher) prepareSharedInformerFactory() error {
 		"StatefulSet":             {gvk.StatefulSet},
 		"Job":                     {gvk.Job},
 		"CronJob":                 {gvk.CronJob, gvk.CronJobBeta},
-		"HorizontalPodAutoscaler": {gvk.HorizontalPodAutoscaler},
+		"HorizontalPodAutoscaler": {gvk.HorizontalPodAutoscaler, gvk.HorizontalPodAutoscalerBeta},
 	}
 
 	for kind, gvks := range supportedKinds {
@@ -197,6 +197,8 @@ func (rw *resourceWatcher) setupInformerForKind(kind schema.GroupVersionKind, fa
 	case gvk.CronJobBeta:
 		rw.setupInformer(kind, factory.Batch().V1beta1().CronJobs().Informer())
 	case gvk.HorizontalPodAutoscaler:
+		rw.setupInformer(kind, factory.Autoscaling().V2().HorizontalPodAutoscalers().Informer())
+	case gvk.HorizontalPodAutoscalerBeta:
 		rw.setupInformer(kind, factory.Autoscaling().V2beta2().HorizontalPodAutoscalers().Informer())
 	default:
 		rw.logger.Error("Could not setup an informer for provided group version kind",

--- a/receiver/k8sclusterreceiver/watcher_test.go
+++ b/receiver/k8sclusterreceiver/watcher_test.go
@@ -181,9 +181,15 @@ func TestPrepareSharedInformerFactory(t *testing.T) {
 						},
 					},
 					{
-						GroupVersion: "autoscaling/v2beta2",
+						GroupVersion: "autoscaling/v2",
 						APIResources: []metav1.APIResource{
 							gvkToAPIResource(gvk.HorizontalPodAutoscaler),
+						},
+					},
+					{
+						GroupVersion: "autoscaling/v2beta2",
+						APIResources: []metav1.APIResource{
+							gvkToAPIResource(gvk.HorizontalPodAutoscalerBeta),
 						},
 					},
 				}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
I missed adding the hpa v2 to the watcher.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20480

Testing:
Added more unit tests. Verified k8s.hpa.* metrics for v2 objects are exporting.
Tested manually with:
- Kubernetes 1.25: Rosa 4.12, Kops on AWS, Minikube

Note:
I haven't been able to stop/catch this warning in  Kubernetes 1.25, I couldn't find what was throwing it in the receiver code. This isn't an issue in 1.26. If I can track it down, I'll add another commit.
_1 warnings.go:70] autoscaling/v2beta2 HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+; use autoscaling/v2 HorizontalPodAutoscaler_
