### PR TITLE
[cmd/mdatagen] Use directory names for Scope name

### DIFF
--- a/.chloggen/chrony-update-scopename.yaml
+++ b/.chloggen/chrony-update-scopename.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/chrony
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update emitted Scope name to "otelcol/chronyreceiver"
+
+# One or more tracking issues related to the change
+issues: [21382]

--- a/.chloggen/filestats-update-scopename.yaml
+++ b/.chloggen/filestats-update-scopename.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/filestats
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update emitted Scope name to "otelcol/filestatsreceiver"
+
+# One or more tracking issues related to the change
+issues: [21382]

--- a/.chloggen/mongodbatlas-update-scopename.yaml
+++ b/.chloggen/mongodbatlas-update-scopename.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/mongodbatlas
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update emitted Scope name to "otelcol/mongodbatlasreceiver"
+
+# One or more tracking issues related to the change
+issues: [21382]

--- a/cmd/mdatagen/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/metadata/generated_metrics.go
@@ -439,7 +439,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/testreceiver")
+	ils.Scope().SetName("otelcol")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricDefaultMetric.emit(ils.Metrics())

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -156,6 +156,7 @@ func Test_loadMetadata(t *testing.T) {
 						},
 					},
 				},
+				ScopeName: "otelcol",
 			},
 		},
 		{

--- a/cmd/mdatagen/main.go
+++ b/cmd/mdatagen/main.go
@@ -48,10 +48,14 @@ func run(ymlPath string) error {
 	if ymlPath == "" {
 		return errors.New("argument must be metadata.yaml file")
 	}
+	ymlPath, err := filepath.Abs(ymlPath)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path for %v: %w", ymlPath, err)
+	}
 
 	ymlDir := filepath.Dir(ymlPath)
 
-	md, err := loadMetadata(filepath.Clean(ymlPath))
+	md, err := loadMetadata(ymlPath)
 	if err != nil {
 		return fmt.Errorf("failed loading %v: %w", ymlPath, err)
 	}

--- a/cmd/mdatagen/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/templates/metrics.go.tmpl
@@ -334,7 +334,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	{{- end }}
 	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/{{ .Type }}")
+	ils.Scope().SetName("{{ .ScopeName }}")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	{{- range $name, $metric := .Metrics }}

--- a/receiver/chronyreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/chronyreceiver/internal/metadata/generated_metrics.go
@@ -578,7 +578,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/chrony receiver")
+	ils.Scope().SetName("otelcol/chronyreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricNtpFrequencyOffset.emit(ils.Metrics())

--- a/receiver/chronyreceiver/scraper_test.go
+++ b/receiver/chronyreceiver/scraper_test.go
@@ -69,7 +69,7 @@ func TestChronyScraper(t *testing.T) {
 				rMetrics := metrics.ResourceMetrics().AppendEmpty()
 
 				metric := rMetrics.ScopeMetrics().AppendEmpty()
-				metric.Scope().SetName("otelcol/chrony receiver")
+				metric.Scope().SetName("otelcol/chronyreceiver")
 				metric.Scope().SetVersion("latest")
 
 				m := metric.Metrics().AppendEmpty()

--- a/receiver/filestatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/filestatsreceiver/internal/metadata/generated_metrics.go
@@ -404,7 +404,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/filestats")
+	ils.Scope().SetName("otelcol/filestatsreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricFileAtime.emit(ils.Metrics())

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
@@ -4534,7 +4534,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/mongoatlasreceiver")
+	ils.Scope().SetName("otelcol/mongodbatlasreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricMongodbatlasDbCounts.emit(ils.Metrics())


### PR DESCRIPTION
Use directory names for the Scope name instead of the type field in metadata.yaml to be able to use type as the actual component type name.

This change brings the scope name to the existing consistent format until we migrate all the receivers to use the package name.

As a side effect, this change updates the emitted scope name for several receivers:

- chrony
- filestats
- mongodbatlas

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21382