### PR TITLE
signalfxexporter: expose dimension client settings

### DIFF
--- a/.chloggen/sfxexporterdimclientconfig.yaml
+++ b/.chloggen/sfxexporterdimclientconfig.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Expose dimension_client configuration for dimension/metadata updates
+
+# One or more tracking issues related to the change
+issues: [21512]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -101,6 +101,13 @@ The following configuration options can also be configured:
     - dimension_name: k8s.pod.uid
       property_name: k8s.workload.name
   ```
+- `dimension_client`: Contains options controlling the dimension update client configuration used for metadata updates.
+  - `max_buffered:` (default = 10,000): The buffer size for queued dimension updates.
+  - `send_delay` (default = 10s): The time to wait between dimension updates for a given dimension.
+  - `max_idle_conns` (default = 20): The maximum idle HTTP connections the client can keep open.
+  - `max_idle_conns_per_host` (default = 20): The maximum idle HTTP connections the client can keep open per host.
+  - `max_conns_per_host` (default = 20): The maximum total number of connections the client can keep open per host.
+  - `idle_conn_timeout` (default = 30s): The maximum amount of time an idle connection will remain open before closing itself.
 - `nonalphanumeric_dimension_chars`: (default = `"_-."`) A string of characters 
 that are allowed to be used as a dimension key in addition to alphanumeric 
 characters. Each nonalphanumeric dimension key character that isn't in this string 

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"time"
 
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
@@ -93,6 +94,9 @@ type Config struct {
 	// Whether to log dimension updates being sent to SignalFx.
 	LogDimensionUpdates bool `mapstructure:"log_dimension_updates"`
 
+	// Dimension update client configuration used for metadata updates.
+	DimensionClient DimensionClientConfig `mapstructure:"dimension_client"`
+
 	splunk.AccessTokenPassthroughConfig `mapstructure:",squash"`
 
 	// TranslationRules defines a set of rules how to translate metrics to a SignalFx compatible format
@@ -140,6 +144,15 @@ type Config struct {
 	// MaxConnections is used to set a limit to the maximum idle HTTP connection the exporter can keep open.
 	// Deprecated: use HTTPClientSettings.MaxIdleConns or HTTPClientSettings.MaxIdleConnsPerHost instead.
 	MaxConnections int `mapstructure:"max_connections"`
+}
+
+type DimensionClientConfig struct {
+	MaxBuffered         int           `mapstructure:"max_buffered"`
+	SendDelay           time.Duration `mapstructure:"send_delay"`
+	MaxIdleConns        int           `mapstructure:"max_idle_conns"`
+	MaxIdleConnsPerHost int           `mapstructure:"max_idle_conns_per_host"`
+	MaxConnsPerHost     int           `mapstructure:"max_conns_per_host"`
+	IdleConnTimeout     time.Duration `mapstructure:"idle_conn_timeout"`
 }
 
 func (cfg *Config) getMetricTranslator(logger *zap.Logger) (*translation.MetricTranslator, error) {

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -45,13 +45,8 @@ func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
 
-	// Realm doesn't have a default value so set it directly.
-	defaultCfg := createDefaultConfig().(*Config)
-	defaultCfg.AccessToken = "testToken"
-	defaultCfg.Realm = "ap0"
-	require.NoError(t, err)
-
 	seventy := 70
+	hundred := 100
 	idleConnTimeout := 30 * time.Second
 
 	tests := []struct {
@@ -59,8 +54,67 @@ func TestLoadConfig(t *testing.T) {
 		expected *Config
 	}{
 		{
-			id:       component.NewIDWithName(metadata.Type, ""),
-			expected: defaultCfg,
+			id: component.NewIDWithName(metadata.Type, ""),
+			expected: &Config{
+				AccessToken: "testToken",
+				Realm:       "ap0",
+				HTTPClientSettings: confighttp.HTTPClientSettings{
+					Timeout:             5 * time.Second,
+					Headers:             nil,
+					MaxIdleConns:        &hundred,
+					MaxIdleConnsPerHost: &hundred,
+					IdleConnTimeout:     &idleConnTimeout,
+				},
+				RetrySettings: exporterhelper.RetrySettings{
+					Enabled:             true,
+					InitialInterval:     5 * time.Second,
+					MaxInterval:         30 * time.Second,
+					MaxElapsedTime:      5 * time.Minute,
+					RandomizationFactor: backoff.DefaultRandomizationFactor,
+					Multiplier:          backoff.DefaultMultiplier,
+				},
+				QueueSettings: exporterhelper.QueueSettings{
+					Enabled:      true,
+					NumConsumers: 10,
+					QueueSize:    5000,
+				}, AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
+					AccessTokenPassthrough: true,
+				},
+				LogDimensionUpdates: false,
+				DimensionClient: DimensionClientConfig{
+					MaxBuffered:         10000,
+					SendDelay:           10 * time.Second,
+					MaxIdleConns:        20,
+					MaxIdleConnsPerHost: 20,
+					MaxConnsPerHost:     20,
+					IdleConnTimeout:     30 * time.Second,
+				},
+				TranslationRules:    nil,
+				ExcludeMetrics:      nil,
+				IncludeMetrics:      nil,
+				DeltaTranslationTTL: 3600,
+				ExcludeProperties:   nil,
+				Correlation: &correlation.Config{
+					HTTPClientSettings: confighttp.HTTPClientSettings{
+						Endpoint: "",
+						Timeout:  5 * time.Second,
+					},
+					StaleServiceTimeout: 5 * time.Minute,
+					SyncAttributes: map[string]string{
+						"k8s.pod.uid":  "k8s.pod.uid",
+						"container.id": "container.id",
+					},
+					Config: apmcorrelation.Config{
+						MaxRequests:     20,
+						MaxBuffered:     10_000,
+						MaxRetries:      2,
+						LogUpdates:      false,
+						RetryDelay:      30 * time.Second,
+						CleanupInterval: 1 * time.Minute,
+					},
+				},
+				NonAlphanumericDimensionChars: "_-.",
+			},
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "allsettings"),
@@ -91,6 +145,15 @@ func TestLoadConfig(t *testing.T) {
 					QueueSize:    10,
 				}, AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
 					AccessTokenPassthrough: false,
+				},
+				LogDimensionUpdates: true,
+				DimensionClient: DimensionClientConfig{
+					MaxBuffered:         1,
+					SendDelay:           time.Hour,
+					MaxIdleConns:        100,
+					MaxIdleConnsPerHost: 10,
+					MaxConnsPerHost:     10000,
+					IdleConnTimeout:     2 * time.Hour,
 				},
 				TranslationRules: []translation.Rule{
 					{

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -152,15 +152,15 @@ func (se *signalfxExporter) start(ctx context.Context, host component.Host) (err
 			APITLSConfig: apiTLSCfg,
 			LogUpdates:   se.config.LogDimensionUpdates,
 			Logger:       se.logger,
-			// Duration to wait between property updates. This might be worth
-			// being made configurable.
-			SendDelay: 10,
-			// In case of having issues sending dimension updates to SignalFx,
-			// buffer a fixed number of updates. Might also be a good candidate
-			// to make configurable.
-			PropertiesMaxBuffered: 10000,
-			MetricsConverter:      *se.converter,
-			ExcludeProperties:     se.config.ExcludeProperties,
+			// Duration to wait between property updates.
+			SendDelay:           se.config.DimensionClient.SendDelay,
+			MaxBuffered:         se.config.DimensionClient.MaxBuffered,
+			MetricsConverter:    *se.converter,
+			ExcludeProperties:   se.config.ExcludeProperties,
+			MaxConnsPerHost:     se.config.DimensionClient.MaxConnsPerHost,
+			MaxIdleConns:        se.config.DimensionClient.MaxIdleConns,
+			MaxIdleConnsPerHost: se.config.DimensionClient.MaxIdleConnsPerHost,
+			IdleConnTimeout:     se.config.DimensionClient.IdleConnTimeout,
 		})
 	dimClient.Start()
 

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -755,7 +755,7 @@ func TestConsumeMetadata(t *testing.T) {
 		excludeProperties      []dpfilters.PropertyFilter
 		expectedDimensionKey   string
 		expectedDimensionValue string
-		sendDelay              int
+		sendDelay              time.Duration
 		shouldNotSendUpdate    bool
 	}{
 		{
@@ -928,7 +928,7 @@ func TestConsumeMetadata(t *testing.T) {
 			},
 			expectedDimensionKey:   "key",
 			expectedDimensionValue: "id",
-			sendDelay:              1,
+			sendDelay:              time.Second,
 		},
 		{
 			name: "Test updates on dimensions with nonalphanumeric characters (other than the default allow list)",
@@ -1044,14 +1044,14 @@ func TestConsumeMetadata(t *testing.T) {
 			dimClient := dimensions.NewDimensionClient(
 				context.Background(),
 				dimensions.DimensionClientOptions{
-					Token:                 "foo",
-					APIURL:                serverURL,
-					LogUpdates:            true,
-					Logger:                logger,
-					SendDelay:             tt.sendDelay,
-					PropertiesMaxBuffered: 10,
-					MetricsConverter:      *converter,
-					ExcludeProperties:     tt.excludeProperties,
+					Token:             "foo",
+					APIURL:            serverURL,
+					LogUpdates:        true,
+					Logger:            logger,
+					SendDelay:         tt.sendDelay,
+					MaxBuffered:       10,
+					MetricsConverter:  *converter,
+					ExcludeProperties: tt.excludeProperties,
 				})
 			dimClient.Start()
 
@@ -1075,7 +1075,7 @@ func TestConsumeMetadata(t *testing.T) {
 			select {
 			case <-c:
 			// wait 500ms longer than send delay
-			case <-time.After(time.Duration(tt.sendDelay)*time.Second + 500*time.Millisecond):
+			case <-time.After(tt.sendDelay + 500*time.Millisecond):
 				require.True(t, tt.shouldNotSendUpdate, "timeout waiting for response")
 			}
 
@@ -1403,14 +1403,14 @@ func TestTLSAPIConnection(t *testing.T) {
 			dimClient := dimensions.NewDimensionClient(
 				cancellable,
 				dimensions.DimensionClientOptions{
-					Token:                 "",
-					APIURL:                serverURL,
-					LogUpdates:            true,
-					Logger:                logger,
-					SendDelay:             1,
-					PropertiesMaxBuffered: 10,
-					MetricsConverter:      *converter,
-					APITLSConfig:          apiTLSCfg,
+					Token:            "",
+					APIURL:           serverURL,
+					LogUpdates:       true,
+					Logger:           logger,
+					SendDelay:        1,
+					MaxBuffered:      10,
+					MetricsConverter: *converter,
+					APITLSConfig:     apiTLSCfg,
 				})
 			dimClient.Start()
 

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -34,8 +34,13 @@ import (
 
 const (
 	defaultHTTPTimeout = time.Second * 5
+	defaultMaxConns    = 100
 
-	defaultMaxConns = 100
+	defaultDimMaxBuffered         = 10000
+	defaultDimSendDelay           = 10 * time.Second
+	defaultDimMaxConnsPerHost     = 20
+	defaultDimMaxIdleConns        = 20
+	defaultDimMaxIdleConnsPerHost = 20
 )
 
 // NewFactory creates a factory for SignalFx exporter.
@@ -68,6 +73,14 @@ func createDefaultConfig() component.Config {
 		DeltaTranslationTTL:           3600,
 		Correlation:                   correlation.DefaultConfig(),
 		NonAlphanumericDimensionChars: "_-.",
+		DimensionClient: DimensionClientConfig{
+			SendDelay:           defaultDimSendDelay,
+			MaxBuffered:         defaultDimMaxBuffered,
+			MaxConnsPerHost:     defaultDimMaxConnsPerHost,
+			MaxIdleConns:        defaultDimMaxIdleConns,
+			MaxIdleConnsPerHost: defaultDimMaxIdleConnsPerHost,
+			IdleConnTimeout:     idleConnTimeout,
+		},
 	}
 }
 

--- a/exporter/signalfxexporter/internal/dimensions/dimclient.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient.go
@@ -76,15 +76,21 @@ type queuedDimension struct {
 }
 
 type DimensionClientOptions struct {
-	Token                 configopaque.String
-	APIURL                *url.URL
-	APITLSConfig          *tls.Config
-	LogUpdates            bool
-	Logger                *zap.Logger
-	SendDelay             int
-	PropertiesMaxBuffered int
-	MetricsConverter      translation.MetricsConverter
-	ExcludeProperties     []dpfilters.PropertyFilter
+	Token        configopaque.String
+	APIURL       *url.URL
+	APITLSConfig *tls.Config
+	LogUpdates   bool
+	Logger       *zap.Logger
+	SendDelay    time.Duration
+	// In case of having issues sending dimension updates to SignalFx,
+	// buffer a fixed number of updates.
+	MaxBuffered         int
+	MetricsConverter    translation.MetricsConverter
+	ExcludeProperties   []dpfilters.PropertyFilter
+	MaxConnsPerHost     int
+	MaxIdleConns        int
+	MaxIdleConnsPerHost int
+	IdleConnTimeout     time.Duration
 }
 
 // NewDimensionClient returns a new client
@@ -98,9 +104,10 @@ func NewDimensionClient(ctx context.Context, options DimensionClientOptions) *Di
 				KeepAlive: 30 * time.Second,
 				DualStack: true,
 			}).DialContext,
-			MaxIdleConns:        20,
-			MaxIdleConnsPerHost: 20,
-			IdleConnTimeout:     30 * time.Second,
+			MaxConnsPerHost:     options.MaxConnsPerHost,
+			MaxIdleConns:        options.MaxIdleConns,
+			MaxIdleConnsPerHost: options.MaxIdleConnsPerHost,
+			IdleConnTimeout:     options.IdleConnTimeout,
 			TLSHandshakeTimeout: 10 * time.Second,
 			TLSClientConfig:     options.APITLSConfig,
 		},
@@ -111,9 +118,9 @@ func NewDimensionClient(ctx context.Context, options DimensionClientOptions) *Di
 		ctx:               ctx,
 		Token:             options.Token,
 		APIURL:            options.APIURL,
-		sendDelay:         time.Duration(options.SendDelay) * time.Second,
+		sendDelay:         options.SendDelay,
 		delayedSet:        make(map[DimensionKey]*DimensionUpdate),
-		delayedQueue:      make(chan *queuedDimension, options.PropertiesMaxBuffered),
+		delayedQueue:      make(chan *queuedDimension, options.MaxBuffered),
 		requestSender:     sender,
 		client:            client,
 		now:               time.Now,

--- a/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
@@ -114,11 +114,11 @@ func setup(t *testing.T) (*DimensionClient, chan dim, *atomic.Int32, context.Can
 	}()
 
 	client := NewDimensionClient(ctx, DimensionClientOptions{
-		APIURL:                serverURL,
-		LogUpdates:            true,
-		Logger:                zap.NewNop(),
-		SendDelay:             1,
-		PropertiesMaxBuffered: 10,
+		APIURL:      serverURL,
+		LogUpdates:  true,
+		Logger:      zap.NewNop(),
+		SendDelay:   time.Second,
+		MaxBuffered: 10,
 	})
 	client.Start()
 

--- a/exporter/signalfxexporter/testdata/config.yaml
+++ b/exporter/signalfxexporter/testdata/config.yaml
@@ -61,6 +61,14 @@ signalfx/allsettings:
   include_metrics:
     - metric_name: metric1
     - metric_names: [metric2, metric3]
+  log_dimension_updates: true
+  dimension_client:
+    max_buffered: 1
+    send_delay: 1h
+    max_idle_conns: 100
+    max_idle_conns_per_host: 10
+    max_conns_per_host: 10000
+    idle_conn_timeout: 2h
   exclude_properties:
     - property_name: globbed*
     - property_value: '!globbed*value'


### PR DESCRIPTION
**Description:**
Adding a feature - Currently the dimension client options used for metadata updates are hardcoded by the exporter, which is undesirable where tuning is needed*. These changes expose the settings through a new config helper, including a slight adjustment to the `PropertiesMaxBuffered` field name, which is a misnomer.

**Testing:** Updated existing config tests to exercise the mapping, as well as updating an existing default setting test to make sure we're checking for more than the factory helper being called.

**Documentation:** Added to readme.