### PR TITLE
[GoogleCloudSpannerReceiver]: Error scrapping metrics for TABLE_SIZES…

### DIFF
--- a/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
@@ -534,7 +534,7 @@ metadata:
     metrics:
       - name: "used_bytes"
         column_name: "USED_BYTES"
-        value_type: "int"
+        value_type: "float"
         data:
           type: "gauge"
         unit: "byte"


### PR DESCRIPTION
…_STATS_1HOUR "failed to decode column 2, type *int64 cannot be used for decoding FLOAT64" (#21499)

Adjusting the type for used_bytes to float instead of int. This change will fix the 267ce3f8a2 which introduced table sizes.

**Description:** Changed the  expected type for USED_BYTES from INT to FLOAT. According to the [documentation](https://cloud.google.com/spanner/docs/introspection/table-sizes-statistics) the USED_BYTES has a type of FLOAT64.


**Link to tracking Issue:** #21499

**Testing:** Performed testing locally by building the receiver.

**Documentation:** N/A