### PR TITLE
[processor/k8sattributesprocessor] Chore Link pointing to wrong doc

### DIFF
--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -187,7 +187,7 @@ type FilterConfig struct {
 	// Then the NodeFromEnv field can be set to `K8S_NODE_NAME` to filter all pods by the node that
 	// the agent is running on.
 	//
-	// More on downward API here: https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/
+	// More on downward API here: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
 	NodeFromEnvVar string `mapstructure:"node_from_env_var"`
 
 	// Namespace filters all pods by the provided namespace. All other pods are ignored.


### PR DESCRIPTION
The link is currently pointing to a doc explaining downward related to volumes and not to env_vars (the use-case of the processor) and it could be misleading