### PR TITLE
[receiver/oracledb] add additional metrics

### DIFF
--- a/.chloggen/add_metrics_oracledbreceiver.yaml
+++ b/.chloggen/add_metrics_oracledbreceiver.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: oracledbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds support for `consistent gets` and `db block gets` metrics. Disabled by default.
+
+# One or more tracking issues related to the change
+issues: [21215]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/oracledbreceiver/documentation.md
+++ b/receiver/oracledbreceiver/documentation.md
@@ -231,6 +231,32 @@ Number of times users manually issue the ROLLBACK statement or an error occurs d
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | 1 | Sum | Int | Cumulative | true |
 
+## Optional Metrics
+
+The following metrics are not emitted by default. Each of them can be enabled by applying the following configuration:
+
+```yaml
+metrics:
+  <metric_name>:
+    enabled: true
+```
+
+### oracledb.consistent_gets
+
+Number of times a consistent read was requested for a block from the buffer cache.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {gets} | Sum | Int | Cumulative | true |
+
+### oracledb.db_block_gets
+
+Number of times a current block was requested from the buffer cache.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {gets} | Sum | Int | Cumulative | true |
+
 ## Resource Attributes
 
 | Name | Description | Values | Enabled |

--- a/receiver/oracledbreceiver/internal/metadata/generated_config.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config.go
@@ -25,7 +25,9 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for oracledbreceiver metrics.
 type MetricsConfig struct {
+	OracledbConsistentGets        MetricConfig `mapstructure:"oracledb.consistent_gets"`
 	OracledbCPUTime               MetricConfig `mapstructure:"oracledb.cpu_time"`
+	OracledbDbBlockGets           MetricConfig `mapstructure:"oracledb.db_block_gets"`
 	OracledbDmlLocksLimit         MetricConfig `mapstructure:"oracledb.dml_locks.limit"`
 	OracledbDmlLocksUsage         MetricConfig `mapstructure:"oracledb.dml_locks.usage"`
 	OracledbEnqueueDeadlocks      MetricConfig `mapstructure:"oracledb.enqueue_deadlocks"`
@@ -54,8 +56,14 @@ type MetricsConfig struct {
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
+		OracledbConsistentGets: MetricConfig{
+			Enabled: false,
+		},
 		OracledbCPUTime: MetricConfig{
 			Enabled: true,
+		},
+		OracledbDbBlockGets: MetricConfig{
+			Enabled: false,
 		},
 		OracledbDmlLocksLimit: MetricConfig{
 			Enabled: true,

--- a/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_config_test.go
@@ -26,7 +26,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					OracledbConsistentGets:        MetricConfig{Enabled: true},
 					OracledbCPUTime:               MetricConfig{Enabled: true},
+					OracledbDbBlockGets:           MetricConfig{Enabled: true},
 					OracledbDmlLocksLimit:         MetricConfig{Enabled: true},
 					OracledbDmlLocksUsage:         MetricConfig{Enabled: true},
 					OracledbEnqueueDeadlocks:      MetricConfig{Enabled: true},
@@ -61,7 +63,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					OracledbConsistentGets:        MetricConfig{Enabled: false},
 					OracledbCPUTime:               MetricConfig{Enabled: false},
+					OracledbDbBlockGets:           MetricConfig{Enabled: false},
 					OracledbDmlLocksLimit:         MetricConfig{Enabled: false},
 					OracledbDmlLocksUsage:         MetricConfig{Enabled: false},
 					OracledbEnqueueDeadlocks:      MetricConfig{Enabled: false},

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -54,9 +54,15 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount := 0
 			allMetricsCount := 0
 
+			allMetricsCount++
+			mb.RecordOracledbConsistentGetsDataPoint(ts, "1")
+
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordOracledbCPUTimeDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordOracledbDbBlockGetsDataPoint(ts, "1")
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -186,6 +192,20 @@ func TestMetricsBuilder(t *testing.T) {
 			validatedMetrics := make(map[string]bool)
 			for i := 0; i < ms.Len(); i++ {
 				switch ms.At(i).Name() {
+				case "oracledb.consistent_gets":
+					assert.False(t, validatedMetrics["oracledb.consistent_gets"], "Found a duplicate in the metrics slice: oracledb.consistent_gets")
+					validatedMetrics["oracledb.consistent_gets"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+					assert.Equal(t, "Number of times a consistent read was requested for a block from the buffer cache.", ms.At(i).Description())
+					assert.Equal(t, "{gets}", ms.At(i).Unit())
+					assert.Equal(t, true, ms.At(i).Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+					dp := ms.At(i).Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "oracledb.cpu_time":
 					assert.False(t, validatedMetrics["oracledb.cpu_time"], "Found a duplicate in the metrics slice: oracledb.cpu_time")
 					validatedMetrics["oracledb.cpu_time"] = true
@@ -200,6 +220,20 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
 					assert.Equal(t, float64(1), dp.DoubleValue())
+				case "oracledb.db_block_gets":
+					assert.False(t, validatedMetrics["oracledb.db_block_gets"], "Found a duplicate in the metrics slice: oracledb.db_block_gets")
+					validatedMetrics["oracledb.db_block_gets"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+					assert.Equal(t, "Number of times a current block was requested from the buffer cache.", ms.At(i).Description())
+					assert.Equal(t, "{gets}", ms.At(i).Unit())
+					assert.Equal(t, true, ms.At(i).Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+					dp := ms.At(i).Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "oracledb.dml_locks.limit":
 					assert.False(t, validatedMetrics["oracledb.dml_locks.limit"], "Found a duplicate in the metrics slice: oracledb.dml_locks.limit")
 					validatedMetrics["oracledb.dml_locks.limit"] = true

--- a/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/oracledbreceiver/internal/metadata/testdata/config.yaml
@@ -1,7 +1,11 @@
 default:
 all_set:
   metrics:
+    oracledb.consistent_gets:
+      enabled: true
     oracledb.cpu_time:
+      enabled: true
+    oracledb.db_block_gets:
       enabled: true
     oracledb.dml_locks.limit:
       enabled: true
@@ -56,7 +60,11 @@ all_set:
       enabled: true
 none_set:
   metrics:
+    oracledb.consistent_gets:
+      enabled: false
     oracledb.cpu_time:
+      enabled: false
+    oracledb.db_block_gets:
       enabled: false
     oracledb.dml_locks.limit:
       enabled: false

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -232,3 +232,21 @@ metrics:
       value_type: int
       input_type: string
     unit: By
+  oracledb.db_block_gets:
+    description: Number of times a current block was requested from the buffer cache.
+    enabled: false
+    sum:
+      aggregation: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{gets}"
+  oracledb.consistent_gets:
+    description: Number of times a consistent read was requested for a block from the buffer cache.
+    enabled: false
+    sum:
+      aggregation: cumulative
+      monotonic: true
+      value_type: int
+      input_type: string
+    unit: "{gets}"


### PR DESCRIPTION
**Description:** 
Adds support for `consistent gets` and `db block gets` metrics. Disabled by default.

**Link to tracking Issue:**
Fixes #21215

**Testing:**
Unit test

**Documentation:**
Added to metrics information