### PR TITLE
[GoogleCloudSpannerReceiver]: Error scrapping metrics for TABLE_SIZES…

### DIFF
--- a/.chloggen/googlecloudspannerreceiver-table_sizes_wrong_type.yaml
+++ b/.chloggen/googlecloudspannerreceiver-table_sizes_wrong_type.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: googlecloudspannerreceiver
+note: Changing type of USED_BYTES from INT to FLOAT
+issues: [21500]
+subtext:

--- a/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml
@@ -534,7 +534,7 @@ metadata:
     metrics:
       - name: "used_bytes"
         column_name: "USED_BYTES"
-        value_type: "int"
+        value_type: "float"
         data:
           type: "gauge"
         unit: "byte"


### PR DESCRIPTION
…_STATS_1HOUR "failed to decode column 2, type *int64 cannot be used for decoding FLOAT64" (#21499)

Adjusting the type for used_bytes to float instead of int. This change will fix the 267ce3f8a2 which introduced table sizes.

**Description:** Fixing a bug - Changing the type of USED_BYTES from INT to FLOAT

**Link to tracking Issue:**

Closes #21499

**Testing:** Manually build docker image to validate the receiver.

