### PR TITLE
[chore] [cmd/mdatagen] Rename structs with Settings suffix to Config

### DIFF
--- a/cmd/mdatagen/internal/metadata/generated_metrics.go
+++ b/cmd/mdatagen/internal/metadata/generated_metrics.go
@@ -13,14 +13,14 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -32,56 +32,56 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for testreceiver metrics.
-type MetricsSettings struct {
-	DefaultMetric            MetricSettings `mapstructure:"default.metric"`
-	DefaultMetricToBeRemoved MetricSettings `mapstructure:"default.metric.to_be_removed"`
-	OptionalMetric           MetricSettings `mapstructure:"optional.metric"`
+// MetricsConfig provides config for testreceiver metrics.
+type MetricsConfig struct {
+	DefaultMetric            MetricConfig `mapstructure:"default.metric"`
+	DefaultMetricToBeRemoved MetricConfig `mapstructure:"default.metric.to_be_removed"`
+	OptionalMetric           MetricConfig `mapstructure:"optional.metric"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		DefaultMetric: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		DefaultMetric: MetricConfig{
 			Enabled: true,
 		},
-		DefaultMetricToBeRemoved: MetricSettings{
+		DefaultMetricToBeRemoved: MetricConfig{
 			Enabled: true,
 		},
-		OptionalMetric: MetricSettings{
+		OptionalMetric: MetricConfig{
 			Enabled: false,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for testreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	MapResourceAttr        ResourceAttributeSettings `mapstructure:"map.resource.attr"`
-	OptionalResourceAttr   ResourceAttributeSettings `mapstructure:"optional.resource.attr"`
-	SliceResourceAttr      ResourceAttributeSettings `mapstructure:"slice.resource.attr"`
-	StringEnumResourceAttr ResourceAttributeSettings `mapstructure:"string.enum.resource.attr"`
-	StringResourceAttr     ResourceAttributeSettings `mapstructure:"string.resource.attr"`
+// ResourceAttributesConfig provides config for testreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	MapResourceAttr        ResourceAttributeConfig `mapstructure:"map.resource.attr"`
+	OptionalResourceAttr   ResourceAttributeConfig `mapstructure:"optional.resource.attr"`
+	SliceResourceAttr      ResourceAttributeConfig `mapstructure:"slice.resource.attr"`
+	StringEnumResourceAttr ResourceAttributeConfig `mapstructure:"string.enum.resource.attr"`
+	StringResourceAttr     ResourceAttributeConfig `mapstructure:"string.resource.attr"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		MapResourceAttr: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		MapResourceAttr: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		OptionalResourceAttr: ResourceAttributeSettings{
+		OptionalResourceAttr: ResourceAttributeConfig{
 			Enabled: false,
 		},
-		SliceResourceAttr: ResourceAttributeSettings{
+		SliceResourceAttr: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		StringEnumResourceAttr: ResourceAttributeSettings{
+		StringEnumResourceAttr: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		StringResourceAttr: ResourceAttributeSettings{
+		StringResourceAttr: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -119,7 +119,7 @@ var MapAttributeEnumAttr = map[string]AttributeEnumAttr{
 
 type metricDefaultMetric struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -135,7 +135,7 @@ func (m *metricDefaultMetric) init() {
 }
 
 func (m *metricDefaultMetric) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stringAttrAttributeValue string, overriddenIntAttrAttributeValue int64, enumAttrAttributeValue string, sliceAttrAttributeValue []any, mapAttrAttributeValue map[string]any) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -158,16 +158,16 @@ func (m *metricDefaultMetric) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricDefaultMetric) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricDefaultMetric(settings MetricSettings) metricDefaultMetric {
-	m := metricDefaultMetric{settings: settings}
-	if settings.Enabled {
+func newMetricDefaultMetric(cfg MetricConfig) metricDefaultMetric {
+	m := metricDefaultMetric{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -176,7 +176,7 @@ func newMetricDefaultMetric(settings MetricSettings) metricDefaultMetric {
 
 type metricDefaultMetricToBeRemoved struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -191,7 +191,7 @@ func (m *metricDefaultMetricToBeRemoved) init() {
 }
 
 func (m *metricDefaultMetricToBeRemoved) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -209,16 +209,16 @@ func (m *metricDefaultMetricToBeRemoved) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricDefaultMetricToBeRemoved) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricDefaultMetricToBeRemoved(settings MetricSettings) metricDefaultMetricToBeRemoved {
-	m := metricDefaultMetricToBeRemoved{settings: settings}
-	if settings.Enabled {
+func newMetricDefaultMetricToBeRemoved(cfg MetricConfig) metricDefaultMetricToBeRemoved {
+	m := metricDefaultMetricToBeRemoved{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -227,7 +227,7 @@ func newMetricDefaultMetricToBeRemoved(settings MetricSettings) metricDefaultMet
 
 type metricOptionalMetric struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -241,7 +241,7 @@ func (m *metricOptionalMetric) init() {
 }
 
 func (m *metricOptionalMetric) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, stringAttrAttributeValue string, booleanAttrAttributeValue bool) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -261,16 +261,16 @@ func (m *metricOptionalMetric) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOptionalMetric) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOptionalMetric(settings MetricSettings) metricOptionalMetric {
-	m := metricOptionalMetric{settings: settings}
-	if settings.Enabled {
+func newMetricOptionalMetric(cfg MetricConfig) metricOptionalMetric {
+	m := metricOptionalMetric{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -279,19 +279,19 @@ func newMetricOptionalMetric(settings MetricSettings) metricOptionalMetric {
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                      pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                int                 // maximum observed number of metrics per resource.
 	resourceCapacity               int                 // maximum observed number of resource attributes.
 	metricsBuffer                  pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                      component.BuildInfo // contains version information
-	resourceAttributesSettings     ResourceAttributesSettings
+	resourceAttributesConfig       ResourceAttributesConfig
 	metricDefaultMetric            metricDefaultMetric
 	metricDefaultMetricToBeRemoved metricDefaultMetricToBeRemoved
 	metricOptionalMetric           metricOptionalMetric
@@ -309,8 +309,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -328,7 +328,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                      pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                  pmetric.NewMetrics(),
 		buildInfo:                      settings.BuildInfo,
-		resourceAttributesSettings:     mbc.ResourceAttributes,
+		resourceAttributesConfig:       mbc.ResourceAttributes,
 		metricDefaultMetric:            newMetricDefaultMetric(mbc.Metrics.DefaultMetric),
 		metricDefaultMetricToBeRemoved: newMetricDefaultMetricToBeRemoved(mbc.Metrics.DefaultMetricToBeRemoved),
 		metricOptionalMetric:           newMetricOptionalMetric(mbc.Metrics.OptionalMetric),
@@ -350,12 +350,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithMapResourceAttr sets provided value as "map.resource.attr" attribute for current resource.
 func WithMapResourceAttr(val map[string]any) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MapResourceAttr.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MapResourceAttr.Enabled {
 			rm.Resource().Attributes().PutEmptyMap("map.resource.attr").FromRaw(val)
 		}
 	}
@@ -363,8 +363,8 @@ func WithMapResourceAttr(val map[string]any) ResourceMetricsOption {
 
 // WithOptionalResourceAttr sets provided value as "optional.resource.attr" attribute for current resource.
 func WithOptionalResourceAttr(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.OptionalResourceAttr.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.OptionalResourceAttr.Enabled {
 			rm.Resource().Attributes().PutStr("optional.resource.attr", val)
 		}
 	}
@@ -372,31 +372,31 @@ func WithOptionalResourceAttr(val string) ResourceMetricsOption {
 
 // WithSliceResourceAttr sets provided value as "slice.resource.attr" attribute for current resource.
 func WithSliceResourceAttr(val []any) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.SliceResourceAttr.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.SliceResourceAttr.Enabled {
 			rm.Resource().Attributes().PutEmptySlice("slice.resource.attr").FromRaw(val)
 		}
 	}
 }
 
 // WithStringEnumResourceAttrOne sets "string.enum.resource.attr=one" attribute for current resource.
-func WithStringEnumResourceAttrOne(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-	if ras.StringEnumResourceAttr.Enabled {
+func WithStringEnumResourceAttrOne(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+	if rac.StringEnumResourceAttr.Enabled {
 		rm.Resource().Attributes().PutStr("string.enum.resource.attr", "one")
 	}
 }
 
 // WithStringEnumResourceAttrTwo sets "string.enum.resource.attr=two" attribute for current resource.
-func WithStringEnumResourceAttrTwo(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-	if ras.StringEnumResourceAttr.Enabled {
+func WithStringEnumResourceAttrTwo(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+	if rac.StringEnumResourceAttr.Enabled {
 		rm.Resource().Attributes().PutStr("string.enum.resource.attr", "two")
 	}
 }
 
 // WithStringResourceAttr sets provided value as "string.resource.attr" attribute for current resource.
 func WithStringResourceAttr(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.StringResourceAttr.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.StringResourceAttr.Enabled {
 			rm.Resource().Attributes().PutStr("string.resource.attr", val)
 		}
 	}
@@ -405,7 +405,7 @@ func WithStringResourceAttr(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -440,7 +440,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricOptionalMetric.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -450,7 +450,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/cmd/mdatagen/internal/metadata/generated_metrics_test.go
+++ b/cmd/mdatagen/internal/metadata/generated_metrics_test.go
@@ -94,36 +94,36 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("map.resource.attr")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MapResourceAttr.Enabled, ok)
-			if mb.resourceAttributesSettings.MapResourceAttr.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MapResourceAttr.Enabled, ok)
+			if mb.resourceAttributesConfig.MapResourceAttr.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, map[string]any{"onek": "onev", "twok": "twov"}, attrVal.Map().AsRaw())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("optional.resource.attr")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.OptionalResourceAttr.Enabled, ok)
-			if mb.resourceAttributesSettings.OptionalResourceAttr.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.OptionalResourceAttr.Enabled, ok)
+			if mb.resourceAttributesConfig.OptionalResourceAttr.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("slice.resource.attr")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.SliceResourceAttr.Enabled, ok)
-			if mb.resourceAttributesSettings.SliceResourceAttr.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.SliceResourceAttr.Enabled, ok)
+			if mb.resourceAttributesConfig.SliceResourceAttr.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, []any{"one", "two"}, attrVal.Slice().AsRaw())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("string.enum.resource.attr")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.StringEnumResourceAttr.Enabled, ok)
-			if mb.resourceAttributesSettings.StringEnumResourceAttr.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.StringEnumResourceAttr.Enabled, ok)
+			if mb.resourceAttributesConfig.StringEnumResourceAttr.Enabled {
 				enabledAttrCount++
 				assert.Equal(t, "one", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("string.resource.attr")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.StringResourceAttr.Enabled, ok)
-			if mb.resourceAttributesSettings.StringResourceAttr.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.StringResourceAttr.Enabled, ok)
+			if mb.resourceAttributesConfig.StringResourceAttr.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/cmd/mdatagen/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/templates/metrics.go.tmpl
@@ -19,14 +19,14 @@ import (
 	{{- end }}
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -38,17 +38,17 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for {{ .Type }} metrics.
-type MetricsSettings struct {
+// MetricsConfig provides config for {{ .Type }} metrics.
+type MetricsConfig struct {
 	{{- range $name, $metric := .Metrics }}
-	{{ $name.Render }} MetricSettings `mapstructure:"{{ $name }}"`
+	{{ $name.Render }} MetricConfig `mapstructure:"{{ $name }}"`
 	{{- end }}
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
 		{{- range $name, $metric := .Metrics }}
-		{{ $name.Render }}: MetricSettings{
+		{{ $name.Render }}: MetricConfig{
 			Enabled: {{ $metric.Enabled }},
 		},
 		{{- end }}
@@ -56,22 +56,22 @@ func DefaultMetricsSettings() MetricsSettings {
 }
 
 {{ if .ResourceAttributes -}}
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for {{ .Type }} resource attributes.
-type ResourceAttributesSettings struct {
+// ResourceAttributesConfig provides config for {{ .Type }} resource attributes.
+type ResourceAttributesConfig struct {
 	{{- range $name, $attr := .ResourceAttributes }}
-	{{ $name.Render }} ResourceAttributeSettings `mapstructure:"{{ $name }}"`
+	{{ $name.Render }} ResourceAttributeConfig `mapstructure:"{{ $name }}"`
 	{{- end }}
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
 		{{- range $name, $attr := .ResourceAttributes }}
-		{{ $name.Render }}: ResourceAttributeSettings {
+		{{ $name.Render }}: ResourceAttributeConfig {
 			Enabled: {{ $attr.Enabled }},
 		},
 		{{- end }}
@@ -114,8 +114,8 @@ var MapAttribute{{ $name.Render }} = map[string]Attribute{{ $name.Render }}{
 
 {{ range $name, $metric := .Metrics -}}
 type metric{{ $name.Render }} struct {
-	data     pmetric.Metric   // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	data     pmetric.Metric // data buffer for generated metric.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -138,7 +138,7 @@ func (m *metric{{ $name.Render }}) init() {
 
 func (m *metric{{ $name.Render }}) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val {{ $metric.Data.MetricValueType.BasicType }}
 {{- range $metric.Attributes -}}, {{ .RenderUnexported }}AttributeValue {{ (attributeInfo .).Type.Primitive }}{{ end }}) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.{{ $metric.Data.Type }}().DataPoints().AppendEmpty()
@@ -167,16 +167,16 @@ func (m *metric{{ $name.Render }}) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metric{{ $name.Render }}) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.{{ $metric.Data.Type }}().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.{{ $metric.Data.Type }}().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetric{{ $name.Render }}(settings MetricSettings) metric{{ $name.Render }} {
-	m := metric{{ $name.Render }}{settings: settings}
-	if settings.Enabled {
+func newMetric{{ $name.Render }}(cfg MetricConfig) metric{{ $name.Render }} {
+	m := metric{{ $name.Render }}{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -187,14 +187,14 @@ func newMetric{{ $name.Render }}(settings MetricSettings) metric{{ $name.Render 
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-    Metrics MetricsSettings `mapstructure:"metrics"`
+    Metrics MetricsConfig `mapstructure:"metrics"`
     {{- if .ResourceAttributes }}
-    ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+    ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
     {{- end }}
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                pcommon.Timestamp // start time that will be applied to all recorded data points.
 	metricsCapacity          int             // maximum observed number of metrics per resource.
@@ -202,7 +202,7 @@ type MetricsBuilder struct {
 	metricsBuffer            pmetric.Metrics   // accumulates metrics data before emitting.
 	buildInfo                component.BuildInfo // contains version information
 	{{- if .ResourceAttributes }}
-	resourceAttributesSettings ResourceAttributesSettings
+	resourceAttributesConfig ResourceAttributesConfig
 	{{- end }}
 	{{- range $name, $metric := .Metrics }}
 	metric{{ $name.Render }} metric{{ $name.Render }}
@@ -221,9 +221,9 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
    return MetricsBuilderConfig {
-        Metrics: DefaultMetricsSettings(),
+        Metrics: DefaultMetricsConfig(),
         {{- if .ResourceAttributes }}
-        ResourceAttributes: DefaultResourceAttributesSettings(),
+        ResourceAttributes: DefaultResourceAttributesConfig(),
         {{- end }}
    }
 }
@@ -251,7 +251,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		metricsBuffer:            pmetric.NewMetrics(),
 		buildInfo:                settings.BuildInfo,
 		{{- if .ResourceAttributes }}
-		resourceAttributesSettings: mbc.ResourceAttributes,
+		resourceAttributesConfig: mbc.ResourceAttributes,
 		{{- end }}
 		{{- range $name, $metric := .Metrics }}
 		metric{{ $name.Render }}: newMetric{{ $name.Render }}(mbc.Metrics.{{ $name.Render }}),
@@ -274,21 +274,21 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func({{ if .ResourceAttributes }}ResourceAttributesSettings, {{ end }}pmetric.ResourceMetrics)
+type ResourceMetricsOption func({{ if .ResourceAttributes }}ResourceAttributesConfig, {{ end }}pmetric.ResourceMetrics)
 
 {{- range $name, $attr := .ResourceAttributes }}
 {{- range $attr.Enum }}
 // With{{ $name.Render }}{{ . | publicVar }} sets "{{ $name }}={{ . }}" attribute for current resource.
-func With{{ $name.Render }}{{ . | publicVar }}(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-	if ras.{{ $name.Render }}.Enabled {
+func With{{ $name.Render }}{{ . | publicVar }}(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+	if rac.{{ $name.Render }}.Enabled {
 		rm.Resource().Attributes().PutStr("{{ attributeName $name}}", "{{ . }}")
 	}
 }
 {{- else }}
 // With{{ $name.Render }} sets provided value as "{{ $name }}" attribute for current resource.
 func With{{ $name.Render }}(val {{ $attr.Type.Primitive }}) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.{{ $name.Render }}.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.{{ $name.Render }}.Enabled {
 			{{- if eq $attr.Type.Primitive "[]byte" }}
 			rm.Resource().Attributes().PutEmptyBytes("{{ attributeName $name}}").FromRaw(val)
 			{{- else if eq $attr.Type.Primitive "[]any" }}
@@ -307,7 +307,7 @@ func With{{ $name.Render }}(val {{ $attr.Type.Primitive }}) ResourceMetricsOptio
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func({{ if .ResourceAttributes }}_ ResourceAttributesSettings, {{ end }}rm pmetric.ResourceMetrics) {
+	return func({{ if .ResourceAttributes }}_ ResourceAttributesConfig, {{ end }}rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -344,7 +344,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	{{- end }}
 
 	for _, op := range rmo {
-		op({{ if .ResourceAttributes }}mb.resourceAttributesSettings, {{ end }}rm)
+		op({{ if .ResourceAttributes }}mb.resourceAttributesConfig, {{ end }}rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -354,7 +354,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/cmd/mdatagen/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/templates/metrics_test.go.tmpl
@@ -110,8 +110,8 @@ func TestMetricsBuilder(t *testing.T) {
 			{{- range $name, $info := .ResourceAttributes }}
 				attrVal, ok {{ $assignSign }} rm.Resource().Attributes().Get("{{ $name }}")
 				attrCount++
-				assert.Equal(t, mb.resourceAttributesSettings.{{ $name.Render }}.Enabled, ok)
-				if mb.resourceAttributesSettings.{{ $name.Render }}.Enabled {
+				assert.Equal(t, mb.resourceAttributesConfig.{{ $name.Render }}.Enabled, ok)
+				if mb.resourceAttributesConfig.{{ $name.Render }}.Enabled {
 					enabledAttrCount++
 					{{- if $info.Enum }}
 						assert.Equal(t, "{{ index $info.Enum 0 }}", attrVal.Str())

--- a/receiver/activedirectorydsreceiver/config_test.go
+++ b/receiver/activedirectorydsreceiver/config_test.go
@@ -67,7 +67,7 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 			assert.NoError(t, component.ValidateConfig(cfg))
-			if diff := cmp.Diff(tt.expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricsBuilderConfig{}), cmpopts.IgnoreUnexported(metadata.MetricSettings{})); diff != "" {
+			if diff := cmp.Diff(tt.expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricsBuilderConfig{}), cmpopts.IgnoreUnexported(metadata.MetricConfig{})); diff != "" {
 				t.Errorf("Config mismatch (-expected +actual):\n%s", diff)
 			}
 		})

--- a/receiver/activedirectorydsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/activedirectorydsreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,82 +31,82 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for activedirectorydsreceiver metrics.
-type MetricsSettings struct {
-	ActiveDirectoryDsBindRate                                  MetricSettings `mapstructure:"active_directory.ds.bind.rate"`
-	ActiveDirectoryDsLdapBindLastSuccessfulTime                MetricSettings `mapstructure:"active_directory.ds.ldap.bind.last_successful.time"`
-	ActiveDirectoryDsLdapBindRate                              MetricSettings `mapstructure:"active_directory.ds.ldap.bind.rate"`
-	ActiveDirectoryDsLdapClientSessionCount                    MetricSettings `mapstructure:"active_directory.ds.ldap.client.session.count"`
-	ActiveDirectoryDsLdapSearchRate                            MetricSettings `mapstructure:"active_directory.ds.ldap.search.rate"`
-	ActiveDirectoryDsNameCacheHitRate                          MetricSettings `mapstructure:"active_directory.ds.name_cache.hit_rate"`
-	ActiveDirectoryDsNotificationQueued                        MetricSettings `mapstructure:"active_directory.ds.notification.queued"`
-	ActiveDirectoryDsOperationRate                             MetricSettings `mapstructure:"active_directory.ds.operation.rate"`
-	ActiveDirectoryDsReplicationNetworkIo                      MetricSettings `mapstructure:"active_directory.ds.replication.network.io"`
-	ActiveDirectoryDsReplicationObjectRate                     MetricSettings `mapstructure:"active_directory.ds.replication.object.rate"`
-	ActiveDirectoryDsReplicationOperationPending               MetricSettings `mapstructure:"active_directory.ds.replication.operation.pending"`
-	ActiveDirectoryDsReplicationPropertyRate                   MetricSettings `mapstructure:"active_directory.ds.replication.property.rate"`
-	ActiveDirectoryDsReplicationSyncObjectPending              MetricSettings `mapstructure:"active_directory.ds.replication.sync.object.pending"`
-	ActiveDirectoryDsReplicationSyncRequestCount               MetricSettings `mapstructure:"active_directory.ds.replication.sync.request.count"`
-	ActiveDirectoryDsReplicationValueRate                      MetricSettings `mapstructure:"active_directory.ds.replication.value.rate"`
-	ActiveDirectoryDsSecurityDescriptorPropagationsEventQueued MetricSettings `mapstructure:"active_directory.ds.security_descriptor_propagations_event.queued"`
-	ActiveDirectoryDsSuboperationRate                          MetricSettings `mapstructure:"active_directory.ds.suboperation.rate"`
-	ActiveDirectoryDsThreadCount                               MetricSettings `mapstructure:"active_directory.ds.thread.count"`
+// MetricsConfig provides config for activedirectorydsreceiver metrics.
+type MetricsConfig struct {
+	ActiveDirectoryDsBindRate                                  MetricConfig `mapstructure:"active_directory.ds.bind.rate"`
+	ActiveDirectoryDsLdapBindLastSuccessfulTime                MetricConfig `mapstructure:"active_directory.ds.ldap.bind.last_successful.time"`
+	ActiveDirectoryDsLdapBindRate                              MetricConfig `mapstructure:"active_directory.ds.ldap.bind.rate"`
+	ActiveDirectoryDsLdapClientSessionCount                    MetricConfig `mapstructure:"active_directory.ds.ldap.client.session.count"`
+	ActiveDirectoryDsLdapSearchRate                            MetricConfig `mapstructure:"active_directory.ds.ldap.search.rate"`
+	ActiveDirectoryDsNameCacheHitRate                          MetricConfig `mapstructure:"active_directory.ds.name_cache.hit_rate"`
+	ActiveDirectoryDsNotificationQueued                        MetricConfig `mapstructure:"active_directory.ds.notification.queued"`
+	ActiveDirectoryDsOperationRate                             MetricConfig `mapstructure:"active_directory.ds.operation.rate"`
+	ActiveDirectoryDsReplicationNetworkIo                      MetricConfig `mapstructure:"active_directory.ds.replication.network.io"`
+	ActiveDirectoryDsReplicationObjectRate                     MetricConfig `mapstructure:"active_directory.ds.replication.object.rate"`
+	ActiveDirectoryDsReplicationOperationPending               MetricConfig `mapstructure:"active_directory.ds.replication.operation.pending"`
+	ActiveDirectoryDsReplicationPropertyRate                   MetricConfig `mapstructure:"active_directory.ds.replication.property.rate"`
+	ActiveDirectoryDsReplicationSyncObjectPending              MetricConfig `mapstructure:"active_directory.ds.replication.sync.object.pending"`
+	ActiveDirectoryDsReplicationSyncRequestCount               MetricConfig `mapstructure:"active_directory.ds.replication.sync.request.count"`
+	ActiveDirectoryDsReplicationValueRate                      MetricConfig `mapstructure:"active_directory.ds.replication.value.rate"`
+	ActiveDirectoryDsSecurityDescriptorPropagationsEventQueued MetricConfig `mapstructure:"active_directory.ds.security_descriptor_propagations_event.queued"`
+	ActiveDirectoryDsSuboperationRate                          MetricConfig `mapstructure:"active_directory.ds.suboperation.rate"`
+	ActiveDirectoryDsThreadCount                               MetricConfig `mapstructure:"active_directory.ds.thread.count"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		ActiveDirectoryDsBindRate: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		ActiveDirectoryDsBindRate: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsLdapBindLastSuccessfulTime: MetricSettings{
+		ActiveDirectoryDsLdapBindLastSuccessfulTime: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsLdapBindRate: MetricSettings{
+		ActiveDirectoryDsLdapBindRate: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsLdapClientSessionCount: MetricSettings{
+		ActiveDirectoryDsLdapClientSessionCount: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsLdapSearchRate: MetricSettings{
+		ActiveDirectoryDsLdapSearchRate: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsNameCacheHitRate: MetricSettings{
+		ActiveDirectoryDsNameCacheHitRate: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsNotificationQueued: MetricSettings{
+		ActiveDirectoryDsNotificationQueued: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsOperationRate: MetricSettings{
+		ActiveDirectoryDsOperationRate: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsReplicationNetworkIo: MetricSettings{
+		ActiveDirectoryDsReplicationNetworkIo: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsReplicationObjectRate: MetricSettings{
+		ActiveDirectoryDsReplicationObjectRate: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsReplicationOperationPending: MetricSettings{
+		ActiveDirectoryDsReplicationOperationPending: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsReplicationPropertyRate: MetricSettings{
+		ActiveDirectoryDsReplicationPropertyRate: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsReplicationSyncObjectPending: MetricSettings{
+		ActiveDirectoryDsReplicationSyncObjectPending: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsReplicationSyncRequestCount: MetricSettings{
+		ActiveDirectoryDsReplicationSyncRequestCount: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsReplicationValueRate: MetricSettings{
+		ActiveDirectoryDsReplicationValueRate: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsSecurityDescriptorPropagationsEventQueued: MetricSettings{
+		ActiveDirectoryDsSecurityDescriptorPropagationsEventQueued: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsSuboperationRate: MetricSettings{
+		ActiveDirectoryDsSuboperationRate: MetricConfig{
 			Enabled: true,
 		},
-		ActiveDirectoryDsThreadCount: MetricSettings{
+		ActiveDirectoryDsThreadCount: MetricConfig{
 			Enabled: true,
 		},
 	}
@@ -304,7 +304,7 @@ var MapAttributeValueType = map[string]AttributeValueType{
 
 type metricActiveDirectoryDsBindRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -320,7 +320,7 @@ func (m *metricActiveDirectoryDsBindRate) init() {
 }
 
 func (m *metricActiveDirectoryDsBindRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, bindTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -339,16 +339,16 @@ func (m *metricActiveDirectoryDsBindRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsBindRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsBindRate(settings MetricSettings) metricActiveDirectoryDsBindRate {
-	m := metricActiveDirectoryDsBindRate{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsBindRate(cfg MetricConfig) metricActiveDirectoryDsBindRate {
+	m := metricActiveDirectoryDsBindRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -357,7 +357,7 @@ func newMetricActiveDirectoryDsBindRate(settings MetricSettings) metricActiveDir
 
 type metricActiveDirectoryDsLdapBindLastSuccessfulTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -370,7 +370,7 @@ func (m *metricActiveDirectoryDsLdapBindLastSuccessfulTime) init() {
 }
 
 func (m *metricActiveDirectoryDsLdapBindLastSuccessfulTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -388,16 +388,16 @@ func (m *metricActiveDirectoryDsLdapBindLastSuccessfulTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsLdapBindLastSuccessfulTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsLdapBindLastSuccessfulTime(settings MetricSettings) metricActiveDirectoryDsLdapBindLastSuccessfulTime {
-	m := metricActiveDirectoryDsLdapBindLastSuccessfulTime{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsLdapBindLastSuccessfulTime(cfg MetricConfig) metricActiveDirectoryDsLdapBindLastSuccessfulTime {
+	m := metricActiveDirectoryDsLdapBindLastSuccessfulTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -406,7 +406,7 @@ func newMetricActiveDirectoryDsLdapBindLastSuccessfulTime(settings MetricSetting
 
 type metricActiveDirectoryDsLdapBindRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -421,7 +421,7 @@ func (m *metricActiveDirectoryDsLdapBindRate) init() {
 }
 
 func (m *metricActiveDirectoryDsLdapBindRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -439,16 +439,16 @@ func (m *metricActiveDirectoryDsLdapBindRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsLdapBindRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsLdapBindRate(settings MetricSettings) metricActiveDirectoryDsLdapBindRate {
-	m := metricActiveDirectoryDsLdapBindRate{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsLdapBindRate(cfg MetricConfig) metricActiveDirectoryDsLdapBindRate {
+	m := metricActiveDirectoryDsLdapBindRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -457,7 +457,7 @@ func newMetricActiveDirectoryDsLdapBindRate(settings MetricSettings) metricActiv
 
 type metricActiveDirectoryDsLdapClientSessionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -472,7 +472,7 @@ func (m *metricActiveDirectoryDsLdapClientSessionCount) init() {
 }
 
 func (m *metricActiveDirectoryDsLdapClientSessionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -490,16 +490,16 @@ func (m *metricActiveDirectoryDsLdapClientSessionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsLdapClientSessionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsLdapClientSessionCount(settings MetricSettings) metricActiveDirectoryDsLdapClientSessionCount {
-	m := metricActiveDirectoryDsLdapClientSessionCount{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsLdapClientSessionCount(cfg MetricConfig) metricActiveDirectoryDsLdapClientSessionCount {
+	m := metricActiveDirectoryDsLdapClientSessionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -508,7 +508,7 @@ func newMetricActiveDirectoryDsLdapClientSessionCount(settings MetricSettings) m
 
 type metricActiveDirectoryDsLdapSearchRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -523,7 +523,7 @@ func (m *metricActiveDirectoryDsLdapSearchRate) init() {
 }
 
 func (m *metricActiveDirectoryDsLdapSearchRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -541,16 +541,16 @@ func (m *metricActiveDirectoryDsLdapSearchRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsLdapSearchRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsLdapSearchRate(settings MetricSettings) metricActiveDirectoryDsLdapSearchRate {
-	m := metricActiveDirectoryDsLdapSearchRate{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsLdapSearchRate(cfg MetricConfig) metricActiveDirectoryDsLdapSearchRate {
+	m := metricActiveDirectoryDsLdapSearchRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -559,7 +559,7 @@ func newMetricActiveDirectoryDsLdapSearchRate(settings MetricSettings) metricAct
 
 type metricActiveDirectoryDsNameCacheHitRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -572,7 +572,7 @@ func (m *metricActiveDirectoryDsNameCacheHitRate) init() {
 }
 
 func (m *metricActiveDirectoryDsNameCacheHitRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -590,16 +590,16 @@ func (m *metricActiveDirectoryDsNameCacheHitRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsNameCacheHitRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsNameCacheHitRate(settings MetricSettings) metricActiveDirectoryDsNameCacheHitRate {
-	m := metricActiveDirectoryDsNameCacheHitRate{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsNameCacheHitRate(cfg MetricConfig) metricActiveDirectoryDsNameCacheHitRate {
+	m := metricActiveDirectoryDsNameCacheHitRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -608,7 +608,7 @@ func newMetricActiveDirectoryDsNameCacheHitRate(settings MetricSettings) metricA
 
 type metricActiveDirectoryDsNotificationQueued struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -623,7 +623,7 @@ func (m *metricActiveDirectoryDsNotificationQueued) init() {
 }
 
 func (m *metricActiveDirectoryDsNotificationQueued) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -641,16 +641,16 @@ func (m *metricActiveDirectoryDsNotificationQueued) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsNotificationQueued) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsNotificationQueued(settings MetricSettings) metricActiveDirectoryDsNotificationQueued {
-	m := metricActiveDirectoryDsNotificationQueued{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsNotificationQueued(cfg MetricConfig) metricActiveDirectoryDsNotificationQueued {
+	m := metricActiveDirectoryDsNotificationQueued{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -659,7 +659,7 @@ func newMetricActiveDirectoryDsNotificationQueued(settings MetricSettings) metri
 
 type metricActiveDirectoryDsOperationRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -675,7 +675,7 @@ func (m *metricActiveDirectoryDsOperationRate) init() {
 }
 
 func (m *metricActiveDirectoryDsOperationRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, operationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -694,16 +694,16 @@ func (m *metricActiveDirectoryDsOperationRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsOperationRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsOperationRate(settings MetricSettings) metricActiveDirectoryDsOperationRate {
-	m := metricActiveDirectoryDsOperationRate{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsOperationRate(cfg MetricConfig) metricActiveDirectoryDsOperationRate {
+	m := metricActiveDirectoryDsOperationRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -712,7 +712,7 @@ func newMetricActiveDirectoryDsOperationRate(settings MetricSettings) metricActi
 
 type metricActiveDirectoryDsReplicationNetworkIo struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -728,7 +728,7 @@ func (m *metricActiveDirectoryDsReplicationNetworkIo) init() {
 }
 
 func (m *metricActiveDirectoryDsReplicationNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string, networkDataTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -748,16 +748,16 @@ func (m *metricActiveDirectoryDsReplicationNetworkIo) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsReplicationNetworkIo) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsReplicationNetworkIo(settings MetricSettings) metricActiveDirectoryDsReplicationNetworkIo {
-	m := metricActiveDirectoryDsReplicationNetworkIo{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsReplicationNetworkIo(cfg MetricConfig) metricActiveDirectoryDsReplicationNetworkIo {
+	m := metricActiveDirectoryDsReplicationNetworkIo{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -766,7 +766,7 @@ func newMetricActiveDirectoryDsReplicationNetworkIo(settings MetricSettings) met
 
 type metricActiveDirectoryDsReplicationObjectRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -782,7 +782,7 @@ func (m *metricActiveDirectoryDsReplicationObjectRate) init() {
 }
 
 func (m *metricActiveDirectoryDsReplicationObjectRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -801,16 +801,16 @@ func (m *metricActiveDirectoryDsReplicationObjectRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsReplicationObjectRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsReplicationObjectRate(settings MetricSettings) metricActiveDirectoryDsReplicationObjectRate {
-	m := metricActiveDirectoryDsReplicationObjectRate{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsReplicationObjectRate(cfg MetricConfig) metricActiveDirectoryDsReplicationObjectRate {
+	m := metricActiveDirectoryDsReplicationObjectRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -819,7 +819,7 @@ func newMetricActiveDirectoryDsReplicationObjectRate(settings MetricSettings) me
 
 type metricActiveDirectoryDsReplicationOperationPending struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -834,7 +834,7 @@ func (m *metricActiveDirectoryDsReplicationOperationPending) init() {
 }
 
 func (m *metricActiveDirectoryDsReplicationOperationPending) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -852,16 +852,16 @@ func (m *metricActiveDirectoryDsReplicationOperationPending) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsReplicationOperationPending) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsReplicationOperationPending(settings MetricSettings) metricActiveDirectoryDsReplicationOperationPending {
-	m := metricActiveDirectoryDsReplicationOperationPending{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsReplicationOperationPending(cfg MetricConfig) metricActiveDirectoryDsReplicationOperationPending {
+	m := metricActiveDirectoryDsReplicationOperationPending{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -870,7 +870,7 @@ func newMetricActiveDirectoryDsReplicationOperationPending(settings MetricSettin
 
 type metricActiveDirectoryDsReplicationPropertyRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -886,7 +886,7 @@ func (m *metricActiveDirectoryDsReplicationPropertyRate) init() {
 }
 
 func (m *metricActiveDirectoryDsReplicationPropertyRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -905,16 +905,16 @@ func (m *metricActiveDirectoryDsReplicationPropertyRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsReplicationPropertyRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsReplicationPropertyRate(settings MetricSettings) metricActiveDirectoryDsReplicationPropertyRate {
-	m := metricActiveDirectoryDsReplicationPropertyRate{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsReplicationPropertyRate(cfg MetricConfig) metricActiveDirectoryDsReplicationPropertyRate {
+	m := metricActiveDirectoryDsReplicationPropertyRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -923,7 +923,7 @@ func newMetricActiveDirectoryDsReplicationPropertyRate(settings MetricSettings) 
 
 type metricActiveDirectoryDsReplicationSyncObjectPending struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -938,7 +938,7 @@ func (m *metricActiveDirectoryDsReplicationSyncObjectPending) init() {
 }
 
 func (m *metricActiveDirectoryDsReplicationSyncObjectPending) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -956,16 +956,16 @@ func (m *metricActiveDirectoryDsReplicationSyncObjectPending) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsReplicationSyncObjectPending) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsReplicationSyncObjectPending(settings MetricSettings) metricActiveDirectoryDsReplicationSyncObjectPending {
-	m := metricActiveDirectoryDsReplicationSyncObjectPending{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsReplicationSyncObjectPending(cfg MetricConfig) metricActiveDirectoryDsReplicationSyncObjectPending {
+	m := metricActiveDirectoryDsReplicationSyncObjectPending{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -974,7 +974,7 @@ func newMetricActiveDirectoryDsReplicationSyncObjectPending(settings MetricSetti
 
 type metricActiveDirectoryDsReplicationSyncRequestCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -990,7 +990,7 @@ func (m *metricActiveDirectoryDsReplicationSyncRequestCount) init() {
 }
 
 func (m *metricActiveDirectoryDsReplicationSyncRequestCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, syncResultAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1009,16 +1009,16 @@ func (m *metricActiveDirectoryDsReplicationSyncRequestCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsReplicationSyncRequestCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsReplicationSyncRequestCount(settings MetricSettings) metricActiveDirectoryDsReplicationSyncRequestCount {
-	m := metricActiveDirectoryDsReplicationSyncRequestCount{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsReplicationSyncRequestCount(cfg MetricConfig) metricActiveDirectoryDsReplicationSyncRequestCount {
+	m := metricActiveDirectoryDsReplicationSyncRequestCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1027,7 +1027,7 @@ func newMetricActiveDirectoryDsReplicationSyncRequestCount(settings MetricSettin
 
 type metricActiveDirectoryDsReplicationValueRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1043,7 +1043,7 @@ func (m *metricActiveDirectoryDsReplicationValueRate) init() {
 }
 
 func (m *metricActiveDirectoryDsReplicationValueRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string, valueTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1063,16 +1063,16 @@ func (m *metricActiveDirectoryDsReplicationValueRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsReplicationValueRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsReplicationValueRate(settings MetricSettings) metricActiveDirectoryDsReplicationValueRate {
-	m := metricActiveDirectoryDsReplicationValueRate{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsReplicationValueRate(cfg MetricConfig) metricActiveDirectoryDsReplicationValueRate {
+	m := metricActiveDirectoryDsReplicationValueRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1081,7 +1081,7 @@ func newMetricActiveDirectoryDsReplicationValueRate(settings MetricSettings) met
 
 type metricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1096,7 +1096,7 @@ func (m *metricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued) init(
 }
 
 func (m *metricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1114,16 +1114,16 @@ func (m *metricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued) updat
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued(settings MetricSettings) metricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued {
-	m := metricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued(cfg MetricConfig) metricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued {
+	m := metricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1132,7 +1132,7 @@ func newMetricActiveDirectoryDsSecurityDescriptorPropagationsEventQueued(setting
 
 type metricActiveDirectoryDsSuboperationRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1148,7 +1148,7 @@ func (m *metricActiveDirectoryDsSuboperationRate) init() {
 }
 
 func (m *metricActiveDirectoryDsSuboperationRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, suboperationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1167,16 +1167,16 @@ func (m *metricActiveDirectoryDsSuboperationRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsSuboperationRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsSuboperationRate(settings MetricSettings) metricActiveDirectoryDsSuboperationRate {
-	m := metricActiveDirectoryDsSuboperationRate{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsSuboperationRate(cfg MetricConfig) metricActiveDirectoryDsSuboperationRate {
+	m := metricActiveDirectoryDsSuboperationRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1185,7 +1185,7 @@ func newMetricActiveDirectoryDsSuboperationRate(settings MetricSettings) metricA
 
 type metricActiveDirectoryDsThreadCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1200,7 +1200,7 @@ func (m *metricActiveDirectoryDsThreadCount) init() {
 }
 
 func (m *metricActiveDirectoryDsThreadCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1218,16 +1218,16 @@ func (m *metricActiveDirectoryDsThreadCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricActiveDirectoryDsThreadCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricActiveDirectoryDsThreadCount(settings MetricSettings) metricActiveDirectoryDsThreadCount {
-	m := metricActiveDirectoryDsThreadCount{settings: settings}
-	if settings.Enabled {
+func newMetricActiveDirectoryDsThreadCount(cfg MetricConfig) metricActiveDirectoryDsThreadCount {
+	m := metricActiveDirectoryDsThreadCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1236,11 +1236,11 @@ func newMetricActiveDirectoryDsThreadCount(settings MetricSettings) metricActive
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics MetricsSettings `mapstructure:"metrics"`
+	Metrics MetricsConfig `mapstructure:"metrics"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                                        pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                                                  int                 // maximum observed number of metrics per resource.
@@ -1279,7 +1279,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics: DefaultMetricsSettings(),
+		Metrics: DefaultMetricsConfig(),
 	}
 }
 
@@ -1388,7 +1388,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/aerospikereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/aerospikereceiver/internal/metadata/generated_metrics.go
@@ -14,14 +14,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -33,88 +33,88 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for aerospikereceiver metrics.
-type MetricsSettings struct {
-	AerospikeNamespaceDiskAvailable                   MetricSettings `mapstructure:"aerospike.namespace.disk.available"`
-	AerospikeNamespaceGeojsonRegionQueryCells         MetricSettings `mapstructure:"aerospike.namespace.geojson.region_query_cells"`
-	AerospikeNamespaceGeojsonRegionQueryFalsePositive MetricSettings `mapstructure:"aerospike.namespace.geojson.region_query_false_positive"`
-	AerospikeNamespaceGeojsonRegionQueryPoints        MetricSettings `mapstructure:"aerospike.namespace.geojson.region_query_points"`
-	AerospikeNamespaceGeojsonRegionQueryRequests      MetricSettings `mapstructure:"aerospike.namespace.geojson.region_query_requests"`
-	AerospikeNamespaceMemoryFree                      MetricSettings `mapstructure:"aerospike.namespace.memory.free"`
-	AerospikeNamespaceMemoryUsage                     MetricSettings `mapstructure:"aerospike.namespace.memory.usage"`
-	AerospikeNamespaceQueryCount                      MetricSettings `mapstructure:"aerospike.namespace.query.count"`
-	AerospikeNamespaceScanCount                       MetricSettings `mapstructure:"aerospike.namespace.scan.count"`
-	AerospikeNamespaceTransactionCount                MetricSettings `mapstructure:"aerospike.namespace.transaction.count"`
-	AerospikeNodeConnectionCount                      MetricSettings `mapstructure:"aerospike.node.connection.count"`
-	AerospikeNodeConnectionOpen                       MetricSettings `mapstructure:"aerospike.node.connection.open"`
-	AerospikeNodeMemoryFree                           MetricSettings `mapstructure:"aerospike.node.memory.free"`
-	AerospikeNodeQueryTracked                         MetricSettings `mapstructure:"aerospike.node.query.tracked"`
+// MetricsConfig provides config for aerospikereceiver metrics.
+type MetricsConfig struct {
+	AerospikeNamespaceDiskAvailable                   MetricConfig `mapstructure:"aerospike.namespace.disk.available"`
+	AerospikeNamespaceGeojsonRegionQueryCells         MetricConfig `mapstructure:"aerospike.namespace.geojson.region_query_cells"`
+	AerospikeNamespaceGeojsonRegionQueryFalsePositive MetricConfig `mapstructure:"aerospike.namespace.geojson.region_query_false_positive"`
+	AerospikeNamespaceGeojsonRegionQueryPoints        MetricConfig `mapstructure:"aerospike.namespace.geojson.region_query_points"`
+	AerospikeNamespaceGeojsonRegionQueryRequests      MetricConfig `mapstructure:"aerospike.namespace.geojson.region_query_requests"`
+	AerospikeNamespaceMemoryFree                      MetricConfig `mapstructure:"aerospike.namespace.memory.free"`
+	AerospikeNamespaceMemoryUsage                     MetricConfig `mapstructure:"aerospike.namespace.memory.usage"`
+	AerospikeNamespaceQueryCount                      MetricConfig `mapstructure:"aerospike.namespace.query.count"`
+	AerospikeNamespaceScanCount                       MetricConfig `mapstructure:"aerospike.namespace.scan.count"`
+	AerospikeNamespaceTransactionCount                MetricConfig `mapstructure:"aerospike.namespace.transaction.count"`
+	AerospikeNodeConnectionCount                      MetricConfig `mapstructure:"aerospike.node.connection.count"`
+	AerospikeNodeConnectionOpen                       MetricConfig `mapstructure:"aerospike.node.connection.open"`
+	AerospikeNodeMemoryFree                           MetricConfig `mapstructure:"aerospike.node.memory.free"`
+	AerospikeNodeQueryTracked                         MetricConfig `mapstructure:"aerospike.node.query.tracked"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		AerospikeNamespaceDiskAvailable: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		AerospikeNamespaceDiskAvailable: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNamespaceGeojsonRegionQueryCells: MetricSettings{
+		AerospikeNamespaceGeojsonRegionQueryCells: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNamespaceGeojsonRegionQueryFalsePositive: MetricSettings{
+		AerospikeNamespaceGeojsonRegionQueryFalsePositive: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNamespaceGeojsonRegionQueryPoints: MetricSettings{
+		AerospikeNamespaceGeojsonRegionQueryPoints: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNamespaceGeojsonRegionQueryRequests: MetricSettings{
+		AerospikeNamespaceGeojsonRegionQueryRequests: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNamespaceMemoryFree: MetricSettings{
+		AerospikeNamespaceMemoryFree: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNamespaceMemoryUsage: MetricSettings{
+		AerospikeNamespaceMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNamespaceQueryCount: MetricSettings{
+		AerospikeNamespaceQueryCount: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNamespaceScanCount: MetricSettings{
+		AerospikeNamespaceScanCount: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNamespaceTransactionCount: MetricSettings{
+		AerospikeNamespaceTransactionCount: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNodeConnectionCount: MetricSettings{
+		AerospikeNodeConnectionCount: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNodeConnectionOpen: MetricSettings{
+		AerospikeNodeConnectionOpen: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNodeMemoryFree: MetricSettings{
+		AerospikeNodeMemoryFree: MetricConfig{
 			Enabled: true,
 		},
-		AerospikeNodeQueryTracked: MetricSettings{
+		AerospikeNodeQueryTracked: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for aerospikereceiver resource attributes.
-type ResourceAttributesSettings struct {
-	AerospikeNamespace ResourceAttributeSettings `mapstructure:"aerospike.namespace"`
-	AerospikeNodeName  ResourceAttributeSettings `mapstructure:"aerospike.node.name"`
+// ResourceAttributesConfig provides config for aerospikereceiver resource attributes.
+type ResourceAttributesConfig struct {
+	AerospikeNamespace ResourceAttributeConfig `mapstructure:"aerospike.namespace"`
+	AerospikeNodeName  ResourceAttributeConfig `mapstructure:"aerospike.node.name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		AerospikeNamespace: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		AerospikeNamespace: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		AerospikeNodeName: ResourceAttributeSettings{
+		AerospikeNodeName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -454,7 +454,7 @@ var MapAttributeTransactionType = map[string]AttributeTransactionType{
 
 type metricAerospikeNamespaceDiskAvailable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -467,7 +467,7 @@ func (m *metricAerospikeNamespaceDiskAvailable) init() {
 }
 
 func (m *metricAerospikeNamespaceDiskAvailable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -485,16 +485,16 @@ func (m *metricAerospikeNamespaceDiskAvailable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNamespaceDiskAvailable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNamespaceDiskAvailable(settings MetricSettings) metricAerospikeNamespaceDiskAvailable {
-	m := metricAerospikeNamespaceDiskAvailable{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNamespaceDiskAvailable(cfg MetricConfig) metricAerospikeNamespaceDiskAvailable {
+	m := metricAerospikeNamespaceDiskAvailable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -503,7 +503,7 @@ func newMetricAerospikeNamespaceDiskAvailable(settings MetricSettings) metricAer
 
 type metricAerospikeNamespaceGeojsonRegionQueryCells struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -518,7 +518,7 @@ func (m *metricAerospikeNamespaceGeojsonRegionQueryCells) init() {
 }
 
 func (m *metricAerospikeNamespaceGeojsonRegionQueryCells) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -536,16 +536,16 @@ func (m *metricAerospikeNamespaceGeojsonRegionQueryCells) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNamespaceGeojsonRegionQueryCells) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNamespaceGeojsonRegionQueryCells(settings MetricSettings) metricAerospikeNamespaceGeojsonRegionQueryCells {
-	m := metricAerospikeNamespaceGeojsonRegionQueryCells{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNamespaceGeojsonRegionQueryCells(cfg MetricConfig) metricAerospikeNamespaceGeojsonRegionQueryCells {
+	m := metricAerospikeNamespaceGeojsonRegionQueryCells{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -554,7 +554,7 @@ func newMetricAerospikeNamespaceGeojsonRegionQueryCells(settings MetricSettings)
 
 type metricAerospikeNamespaceGeojsonRegionQueryFalsePositive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -569,7 +569,7 @@ func (m *metricAerospikeNamespaceGeojsonRegionQueryFalsePositive) init() {
 }
 
 func (m *metricAerospikeNamespaceGeojsonRegionQueryFalsePositive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -587,16 +587,16 @@ func (m *metricAerospikeNamespaceGeojsonRegionQueryFalsePositive) updateCapacity
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNamespaceGeojsonRegionQueryFalsePositive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNamespaceGeojsonRegionQueryFalsePositive(settings MetricSettings) metricAerospikeNamespaceGeojsonRegionQueryFalsePositive {
-	m := metricAerospikeNamespaceGeojsonRegionQueryFalsePositive{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNamespaceGeojsonRegionQueryFalsePositive(cfg MetricConfig) metricAerospikeNamespaceGeojsonRegionQueryFalsePositive {
+	m := metricAerospikeNamespaceGeojsonRegionQueryFalsePositive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -605,7 +605,7 @@ func newMetricAerospikeNamespaceGeojsonRegionQueryFalsePositive(settings MetricS
 
 type metricAerospikeNamespaceGeojsonRegionQueryPoints struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -620,7 +620,7 @@ func (m *metricAerospikeNamespaceGeojsonRegionQueryPoints) init() {
 }
 
 func (m *metricAerospikeNamespaceGeojsonRegionQueryPoints) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -638,16 +638,16 @@ func (m *metricAerospikeNamespaceGeojsonRegionQueryPoints) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNamespaceGeojsonRegionQueryPoints) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNamespaceGeojsonRegionQueryPoints(settings MetricSettings) metricAerospikeNamespaceGeojsonRegionQueryPoints {
-	m := metricAerospikeNamespaceGeojsonRegionQueryPoints{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNamespaceGeojsonRegionQueryPoints(cfg MetricConfig) metricAerospikeNamespaceGeojsonRegionQueryPoints {
+	m := metricAerospikeNamespaceGeojsonRegionQueryPoints{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -656,7 +656,7 @@ func newMetricAerospikeNamespaceGeojsonRegionQueryPoints(settings MetricSettings
 
 type metricAerospikeNamespaceGeojsonRegionQueryRequests struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -671,7 +671,7 @@ func (m *metricAerospikeNamespaceGeojsonRegionQueryRequests) init() {
 }
 
 func (m *metricAerospikeNamespaceGeojsonRegionQueryRequests) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -689,16 +689,16 @@ func (m *metricAerospikeNamespaceGeojsonRegionQueryRequests) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNamespaceGeojsonRegionQueryRequests) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNamespaceGeojsonRegionQueryRequests(settings MetricSettings) metricAerospikeNamespaceGeojsonRegionQueryRequests {
-	m := metricAerospikeNamespaceGeojsonRegionQueryRequests{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNamespaceGeojsonRegionQueryRequests(cfg MetricConfig) metricAerospikeNamespaceGeojsonRegionQueryRequests {
+	m := metricAerospikeNamespaceGeojsonRegionQueryRequests{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -707,7 +707,7 @@ func newMetricAerospikeNamespaceGeojsonRegionQueryRequests(settings MetricSettin
 
 type metricAerospikeNamespaceMemoryFree struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -720,7 +720,7 @@ func (m *metricAerospikeNamespaceMemoryFree) init() {
 }
 
 func (m *metricAerospikeNamespaceMemoryFree) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -738,16 +738,16 @@ func (m *metricAerospikeNamespaceMemoryFree) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNamespaceMemoryFree) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNamespaceMemoryFree(settings MetricSettings) metricAerospikeNamespaceMemoryFree {
-	m := metricAerospikeNamespaceMemoryFree{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNamespaceMemoryFree(cfg MetricConfig) metricAerospikeNamespaceMemoryFree {
+	m := metricAerospikeNamespaceMemoryFree{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -756,7 +756,7 @@ func newMetricAerospikeNamespaceMemoryFree(settings MetricSettings) metricAerosp
 
 type metricAerospikeNamespaceMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -772,7 +772,7 @@ func (m *metricAerospikeNamespaceMemoryUsage) init() {
 }
 
 func (m *metricAerospikeNamespaceMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, namespaceComponentAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -791,16 +791,16 @@ func (m *metricAerospikeNamespaceMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNamespaceMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNamespaceMemoryUsage(settings MetricSettings) metricAerospikeNamespaceMemoryUsage {
-	m := metricAerospikeNamespaceMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNamespaceMemoryUsage(cfg MetricConfig) metricAerospikeNamespaceMemoryUsage {
+	m := metricAerospikeNamespaceMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -809,7 +809,7 @@ func newMetricAerospikeNamespaceMemoryUsage(settings MetricSettings) metricAeros
 
 type metricAerospikeNamespaceQueryCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -825,7 +825,7 @@ func (m *metricAerospikeNamespaceQueryCount) init() {
 }
 
 func (m *metricAerospikeNamespaceQueryCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, queryTypeAttributeValue string, indexTypeAttributeValue string, queryResultAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -846,16 +846,16 @@ func (m *metricAerospikeNamespaceQueryCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNamespaceQueryCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNamespaceQueryCount(settings MetricSettings) metricAerospikeNamespaceQueryCount {
-	m := metricAerospikeNamespaceQueryCount{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNamespaceQueryCount(cfg MetricConfig) metricAerospikeNamespaceQueryCount {
+	m := metricAerospikeNamespaceQueryCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -864,7 +864,7 @@ func newMetricAerospikeNamespaceQueryCount(settings MetricSettings) metricAerosp
 
 type metricAerospikeNamespaceScanCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -880,7 +880,7 @@ func (m *metricAerospikeNamespaceScanCount) init() {
 }
 
 func (m *metricAerospikeNamespaceScanCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, scanTypeAttributeValue string, scanResultAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -900,16 +900,16 @@ func (m *metricAerospikeNamespaceScanCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNamespaceScanCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNamespaceScanCount(settings MetricSettings) metricAerospikeNamespaceScanCount {
-	m := metricAerospikeNamespaceScanCount{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNamespaceScanCount(cfg MetricConfig) metricAerospikeNamespaceScanCount {
+	m := metricAerospikeNamespaceScanCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -918,7 +918,7 @@ func newMetricAerospikeNamespaceScanCount(settings MetricSettings) metricAerospi
 
 type metricAerospikeNamespaceTransactionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -934,7 +934,7 @@ func (m *metricAerospikeNamespaceTransactionCount) init() {
 }
 
 func (m *metricAerospikeNamespaceTransactionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, transactionTypeAttributeValue string, transactionResultAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -954,16 +954,16 @@ func (m *metricAerospikeNamespaceTransactionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNamespaceTransactionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNamespaceTransactionCount(settings MetricSettings) metricAerospikeNamespaceTransactionCount {
-	m := metricAerospikeNamespaceTransactionCount{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNamespaceTransactionCount(cfg MetricConfig) metricAerospikeNamespaceTransactionCount {
+	m := metricAerospikeNamespaceTransactionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -972,7 +972,7 @@ func newMetricAerospikeNamespaceTransactionCount(settings MetricSettings) metric
 
 type metricAerospikeNodeConnectionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -988,7 +988,7 @@ func (m *metricAerospikeNodeConnectionCount) init() {
 }
 
 func (m *metricAerospikeNodeConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, connectionTypeAttributeValue string, connectionOpAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1008,16 +1008,16 @@ func (m *metricAerospikeNodeConnectionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNodeConnectionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNodeConnectionCount(settings MetricSettings) metricAerospikeNodeConnectionCount {
-	m := metricAerospikeNodeConnectionCount{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNodeConnectionCount(cfg MetricConfig) metricAerospikeNodeConnectionCount {
+	m := metricAerospikeNodeConnectionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1026,7 +1026,7 @@ func newMetricAerospikeNodeConnectionCount(settings MetricSettings) metricAerosp
 
 type metricAerospikeNodeConnectionOpen struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1042,7 +1042,7 @@ func (m *metricAerospikeNodeConnectionOpen) init() {
 }
 
 func (m *metricAerospikeNodeConnectionOpen) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, connectionTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1061,16 +1061,16 @@ func (m *metricAerospikeNodeConnectionOpen) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNodeConnectionOpen) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNodeConnectionOpen(settings MetricSettings) metricAerospikeNodeConnectionOpen {
-	m := metricAerospikeNodeConnectionOpen{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNodeConnectionOpen(cfg MetricConfig) metricAerospikeNodeConnectionOpen {
+	m := metricAerospikeNodeConnectionOpen{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1079,7 +1079,7 @@ func newMetricAerospikeNodeConnectionOpen(settings MetricSettings) metricAerospi
 
 type metricAerospikeNodeMemoryFree struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1092,7 +1092,7 @@ func (m *metricAerospikeNodeMemoryFree) init() {
 }
 
 func (m *metricAerospikeNodeMemoryFree) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1110,16 +1110,16 @@ func (m *metricAerospikeNodeMemoryFree) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNodeMemoryFree) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNodeMemoryFree(settings MetricSettings) metricAerospikeNodeMemoryFree {
-	m := metricAerospikeNodeMemoryFree{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNodeMemoryFree(cfg MetricConfig) metricAerospikeNodeMemoryFree {
+	m := metricAerospikeNodeMemoryFree{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1128,7 +1128,7 @@ func newMetricAerospikeNodeMemoryFree(settings MetricSettings) metricAerospikeNo
 
 type metricAerospikeNodeQueryTracked struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1143,7 +1143,7 @@ func (m *metricAerospikeNodeQueryTracked) init() {
 }
 
 func (m *metricAerospikeNodeQueryTracked) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1161,16 +1161,16 @@ func (m *metricAerospikeNodeQueryTracked) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricAerospikeNodeQueryTracked) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricAerospikeNodeQueryTracked(settings MetricSettings) metricAerospikeNodeQueryTracked {
-	m := metricAerospikeNodeQueryTracked{settings: settings}
-	if settings.Enabled {
+func newMetricAerospikeNodeQueryTracked(cfg MetricConfig) metricAerospikeNodeQueryTracked {
+	m := metricAerospikeNodeQueryTracked{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1179,19 +1179,19 @@ func newMetricAerospikeNodeQueryTracked(settings MetricSettings) metricAerospike
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                               pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                                         int                 // maximum observed number of metrics per resource.
 	resourceCapacity                                        int                 // maximum observed number of resource attributes.
 	metricsBuffer                                           pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                                               component.BuildInfo // contains version information
-	resourceAttributesSettings                              ResourceAttributesSettings
+	resourceAttributesConfig                                ResourceAttributesConfig
 	metricAerospikeNamespaceDiskAvailable                   metricAerospikeNamespaceDiskAvailable
 	metricAerospikeNamespaceGeojsonRegionQueryCells         metricAerospikeNamespaceGeojsonRegionQueryCells
 	metricAerospikeNamespaceGeojsonRegionQueryFalsePositive metricAerospikeNamespaceGeojsonRegionQueryFalsePositive
@@ -1220,8 +1220,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -1230,7 +1230,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                             pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                         pmetric.NewMetrics(),
 		buildInfo:                             settings.BuildInfo,
-		resourceAttributesSettings:            mbc.ResourceAttributes,
+		resourceAttributesConfig:              mbc.ResourceAttributes,
 		metricAerospikeNamespaceDiskAvailable: newMetricAerospikeNamespaceDiskAvailable(mbc.Metrics.AerospikeNamespaceDiskAvailable),
 		metricAerospikeNamespaceGeojsonRegionQueryCells:         newMetricAerospikeNamespaceGeojsonRegionQueryCells(mbc.Metrics.AerospikeNamespaceGeojsonRegionQueryCells),
 		metricAerospikeNamespaceGeojsonRegionQueryFalsePositive: newMetricAerospikeNamespaceGeojsonRegionQueryFalsePositive(mbc.Metrics.AerospikeNamespaceGeojsonRegionQueryFalsePositive),
@@ -1263,12 +1263,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithAerospikeNamespace sets provided value as "aerospike.namespace" attribute for current resource.
 func WithAerospikeNamespace(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.AerospikeNamespace.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.AerospikeNamespace.Enabled {
 			rm.Resource().Attributes().PutStr("aerospike.namespace", val)
 		}
 	}
@@ -1276,8 +1276,8 @@ func WithAerospikeNamespace(val string) ResourceMetricsOption {
 
 // WithAerospikeNodeName sets provided value as "aerospike.node.name" attribute for current resource.
 func WithAerospikeNodeName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.AerospikeNodeName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.AerospikeNodeName.Enabled {
 			rm.Resource().Attributes().PutStr("aerospike.node.name", val)
 		}
 	}
@@ -1286,7 +1286,7 @@ func WithAerospikeNodeName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -1331,7 +1331,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricAerospikeNodeQueryTracked.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -1341,7 +1341,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/aerospikereceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/aerospikereceiver/internal/metadata/generated_metrics_test.go
@@ -127,15 +127,15 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("aerospike.namespace")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.AerospikeNamespace.Enabled, ok)
-			if mb.resourceAttributesSettings.AerospikeNamespace.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.AerospikeNamespace.Enabled, ok)
+			if mb.resourceAttributesConfig.AerospikeNamespace.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("aerospike.node.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.AerospikeNodeName.Enabled, ok)
-			if mb.resourceAttributesSettings.AerospikeNodeName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.AerospikeNodeName.Enabled, ok)
+			if mb.resourceAttributesConfig.AerospikeNodeName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/apachereceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics_test.go
@@ -119,15 +119,15 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("apache.server.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ApacheServerName.Enabled, ok)
-			if mb.resourceAttributesSettings.ApacheServerName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ApacheServerName.Enabled, ok)
+			if mb.resourceAttributesConfig.ApacheServerName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("apache.server.port")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ApacheServerPort.Enabled, ok)
-			if mb.resourceAttributesSettings.ApacheServerPort.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ApacheServerPort.Enabled, ok)
+			if mb.resourceAttributesConfig.ApacheServerPort.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/bigipreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/bigipreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,160 +31,160 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for bigipreceiver metrics.
-type MetricsSettings struct {
-	BigipNodeAvailability             MetricSettings `mapstructure:"bigip.node.availability"`
-	BigipNodeConnectionCount          MetricSettings `mapstructure:"bigip.node.connection.count"`
-	BigipNodeDataTransmitted          MetricSettings `mapstructure:"bigip.node.data.transmitted"`
-	BigipNodeEnabled                  MetricSettings `mapstructure:"bigip.node.enabled"`
-	BigipNodePacketCount              MetricSettings `mapstructure:"bigip.node.packet.count"`
-	BigipNodeRequestCount             MetricSettings `mapstructure:"bigip.node.request.count"`
-	BigipNodeSessionCount             MetricSettings `mapstructure:"bigip.node.session.count"`
-	BigipPoolAvailability             MetricSettings `mapstructure:"bigip.pool.availability"`
-	BigipPoolConnectionCount          MetricSettings `mapstructure:"bigip.pool.connection.count"`
-	BigipPoolDataTransmitted          MetricSettings `mapstructure:"bigip.pool.data.transmitted"`
-	BigipPoolEnabled                  MetricSettings `mapstructure:"bigip.pool.enabled"`
-	BigipPoolMemberCount              MetricSettings `mapstructure:"bigip.pool.member.count"`
-	BigipPoolPacketCount              MetricSettings `mapstructure:"bigip.pool.packet.count"`
-	BigipPoolRequestCount             MetricSettings `mapstructure:"bigip.pool.request.count"`
-	BigipPoolMemberAvailability       MetricSettings `mapstructure:"bigip.pool_member.availability"`
-	BigipPoolMemberConnectionCount    MetricSettings `mapstructure:"bigip.pool_member.connection.count"`
-	BigipPoolMemberDataTransmitted    MetricSettings `mapstructure:"bigip.pool_member.data.transmitted"`
-	BigipPoolMemberEnabled            MetricSettings `mapstructure:"bigip.pool_member.enabled"`
-	BigipPoolMemberPacketCount        MetricSettings `mapstructure:"bigip.pool_member.packet.count"`
-	BigipPoolMemberRequestCount       MetricSettings `mapstructure:"bigip.pool_member.request.count"`
-	BigipPoolMemberSessionCount       MetricSettings `mapstructure:"bigip.pool_member.session.count"`
-	BigipVirtualServerAvailability    MetricSettings `mapstructure:"bigip.virtual_server.availability"`
-	BigipVirtualServerConnectionCount MetricSettings `mapstructure:"bigip.virtual_server.connection.count"`
-	BigipVirtualServerDataTransmitted MetricSettings `mapstructure:"bigip.virtual_server.data.transmitted"`
-	BigipVirtualServerEnabled         MetricSettings `mapstructure:"bigip.virtual_server.enabled"`
-	BigipVirtualServerPacketCount     MetricSettings `mapstructure:"bigip.virtual_server.packet.count"`
-	BigipVirtualServerRequestCount    MetricSettings `mapstructure:"bigip.virtual_server.request.count"`
+// MetricsConfig provides config for bigipreceiver metrics.
+type MetricsConfig struct {
+	BigipNodeAvailability             MetricConfig `mapstructure:"bigip.node.availability"`
+	BigipNodeConnectionCount          MetricConfig `mapstructure:"bigip.node.connection.count"`
+	BigipNodeDataTransmitted          MetricConfig `mapstructure:"bigip.node.data.transmitted"`
+	BigipNodeEnabled                  MetricConfig `mapstructure:"bigip.node.enabled"`
+	BigipNodePacketCount              MetricConfig `mapstructure:"bigip.node.packet.count"`
+	BigipNodeRequestCount             MetricConfig `mapstructure:"bigip.node.request.count"`
+	BigipNodeSessionCount             MetricConfig `mapstructure:"bigip.node.session.count"`
+	BigipPoolAvailability             MetricConfig `mapstructure:"bigip.pool.availability"`
+	BigipPoolConnectionCount          MetricConfig `mapstructure:"bigip.pool.connection.count"`
+	BigipPoolDataTransmitted          MetricConfig `mapstructure:"bigip.pool.data.transmitted"`
+	BigipPoolEnabled                  MetricConfig `mapstructure:"bigip.pool.enabled"`
+	BigipPoolMemberCount              MetricConfig `mapstructure:"bigip.pool.member.count"`
+	BigipPoolPacketCount              MetricConfig `mapstructure:"bigip.pool.packet.count"`
+	BigipPoolRequestCount             MetricConfig `mapstructure:"bigip.pool.request.count"`
+	BigipPoolMemberAvailability       MetricConfig `mapstructure:"bigip.pool_member.availability"`
+	BigipPoolMemberConnectionCount    MetricConfig `mapstructure:"bigip.pool_member.connection.count"`
+	BigipPoolMemberDataTransmitted    MetricConfig `mapstructure:"bigip.pool_member.data.transmitted"`
+	BigipPoolMemberEnabled            MetricConfig `mapstructure:"bigip.pool_member.enabled"`
+	BigipPoolMemberPacketCount        MetricConfig `mapstructure:"bigip.pool_member.packet.count"`
+	BigipPoolMemberRequestCount       MetricConfig `mapstructure:"bigip.pool_member.request.count"`
+	BigipPoolMemberSessionCount       MetricConfig `mapstructure:"bigip.pool_member.session.count"`
+	BigipVirtualServerAvailability    MetricConfig `mapstructure:"bigip.virtual_server.availability"`
+	BigipVirtualServerConnectionCount MetricConfig `mapstructure:"bigip.virtual_server.connection.count"`
+	BigipVirtualServerDataTransmitted MetricConfig `mapstructure:"bigip.virtual_server.data.transmitted"`
+	BigipVirtualServerEnabled         MetricConfig `mapstructure:"bigip.virtual_server.enabled"`
+	BigipVirtualServerPacketCount     MetricConfig `mapstructure:"bigip.virtual_server.packet.count"`
+	BigipVirtualServerRequestCount    MetricConfig `mapstructure:"bigip.virtual_server.request.count"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		BigipNodeAvailability: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		BigipNodeAvailability: MetricConfig{
 			Enabled: true,
 		},
-		BigipNodeConnectionCount: MetricSettings{
+		BigipNodeConnectionCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipNodeDataTransmitted: MetricSettings{
+		BigipNodeDataTransmitted: MetricConfig{
 			Enabled: true,
 		},
-		BigipNodeEnabled: MetricSettings{
+		BigipNodeEnabled: MetricConfig{
 			Enabled: true,
 		},
-		BigipNodePacketCount: MetricSettings{
+		BigipNodePacketCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipNodeRequestCount: MetricSettings{
+		BigipNodeRequestCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipNodeSessionCount: MetricSettings{
+		BigipNodeSessionCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolAvailability: MetricSettings{
+		BigipPoolAvailability: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolConnectionCount: MetricSettings{
+		BigipPoolConnectionCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolDataTransmitted: MetricSettings{
+		BigipPoolDataTransmitted: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolEnabled: MetricSettings{
+		BigipPoolEnabled: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolMemberCount: MetricSettings{
+		BigipPoolMemberCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolPacketCount: MetricSettings{
+		BigipPoolPacketCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolRequestCount: MetricSettings{
+		BigipPoolRequestCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolMemberAvailability: MetricSettings{
+		BigipPoolMemberAvailability: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolMemberConnectionCount: MetricSettings{
+		BigipPoolMemberConnectionCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolMemberDataTransmitted: MetricSettings{
+		BigipPoolMemberDataTransmitted: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolMemberEnabled: MetricSettings{
+		BigipPoolMemberEnabled: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolMemberPacketCount: MetricSettings{
+		BigipPoolMemberPacketCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolMemberRequestCount: MetricSettings{
+		BigipPoolMemberRequestCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipPoolMemberSessionCount: MetricSettings{
+		BigipPoolMemberSessionCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipVirtualServerAvailability: MetricSettings{
+		BigipVirtualServerAvailability: MetricConfig{
 			Enabled: true,
 		},
-		BigipVirtualServerConnectionCount: MetricSettings{
+		BigipVirtualServerConnectionCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipVirtualServerDataTransmitted: MetricSettings{
+		BigipVirtualServerDataTransmitted: MetricConfig{
 			Enabled: true,
 		},
-		BigipVirtualServerEnabled: MetricSettings{
+		BigipVirtualServerEnabled: MetricConfig{
 			Enabled: true,
 		},
-		BigipVirtualServerPacketCount: MetricSettings{
+		BigipVirtualServerPacketCount: MetricConfig{
 			Enabled: true,
 		},
-		BigipVirtualServerRequestCount: MetricSettings{
+		BigipVirtualServerRequestCount: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for bigipreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	BigipNodeIPAddress            ResourceAttributeSettings `mapstructure:"bigip.node.ip_address"`
-	BigipNodeName                 ResourceAttributeSettings `mapstructure:"bigip.node.name"`
-	BigipPoolName                 ResourceAttributeSettings `mapstructure:"bigip.pool.name"`
-	BigipPoolMemberIPAddress      ResourceAttributeSettings `mapstructure:"bigip.pool_member.ip_address"`
-	BigipPoolMemberName           ResourceAttributeSettings `mapstructure:"bigip.pool_member.name"`
-	BigipVirtualServerDestination ResourceAttributeSettings `mapstructure:"bigip.virtual_server.destination"`
-	BigipVirtualServerName        ResourceAttributeSettings `mapstructure:"bigip.virtual_server.name"`
+// ResourceAttributesConfig provides config for bigipreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	BigipNodeIPAddress            ResourceAttributeConfig `mapstructure:"bigip.node.ip_address"`
+	BigipNodeName                 ResourceAttributeConfig `mapstructure:"bigip.node.name"`
+	BigipPoolName                 ResourceAttributeConfig `mapstructure:"bigip.pool.name"`
+	BigipPoolMemberIPAddress      ResourceAttributeConfig `mapstructure:"bigip.pool_member.ip_address"`
+	BigipPoolMemberName           ResourceAttributeConfig `mapstructure:"bigip.pool_member.name"`
+	BigipVirtualServerDestination ResourceAttributeConfig `mapstructure:"bigip.virtual_server.destination"`
+	BigipVirtualServerName        ResourceAttributeConfig `mapstructure:"bigip.virtual_server.name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		BigipNodeIPAddress: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		BigipNodeIPAddress: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		BigipNodeName: ResourceAttributeSettings{
+		BigipNodeName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		BigipPoolName: ResourceAttributeSettings{
+		BigipPoolName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		BigipPoolMemberIPAddress: ResourceAttributeSettings{
+		BigipPoolMemberIPAddress: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		BigipPoolMemberName: ResourceAttributeSettings{
+		BigipPoolMemberName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		BigipVirtualServerDestination: ResourceAttributeSettings{
+		BigipVirtualServerDestination: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		BigipVirtualServerName: ResourceAttributeSettings{
+		BigipVirtualServerName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -300,7 +300,7 @@ var MapAttributeEnabledStatus = map[string]AttributeEnabledStatus{
 
 type metricBigipNodeAvailability struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -314,7 +314,7 @@ func (m *metricBigipNodeAvailability) init() {
 }
 
 func (m *metricBigipNodeAvailability) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, availabilityStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -333,16 +333,16 @@ func (m *metricBigipNodeAvailability) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipNodeAvailability) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipNodeAvailability(settings MetricSettings) metricBigipNodeAvailability {
-	m := metricBigipNodeAvailability{settings: settings}
-	if settings.Enabled {
+func newMetricBigipNodeAvailability(cfg MetricConfig) metricBigipNodeAvailability {
+	m := metricBigipNodeAvailability{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -351,7 +351,7 @@ func newMetricBigipNodeAvailability(settings MetricSettings) metricBigipNodeAvai
 
 type metricBigipNodeConnectionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -366,7 +366,7 @@ func (m *metricBigipNodeConnectionCount) init() {
 }
 
 func (m *metricBigipNodeConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -384,16 +384,16 @@ func (m *metricBigipNodeConnectionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipNodeConnectionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipNodeConnectionCount(settings MetricSettings) metricBigipNodeConnectionCount {
-	m := metricBigipNodeConnectionCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipNodeConnectionCount(cfg MetricConfig) metricBigipNodeConnectionCount {
+	m := metricBigipNodeConnectionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -402,7 +402,7 @@ func newMetricBigipNodeConnectionCount(settings MetricSettings) metricBigipNodeC
 
 type metricBigipNodeDataTransmitted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -418,7 +418,7 @@ func (m *metricBigipNodeDataTransmitted) init() {
 }
 
 func (m *metricBigipNodeDataTransmitted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -437,16 +437,16 @@ func (m *metricBigipNodeDataTransmitted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipNodeDataTransmitted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipNodeDataTransmitted(settings MetricSettings) metricBigipNodeDataTransmitted {
-	m := metricBigipNodeDataTransmitted{settings: settings}
-	if settings.Enabled {
+func newMetricBigipNodeDataTransmitted(cfg MetricConfig) metricBigipNodeDataTransmitted {
+	m := metricBigipNodeDataTransmitted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -455,7 +455,7 @@ func newMetricBigipNodeDataTransmitted(settings MetricSettings) metricBigipNodeD
 
 type metricBigipNodeEnabled struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -469,7 +469,7 @@ func (m *metricBigipNodeEnabled) init() {
 }
 
 func (m *metricBigipNodeEnabled) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, enabledStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -488,16 +488,16 @@ func (m *metricBigipNodeEnabled) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipNodeEnabled) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipNodeEnabled(settings MetricSettings) metricBigipNodeEnabled {
-	m := metricBigipNodeEnabled{settings: settings}
-	if settings.Enabled {
+func newMetricBigipNodeEnabled(cfg MetricConfig) metricBigipNodeEnabled {
+	m := metricBigipNodeEnabled{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -506,7 +506,7 @@ func newMetricBigipNodeEnabled(settings MetricSettings) metricBigipNodeEnabled {
 
 type metricBigipNodePacketCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -522,7 +522,7 @@ func (m *metricBigipNodePacketCount) init() {
 }
 
 func (m *metricBigipNodePacketCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -541,16 +541,16 @@ func (m *metricBigipNodePacketCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipNodePacketCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipNodePacketCount(settings MetricSettings) metricBigipNodePacketCount {
-	m := metricBigipNodePacketCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipNodePacketCount(cfg MetricConfig) metricBigipNodePacketCount {
+	m := metricBigipNodePacketCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -559,7 +559,7 @@ func newMetricBigipNodePacketCount(settings MetricSettings) metricBigipNodePacke
 
 type metricBigipNodeRequestCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -574,7 +574,7 @@ func (m *metricBigipNodeRequestCount) init() {
 }
 
 func (m *metricBigipNodeRequestCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -592,16 +592,16 @@ func (m *metricBigipNodeRequestCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipNodeRequestCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipNodeRequestCount(settings MetricSettings) metricBigipNodeRequestCount {
-	m := metricBigipNodeRequestCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipNodeRequestCount(cfg MetricConfig) metricBigipNodeRequestCount {
+	m := metricBigipNodeRequestCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -610,7 +610,7 @@ func newMetricBigipNodeRequestCount(settings MetricSettings) metricBigipNodeRequ
 
 type metricBigipNodeSessionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -625,7 +625,7 @@ func (m *metricBigipNodeSessionCount) init() {
 }
 
 func (m *metricBigipNodeSessionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -643,16 +643,16 @@ func (m *metricBigipNodeSessionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipNodeSessionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipNodeSessionCount(settings MetricSettings) metricBigipNodeSessionCount {
-	m := metricBigipNodeSessionCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipNodeSessionCount(cfg MetricConfig) metricBigipNodeSessionCount {
+	m := metricBigipNodeSessionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -661,7 +661,7 @@ func newMetricBigipNodeSessionCount(settings MetricSettings) metricBigipNodeSess
 
 type metricBigipPoolAvailability struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -675,7 +675,7 @@ func (m *metricBigipPoolAvailability) init() {
 }
 
 func (m *metricBigipPoolAvailability) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, availabilityStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -694,16 +694,16 @@ func (m *metricBigipPoolAvailability) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolAvailability) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolAvailability(settings MetricSettings) metricBigipPoolAvailability {
-	m := metricBigipPoolAvailability{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolAvailability(cfg MetricConfig) metricBigipPoolAvailability {
+	m := metricBigipPoolAvailability{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -712,7 +712,7 @@ func newMetricBigipPoolAvailability(settings MetricSettings) metricBigipPoolAvai
 
 type metricBigipPoolConnectionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -727,7 +727,7 @@ func (m *metricBigipPoolConnectionCount) init() {
 }
 
 func (m *metricBigipPoolConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -745,16 +745,16 @@ func (m *metricBigipPoolConnectionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolConnectionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolConnectionCount(settings MetricSettings) metricBigipPoolConnectionCount {
-	m := metricBigipPoolConnectionCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolConnectionCount(cfg MetricConfig) metricBigipPoolConnectionCount {
+	m := metricBigipPoolConnectionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -763,7 +763,7 @@ func newMetricBigipPoolConnectionCount(settings MetricSettings) metricBigipPoolC
 
 type metricBigipPoolDataTransmitted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -779,7 +779,7 @@ func (m *metricBigipPoolDataTransmitted) init() {
 }
 
 func (m *metricBigipPoolDataTransmitted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -798,16 +798,16 @@ func (m *metricBigipPoolDataTransmitted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolDataTransmitted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolDataTransmitted(settings MetricSettings) metricBigipPoolDataTransmitted {
-	m := metricBigipPoolDataTransmitted{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolDataTransmitted(cfg MetricConfig) metricBigipPoolDataTransmitted {
+	m := metricBigipPoolDataTransmitted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -816,7 +816,7 @@ func newMetricBigipPoolDataTransmitted(settings MetricSettings) metricBigipPoolD
 
 type metricBigipPoolEnabled struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -830,7 +830,7 @@ func (m *metricBigipPoolEnabled) init() {
 }
 
 func (m *metricBigipPoolEnabled) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, enabledStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -849,16 +849,16 @@ func (m *metricBigipPoolEnabled) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolEnabled) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolEnabled(settings MetricSettings) metricBigipPoolEnabled {
-	m := metricBigipPoolEnabled{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolEnabled(cfg MetricConfig) metricBigipPoolEnabled {
+	m := metricBigipPoolEnabled{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -867,7 +867,7 @@ func newMetricBigipPoolEnabled(settings MetricSettings) metricBigipPoolEnabled {
 
 type metricBigipPoolMemberCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -883,7 +883,7 @@ func (m *metricBigipPoolMemberCount) init() {
 }
 
 func (m *metricBigipPoolMemberCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, activeStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -902,16 +902,16 @@ func (m *metricBigipPoolMemberCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolMemberCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolMemberCount(settings MetricSettings) metricBigipPoolMemberCount {
-	m := metricBigipPoolMemberCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolMemberCount(cfg MetricConfig) metricBigipPoolMemberCount {
+	m := metricBigipPoolMemberCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -920,7 +920,7 @@ func newMetricBigipPoolMemberCount(settings MetricSettings) metricBigipPoolMembe
 
 type metricBigipPoolPacketCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -936,7 +936,7 @@ func (m *metricBigipPoolPacketCount) init() {
 }
 
 func (m *metricBigipPoolPacketCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -955,16 +955,16 @@ func (m *metricBigipPoolPacketCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolPacketCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolPacketCount(settings MetricSettings) metricBigipPoolPacketCount {
-	m := metricBigipPoolPacketCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolPacketCount(cfg MetricConfig) metricBigipPoolPacketCount {
+	m := metricBigipPoolPacketCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -973,7 +973,7 @@ func newMetricBigipPoolPacketCount(settings MetricSettings) metricBigipPoolPacke
 
 type metricBigipPoolRequestCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -988,7 +988,7 @@ func (m *metricBigipPoolRequestCount) init() {
 }
 
 func (m *metricBigipPoolRequestCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1006,16 +1006,16 @@ func (m *metricBigipPoolRequestCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolRequestCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolRequestCount(settings MetricSettings) metricBigipPoolRequestCount {
-	m := metricBigipPoolRequestCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolRequestCount(cfg MetricConfig) metricBigipPoolRequestCount {
+	m := metricBigipPoolRequestCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1024,7 +1024,7 @@ func newMetricBigipPoolRequestCount(settings MetricSettings) metricBigipPoolRequ
 
 type metricBigipPoolMemberAvailability struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1038,7 +1038,7 @@ func (m *metricBigipPoolMemberAvailability) init() {
 }
 
 func (m *metricBigipPoolMemberAvailability) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, availabilityStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1057,16 +1057,16 @@ func (m *metricBigipPoolMemberAvailability) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolMemberAvailability) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolMemberAvailability(settings MetricSettings) metricBigipPoolMemberAvailability {
-	m := metricBigipPoolMemberAvailability{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolMemberAvailability(cfg MetricConfig) metricBigipPoolMemberAvailability {
+	m := metricBigipPoolMemberAvailability{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1075,7 +1075,7 @@ func newMetricBigipPoolMemberAvailability(settings MetricSettings) metricBigipPo
 
 type metricBigipPoolMemberConnectionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1090,7 +1090,7 @@ func (m *metricBigipPoolMemberConnectionCount) init() {
 }
 
 func (m *metricBigipPoolMemberConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1108,16 +1108,16 @@ func (m *metricBigipPoolMemberConnectionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolMemberConnectionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolMemberConnectionCount(settings MetricSettings) metricBigipPoolMemberConnectionCount {
-	m := metricBigipPoolMemberConnectionCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolMemberConnectionCount(cfg MetricConfig) metricBigipPoolMemberConnectionCount {
+	m := metricBigipPoolMemberConnectionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1126,7 +1126,7 @@ func newMetricBigipPoolMemberConnectionCount(settings MetricSettings) metricBigi
 
 type metricBigipPoolMemberDataTransmitted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1142,7 +1142,7 @@ func (m *metricBigipPoolMemberDataTransmitted) init() {
 }
 
 func (m *metricBigipPoolMemberDataTransmitted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1161,16 +1161,16 @@ func (m *metricBigipPoolMemberDataTransmitted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolMemberDataTransmitted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolMemberDataTransmitted(settings MetricSettings) metricBigipPoolMemberDataTransmitted {
-	m := metricBigipPoolMemberDataTransmitted{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolMemberDataTransmitted(cfg MetricConfig) metricBigipPoolMemberDataTransmitted {
+	m := metricBigipPoolMemberDataTransmitted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1179,7 +1179,7 @@ func newMetricBigipPoolMemberDataTransmitted(settings MetricSettings) metricBigi
 
 type metricBigipPoolMemberEnabled struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1193,7 +1193,7 @@ func (m *metricBigipPoolMemberEnabled) init() {
 }
 
 func (m *metricBigipPoolMemberEnabled) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, enabledStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1212,16 +1212,16 @@ func (m *metricBigipPoolMemberEnabled) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolMemberEnabled) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolMemberEnabled(settings MetricSettings) metricBigipPoolMemberEnabled {
-	m := metricBigipPoolMemberEnabled{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolMemberEnabled(cfg MetricConfig) metricBigipPoolMemberEnabled {
+	m := metricBigipPoolMemberEnabled{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1230,7 +1230,7 @@ func newMetricBigipPoolMemberEnabled(settings MetricSettings) metricBigipPoolMem
 
 type metricBigipPoolMemberPacketCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1246,7 +1246,7 @@ func (m *metricBigipPoolMemberPacketCount) init() {
 }
 
 func (m *metricBigipPoolMemberPacketCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1265,16 +1265,16 @@ func (m *metricBigipPoolMemberPacketCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolMemberPacketCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolMemberPacketCount(settings MetricSettings) metricBigipPoolMemberPacketCount {
-	m := metricBigipPoolMemberPacketCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolMemberPacketCount(cfg MetricConfig) metricBigipPoolMemberPacketCount {
+	m := metricBigipPoolMemberPacketCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1283,7 +1283,7 @@ func newMetricBigipPoolMemberPacketCount(settings MetricSettings) metricBigipPoo
 
 type metricBigipPoolMemberRequestCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1298,7 +1298,7 @@ func (m *metricBigipPoolMemberRequestCount) init() {
 }
 
 func (m *metricBigipPoolMemberRequestCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1316,16 +1316,16 @@ func (m *metricBigipPoolMemberRequestCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolMemberRequestCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolMemberRequestCount(settings MetricSettings) metricBigipPoolMemberRequestCount {
-	m := metricBigipPoolMemberRequestCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolMemberRequestCount(cfg MetricConfig) metricBigipPoolMemberRequestCount {
+	m := metricBigipPoolMemberRequestCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1334,7 +1334,7 @@ func newMetricBigipPoolMemberRequestCount(settings MetricSettings) metricBigipPo
 
 type metricBigipPoolMemberSessionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1349,7 +1349,7 @@ func (m *metricBigipPoolMemberSessionCount) init() {
 }
 
 func (m *metricBigipPoolMemberSessionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1367,16 +1367,16 @@ func (m *metricBigipPoolMemberSessionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipPoolMemberSessionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipPoolMemberSessionCount(settings MetricSettings) metricBigipPoolMemberSessionCount {
-	m := metricBigipPoolMemberSessionCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipPoolMemberSessionCount(cfg MetricConfig) metricBigipPoolMemberSessionCount {
+	m := metricBigipPoolMemberSessionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1385,7 +1385,7 @@ func newMetricBigipPoolMemberSessionCount(settings MetricSettings) metricBigipPo
 
 type metricBigipVirtualServerAvailability struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1399,7 +1399,7 @@ func (m *metricBigipVirtualServerAvailability) init() {
 }
 
 func (m *metricBigipVirtualServerAvailability) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, availabilityStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1418,16 +1418,16 @@ func (m *metricBigipVirtualServerAvailability) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipVirtualServerAvailability) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipVirtualServerAvailability(settings MetricSettings) metricBigipVirtualServerAvailability {
-	m := metricBigipVirtualServerAvailability{settings: settings}
-	if settings.Enabled {
+func newMetricBigipVirtualServerAvailability(cfg MetricConfig) metricBigipVirtualServerAvailability {
+	m := metricBigipVirtualServerAvailability{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1436,7 +1436,7 @@ func newMetricBigipVirtualServerAvailability(settings MetricSettings) metricBigi
 
 type metricBigipVirtualServerConnectionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1451,7 +1451,7 @@ func (m *metricBigipVirtualServerConnectionCount) init() {
 }
 
 func (m *metricBigipVirtualServerConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1469,16 +1469,16 @@ func (m *metricBigipVirtualServerConnectionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipVirtualServerConnectionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipVirtualServerConnectionCount(settings MetricSettings) metricBigipVirtualServerConnectionCount {
-	m := metricBigipVirtualServerConnectionCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipVirtualServerConnectionCount(cfg MetricConfig) metricBigipVirtualServerConnectionCount {
+	m := metricBigipVirtualServerConnectionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1487,7 +1487,7 @@ func newMetricBigipVirtualServerConnectionCount(settings MetricSettings) metricB
 
 type metricBigipVirtualServerDataTransmitted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1503,7 +1503,7 @@ func (m *metricBigipVirtualServerDataTransmitted) init() {
 }
 
 func (m *metricBigipVirtualServerDataTransmitted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1522,16 +1522,16 @@ func (m *metricBigipVirtualServerDataTransmitted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipVirtualServerDataTransmitted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipVirtualServerDataTransmitted(settings MetricSettings) metricBigipVirtualServerDataTransmitted {
-	m := metricBigipVirtualServerDataTransmitted{settings: settings}
-	if settings.Enabled {
+func newMetricBigipVirtualServerDataTransmitted(cfg MetricConfig) metricBigipVirtualServerDataTransmitted {
+	m := metricBigipVirtualServerDataTransmitted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1540,7 +1540,7 @@ func newMetricBigipVirtualServerDataTransmitted(settings MetricSettings) metricB
 
 type metricBigipVirtualServerEnabled struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1554,7 +1554,7 @@ func (m *metricBigipVirtualServerEnabled) init() {
 }
 
 func (m *metricBigipVirtualServerEnabled) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, enabledStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1573,16 +1573,16 @@ func (m *metricBigipVirtualServerEnabled) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipVirtualServerEnabled) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipVirtualServerEnabled(settings MetricSettings) metricBigipVirtualServerEnabled {
-	m := metricBigipVirtualServerEnabled{settings: settings}
-	if settings.Enabled {
+func newMetricBigipVirtualServerEnabled(cfg MetricConfig) metricBigipVirtualServerEnabled {
+	m := metricBigipVirtualServerEnabled{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1591,7 +1591,7 @@ func newMetricBigipVirtualServerEnabled(settings MetricSettings) metricBigipVirt
 
 type metricBigipVirtualServerPacketCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1607,7 +1607,7 @@ func (m *metricBigipVirtualServerPacketCount) init() {
 }
 
 func (m *metricBigipVirtualServerPacketCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1626,16 +1626,16 @@ func (m *metricBigipVirtualServerPacketCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipVirtualServerPacketCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipVirtualServerPacketCount(settings MetricSettings) metricBigipVirtualServerPacketCount {
-	m := metricBigipVirtualServerPacketCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipVirtualServerPacketCount(cfg MetricConfig) metricBigipVirtualServerPacketCount {
+	m := metricBigipVirtualServerPacketCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1644,7 +1644,7 @@ func newMetricBigipVirtualServerPacketCount(settings MetricSettings) metricBigip
 
 type metricBigipVirtualServerRequestCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1659,7 +1659,7 @@ func (m *metricBigipVirtualServerRequestCount) init() {
 }
 
 func (m *metricBigipVirtualServerRequestCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1677,16 +1677,16 @@ func (m *metricBigipVirtualServerRequestCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricBigipVirtualServerRequestCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricBigipVirtualServerRequestCount(settings MetricSettings) metricBigipVirtualServerRequestCount {
-	m := metricBigipVirtualServerRequestCount{settings: settings}
-	if settings.Enabled {
+func newMetricBigipVirtualServerRequestCount(cfg MetricConfig) metricBigipVirtualServerRequestCount {
+	m := metricBigipVirtualServerRequestCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1695,19 +1695,19 @@ func newMetricBigipVirtualServerRequestCount(settings MetricSettings) metricBigi
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                               pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                         int                 // maximum observed number of metrics per resource.
 	resourceCapacity                        int                 // maximum observed number of resource attributes.
 	metricsBuffer                           pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                               component.BuildInfo // contains version information
-	resourceAttributesSettings              ResourceAttributesSettings
+	resourceAttributesConfig                ResourceAttributesConfig
 	metricBigipNodeAvailability             metricBigipNodeAvailability
 	metricBigipNodeConnectionCount          metricBigipNodeConnectionCount
 	metricBigipNodeDataTransmitted          metricBigipNodeDataTransmitted
@@ -1749,8 +1749,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -1759,7 +1759,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                               pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                           pmetric.NewMetrics(),
 		buildInfo:                               settings.BuildInfo,
-		resourceAttributesSettings:              mbc.ResourceAttributes,
+		resourceAttributesConfig:                mbc.ResourceAttributes,
 		metricBigipNodeAvailability:             newMetricBigipNodeAvailability(mbc.Metrics.BigipNodeAvailability),
 		metricBigipNodeConnectionCount:          newMetricBigipNodeConnectionCount(mbc.Metrics.BigipNodeConnectionCount),
 		metricBigipNodeDataTransmitted:          newMetricBigipNodeDataTransmitted(mbc.Metrics.BigipNodeDataTransmitted),
@@ -1805,12 +1805,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithBigipNodeIPAddress sets provided value as "bigip.node.ip_address" attribute for current resource.
 func WithBigipNodeIPAddress(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.BigipNodeIPAddress.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.BigipNodeIPAddress.Enabled {
 			rm.Resource().Attributes().PutStr("bigip.node.ip_address", val)
 		}
 	}
@@ -1818,8 +1818,8 @@ func WithBigipNodeIPAddress(val string) ResourceMetricsOption {
 
 // WithBigipNodeName sets provided value as "bigip.node.name" attribute for current resource.
 func WithBigipNodeName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.BigipNodeName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.BigipNodeName.Enabled {
 			rm.Resource().Attributes().PutStr("bigip.node.name", val)
 		}
 	}
@@ -1827,8 +1827,8 @@ func WithBigipNodeName(val string) ResourceMetricsOption {
 
 // WithBigipPoolName sets provided value as "bigip.pool.name" attribute for current resource.
 func WithBigipPoolName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.BigipPoolName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.BigipPoolName.Enabled {
 			rm.Resource().Attributes().PutStr("bigip.pool.name", val)
 		}
 	}
@@ -1836,8 +1836,8 @@ func WithBigipPoolName(val string) ResourceMetricsOption {
 
 // WithBigipPoolMemberIPAddress sets provided value as "bigip.pool_member.ip_address" attribute for current resource.
 func WithBigipPoolMemberIPAddress(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.BigipPoolMemberIPAddress.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.BigipPoolMemberIPAddress.Enabled {
 			rm.Resource().Attributes().PutStr("bigip.pool_member.ip_address", val)
 		}
 	}
@@ -1845,8 +1845,8 @@ func WithBigipPoolMemberIPAddress(val string) ResourceMetricsOption {
 
 // WithBigipPoolMemberName sets provided value as "bigip.pool_member.name" attribute for current resource.
 func WithBigipPoolMemberName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.BigipPoolMemberName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.BigipPoolMemberName.Enabled {
 			rm.Resource().Attributes().PutStr("bigip.pool_member.name", val)
 		}
 	}
@@ -1854,8 +1854,8 @@ func WithBigipPoolMemberName(val string) ResourceMetricsOption {
 
 // WithBigipVirtualServerDestination sets provided value as "bigip.virtual_server.destination" attribute for current resource.
 func WithBigipVirtualServerDestination(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.BigipVirtualServerDestination.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.BigipVirtualServerDestination.Enabled {
 			rm.Resource().Attributes().PutStr("bigip.virtual_server.destination", val)
 		}
 	}
@@ -1863,8 +1863,8 @@ func WithBigipVirtualServerDestination(val string) ResourceMetricsOption {
 
 // WithBigipVirtualServerName sets provided value as "bigip.virtual_server.name" attribute for current resource.
 func WithBigipVirtualServerName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.BigipVirtualServerName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.BigipVirtualServerName.Enabled {
 			rm.Resource().Attributes().PutStr("bigip.virtual_server.name", val)
 		}
 	}
@@ -1873,7 +1873,7 @@ func WithBigipVirtualServerName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -1931,7 +1931,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricBigipVirtualServerRequestCount.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -1941,7 +1941,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/bigipreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/bigipreceiver/internal/metadata/generated_metrics_test.go
@@ -179,50 +179,50 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("bigip.node.ip_address")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.BigipNodeIPAddress.Enabled, ok)
-			if mb.resourceAttributesSettings.BigipNodeIPAddress.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.BigipNodeIPAddress.Enabled, ok)
+			if mb.resourceAttributesConfig.BigipNodeIPAddress.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("bigip.node.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.BigipNodeName.Enabled, ok)
-			if mb.resourceAttributesSettings.BigipNodeName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.BigipNodeName.Enabled, ok)
+			if mb.resourceAttributesConfig.BigipNodeName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("bigip.pool.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.BigipPoolName.Enabled, ok)
-			if mb.resourceAttributesSettings.BigipPoolName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.BigipPoolName.Enabled, ok)
+			if mb.resourceAttributesConfig.BigipPoolName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("bigip.pool_member.ip_address")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.BigipPoolMemberIPAddress.Enabled, ok)
-			if mb.resourceAttributesSettings.BigipPoolMemberIPAddress.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.BigipPoolMemberIPAddress.Enabled, ok)
+			if mb.resourceAttributesConfig.BigipPoolMemberIPAddress.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("bigip.pool_member.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.BigipPoolMemberName.Enabled, ok)
-			if mb.resourceAttributesSettings.BigipPoolMemberName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.BigipPoolMemberName.Enabled, ok)
+			if mb.resourceAttributesConfig.BigipPoolMemberName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("bigip.virtual_server.destination")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.BigipVirtualServerDestination.Enabled, ok)
-			if mb.resourceAttributesSettings.BigipVirtualServerDestination.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.BigipVirtualServerDestination.Enabled, ok)
+			if mb.resourceAttributesConfig.BigipVirtualServerDestination.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("bigip.virtual_server.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.BigipVirtualServerName.Enabled, ok)
-			if mb.resourceAttributesSettings.BigipVirtualServerName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.BigipVirtualServerName.Enabled, ok)
+			if mb.resourceAttributesConfig.BigipVirtualServerName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/chronyreceiver/factory_test.go
+++ b/receiver/chronyreceiver/factory_test.go
@@ -48,11 +48,11 @@ func TestCreatingMetricsReceiver(t *testing.T) {
 
 	factory := NewFactory()
 	mbc := metadata.DefaultMetricsBuilderConfig()
-	mbc.Metrics = metadata.MetricsSettings{
-		NtpTimeCorrection: metadata.MetricSettings{
+	mbc.Metrics = metadata.MetricsConfig{
+		NtpTimeCorrection: metadata.MetricConfig{
 			Enabled: true,
 		},
-		NtpSkew: metadata.MetricSettings{
+		NtpSkew: metadata.MetricConfig{
 			Enabled: true,
 		},
 	}

--- a/receiver/couchdbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,60 +31,60 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for couchdbreceiver metrics.
-type MetricsSettings struct {
-	CouchdbAverageRequestTime MetricSettings `mapstructure:"couchdb.average_request_time"`
-	CouchdbDatabaseOpen       MetricSettings `mapstructure:"couchdb.database.open"`
-	CouchdbDatabaseOperations MetricSettings `mapstructure:"couchdb.database.operations"`
-	CouchdbFileDescriptorOpen MetricSettings `mapstructure:"couchdb.file_descriptor.open"`
-	CouchdbHttpdBulkRequests  MetricSettings `mapstructure:"couchdb.httpd.bulk_requests"`
-	CouchdbHttpdRequests      MetricSettings `mapstructure:"couchdb.httpd.requests"`
-	CouchdbHttpdResponses     MetricSettings `mapstructure:"couchdb.httpd.responses"`
-	CouchdbHttpdViews         MetricSettings `mapstructure:"couchdb.httpd.views"`
+// MetricsConfig provides config for couchdbreceiver metrics.
+type MetricsConfig struct {
+	CouchdbAverageRequestTime MetricConfig `mapstructure:"couchdb.average_request_time"`
+	CouchdbDatabaseOpen       MetricConfig `mapstructure:"couchdb.database.open"`
+	CouchdbDatabaseOperations MetricConfig `mapstructure:"couchdb.database.operations"`
+	CouchdbFileDescriptorOpen MetricConfig `mapstructure:"couchdb.file_descriptor.open"`
+	CouchdbHttpdBulkRequests  MetricConfig `mapstructure:"couchdb.httpd.bulk_requests"`
+	CouchdbHttpdRequests      MetricConfig `mapstructure:"couchdb.httpd.requests"`
+	CouchdbHttpdResponses     MetricConfig `mapstructure:"couchdb.httpd.responses"`
+	CouchdbHttpdViews         MetricConfig `mapstructure:"couchdb.httpd.views"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		CouchdbAverageRequestTime: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		CouchdbAverageRequestTime: MetricConfig{
 			Enabled: true,
 		},
-		CouchdbDatabaseOpen: MetricSettings{
+		CouchdbDatabaseOpen: MetricConfig{
 			Enabled: true,
 		},
-		CouchdbDatabaseOperations: MetricSettings{
+		CouchdbDatabaseOperations: MetricConfig{
 			Enabled: true,
 		},
-		CouchdbFileDescriptorOpen: MetricSettings{
+		CouchdbFileDescriptorOpen: MetricConfig{
 			Enabled: true,
 		},
-		CouchdbHttpdBulkRequests: MetricSettings{
+		CouchdbHttpdBulkRequests: MetricConfig{
 			Enabled: true,
 		},
-		CouchdbHttpdRequests: MetricSettings{
+		CouchdbHttpdRequests: MetricConfig{
 			Enabled: true,
 		},
-		CouchdbHttpdResponses: MetricSettings{
+		CouchdbHttpdResponses: MetricConfig{
 			Enabled: true,
 		},
-		CouchdbHttpdViews: MetricSettings{
+		CouchdbHttpdViews: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for couchdbreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	CouchdbNodeName ResourceAttributeSettings `mapstructure:"couchdb.node.name"`
+// ResourceAttributesConfig provides config for couchdbreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	CouchdbNodeName ResourceAttributeConfig `mapstructure:"couchdb.node.name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		CouchdbNodeName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		CouchdbNodeName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -190,7 +190,7 @@ var MapAttributeView = map[string]AttributeView{
 
 type metricCouchdbAverageRequestTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -203,7 +203,7 @@ func (m *metricCouchdbAverageRequestTime) init() {
 }
 
 func (m *metricCouchdbAverageRequestTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -221,16 +221,16 @@ func (m *metricCouchdbAverageRequestTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbAverageRequestTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbAverageRequestTime(settings MetricSettings) metricCouchdbAverageRequestTime {
-	m := metricCouchdbAverageRequestTime{settings: settings}
-	if settings.Enabled {
+func newMetricCouchdbAverageRequestTime(cfg MetricConfig) metricCouchdbAverageRequestTime {
+	m := metricCouchdbAverageRequestTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -239,7 +239,7 @@ func newMetricCouchdbAverageRequestTime(settings MetricSettings) metricCouchdbAv
 
 type metricCouchdbDatabaseOpen struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -254,7 +254,7 @@ func (m *metricCouchdbDatabaseOpen) init() {
 }
 
 func (m *metricCouchdbDatabaseOpen) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -272,16 +272,16 @@ func (m *metricCouchdbDatabaseOpen) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbDatabaseOpen) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbDatabaseOpen(settings MetricSettings) metricCouchdbDatabaseOpen {
-	m := metricCouchdbDatabaseOpen{settings: settings}
-	if settings.Enabled {
+func newMetricCouchdbDatabaseOpen(cfg MetricConfig) metricCouchdbDatabaseOpen {
+	m := metricCouchdbDatabaseOpen{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -290,7 +290,7 @@ func newMetricCouchdbDatabaseOpen(settings MetricSettings) metricCouchdbDatabase
 
 type metricCouchdbDatabaseOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -306,7 +306,7 @@ func (m *metricCouchdbDatabaseOperations) init() {
 }
 
 func (m *metricCouchdbDatabaseOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -325,16 +325,16 @@ func (m *metricCouchdbDatabaseOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbDatabaseOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbDatabaseOperations(settings MetricSettings) metricCouchdbDatabaseOperations {
-	m := metricCouchdbDatabaseOperations{settings: settings}
-	if settings.Enabled {
+func newMetricCouchdbDatabaseOperations(cfg MetricConfig) metricCouchdbDatabaseOperations {
+	m := metricCouchdbDatabaseOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -343,7 +343,7 @@ func newMetricCouchdbDatabaseOperations(settings MetricSettings) metricCouchdbDa
 
 type metricCouchdbFileDescriptorOpen struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -358,7 +358,7 @@ func (m *metricCouchdbFileDescriptorOpen) init() {
 }
 
 func (m *metricCouchdbFileDescriptorOpen) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -376,16 +376,16 @@ func (m *metricCouchdbFileDescriptorOpen) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbFileDescriptorOpen) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbFileDescriptorOpen(settings MetricSettings) metricCouchdbFileDescriptorOpen {
-	m := metricCouchdbFileDescriptorOpen{settings: settings}
-	if settings.Enabled {
+func newMetricCouchdbFileDescriptorOpen(cfg MetricConfig) metricCouchdbFileDescriptorOpen {
+	m := metricCouchdbFileDescriptorOpen{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -394,7 +394,7 @@ func newMetricCouchdbFileDescriptorOpen(settings MetricSettings) metricCouchdbFi
 
 type metricCouchdbHttpdBulkRequests struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -409,7 +409,7 @@ func (m *metricCouchdbHttpdBulkRequests) init() {
 }
 
 func (m *metricCouchdbHttpdBulkRequests) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -427,16 +427,16 @@ func (m *metricCouchdbHttpdBulkRequests) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbHttpdBulkRequests) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbHttpdBulkRequests(settings MetricSettings) metricCouchdbHttpdBulkRequests {
-	m := metricCouchdbHttpdBulkRequests{settings: settings}
-	if settings.Enabled {
+func newMetricCouchdbHttpdBulkRequests(cfg MetricConfig) metricCouchdbHttpdBulkRequests {
+	m := metricCouchdbHttpdBulkRequests{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -445,7 +445,7 @@ func newMetricCouchdbHttpdBulkRequests(settings MetricSettings) metricCouchdbHtt
 
 type metricCouchdbHttpdRequests struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -461,7 +461,7 @@ func (m *metricCouchdbHttpdRequests) init() {
 }
 
 func (m *metricCouchdbHttpdRequests) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpMethodAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -480,16 +480,16 @@ func (m *metricCouchdbHttpdRequests) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbHttpdRequests) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbHttpdRequests(settings MetricSettings) metricCouchdbHttpdRequests {
-	m := metricCouchdbHttpdRequests{settings: settings}
-	if settings.Enabled {
+func newMetricCouchdbHttpdRequests(cfg MetricConfig) metricCouchdbHttpdRequests {
+	m := metricCouchdbHttpdRequests{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -498,7 +498,7 @@ func newMetricCouchdbHttpdRequests(settings MetricSettings) metricCouchdbHttpdRe
 
 type metricCouchdbHttpdResponses struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -514,7 +514,7 @@ func (m *metricCouchdbHttpdResponses) init() {
 }
 
 func (m *metricCouchdbHttpdResponses) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpStatusCodeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -533,16 +533,16 @@ func (m *metricCouchdbHttpdResponses) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbHttpdResponses) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbHttpdResponses(settings MetricSettings) metricCouchdbHttpdResponses {
-	m := metricCouchdbHttpdResponses{settings: settings}
-	if settings.Enabled {
+func newMetricCouchdbHttpdResponses(cfg MetricConfig) metricCouchdbHttpdResponses {
+	m := metricCouchdbHttpdResponses{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -551,7 +551,7 @@ func newMetricCouchdbHttpdResponses(settings MetricSettings) metricCouchdbHttpdR
 
 type metricCouchdbHttpdViews struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -567,7 +567,7 @@ func (m *metricCouchdbHttpdViews) init() {
 }
 
 func (m *metricCouchdbHttpdViews) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, viewAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -586,16 +586,16 @@ func (m *metricCouchdbHttpdViews) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricCouchdbHttpdViews) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricCouchdbHttpdViews(settings MetricSettings) metricCouchdbHttpdViews {
-	m := metricCouchdbHttpdViews{settings: settings}
-	if settings.Enabled {
+func newMetricCouchdbHttpdViews(cfg MetricConfig) metricCouchdbHttpdViews {
+	m := metricCouchdbHttpdViews{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -604,19 +604,19 @@ func newMetricCouchdbHttpdViews(settings MetricSettings) metricCouchdbHttpdViews
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                       pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                 int                 // maximum observed number of metrics per resource.
 	resourceCapacity                int                 // maximum observed number of resource attributes.
 	metricsBuffer                   pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                       component.BuildInfo // contains version information
-	resourceAttributesSettings      ResourceAttributesSettings
+	resourceAttributesConfig        ResourceAttributesConfig
 	metricCouchdbAverageRequestTime metricCouchdbAverageRequestTime
 	metricCouchdbDatabaseOpen       metricCouchdbDatabaseOpen
 	metricCouchdbDatabaseOperations metricCouchdbDatabaseOperations
@@ -639,8 +639,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -649,7 +649,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                       pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                   pmetric.NewMetrics(),
 		buildInfo:                       settings.BuildInfo,
-		resourceAttributesSettings:      mbc.ResourceAttributes,
+		resourceAttributesConfig:        mbc.ResourceAttributes,
 		metricCouchdbAverageRequestTime: newMetricCouchdbAverageRequestTime(mbc.Metrics.CouchdbAverageRequestTime),
 		metricCouchdbDatabaseOpen:       newMetricCouchdbDatabaseOpen(mbc.Metrics.CouchdbDatabaseOpen),
 		metricCouchdbDatabaseOperations: newMetricCouchdbDatabaseOperations(mbc.Metrics.CouchdbDatabaseOperations),
@@ -676,12 +676,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithCouchdbNodeName sets provided value as "couchdb.node.name" attribute for current resource.
 func WithCouchdbNodeName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.CouchdbNodeName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.CouchdbNodeName.Enabled {
 			rm.Resource().Attributes().PutStr("couchdb.node.name", val)
 		}
 	}
@@ -690,7 +690,7 @@ func WithCouchdbNodeName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -729,7 +729,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricCouchdbHttpdViews.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -739,7 +739,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/couchdbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_metrics_test.go
@@ -103,8 +103,8 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("couchdb.node.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.CouchdbNodeName.Enabled, ok)
-			if mb.resourceAttributesSettings.CouchdbNodeName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.CouchdbNodeName.Enabled, ok)
+			if mb.resourceAttributesConfig.CouchdbNodeName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -158,15 +158,15 @@ func TestMetricSettings(t *testing.T) {
 	mockClient := new(MockClient)
 	mockClient.On("GetStats", "_local").Return(getStats("response_2.31.json"))
 	mbc := metadata.DefaultMetricsBuilderConfig()
-	mbc.Metrics = metadata.MetricsSettings{
-		CouchdbAverageRequestTime: metadata.MetricSettings{Enabled: false},
-		CouchdbDatabaseOpen:       metadata.MetricSettings{Enabled: false},
-		CouchdbDatabaseOperations: metadata.MetricSettings{Enabled: true},
-		CouchdbFileDescriptorOpen: metadata.MetricSettings{Enabled: false},
-		CouchdbHttpdBulkRequests:  metadata.MetricSettings{Enabled: false},
-		CouchdbHttpdRequests:      metadata.MetricSettings{Enabled: false},
-		CouchdbHttpdResponses:     metadata.MetricSettings{Enabled: false},
-		CouchdbHttpdViews:         metadata.MetricSettings{Enabled: false},
+	mbc.Metrics = metadata.MetricsConfig{
+		CouchdbAverageRequestTime: metadata.MetricConfig{Enabled: false},
+		CouchdbDatabaseOpen:       metadata.MetricConfig{Enabled: false},
+		CouchdbDatabaseOperations: metadata.MetricConfig{Enabled: true},
+		CouchdbFileDescriptorOpen: metadata.MetricConfig{Enabled: false},
+		CouchdbHttpdBulkRequests:  metadata.MetricConfig{Enabled: false},
+		CouchdbHttpdRequests:      metadata.MetricConfig{Enabled: false},
+		CouchdbHttpdResponses:     metadata.MetricConfig{Enabled: false},
+		CouchdbHttpdViews:         metadata.MetricConfig{Enabled: false},
 	}
 	cfg := &Config{
 		HTTPClientSettings:   confighttp.HTTPClientSettings{},

--- a/receiver/dockerstatsreceiver/config_test.go
+++ b/receiver/dockerstatsreceiver/config_test.go
@@ -68,10 +68,10 @@ func TestLoadConfig(t *testing.T) {
 				},
 				MetricsBuilderConfig: func() metadata.MetricsBuilderConfig {
 					m := metadata.DefaultMetricsBuilderConfig()
-					m.Metrics.ContainerCPUUsageSystem = metadata.MetricSettings{
+					m.Metrics.ContainerCPUUsageSystem = metadata.MetricConfig{
 						Enabled: false,
 					}
-					m.Metrics.ContainerMemoryTotalRss = metadata.MetricSettings{
+					m.Metrics.ContainerMemoryTotalRss = metadata.MetricConfig{
 						Enabled: true,
 					}
 					return m
@@ -93,7 +93,7 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 			assert.NoError(t, component.ValidateConfig(cfg))
-			if diff := cmp.Diff(tt.expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricSettings{})); diff != "" {
+			if diff := cmp.Diff(tt.expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricConfig{})); diff != "" {
 				t.Errorf("Config mismatch (-expected +actual):\n%s", diff)
 			}
 		})

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
@@ -13,14 +13,14 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -32,296 +32,296 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for dockerstatsreceiver metrics.
-type MetricsSettings struct {
-	ContainerBlockioIoMergedRecursive          MetricSettings `mapstructure:"container.blockio.io_merged_recursive"`
-	ContainerBlockioIoQueuedRecursive          MetricSettings `mapstructure:"container.blockio.io_queued_recursive"`
-	ContainerBlockioIoServiceBytesRecursive    MetricSettings `mapstructure:"container.blockio.io_service_bytes_recursive"`
-	ContainerBlockioIoServiceTimeRecursive     MetricSettings `mapstructure:"container.blockio.io_service_time_recursive"`
-	ContainerBlockioIoServicedRecursive        MetricSettings `mapstructure:"container.blockio.io_serviced_recursive"`
-	ContainerBlockioIoTimeRecursive            MetricSettings `mapstructure:"container.blockio.io_time_recursive"`
-	ContainerBlockioIoWaitTimeRecursive        MetricSettings `mapstructure:"container.blockio.io_wait_time_recursive"`
-	ContainerBlockioSectorsRecursive           MetricSettings `mapstructure:"container.blockio.sectors_recursive"`
-	ContainerCPUPercent                        MetricSettings `mapstructure:"container.cpu.percent"`
-	ContainerCPUThrottlingDataPeriods          MetricSettings `mapstructure:"container.cpu.throttling_data.periods"`
-	ContainerCPUThrottlingDataThrottledPeriods MetricSettings `mapstructure:"container.cpu.throttling_data.throttled_periods"`
-	ContainerCPUThrottlingDataThrottledTime    MetricSettings `mapstructure:"container.cpu.throttling_data.throttled_time"`
-	ContainerCPUUsageKernelmode                MetricSettings `mapstructure:"container.cpu.usage.kernelmode"`
-	ContainerCPUUsagePercpu                    MetricSettings `mapstructure:"container.cpu.usage.percpu"`
-	ContainerCPUUsageSystem                    MetricSettings `mapstructure:"container.cpu.usage.system"`
-	ContainerCPUUsageTotal                     MetricSettings `mapstructure:"container.cpu.usage.total"`
-	ContainerCPUUsageUsermode                  MetricSettings `mapstructure:"container.cpu.usage.usermode"`
-	ContainerMemoryActiveAnon                  MetricSettings `mapstructure:"container.memory.active_anon"`
-	ContainerMemoryActiveFile                  MetricSettings `mapstructure:"container.memory.active_file"`
-	ContainerMemoryCache                       MetricSettings `mapstructure:"container.memory.cache"`
-	ContainerMemoryDirty                       MetricSettings `mapstructure:"container.memory.dirty"`
-	ContainerMemoryHierarchicalMemoryLimit     MetricSettings `mapstructure:"container.memory.hierarchical_memory_limit"`
-	ContainerMemoryHierarchicalMemswLimit      MetricSettings `mapstructure:"container.memory.hierarchical_memsw_limit"`
-	ContainerMemoryInactiveAnon                MetricSettings `mapstructure:"container.memory.inactive_anon"`
-	ContainerMemoryInactiveFile                MetricSettings `mapstructure:"container.memory.inactive_file"`
-	ContainerMemoryMappedFile                  MetricSettings `mapstructure:"container.memory.mapped_file"`
-	ContainerMemoryPercent                     MetricSettings `mapstructure:"container.memory.percent"`
-	ContainerMemoryPgfault                     MetricSettings `mapstructure:"container.memory.pgfault"`
-	ContainerMemoryPgmajfault                  MetricSettings `mapstructure:"container.memory.pgmajfault"`
-	ContainerMemoryPgpgin                      MetricSettings `mapstructure:"container.memory.pgpgin"`
-	ContainerMemoryPgpgout                     MetricSettings `mapstructure:"container.memory.pgpgout"`
-	ContainerMemoryRss                         MetricSettings `mapstructure:"container.memory.rss"`
-	ContainerMemoryRssHuge                     MetricSettings `mapstructure:"container.memory.rss_huge"`
-	ContainerMemorySwap                        MetricSettings `mapstructure:"container.memory.swap"`
-	ContainerMemoryTotalActiveAnon             MetricSettings `mapstructure:"container.memory.total_active_anon"`
-	ContainerMemoryTotalActiveFile             MetricSettings `mapstructure:"container.memory.total_active_file"`
-	ContainerMemoryTotalCache                  MetricSettings `mapstructure:"container.memory.total_cache"`
-	ContainerMemoryTotalDirty                  MetricSettings `mapstructure:"container.memory.total_dirty"`
-	ContainerMemoryTotalInactiveAnon           MetricSettings `mapstructure:"container.memory.total_inactive_anon"`
-	ContainerMemoryTotalInactiveFile           MetricSettings `mapstructure:"container.memory.total_inactive_file"`
-	ContainerMemoryTotalMappedFile             MetricSettings `mapstructure:"container.memory.total_mapped_file"`
-	ContainerMemoryTotalPgfault                MetricSettings `mapstructure:"container.memory.total_pgfault"`
-	ContainerMemoryTotalPgmajfault             MetricSettings `mapstructure:"container.memory.total_pgmajfault"`
-	ContainerMemoryTotalPgpgin                 MetricSettings `mapstructure:"container.memory.total_pgpgin"`
-	ContainerMemoryTotalPgpgout                MetricSettings `mapstructure:"container.memory.total_pgpgout"`
-	ContainerMemoryTotalRss                    MetricSettings `mapstructure:"container.memory.total_rss"`
-	ContainerMemoryTotalRssHuge                MetricSettings `mapstructure:"container.memory.total_rss_huge"`
-	ContainerMemoryTotalSwap                   MetricSettings `mapstructure:"container.memory.total_swap"`
-	ContainerMemoryTotalUnevictable            MetricSettings `mapstructure:"container.memory.total_unevictable"`
-	ContainerMemoryTotalWriteback              MetricSettings `mapstructure:"container.memory.total_writeback"`
-	ContainerMemoryUnevictable                 MetricSettings `mapstructure:"container.memory.unevictable"`
-	ContainerMemoryUsageLimit                  MetricSettings `mapstructure:"container.memory.usage.limit"`
-	ContainerMemoryUsageMax                    MetricSettings `mapstructure:"container.memory.usage.max"`
-	ContainerMemoryUsageTotal                  MetricSettings `mapstructure:"container.memory.usage.total"`
-	ContainerMemoryWriteback                   MetricSettings `mapstructure:"container.memory.writeback"`
-	ContainerNetworkIoUsageRxBytes             MetricSettings `mapstructure:"container.network.io.usage.rx_bytes"`
-	ContainerNetworkIoUsageRxDropped           MetricSettings `mapstructure:"container.network.io.usage.rx_dropped"`
-	ContainerNetworkIoUsageRxErrors            MetricSettings `mapstructure:"container.network.io.usage.rx_errors"`
-	ContainerNetworkIoUsageRxPackets           MetricSettings `mapstructure:"container.network.io.usage.rx_packets"`
-	ContainerNetworkIoUsageTxBytes             MetricSettings `mapstructure:"container.network.io.usage.tx_bytes"`
-	ContainerNetworkIoUsageTxDropped           MetricSettings `mapstructure:"container.network.io.usage.tx_dropped"`
-	ContainerNetworkIoUsageTxErrors            MetricSettings `mapstructure:"container.network.io.usage.tx_errors"`
-	ContainerNetworkIoUsageTxPackets           MetricSettings `mapstructure:"container.network.io.usage.tx_packets"`
+// MetricsConfig provides config for dockerstatsreceiver metrics.
+type MetricsConfig struct {
+	ContainerBlockioIoMergedRecursive          MetricConfig `mapstructure:"container.blockio.io_merged_recursive"`
+	ContainerBlockioIoQueuedRecursive          MetricConfig `mapstructure:"container.blockio.io_queued_recursive"`
+	ContainerBlockioIoServiceBytesRecursive    MetricConfig `mapstructure:"container.blockio.io_service_bytes_recursive"`
+	ContainerBlockioIoServiceTimeRecursive     MetricConfig `mapstructure:"container.blockio.io_service_time_recursive"`
+	ContainerBlockioIoServicedRecursive        MetricConfig `mapstructure:"container.blockio.io_serviced_recursive"`
+	ContainerBlockioIoTimeRecursive            MetricConfig `mapstructure:"container.blockio.io_time_recursive"`
+	ContainerBlockioIoWaitTimeRecursive        MetricConfig `mapstructure:"container.blockio.io_wait_time_recursive"`
+	ContainerBlockioSectorsRecursive           MetricConfig `mapstructure:"container.blockio.sectors_recursive"`
+	ContainerCPUPercent                        MetricConfig `mapstructure:"container.cpu.percent"`
+	ContainerCPUThrottlingDataPeriods          MetricConfig `mapstructure:"container.cpu.throttling_data.periods"`
+	ContainerCPUThrottlingDataThrottledPeriods MetricConfig `mapstructure:"container.cpu.throttling_data.throttled_periods"`
+	ContainerCPUThrottlingDataThrottledTime    MetricConfig `mapstructure:"container.cpu.throttling_data.throttled_time"`
+	ContainerCPUUsageKernelmode                MetricConfig `mapstructure:"container.cpu.usage.kernelmode"`
+	ContainerCPUUsagePercpu                    MetricConfig `mapstructure:"container.cpu.usage.percpu"`
+	ContainerCPUUsageSystem                    MetricConfig `mapstructure:"container.cpu.usage.system"`
+	ContainerCPUUsageTotal                     MetricConfig `mapstructure:"container.cpu.usage.total"`
+	ContainerCPUUsageUsermode                  MetricConfig `mapstructure:"container.cpu.usage.usermode"`
+	ContainerMemoryActiveAnon                  MetricConfig `mapstructure:"container.memory.active_anon"`
+	ContainerMemoryActiveFile                  MetricConfig `mapstructure:"container.memory.active_file"`
+	ContainerMemoryCache                       MetricConfig `mapstructure:"container.memory.cache"`
+	ContainerMemoryDirty                       MetricConfig `mapstructure:"container.memory.dirty"`
+	ContainerMemoryHierarchicalMemoryLimit     MetricConfig `mapstructure:"container.memory.hierarchical_memory_limit"`
+	ContainerMemoryHierarchicalMemswLimit      MetricConfig `mapstructure:"container.memory.hierarchical_memsw_limit"`
+	ContainerMemoryInactiveAnon                MetricConfig `mapstructure:"container.memory.inactive_anon"`
+	ContainerMemoryInactiveFile                MetricConfig `mapstructure:"container.memory.inactive_file"`
+	ContainerMemoryMappedFile                  MetricConfig `mapstructure:"container.memory.mapped_file"`
+	ContainerMemoryPercent                     MetricConfig `mapstructure:"container.memory.percent"`
+	ContainerMemoryPgfault                     MetricConfig `mapstructure:"container.memory.pgfault"`
+	ContainerMemoryPgmajfault                  MetricConfig `mapstructure:"container.memory.pgmajfault"`
+	ContainerMemoryPgpgin                      MetricConfig `mapstructure:"container.memory.pgpgin"`
+	ContainerMemoryPgpgout                     MetricConfig `mapstructure:"container.memory.pgpgout"`
+	ContainerMemoryRss                         MetricConfig `mapstructure:"container.memory.rss"`
+	ContainerMemoryRssHuge                     MetricConfig `mapstructure:"container.memory.rss_huge"`
+	ContainerMemorySwap                        MetricConfig `mapstructure:"container.memory.swap"`
+	ContainerMemoryTotalActiveAnon             MetricConfig `mapstructure:"container.memory.total_active_anon"`
+	ContainerMemoryTotalActiveFile             MetricConfig `mapstructure:"container.memory.total_active_file"`
+	ContainerMemoryTotalCache                  MetricConfig `mapstructure:"container.memory.total_cache"`
+	ContainerMemoryTotalDirty                  MetricConfig `mapstructure:"container.memory.total_dirty"`
+	ContainerMemoryTotalInactiveAnon           MetricConfig `mapstructure:"container.memory.total_inactive_anon"`
+	ContainerMemoryTotalInactiveFile           MetricConfig `mapstructure:"container.memory.total_inactive_file"`
+	ContainerMemoryTotalMappedFile             MetricConfig `mapstructure:"container.memory.total_mapped_file"`
+	ContainerMemoryTotalPgfault                MetricConfig `mapstructure:"container.memory.total_pgfault"`
+	ContainerMemoryTotalPgmajfault             MetricConfig `mapstructure:"container.memory.total_pgmajfault"`
+	ContainerMemoryTotalPgpgin                 MetricConfig `mapstructure:"container.memory.total_pgpgin"`
+	ContainerMemoryTotalPgpgout                MetricConfig `mapstructure:"container.memory.total_pgpgout"`
+	ContainerMemoryTotalRss                    MetricConfig `mapstructure:"container.memory.total_rss"`
+	ContainerMemoryTotalRssHuge                MetricConfig `mapstructure:"container.memory.total_rss_huge"`
+	ContainerMemoryTotalSwap                   MetricConfig `mapstructure:"container.memory.total_swap"`
+	ContainerMemoryTotalUnevictable            MetricConfig `mapstructure:"container.memory.total_unevictable"`
+	ContainerMemoryTotalWriteback              MetricConfig `mapstructure:"container.memory.total_writeback"`
+	ContainerMemoryUnevictable                 MetricConfig `mapstructure:"container.memory.unevictable"`
+	ContainerMemoryUsageLimit                  MetricConfig `mapstructure:"container.memory.usage.limit"`
+	ContainerMemoryUsageMax                    MetricConfig `mapstructure:"container.memory.usage.max"`
+	ContainerMemoryUsageTotal                  MetricConfig `mapstructure:"container.memory.usage.total"`
+	ContainerMemoryWriteback                   MetricConfig `mapstructure:"container.memory.writeback"`
+	ContainerNetworkIoUsageRxBytes             MetricConfig `mapstructure:"container.network.io.usage.rx_bytes"`
+	ContainerNetworkIoUsageRxDropped           MetricConfig `mapstructure:"container.network.io.usage.rx_dropped"`
+	ContainerNetworkIoUsageRxErrors            MetricConfig `mapstructure:"container.network.io.usage.rx_errors"`
+	ContainerNetworkIoUsageRxPackets           MetricConfig `mapstructure:"container.network.io.usage.rx_packets"`
+	ContainerNetworkIoUsageTxBytes             MetricConfig `mapstructure:"container.network.io.usage.tx_bytes"`
+	ContainerNetworkIoUsageTxDropped           MetricConfig `mapstructure:"container.network.io.usage.tx_dropped"`
+	ContainerNetworkIoUsageTxErrors            MetricConfig `mapstructure:"container.network.io.usage.tx_errors"`
+	ContainerNetworkIoUsageTxPackets           MetricConfig `mapstructure:"container.network.io.usage.tx_packets"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		ContainerBlockioIoMergedRecursive: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		ContainerBlockioIoMergedRecursive: MetricConfig{
 			Enabled: false,
 		},
-		ContainerBlockioIoQueuedRecursive: MetricSettings{
+		ContainerBlockioIoQueuedRecursive: MetricConfig{
 			Enabled: false,
 		},
-		ContainerBlockioIoServiceBytesRecursive: MetricSettings{
+		ContainerBlockioIoServiceBytesRecursive: MetricConfig{
 			Enabled: true,
 		},
-		ContainerBlockioIoServiceTimeRecursive: MetricSettings{
+		ContainerBlockioIoServiceTimeRecursive: MetricConfig{
 			Enabled: false,
 		},
-		ContainerBlockioIoServicedRecursive: MetricSettings{
+		ContainerBlockioIoServicedRecursive: MetricConfig{
 			Enabled: false,
 		},
-		ContainerBlockioIoTimeRecursive: MetricSettings{
+		ContainerBlockioIoTimeRecursive: MetricConfig{
 			Enabled: false,
 		},
-		ContainerBlockioIoWaitTimeRecursive: MetricSettings{
+		ContainerBlockioIoWaitTimeRecursive: MetricConfig{
 			Enabled: false,
 		},
-		ContainerBlockioSectorsRecursive: MetricSettings{
+		ContainerBlockioSectorsRecursive: MetricConfig{
 			Enabled: false,
 		},
-		ContainerCPUPercent: MetricSettings{
+		ContainerCPUPercent: MetricConfig{
 			Enabled: true,
 		},
-		ContainerCPUThrottlingDataPeriods: MetricSettings{
+		ContainerCPUThrottlingDataPeriods: MetricConfig{
 			Enabled: false,
 		},
-		ContainerCPUThrottlingDataThrottledPeriods: MetricSettings{
+		ContainerCPUThrottlingDataThrottledPeriods: MetricConfig{
 			Enabled: false,
 		},
-		ContainerCPUThrottlingDataThrottledTime: MetricSettings{
+		ContainerCPUThrottlingDataThrottledTime: MetricConfig{
 			Enabled: false,
 		},
-		ContainerCPUUsageKernelmode: MetricSettings{
+		ContainerCPUUsageKernelmode: MetricConfig{
 			Enabled: true,
 		},
-		ContainerCPUUsagePercpu: MetricSettings{
+		ContainerCPUUsagePercpu: MetricConfig{
 			Enabled: false,
 		},
-		ContainerCPUUsageSystem: MetricSettings{
+		ContainerCPUUsageSystem: MetricConfig{
 			Enabled: false,
 		},
-		ContainerCPUUsageTotal: MetricSettings{
+		ContainerCPUUsageTotal: MetricConfig{
 			Enabled: true,
 		},
-		ContainerCPUUsageUsermode: MetricSettings{
+		ContainerCPUUsageUsermode: MetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryActiveAnon: MetricSettings{
+		ContainerMemoryActiveAnon: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryActiveFile: MetricSettings{
+		ContainerMemoryActiveFile: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryCache: MetricSettings{
+		ContainerMemoryCache: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryDirty: MetricSettings{
+		ContainerMemoryDirty: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryHierarchicalMemoryLimit: MetricSettings{
+		ContainerMemoryHierarchicalMemoryLimit: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryHierarchicalMemswLimit: MetricSettings{
+		ContainerMemoryHierarchicalMemswLimit: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryInactiveAnon: MetricSettings{
+		ContainerMemoryInactiveAnon: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryInactiveFile: MetricSettings{
+		ContainerMemoryInactiveFile: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryMappedFile: MetricSettings{
+		ContainerMemoryMappedFile: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryPercent: MetricSettings{
+		ContainerMemoryPercent: MetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryPgfault: MetricSettings{
+		ContainerMemoryPgfault: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryPgmajfault: MetricSettings{
+		ContainerMemoryPgmajfault: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryPgpgin: MetricSettings{
+		ContainerMemoryPgpgin: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryPgpgout: MetricSettings{
+		ContainerMemoryPgpgout: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryRss: MetricSettings{
+		ContainerMemoryRss: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryRssHuge: MetricSettings{
+		ContainerMemoryRssHuge: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemorySwap: MetricSettings{
+		ContainerMemorySwap: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalActiveAnon: MetricSettings{
+		ContainerMemoryTotalActiveAnon: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalActiveFile: MetricSettings{
+		ContainerMemoryTotalActiveFile: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalCache: MetricSettings{
+		ContainerMemoryTotalCache: MetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryTotalDirty: MetricSettings{
+		ContainerMemoryTotalDirty: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalInactiveAnon: MetricSettings{
+		ContainerMemoryTotalInactiveAnon: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalInactiveFile: MetricSettings{
+		ContainerMemoryTotalInactiveFile: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalMappedFile: MetricSettings{
+		ContainerMemoryTotalMappedFile: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalPgfault: MetricSettings{
+		ContainerMemoryTotalPgfault: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalPgmajfault: MetricSettings{
+		ContainerMemoryTotalPgmajfault: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalPgpgin: MetricSettings{
+		ContainerMemoryTotalPgpgin: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalPgpgout: MetricSettings{
+		ContainerMemoryTotalPgpgout: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalRss: MetricSettings{
+		ContainerMemoryTotalRss: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalRssHuge: MetricSettings{
+		ContainerMemoryTotalRssHuge: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalSwap: MetricSettings{
+		ContainerMemoryTotalSwap: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalUnevictable: MetricSettings{
+		ContainerMemoryTotalUnevictable: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryTotalWriteback: MetricSettings{
+		ContainerMemoryTotalWriteback: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryUnevictable: MetricSettings{
+		ContainerMemoryUnevictable: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryUsageLimit: MetricSettings{
+		ContainerMemoryUsageLimit: MetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryUsageMax: MetricSettings{
+		ContainerMemoryUsageMax: MetricConfig{
 			Enabled: false,
 		},
-		ContainerMemoryUsageTotal: MetricSettings{
+		ContainerMemoryUsageTotal: MetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryWriteback: MetricSettings{
+		ContainerMemoryWriteback: MetricConfig{
 			Enabled: false,
 		},
-		ContainerNetworkIoUsageRxBytes: MetricSettings{
+		ContainerNetworkIoUsageRxBytes: MetricConfig{
 			Enabled: true,
 		},
-		ContainerNetworkIoUsageRxDropped: MetricSettings{
+		ContainerNetworkIoUsageRxDropped: MetricConfig{
 			Enabled: true,
 		},
-		ContainerNetworkIoUsageRxErrors: MetricSettings{
+		ContainerNetworkIoUsageRxErrors: MetricConfig{
 			Enabled: false,
 		},
-		ContainerNetworkIoUsageRxPackets: MetricSettings{
+		ContainerNetworkIoUsageRxPackets: MetricConfig{
 			Enabled: false,
 		},
-		ContainerNetworkIoUsageTxBytes: MetricSettings{
+		ContainerNetworkIoUsageTxBytes: MetricConfig{
 			Enabled: true,
 		},
-		ContainerNetworkIoUsageTxDropped: MetricSettings{
+		ContainerNetworkIoUsageTxDropped: MetricConfig{
 			Enabled: true,
 		},
-		ContainerNetworkIoUsageTxErrors: MetricSettings{
+		ContainerNetworkIoUsageTxErrors: MetricConfig{
 			Enabled: false,
 		},
-		ContainerNetworkIoUsageTxPackets: MetricSettings{
+		ContainerNetworkIoUsageTxPackets: MetricConfig{
 			Enabled: false,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for dockerstatsreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	ContainerHostname  ResourceAttributeSettings `mapstructure:"container.hostname"`
-	ContainerID        ResourceAttributeSettings `mapstructure:"container.id"`
-	ContainerImageName ResourceAttributeSettings `mapstructure:"container.image.name"`
-	ContainerName      ResourceAttributeSettings `mapstructure:"container.name"`
-	ContainerRuntime   ResourceAttributeSettings `mapstructure:"container.runtime"`
+// ResourceAttributesConfig provides config for dockerstatsreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	ContainerHostname  ResourceAttributeConfig `mapstructure:"container.hostname"`
+	ContainerID        ResourceAttributeConfig `mapstructure:"container.id"`
+	ContainerImageName ResourceAttributeConfig `mapstructure:"container.image.name"`
+	ContainerName      ResourceAttributeConfig `mapstructure:"container.name"`
+	ContainerRuntime   ResourceAttributeConfig `mapstructure:"container.runtime"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		ContainerHostname: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		ContainerHostname: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ContainerID: ResourceAttributeSettings{
+		ContainerID: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ContainerImageName: ResourceAttributeSettings{
+		ContainerImageName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ContainerName: ResourceAttributeSettings{
+		ContainerName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ContainerRuntime: ResourceAttributeSettings{
+		ContainerRuntime: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -329,7 +329,7 @@ func DefaultResourceAttributesSettings() ResourceAttributesSettings {
 
 type metricContainerBlockioIoMergedRecursive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -345,7 +345,7 @@ func (m *metricContainerBlockioIoMergedRecursive) init() {
 }
 
 func (m *metricContainerBlockioIoMergedRecursive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceMajorAttributeValue string, deviceMinorAttributeValue string, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -366,16 +366,16 @@ func (m *metricContainerBlockioIoMergedRecursive) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerBlockioIoMergedRecursive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerBlockioIoMergedRecursive(settings MetricSettings) metricContainerBlockioIoMergedRecursive {
-	m := metricContainerBlockioIoMergedRecursive{settings: settings}
-	if settings.Enabled {
+func newMetricContainerBlockioIoMergedRecursive(cfg MetricConfig) metricContainerBlockioIoMergedRecursive {
+	m := metricContainerBlockioIoMergedRecursive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -384,7 +384,7 @@ func newMetricContainerBlockioIoMergedRecursive(settings MetricSettings) metricC
 
 type metricContainerBlockioIoQueuedRecursive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -400,7 +400,7 @@ func (m *metricContainerBlockioIoQueuedRecursive) init() {
 }
 
 func (m *metricContainerBlockioIoQueuedRecursive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceMajorAttributeValue string, deviceMinorAttributeValue string, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -421,16 +421,16 @@ func (m *metricContainerBlockioIoQueuedRecursive) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerBlockioIoQueuedRecursive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerBlockioIoQueuedRecursive(settings MetricSettings) metricContainerBlockioIoQueuedRecursive {
-	m := metricContainerBlockioIoQueuedRecursive{settings: settings}
-	if settings.Enabled {
+func newMetricContainerBlockioIoQueuedRecursive(cfg MetricConfig) metricContainerBlockioIoQueuedRecursive {
+	m := metricContainerBlockioIoQueuedRecursive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -439,7 +439,7 @@ func newMetricContainerBlockioIoQueuedRecursive(settings MetricSettings) metricC
 
 type metricContainerBlockioIoServiceBytesRecursive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -455,7 +455,7 @@ func (m *metricContainerBlockioIoServiceBytesRecursive) init() {
 }
 
 func (m *metricContainerBlockioIoServiceBytesRecursive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceMajorAttributeValue string, deviceMinorAttributeValue string, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -476,16 +476,16 @@ func (m *metricContainerBlockioIoServiceBytesRecursive) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerBlockioIoServiceBytesRecursive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerBlockioIoServiceBytesRecursive(settings MetricSettings) metricContainerBlockioIoServiceBytesRecursive {
-	m := metricContainerBlockioIoServiceBytesRecursive{settings: settings}
-	if settings.Enabled {
+func newMetricContainerBlockioIoServiceBytesRecursive(cfg MetricConfig) metricContainerBlockioIoServiceBytesRecursive {
+	m := metricContainerBlockioIoServiceBytesRecursive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -494,7 +494,7 @@ func newMetricContainerBlockioIoServiceBytesRecursive(settings MetricSettings) m
 
 type metricContainerBlockioIoServiceTimeRecursive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -510,7 +510,7 @@ func (m *metricContainerBlockioIoServiceTimeRecursive) init() {
 }
 
 func (m *metricContainerBlockioIoServiceTimeRecursive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceMajorAttributeValue string, deviceMinorAttributeValue string, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -531,16 +531,16 @@ func (m *metricContainerBlockioIoServiceTimeRecursive) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerBlockioIoServiceTimeRecursive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerBlockioIoServiceTimeRecursive(settings MetricSettings) metricContainerBlockioIoServiceTimeRecursive {
-	m := metricContainerBlockioIoServiceTimeRecursive{settings: settings}
-	if settings.Enabled {
+func newMetricContainerBlockioIoServiceTimeRecursive(cfg MetricConfig) metricContainerBlockioIoServiceTimeRecursive {
+	m := metricContainerBlockioIoServiceTimeRecursive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -549,7 +549,7 @@ func newMetricContainerBlockioIoServiceTimeRecursive(settings MetricSettings) me
 
 type metricContainerBlockioIoServicedRecursive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -565,7 +565,7 @@ func (m *metricContainerBlockioIoServicedRecursive) init() {
 }
 
 func (m *metricContainerBlockioIoServicedRecursive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceMajorAttributeValue string, deviceMinorAttributeValue string, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -586,16 +586,16 @@ func (m *metricContainerBlockioIoServicedRecursive) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerBlockioIoServicedRecursive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerBlockioIoServicedRecursive(settings MetricSettings) metricContainerBlockioIoServicedRecursive {
-	m := metricContainerBlockioIoServicedRecursive{settings: settings}
-	if settings.Enabled {
+func newMetricContainerBlockioIoServicedRecursive(cfg MetricConfig) metricContainerBlockioIoServicedRecursive {
+	m := metricContainerBlockioIoServicedRecursive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -604,7 +604,7 @@ func newMetricContainerBlockioIoServicedRecursive(settings MetricSettings) metri
 
 type metricContainerBlockioIoTimeRecursive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -620,7 +620,7 @@ func (m *metricContainerBlockioIoTimeRecursive) init() {
 }
 
 func (m *metricContainerBlockioIoTimeRecursive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceMajorAttributeValue string, deviceMinorAttributeValue string, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -641,16 +641,16 @@ func (m *metricContainerBlockioIoTimeRecursive) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerBlockioIoTimeRecursive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerBlockioIoTimeRecursive(settings MetricSettings) metricContainerBlockioIoTimeRecursive {
-	m := metricContainerBlockioIoTimeRecursive{settings: settings}
-	if settings.Enabled {
+func newMetricContainerBlockioIoTimeRecursive(cfg MetricConfig) metricContainerBlockioIoTimeRecursive {
+	m := metricContainerBlockioIoTimeRecursive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -659,7 +659,7 @@ func newMetricContainerBlockioIoTimeRecursive(settings MetricSettings) metricCon
 
 type metricContainerBlockioIoWaitTimeRecursive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -675,7 +675,7 @@ func (m *metricContainerBlockioIoWaitTimeRecursive) init() {
 }
 
 func (m *metricContainerBlockioIoWaitTimeRecursive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceMajorAttributeValue string, deviceMinorAttributeValue string, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -696,16 +696,16 @@ func (m *metricContainerBlockioIoWaitTimeRecursive) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerBlockioIoWaitTimeRecursive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerBlockioIoWaitTimeRecursive(settings MetricSettings) metricContainerBlockioIoWaitTimeRecursive {
-	m := metricContainerBlockioIoWaitTimeRecursive{settings: settings}
-	if settings.Enabled {
+func newMetricContainerBlockioIoWaitTimeRecursive(cfg MetricConfig) metricContainerBlockioIoWaitTimeRecursive {
+	m := metricContainerBlockioIoWaitTimeRecursive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -714,7 +714,7 @@ func newMetricContainerBlockioIoWaitTimeRecursive(settings MetricSettings) metri
 
 type metricContainerBlockioSectorsRecursive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -730,7 +730,7 @@ func (m *metricContainerBlockioSectorsRecursive) init() {
 }
 
 func (m *metricContainerBlockioSectorsRecursive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceMajorAttributeValue string, deviceMinorAttributeValue string, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -751,16 +751,16 @@ func (m *metricContainerBlockioSectorsRecursive) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerBlockioSectorsRecursive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerBlockioSectorsRecursive(settings MetricSettings) metricContainerBlockioSectorsRecursive {
-	m := metricContainerBlockioSectorsRecursive{settings: settings}
-	if settings.Enabled {
+func newMetricContainerBlockioSectorsRecursive(cfg MetricConfig) metricContainerBlockioSectorsRecursive {
+	m := metricContainerBlockioSectorsRecursive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -769,7 +769,7 @@ func newMetricContainerBlockioSectorsRecursive(settings MetricSettings) metricCo
 
 type metricContainerCPUPercent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -782,7 +782,7 @@ func (m *metricContainerCPUPercent) init() {
 }
 
 func (m *metricContainerCPUPercent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -800,16 +800,16 @@ func (m *metricContainerCPUPercent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerCPUPercent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerCPUPercent(settings MetricSettings) metricContainerCPUPercent {
-	m := metricContainerCPUPercent{settings: settings}
-	if settings.Enabled {
+func newMetricContainerCPUPercent(cfg MetricConfig) metricContainerCPUPercent {
+	m := metricContainerCPUPercent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -818,7 +818,7 @@ func newMetricContainerCPUPercent(settings MetricSettings) metricContainerCPUPer
 
 type metricContainerCPUThrottlingDataPeriods struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -833,7 +833,7 @@ func (m *metricContainerCPUThrottlingDataPeriods) init() {
 }
 
 func (m *metricContainerCPUThrottlingDataPeriods) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -851,16 +851,16 @@ func (m *metricContainerCPUThrottlingDataPeriods) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerCPUThrottlingDataPeriods) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerCPUThrottlingDataPeriods(settings MetricSettings) metricContainerCPUThrottlingDataPeriods {
-	m := metricContainerCPUThrottlingDataPeriods{settings: settings}
-	if settings.Enabled {
+func newMetricContainerCPUThrottlingDataPeriods(cfg MetricConfig) metricContainerCPUThrottlingDataPeriods {
+	m := metricContainerCPUThrottlingDataPeriods{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -869,7 +869,7 @@ func newMetricContainerCPUThrottlingDataPeriods(settings MetricSettings) metricC
 
 type metricContainerCPUThrottlingDataThrottledPeriods struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -884,7 +884,7 @@ func (m *metricContainerCPUThrottlingDataThrottledPeriods) init() {
 }
 
 func (m *metricContainerCPUThrottlingDataThrottledPeriods) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -902,16 +902,16 @@ func (m *metricContainerCPUThrottlingDataThrottledPeriods) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerCPUThrottlingDataThrottledPeriods) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerCPUThrottlingDataThrottledPeriods(settings MetricSettings) metricContainerCPUThrottlingDataThrottledPeriods {
-	m := metricContainerCPUThrottlingDataThrottledPeriods{settings: settings}
-	if settings.Enabled {
+func newMetricContainerCPUThrottlingDataThrottledPeriods(cfg MetricConfig) metricContainerCPUThrottlingDataThrottledPeriods {
+	m := metricContainerCPUThrottlingDataThrottledPeriods{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -920,7 +920,7 @@ func newMetricContainerCPUThrottlingDataThrottledPeriods(settings MetricSettings
 
 type metricContainerCPUThrottlingDataThrottledTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -935,7 +935,7 @@ func (m *metricContainerCPUThrottlingDataThrottledTime) init() {
 }
 
 func (m *metricContainerCPUThrottlingDataThrottledTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -953,16 +953,16 @@ func (m *metricContainerCPUThrottlingDataThrottledTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerCPUThrottlingDataThrottledTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerCPUThrottlingDataThrottledTime(settings MetricSettings) metricContainerCPUThrottlingDataThrottledTime {
-	m := metricContainerCPUThrottlingDataThrottledTime{settings: settings}
-	if settings.Enabled {
+func newMetricContainerCPUThrottlingDataThrottledTime(cfg MetricConfig) metricContainerCPUThrottlingDataThrottledTime {
+	m := metricContainerCPUThrottlingDataThrottledTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -971,7 +971,7 @@ func newMetricContainerCPUThrottlingDataThrottledTime(settings MetricSettings) m
 
 type metricContainerCPUUsageKernelmode struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -986,7 +986,7 @@ func (m *metricContainerCPUUsageKernelmode) init() {
 }
 
 func (m *metricContainerCPUUsageKernelmode) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1004,16 +1004,16 @@ func (m *metricContainerCPUUsageKernelmode) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerCPUUsageKernelmode) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerCPUUsageKernelmode(settings MetricSettings) metricContainerCPUUsageKernelmode {
-	m := metricContainerCPUUsageKernelmode{settings: settings}
-	if settings.Enabled {
+func newMetricContainerCPUUsageKernelmode(cfg MetricConfig) metricContainerCPUUsageKernelmode {
+	m := metricContainerCPUUsageKernelmode{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1022,7 +1022,7 @@ func newMetricContainerCPUUsageKernelmode(settings MetricSettings) metricContain
 
 type metricContainerCPUUsagePercpu struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1038,7 +1038,7 @@ func (m *metricContainerCPUUsagePercpu) init() {
 }
 
 func (m *metricContainerCPUUsagePercpu) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, coreAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1057,16 +1057,16 @@ func (m *metricContainerCPUUsagePercpu) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerCPUUsagePercpu) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerCPUUsagePercpu(settings MetricSettings) metricContainerCPUUsagePercpu {
-	m := metricContainerCPUUsagePercpu{settings: settings}
-	if settings.Enabled {
+func newMetricContainerCPUUsagePercpu(cfg MetricConfig) metricContainerCPUUsagePercpu {
+	m := metricContainerCPUUsagePercpu{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1075,7 +1075,7 @@ func newMetricContainerCPUUsagePercpu(settings MetricSettings) metricContainerCP
 
 type metricContainerCPUUsageSystem struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1090,7 +1090,7 @@ func (m *metricContainerCPUUsageSystem) init() {
 }
 
 func (m *metricContainerCPUUsageSystem) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1108,16 +1108,16 @@ func (m *metricContainerCPUUsageSystem) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerCPUUsageSystem) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerCPUUsageSystem(settings MetricSettings) metricContainerCPUUsageSystem {
-	m := metricContainerCPUUsageSystem{settings: settings}
-	if settings.Enabled {
+func newMetricContainerCPUUsageSystem(cfg MetricConfig) metricContainerCPUUsageSystem {
+	m := metricContainerCPUUsageSystem{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1126,7 +1126,7 @@ func newMetricContainerCPUUsageSystem(settings MetricSettings) metricContainerCP
 
 type metricContainerCPUUsageTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1141,7 +1141,7 @@ func (m *metricContainerCPUUsageTotal) init() {
 }
 
 func (m *metricContainerCPUUsageTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1159,16 +1159,16 @@ func (m *metricContainerCPUUsageTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerCPUUsageTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerCPUUsageTotal(settings MetricSettings) metricContainerCPUUsageTotal {
-	m := metricContainerCPUUsageTotal{settings: settings}
-	if settings.Enabled {
+func newMetricContainerCPUUsageTotal(cfg MetricConfig) metricContainerCPUUsageTotal {
+	m := metricContainerCPUUsageTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1177,7 +1177,7 @@ func newMetricContainerCPUUsageTotal(settings MetricSettings) metricContainerCPU
 
 type metricContainerCPUUsageUsermode struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1192,7 +1192,7 @@ func (m *metricContainerCPUUsageUsermode) init() {
 }
 
 func (m *metricContainerCPUUsageUsermode) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1210,16 +1210,16 @@ func (m *metricContainerCPUUsageUsermode) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerCPUUsageUsermode) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerCPUUsageUsermode(settings MetricSettings) metricContainerCPUUsageUsermode {
-	m := metricContainerCPUUsageUsermode{settings: settings}
-	if settings.Enabled {
+func newMetricContainerCPUUsageUsermode(cfg MetricConfig) metricContainerCPUUsageUsermode {
+	m := metricContainerCPUUsageUsermode{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1228,7 +1228,7 @@ func newMetricContainerCPUUsageUsermode(settings MetricSettings) metricContainer
 
 type metricContainerMemoryActiveAnon struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1243,7 +1243,7 @@ func (m *metricContainerMemoryActiveAnon) init() {
 }
 
 func (m *metricContainerMemoryActiveAnon) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1261,16 +1261,16 @@ func (m *metricContainerMemoryActiveAnon) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryActiveAnon) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryActiveAnon(settings MetricSettings) metricContainerMemoryActiveAnon {
-	m := metricContainerMemoryActiveAnon{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryActiveAnon(cfg MetricConfig) metricContainerMemoryActiveAnon {
+	m := metricContainerMemoryActiveAnon{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1279,7 +1279,7 @@ func newMetricContainerMemoryActiveAnon(settings MetricSettings) metricContainer
 
 type metricContainerMemoryActiveFile struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1294,7 +1294,7 @@ func (m *metricContainerMemoryActiveFile) init() {
 }
 
 func (m *metricContainerMemoryActiveFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1312,16 +1312,16 @@ func (m *metricContainerMemoryActiveFile) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryActiveFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryActiveFile(settings MetricSettings) metricContainerMemoryActiveFile {
-	m := metricContainerMemoryActiveFile{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryActiveFile(cfg MetricConfig) metricContainerMemoryActiveFile {
+	m := metricContainerMemoryActiveFile{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1330,7 +1330,7 @@ func newMetricContainerMemoryActiveFile(settings MetricSettings) metricContainer
 
 type metricContainerMemoryCache struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1345,7 +1345,7 @@ func (m *metricContainerMemoryCache) init() {
 }
 
 func (m *metricContainerMemoryCache) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1363,16 +1363,16 @@ func (m *metricContainerMemoryCache) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryCache) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryCache(settings MetricSettings) metricContainerMemoryCache {
-	m := metricContainerMemoryCache{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryCache(cfg MetricConfig) metricContainerMemoryCache {
+	m := metricContainerMemoryCache{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1381,7 +1381,7 @@ func newMetricContainerMemoryCache(settings MetricSettings) metricContainerMemor
 
 type metricContainerMemoryDirty struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1396,7 +1396,7 @@ func (m *metricContainerMemoryDirty) init() {
 }
 
 func (m *metricContainerMemoryDirty) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1414,16 +1414,16 @@ func (m *metricContainerMemoryDirty) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryDirty) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryDirty(settings MetricSettings) metricContainerMemoryDirty {
-	m := metricContainerMemoryDirty{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryDirty(cfg MetricConfig) metricContainerMemoryDirty {
+	m := metricContainerMemoryDirty{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1432,7 +1432,7 @@ func newMetricContainerMemoryDirty(settings MetricSettings) metricContainerMemor
 
 type metricContainerMemoryHierarchicalMemoryLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1447,7 +1447,7 @@ func (m *metricContainerMemoryHierarchicalMemoryLimit) init() {
 }
 
 func (m *metricContainerMemoryHierarchicalMemoryLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1465,16 +1465,16 @@ func (m *metricContainerMemoryHierarchicalMemoryLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryHierarchicalMemoryLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryHierarchicalMemoryLimit(settings MetricSettings) metricContainerMemoryHierarchicalMemoryLimit {
-	m := metricContainerMemoryHierarchicalMemoryLimit{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryHierarchicalMemoryLimit(cfg MetricConfig) metricContainerMemoryHierarchicalMemoryLimit {
+	m := metricContainerMemoryHierarchicalMemoryLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1483,7 +1483,7 @@ func newMetricContainerMemoryHierarchicalMemoryLimit(settings MetricSettings) me
 
 type metricContainerMemoryHierarchicalMemswLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1498,7 +1498,7 @@ func (m *metricContainerMemoryHierarchicalMemswLimit) init() {
 }
 
 func (m *metricContainerMemoryHierarchicalMemswLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1516,16 +1516,16 @@ func (m *metricContainerMemoryHierarchicalMemswLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryHierarchicalMemswLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryHierarchicalMemswLimit(settings MetricSettings) metricContainerMemoryHierarchicalMemswLimit {
-	m := metricContainerMemoryHierarchicalMemswLimit{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryHierarchicalMemswLimit(cfg MetricConfig) metricContainerMemoryHierarchicalMemswLimit {
+	m := metricContainerMemoryHierarchicalMemswLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1534,7 +1534,7 @@ func newMetricContainerMemoryHierarchicalMemswLimit(settings MetricSettings) met
 
 type metricContainerMemoryInactiveAnon struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1549,7 +1549,7 @@ func (m *metricContainerMemoryInactiveAnon) init() {
 }
 
 func (m *metricContainerMemoryInactiveAnon) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1567,16 +1567,16 @@ func (m *metricContainerMemoryInactiveAnon) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryInactiveAnon) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryInactiveAnon(settings MetricSettings) metricContainerMemoryInactiveAnon {
-	m := metricContainerMemoryInactiveAnon{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryInactiveAnon(cfg MetricConfig) metricContainerMemoryInactiveAnon {
+	m := metricContainerMemoryInactiveAnon{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1585,7 +1585,7 @@ func newMetricContainerMemoryInactiveAnon(settings MetricSettings) metricContain
 
 type metricContainerMemoryInactiveFile struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1600,7 +1600,7 @@ func (m *metricContainerMemoryInactiveFile) init() {
 }
 
 func (m *metricContainerMemoryInactiveFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1618,16 +1618,16 @@ func (m *metricContainerMemoryInactiveFile) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryInactiveFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryInactiveFile(settings MetricSettings) metricContainerMemoryInactiveFile {
-	m := metricContainerMemoryInactiveFile{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryInactiveFile(cfg MetricConfig) metricContainerMemoryInactiveFile {
+	m := metricContainerMemoryInactiveFile{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1636,7 +1636,7 @@ func newMetricContainerMemoryInactiveFile(settings MetricSettings) metricContain
 
 type metricContainerMemoryMappedFile struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1651,7 +1651,7 @@ func (m *metricContainerMemoryMappedFile) init() {
 }
 
 func (m *metricContainerMemoryMappedFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1669,16 +1669,16 @@ func (m *metricContainerMemoryMappedFile) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryMappedFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryMappedFile(settings MetricSettings) metricContainerMemoryMappedFile {
-	m := metricContainerMemoryMappedFile{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryMappedFile(cfg MetricConfig) metricContainerMemoryMappedFile {
+	m := metricContainerMemoryMappedFile{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1687,7 +1687,7 @@ func newMetricContainerMemoryMappedFile(settings MetricSettings) metricContainer
 
 type metricContainerMemoryPercent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1700,7 +1700,7 @@ func (m *metricContainerMemoryPercent) init() {
 }
 
 func (m *metricContainerMemoryPercent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1718,16 +1718,16 @@ func (m *metricContainerMemoryPercent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryPercent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryPercent(settings MetricSettings) metricContainerMemoryPercent {
-	m := metricContainerMemoryPercent{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryPercent(cfg MetricConfig) metricContainerMemoryPercent {
+	m := metricContainerMemoryPercent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1736,7 +1736,7 @@ func newMetricContainerMemoryPercent(settings MetricSettings) metricContainerMem
 
 type metricContainerMemoryPgfault struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1751,7 +1751,7 @@ func (m *metricContainerMemoryPgfault) init() {
 }
 
 func (m *metricContainerMemoryPgfault) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1769,16 +1769,16 @@ func (m *metricContainerMemoryPgfault) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryPgfault) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryPgfault(settings MetricSettings) metricContainerMemoryPgfault {
-	m := metricContainerMemoryPgfault{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryPgfault(cfg MetricConfig) metricContainerMemoryPgfault {
+	m := metricContainerMemoryPgfault{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1787,7 +1787,7 @@ func newMetricContainerMemoryPgfault(settings MetricSettings) metricContainerMem
 
 type metricContainerMemoryPgmajfault struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1802,7 +1802,7 @@ func (m *metricContainerMemoryPgmajfault) init() {
 }
 
 func (m *metricContainerMemoryPgmajfault) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1820,16 +1820,16 @@ func (m *metricContainerMemoryPgmajfault) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryPgmajfault) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryPgmajfault(settings MetricSettings) metricContainerMemoryPgmajfault {
-	m := metricContainerMemoryPgmajfault{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryPgmajfault(cfg MetricConfig) metricContainerMemoryPgmajfault {
+	m := metricContainerMemoryPgmajfault{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1838,7 +1838,7 @@ func newMetricContainerMemoryPgmajfault(settings MetricSettings) metricContainer
 
 type metricContainerMemoryPgpgin struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1853,7 +1853,7 @@ func (m *metricContainerMemoryPgpgin) init() {
 }
 
 func (m *metricContainerMemoryPgpgin) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1871,16 +1871,16 @@ func (m *metricContainerMemoryPgpgin) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryPgpgin) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryPgpgin(settings MetricSettings) metricContainerMemoryPgpgin {
-	m := metricContainerMemoryPgpgin{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryPgpgin(cfg MetricConfig) metricContainerMemoryPgpgin {
+	m := metricContainerMemoryPgpgin{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1889,7 +1889,7 @@ func newMetricContainerMemoryPgpgin(settings MetricSettings) metricContainerMemo
 
 type metricContainerMemoryPgpgout struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1904,7 +1904,7 @@ func (m *metricContainerMemoryPgpgout) init() {
 }
 
 func (m *metricContainerMemoryPgpgout) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1922,16 +1922,16 @@ func (m *metricContainerMemoryPgpgout) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryPgpgout) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryPgpgout(settings MetricSettings) metricContainerMemoryPgpgout {
-	m := metricContainerMemoryPgpgout{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryPgpgout(cfg MetricConfig) metricContainerMemoryPgpgout {
+	m := metricContainerMemoryPgpgout{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1940,7 +1940,7 @@ func newMetricContainerMemoryPgpgout(settings MetricSettings) metricContainerMem
 
 type metricContainerMemoryRss struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1955,7 +1955,7 @@ func (m *metricContainerMemoryRss) init() {
 }
 
 func (m *metricContainerMemoryRss) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1973,16 +1973,16 @@ func (m *metricContainerMemoryRss) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryRss) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryRss(settings MetricSettings) metricContainerMemoryRss {
-	m := metricContainerMemoryRss{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryRss(cfg MetricConfig) metricContainerMemoryRss {
+	m := metricContainerMemoryRss{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1991,7 +1991,7 @@ func newMetricContainerMemoryRss(settings MetricSettings) metricContainerMemoryR
 
 type metricContainerMemoryRssHuge struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2006,7 +2006,7 @@ func (m *metricContainerMemoryRssHuge) init() {
 }
 
 func (m *metricContainerMemoryRssHuge) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2024,16 +2024,16 @@ func (m *metricContainerMemoryRssHuge) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryRssHuge) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryRssHuge(settings MetricSettings) metricContainerMemoryRssHuge {
-	m := metricContainerMemoryRssHuge{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryRssHuge(cfg MetricConfig) metricContainerMemoryRssHuge {
+	m := metricContainerMemoryRssHuge{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2042,7 +2042,7 @@ func newMetricContainerMemoryRssHuge(settings MetricSettings) metricContainerMem
 
 type metricContainerMemorySwap struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2057,7 +2057,7 @@ func (m *metricContainerMemorySwap) init() {
 }
 
 func (m *metricContainerMemorySwap) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2075,16 +2075,16 @@ func (m *metricContainerMemorySwap) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemorySwap) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemorySwap(settings MetricSettings) metricContainerMemorySwap {
-	m := metricContainerMemorySwap{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemorySwap(cfg MetricConfig) metricContainerMemorySwap {
+	m := metricContainerMemorySwap{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2093,7 +2093,7 @@ func newMetricContainerMemorySwap(settings MetricSettings) metricContainerMemory
 
 type metricContainerMemoryTotalActiveAnon struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2108,7 +2108,7 @@ func (m *metricContainerMemoryTotalActiveAnon) init() {
 }
 
 func (m *metricContainerMemoryTotalActiveAnon) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2126,16 +2126,16 @@ func (m *metricContainerMemoryTotalActiveAnon) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalActiveAnon) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalActiveAnon(settings MetricSettings) metricContainerMemoryTotalActiveAnon {
-	m := metricContainerMemoryTotalActiveAnon{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalActiveAnon(cfg MetricConfig) metricContainerMemoryTotalActiveAnon {
+	m := metricContainerMemoryTotalActiveAnon{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2144,7 +2144,7 @@ func newMetricContainerMemoryTotalActiveAnon(settings MetricSettings) metricCont
 
 type metricContainerMemoryTotalActiveFile struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2159,7 +2159,7 @@ func (m *metricContainerMemoryTotalActiveFile) init() {
 }
 
 func (m *metricContainerMemoryTotalActiveFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2177,16 +2177,16 @@ func (m *metricContainerMemoryTotalActiveFile) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalActiveFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalActiveFile(settings MetricSettings) metricContainerMemoryTotalActiveFile {
-	m := metricContainerMemoryTotalActiveFile{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalActiveFile(cfg MetricConfig) metricContainerMemoryTotalActiveFile {
+	m := metricContainerMemoryTotalActiveFile{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2195,7 +2195,7 @@ func newMetricContainerMemoryTotalActiveFile(settings MetricSettings) metricCont
 
 type metricContainerMemoryTotalCache struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2210,7 +2210,7 @@ func (m *metricContainerMemoryTotalCache) init() {
 }
 
 func (m *metricContainerMemoryTotalCache) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2228,16 +2228,16 @@ func (m *metricContainerMemoryTotalCache) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalCache) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalCache(settings MetricSettings) metricContainerMemoryTotalCache {
-	m := metricContainerMemoryTotalCache{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalCache(cfg MetricConfig) metricContainerMemoryTotalCache {
+	m := metricContainerMemoryTotalCache{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2246,7 +2246,7 @@ func newMetricContainerMemoryTotalCache(settings MetricSettings) metricContainer
 
 type metricContainerMemoryTotalDirty struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2261,7 +2261,7 @@ func (m *metricContainerMemoryTotalDirty) init() {
 }
 
 func (m *metricContainerMemoryTotalDirty) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2279,16 +2279,16 @@ func (m *metricContainerMemoryTotalDirty) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalDirty) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalDirty(settings MetricSettings) metricContainerMemoryTotalDirty {
-	m := metricContainerMemoryTotalDirty{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalDirty(cfg MetricConfig) metricContainerMemoryTotalDirty {
+	m := metricContainerMemoryTotalDirty{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2297,7 +2297,7 @@ func newMetricContainerMemoryTotalDirty(settings MetricSettings) metricContainer
 
 type metricContainerMemoryTotalInactiveAnon struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2312,7 +2312,7 @@ func (m *metricContainerMemoryTotalInactiveAnon) init() {
 }
 
 func (m *metricContainerMemoryTotalInactiveAnon) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2330,16 +2330,16 @@ func (m *metricContainerMemoryTotalInactiveAnon) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalInactiveAnon) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalInactiveAnon(settings MetricSettings) metricContainerMemoryTotalInactiveAnon {
-	m := metricContainerMemoryTotalInactiveAnon{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalInactiveAnon(cfg MetricConfig) metricContainerMemoryTotalInactiveAnon {
+	m := metricContainerMemoryTotalInactiveAnon{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2348,7 +2348,7 @@ func newMetricContainerMemoryTotalInactiveAnon(settings MetricSettings) metricCo
 
 type metricContainerMemoryTotalInactiveFile struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2363,7 +2363,7 @@ func (m *metricContainerMemoryTotalInactiveFile) init() {
 }
 
 func (m *metricContainerMemoryTotalInactiveFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2381,16 +2381,16 @@ func (m *metricContainerMemoryTotalInactiveFile) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalInactiveFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalInactiveFile(settings MetricSettings) metricContainerMemoryTotalInactiveFile {
-	m := metricContainerMemoryTotalInactiveFile{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalInactiveFile(cfg MetricConfig) metricContainerMemoryTotalInactiveFile {
+	m := metricContainerMemoryTotalInactiveFile{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2399,7 +2399,7 @@ func newMetricContainerMemoryTotalInactiveFile(settings MetricSettings) metricCo
 
 type metricContainerMemoryTotalMappedFile struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2414,7 +2414,7 @@ func (m *metricContainerMemoryTotalMappedFile) init() {
 }
 
 func (m *metricContainerMemoryTotalMappedFile) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2432,16 +2432,16 @@ func (m *metricContainerMemoryTotalMappedFile) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalMappedFile) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalMappedFile(settings MetricSettings) metricContainerMemoryTotalMappedFile {
-	m := metricContainerMemoryTotalMappedFile{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalMappedFile(cfg MetricConfig) metricContainerMemoryTotalMappedFile {
+	m := metricContainerMemoryTotalMappedFile{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2450,7 +2450,7 @@ func newMetricContainerMemoryTotalMappedFile(settings MetricSettings) metricCont
 
 type metricContainerMemoryTotalPgfault struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2465,7 +2465,7 @@ func (m *metricContainerMemoryTotalPgfault) init() {
 }
 
 func (m *metricContainerMemoryTotalPgfault) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2483,16 +2483,16 @@ func (m *metricContainerMemoryTotalPgfault) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalPgfault) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalPgfault(settings MetricSettings) metricContainerMemoryTotalPgfault {
-	m := metricContainerMemoryTotalPgfault{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalPgfault(cfg MetricConfig) metricContainerMemoryTotalPgfault {
+	m := metricContainerMemoryTotalPgfault{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2501,7 +2501,7 @@ func newMetricContainerMemoryTotalPgfault(settings MetricSettings) metricContain
 
 type metricContainerMemoryTotalPgmajfault struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2516,7 +2516,7 @@ func (m *metricContainerMemoryTotalPgmajfault) init() {
 }
 
 func (m *metricContainerMemoryTotalPgmajfault) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2534,16 +2534,16 @@ func (m *metricContainerMemoryTotalPgmajfault) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalPgmajfault) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalPgmajfault(settings MetricSettings) metricContainerMemoryTotalPgmajfault {
-	m := metricContainerMemoryTotalPgmajfault{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalPgmajfault(cfg MetricConfig) metricContainerMemoryTotalPgmajfault {
+	m := metricContainerMemoryTotalPgmajfault{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2552,7 +2552,7 @@ func newMetricContainerMemoryTotalPgmajfault(settings MetricSettings) metricCont
 
 type metricContainerMemoryTotalPgpgin struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2567,7 +2567,7 @@ func (m *metricContainerMemoryTotalPgpgin) init() {
 }
 
 func (m *metricContainerMemoryTotalPgpgin) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2585,16 +2585,16 @@ func (m *metricContainerMemoryTotalPgpgin) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalPgpgin) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalPgpgin(settings MetricSettings) metricContainerMemoryTotalPgpgin {
-	m := metricContainerMemoryTotalPgpgin{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalPgpgin(cfg MetricConfig) metricContainerMemoryTotalPgpgin {
+	m := metricContainerMemoryTotalPgpgin{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2603,7 +2603,7 @@ func newMetricContainerMemoryTotalPgpgin(settings MetricSettings) metricContaine
 
 type metricContainerMemoryTotalPgpgout struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2618,7 +2618,7 @@ func (m *metricContainerMemoryTotalPgpgout) init() {
 }
 
 func (m *metricContainerMemoryTotalPgpgout) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2636,16 +2636,16 @@ func (m *metricContainerMemoryTotalPgpgout) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalPgpgout) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalPgpgout(settings MetricSettings) metricContainerMemoryTotalPgpgout {
-	m := metricContainerMemoryTotalPgpgout{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalPgpgout(cfg MetricConfig) metricContainerMemoryTotalPgpgout {
+	m := metricContainerMemoryTotalPgpgout{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2654,7 +2654,7 @@ func newMetricContainerMemoryTotalPgpgout(settings MetricSettings) metricContain
 
 type metricContainerMemoryTotalRss struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2669,7 +2669,7 @@ func (m *metricContainerMemoryTotalRss) init() {
 }
 
 func (m *metricContainerMemoryTotalRss) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2687,16 +2687,16 @@ func (m *metricContainerMemoryTotalRss) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalRss) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalRss(settings MetricSettings) metricContainerMemoryTotalRss {
-	m := metricContainerMemoryTotalRss{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalRss(cfg MetricConfig) metricContainerMemoryTotalRss {
+	m := metricContainerMemoryTotalRss{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2705,7 +2705,7 @@ func newMetricContainerMemoryTotalRss(settings MetricSettings) metricContainerMe
 
 type metricContainerMemoryTotalRssHuge struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2720,7 +2720,7 @@ func (m *metricContainerMemoryTotalRssHuge) init() {
 }
 
 func (m *metricContainerMemoryTotalRssHuge) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2738,16 +2738,16 @@ func (m *metricContainerMemoryTotalRssHuge) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalRssHuge) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalRssHuge(settings MetricSettings) metricContainerMemoryTotalRssHuge {
-	m := metricContainerMemoryTotalRssHuge{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalRssHuge(cfg MetricConfig) metricContainerMemoryTotalRssHuge {
+	m := metricContainerMemoryTotalRssHuge{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2756,7 +2756,7 @@ func newMetricContainerMemoryTotalRssHuge(settings MetricSettings) metricContain
 
 type metricContainerMemoryTotalSwap struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2771,7 +2771,7 @@ func (m *metricContainerMemoryTotalSwap) init() {
 }
 
 func (m *metricContainerMemoryTotalSwap) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2789,16 +2789,16 @@ func (m *metricContainerMemoryTotalSwap) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalSwap) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalSwap(settings MetricSettings) metricContainerMemoryTotalSwap {
-	m := metricContainerMemoryTotalSwap{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalSwap(cfg MetricConfig) metricContainerMemoryTotalSwap {
+	m := metricContainerMemoryTotalSwap{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2807,7 +2807,7 @@ func newMetricContainerMemoryTotalSwap(settings MetricSettings) metricContainerM
 
 type metricContainerMemoryTotalUnevictable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2822,7 +2822,7 @@ func (m *metricContainerMemoryTotalUnevictable) init() {
 }
 
 func (m *metricContainerMemoryTotalUnevictable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2840,16 +2840,16 @@ func (m *metricContainerMemoryTotalUnevictable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalUnevictable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalUnevictable(settings MetricSettings) metricContainerMemoryTotalUnevictable {
-	m := metricContainerMemoryTotalUnevictable{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalUnevictable(cfg MetricConfig) metricContainerMemoryTotalUnevictable {
+	m := metricContainerMemoryTotalUnevictable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2858,7 +2858,7 @@ func newMetricContainerMemoryTotalUnevictable(settings MetricSettings) metricCon
 
 type metricContainerMemoryTotalWriteback struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2873,7 +2873,7 @@ func (m *metricContainerMemoryTotalWriteback) init() {
 }
 
 func (m *metricContainerMemoryTotalWriteback) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2891,16 +2891,16 @@ func (m *metricContainerMemoryTotalWriteback) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryTotalWriteback) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryTotalWriteback(settings MetricSettings) metricContainerMemoryTotalWriteback {
-	m := metricContainerMemoryTotalWriteback{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryTotalWriteback(cfg MetricConfig) metricContainerMemoryTotalWriteback {
+	m := metricContainerMemoryTotalWriteback{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2909,7 +2909,7 @@ func newMetricContainerMemoryTotalWriteback(settings MetricSettings) metricConta
 
 type metricContainerMemoryUnevictable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2924,7 +2924,7 @@ func (m *metricContainerMemoryUnevictable) init() {
 }
 
 func (m *metricContainerMemoryUnevictable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2942,16 +2942,16 @@ func (m *metricContainerMemoryUnevictable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryUnevictable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryUnevictable(settings MetricSettings) metricContainerMemoryUnevictable {
-	m := metricContainerMemoryUnevictable{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryUnevictable(cfg MetricConfig) metricContainerMemoryUnevictable {
+	m := metricContainerMemoryUnevictable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2960,7 +2960,7 @@ func newMetricContainerMemoryUnevictable(settings MetricSettings) metricContaine
 
 type metricContainerMemoryUsageLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2975,7 +2975,7 @@ func (m *metricContainerMemoryUsageLimit) init() {
 }
 
 func (m *metricContainerMemoryUsageLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2993,16 +2993,16 @@ func (m *metricContainerMemoryUsageLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryUsageLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryUsageLimit(settings MetricSettings) metricContainerMemoryUsageLimit {
-	m := metricContainerMemoryUsageLimit{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryUsageLimit(cfg MetricConfig) metricContainerMemoryUsageLimit {
+	m := metricContainerMemoryUsageLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3011,7 +3011,7 @@ func newMetricContainerMemoryUsageLimit(settings MetricSettings) metricContainer
 
 type metricContainerMemoryUsageMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3026,7 +3026,7 @@ func (m *metricContainerMemoryUsageMax) init() {
 }
 
 func (m *metricContainerMemoryUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3044,16 +3044,16 @@ func (m *metricContainerMemoryUsageMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryUsageMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryUsageMax(settings MetricSettings) metricContainerMemoryUsageMax {
-	m := metricContainerMemoryUsageMax{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryUsageMax(cfg MetricConfig) metricContainerMemoryUsageMax {
+	m := metricContainerMemoryUsageMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3062,7 +3062,7 @@ func newMetricContainerMemoryUsageMax(settings MetricSettings) metricContainerMe
 
 type metricContainerMemoryUsageTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3077,7 +3077,7 @@ func (m *metricContainerMemoryUsageTotal) init() {
 }
 
 func (m *metricContainerMemoryUsageTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3095,16 +3095,16 @@ func (m *metricContainerMemoryUsageTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryUsageTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryUsageTotal(settings MetricSettings) metricContainerMemoryUsageTotal {
-	m := metricContainerMemoryUsageTotal{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryUsageTotal(cfg MetricConfig) metricContainerMemoryUsageTotal {
+	m := metricContainerMemoryUsageTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3113,7 +3113,7 @@ func newMetricContainerMemoryUsageTotal(settings MetricSettings) metricContainer
 
 type metricContainerMemoryWriteback struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3128,7 +3128,7 @@ func (m *metricContainerMemoryWriteback) init() {
 }
 
 func (m *metricContainerMemoryWriteback) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3146,16 +3146,16 @@ func (m *metricContainerMemoryWriteback) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryWriteback) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryWriteback(settings MetricSettings) metricContainerMemoryWriteback {
-	m := metricContainerMemoryWriteback{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryWriteback(cfg MetricConfig) metricContainerMemoryWriteback {
+	m := metricContainerMemoryWriteback{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3164,7 +3164,7 @@ func newMetricContainerMemoryWriteback(settings MetricSettings) metricContainerM
 
 type metricContainerNetworkIoUsageRxBytes struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3180,7 +3180,7 @@ func (m *metricContainerNetworkIoUsageRxBytes) init() {
 }
 
 func (m *metricContainerNetworkIoUsageRxBytes) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3199,16 +3199,16 @@ func (m *metricContainerNetworkIoUsageRxBytes) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerNetworkIoUsageRxBytes) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerNetworkIoUsageRxBytes(settings MetricSettings) metricContainerNetworkIoUsageRxBytes {
-	m := metricContainerNetworkIoUsageRxBytes{settings: settings}
-	if settings.Enabled {
+func newMetricContainerNetworkIoUsageRxBytes(cfg MetricConfig) metricContainerNetworkIoUsageRxBytes {
+	m := metricContainerNetworkIoUsageRxBytes{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3217,7 +3217,7 @@ func newMetricContainerNetworkIoUsageRxBytes(settings MetricSettings) metricCont
 
 type metricContainerNetworkIoUsageRxDropped struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3233,7 +3233,7 @@ func (m *metricContainerNetworkIoUsageRxDropped) init() {
 }
 
 func (m *metricContainerNetworkIoUsageRxDropped) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3252,16 +3252,16 @@ func (m *metricContainerNetworkIoUsageRxDropped) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerNetworkIoUsageRxDropped) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerNetworkIoUsageRxDropped(settings MetricSettings) metricContainerNetworkIoUsageRxDropped {
-	m := metricContainerNetworkIoUsageRxDropped{settings: settings}
-	if settings.Enabled {
+func newMetricContainerNetworkIoUsageRxDropped(cfg MetricConfig) metricContainerNetworkIoUsageRxDropped {
+	m := metricContainerNetworkIoUsageRxDropped{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3270,7 +3270,7 @@ func newMetricContainerNetworkIoUsageRxDropped(settings MetricSettings) metricCo
 
 type metricContainerNetworkIoUsageRxErrors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3286,7 +3286,7 @@ func (m *metricContainerNetworkIoUsageRxErrors) init() {
 }
 
 func (m *metricContainerNetworkIoUsageRxErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3305,16 +3305,16 @@ func (m *metricContainerNetworkIoUsageRxErrors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerNetworkIoUsageRxErrors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerNetworkIoUsageRxErrors(settings MetricSettings) metricContainerNetworkIoUsageRxErrors {
-	m := metricContainerNetworkIoUsageRxErrors{settings: settings}
-	if settings.Enabled {
+func newMetricContainerNetworkIoUsageRxErrors(cfg MetricConfig) metricContainerNetworkIoUsageRxErrors {
+	m := metricContainerNetworkIoUsageRxErrors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3323,7 +3323,7 @@ func newMetricContainerNetworkIoUsageRxErrors(settings MetricSettings) metricCon
 
 type metricContainerNetworkIoUsageRxPackets struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3339,7 +3339,7 @@ func (m *metricContainerNetworkIoUsageRxPackets) init() {
 }
 
 func (m *metricContainerNetworkIoUsageRxPackets) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3358,16 +3358,16 @@ func (m *metricContainerNetworkIoUsageRxPackets) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerNetworkIoUsageRxPackets) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerNetworkIoUsageRxPackets(settings MetricSettings) metricContainerNetworkIoUsageRxPackets {
-	m := metricContainerNetworkIoUsageRxPackets{settings: settings}
-	if settings.Enabled {
+func newMetricContainerNetworkIoUsageRxPackets(cfg MetricConfig) metricContainerNetworkIoUsageRxPackets {
+	m := metricContainerNetworkIoUsageRxPackets{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3376,7 +3376,7 @@ func newMetricContainerNetworkIoUsageRxPackets(settings MetricSettings) metricCo
 
 type metricContainerNetworkIoUsageTxBytes struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3392,7 +3392,7 @@ func (m *metricContainerNetworkIoUsageTxBytes) init() {
 }
 
 func (m *metricContainerNetworkIoUsageTxBytes) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3411,16 +3411,16 @@ func (m *metricContainerNetworkIoUsageTxBytes) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerNetworkIoUsageTxBytes) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerNetworkIoUsageTxBytes(settings MetricSettings) metricContainerNetworkIoUsageTxBytes {
-	m := metricContainerNetworkIoUsageTxBytes{settings: settings}
-	if settings.Enabled {
+func newMetricContainerNetworkIoUsageTxBytes(cfg MetricConfig) metricContainerNetworkIoUsageTxBytes {
+	m := metricContainerNetworkIoUsageTxBytes{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3429,7 +3429,7 @@ func newMetricContainerNetworkIoUsageTxBytes(settings MetricSettings) metricCont
 
 type metricContainerNetworkIoUsageTxDropped struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3445,7 +3445,7 @@ func (m *metricContainerNetworkIoUsageTxDropped) init() {
 }
 
 func (m *metricContainerNetworkIoUsageTxDropped) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3464,16 +3464,16 @@ func (m *metricContainerNetworkIoUsageTxDropped) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerNetworkIoUsageTxDropped) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerNetworkIoUsageTxDropped(settings MetricSettings) metricContainerNetworkIoUsageTxDropped {
-	m := metricContainerNetworkIoUsageTxDropped{settings: settings}
-	if settings.Enabled {
+func newMetricContainerNetworkIoUsageTxDropped(cfg MetricConfig) metricContainerNetworkIoUsageTxDropped {
+	m := metricContainerNetworkIoUsageTxDropped{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3482,7 +3482,7 @@ func newMetricContainerNetworkIoUsageTxDropped(settings MetricSettings) metricCo
 
 type metricContainerNetworkIoUsageTxErrors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3498,7 +3498,7 @@ func (m *metricContainerNetworkIoUsageTxErrors) init() {
 }
 
 func (m *metricContainerNetworkIoUsageTxErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3517,16 +3517,16 @@ func (m *metricContainerNetworkIoUsageTxErrors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerNetworkIoUsageTxErrors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerNetworkIoUsageTxErrors(settings MetricSettings) metricContainerNetworkIoUsageTxErrors {
-	m := metricContainerNetworkIoUsageTxErrors{settings: settings}
-	if settings.Enabled {
+func newMetricContainerNetworkIoUsageTxErrors(cfg MetricConfig) metricContainerNetworkIoUsageTxErrors {
+	m := metricContainerNetworkIoUsageTxErrors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3535,7 +3535,7 @@ func newMetricContainerNetworkIoUsageTxErrors(settings MetricSettings) metricCon
 
 type metricContainerNetworkIoUsageTxPackets struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3551,7 +3551,7 @@ func (m *metricContainerNetworkIoUsageTxPackets) init() {
 }
 
 func (m *metricContainerNetworkIoUsageTxPackets) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3570,16 +3570,16 @@ func (m *metricContainerNetworkIoUsageTxPackets) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerNetworkIoUsageTxPackets) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerNetworkIoUsageTxPackets(settings MetricSettings) metricContainerNetworkIoUsageTxPackets {
-	m := metricContainerNetworkIoUsageTxPackets{settings: settings}
-	if settings.Enabled {
+func newMetricContainerNetworkIoUsageTxPackets(cfg MetricConfig) metricContainerNetworkIoUsageTxPackets {
+	m := metricContainerNetworkIoUsageTxPackets{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3588,19 +3588,19 @@ func newMetricContainerNetworkIoUsageTxPackets(settings MetricSettings) metricCo
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                        pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                                  int                 // maximum observed number of metrics per resource.
 	resourceCapacity                                 int                 // maximum observed number of resource attributes.
 	metricsBuffer                                    pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                                        component.BuildInfo // contains version information
-	resourceAttributesSettings                       ResourceAttributesSettings
+	resourceAttributesConfig                         ResourceAttributesConfig
 	metricContainerBlockioIoMergedRecursive          metricContainerBlockioIoMergedRecursive
 	metricContainerBlockioIoQueuedRecursive          metricContainerBlockioIoQueuedRecursive
 	metricContainerBlockioIoServiceBytesRecursive    metricContainerBlockioIoServiceBytesRecursive
@@ -3678,8 +3678,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -3688,7 +3688,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                                        pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                                    pmetric.NewMetrics(),
 		buildInfo:                                        settings.BuildInfo,
-		resourceAttributesSettings:                       mbc.ResourceAttributes,
+		resourceAttributesConfig:                         mbc.ResourceAttributes,
 		metricContainerBlockioIoMergedRecursive:          newMetricContainerBlockioIoMergedRecursive(mbc.Metrics.ContainerBlockioIoMergedRecursive),
 		metricContainerBlockioIoQueuedRecursive:          newMetricContainerBlockioIoQueuedRecursive(mbc.Metrics.ContainerBlockioIoQueuedRecursive),
 		metricContainerBlockioIoServiceBytesRecursive:    newMetricContainerBlockioIoServiceBytesRecursive(mbc.Metrics.ContainerBlockioIoServiceBytesRecursive),
@@ -3770,12 +3770,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithContainerHostname sets provided value as "container.hostname" attribute for current resource.
 func WithContainerHostname(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ContainerHostname.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ContainerHostname.Enabled {
 			rm.Resource().Attributes().PutStr("container.hostname", val)
 		}
 	}
@@ -3783,8 +3783,8 @@ func WithContainerHostname(val string) ResourceMetricsOption {
 
 // WithContainerID sets provided value as "container.id" attribute for current resource.
 func WithContainerID(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ContainerID.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ContainerID.Enabled {
 			rm.Resource().Attributes().PutStr("container.id", val)
 		}
 	}
@@ -3792,8 +3792,8 @@ func WithContainerID(val string) ResourceMetricsOption {
 
 // WithContainerImageName sets provided value as "container.image.name" attribute for current resource.
 func WithContainerImageName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ContainerImageName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ContainerImageName.Enabled {
 			rm.Resource().Attributes().PutStr("container.image.name", val)
 		}
 	}
@@ -3801,8 +3801,8 @@ func WithContainerImageName(val string) ResourceMetricsOption {
 
 // WithContainerName sets provided value as "container.name" attribute for current resource.
 func WithContainerName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ContainerName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ContainerName.Enabled {
 			rm.Resource().Attributes().PutStr("container.name", val)
 		}
 	}
@@ -3810,8 +3810,8 @@ func WithContainerName(val string) ResourceMetricsOption {
 
 // WithContainerRuntime sets provided value as "container.runtime" attribute for current resource.
 func WithContainerRuntime(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ContainerRuntime.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ContainerRuntime.Enabled {
 			rm.Resource().Attributes().PutStr("container.runtime", val)
 		}
 	}
@@ -3820,7 +3820,7 @@ func WithContainerRuntime(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -3915,7 +3915,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricContainerNetworkIoUsageTxPackets.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -3925,7 +3925,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics_test.go
@@ -273,36 +273,36 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("container.hostname")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ContainerHostname.Enabled, ok)
-			if mb.resourceAttributesSettings.ContainerHostname.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ContainerHostname.Enabled, ok)
+			if mb.resourceAttributesConfig.ContainerHostname.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("container.id")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ContainerID.Enabled, ok)
-			if mb.resourceAttributesSettings.ContainerID.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ContainerID.Enabled, ok)
+			if mb.resourceAttributesConfig.ContainerID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("container.image.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ContainerImageName.Enabled, ok)
-			if mb.resourceAttributesSettings.ContainerImageName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ContainerImageName.Enabled, ok)
+			if mb.resourceAttributesConfig.ContainerImageName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("container.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ContainerName.Enabled, ok)
-			if mb.resourceAttributesSettings.ContainerName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ContainerName.Enabled, ok)
+			if mb.resourceAttributesConfig.ContainerName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("container.runtime")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ContainerRuntime.Enabled, ok)
-			if mb.resourceAttributesSettings.ContainerRuntime.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ContainerRuntime.Enabled, ok)
+			if mb.resourceAttributesConfig.ContainerRuntime.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/dockerstatsreceiver/receiver.go
+++ b/receiver/dockerstatsreceiver/receiver.go
@@ -139,14 +139,14 @@ func (r *receiver) recordContainerStats(now pcommon.Timestamp, containerStats *d
 
 	for k, label := range r.config.EnvVarsToMetricLabels {
 		if v := container.EnvMap[k]; v != "" {
-			resourceMetricsOptions = append(resourceMetricsOptions, func(ras metadata.ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+			resourceMetricsOptions = append(resourceMetricsOptions, func(ras metadata.ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 				rm.Resource().Attributes().PutStr(label, v)
 			})
 		}
 	}
 	for k, label := range r.config.ContainerLabelsToMetricLabels {
 		if v := container.Config.Labels[k]; v != "" {
-			resourceMetricsOptions = append(resourceMetricsOptions, func(ras metadata.ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+			resourceMetricsOptions = append(resourceMetricsOptions, func(ras metadata.ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 				rm.Resource().Attributes().PutStr(label, v)
 			})
 		}

--- a/receiver/dockerstatsreceiver/receiver_test.go
+++ b/receiver/dockerstatsreceiver/receiver_test.go
@@ -42,8 +42,8 @@ import (
 var mockFolder = filepath.Join("testdata", "mock")
 
 var (
-	metricEnabled     = metadata.MetricSettings{Enabled: true}
-	allMetricsEnabled = metadata.MetricsSettings{
+	metricEnabled     = metadata.MetricConfig{Enabled: true}
+	allMetricsEnabled = metadata.MetricsConfig{
 		ContainerBlockioIoMergedRecursive:          metricEnabled,
 		ContainerBlockioIoQueuedRecursive:          metricEnabled,
 		ContainerBlockioIoServiceBytesRecursive:    metricEnabled,

--- a/receiver/elasticsearchreceiver/config_test.go
+++ b/receiver/elasticsearchreceiver/config_test.go
@@ -195,7 +195,7 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 			assert.NoError(t, component.ValidateConfig(cfg))
-			if diff := cmp.Diff(tt.expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricSettings{})); diff != "" {
+			if diff := cmp.Diff(tt.expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricConfig{})); diff != "" {
 				t.Errorf("Config mismatch (-expected +actual):\n%s", diff)
 			}
 		})

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,404 +31,404 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for elasticsearchreceiver metrics.
-type MetricsSettings struct {
-	ElasticsearchBreakerMemoryEstimated                       MetricSettings `mapstructure:"elasticsearch.breaker.memory.estimated"`
-	ElasticsearchBreakerMemoryLimit                           MetricSettings `mapstructure:"elasticsearch.breaker.memory.limit"`
-	ElasticsearchBreakerTripped                               MetricSettings `mapstructure:"elasticsearch.breaker.tripped"`
-	ElasticsearchClusterDataNodes                             MetricSettings `mapstructure:"elasticsearch.cluster.data_nodes"`
-	ElasticsearchClusterHealth                                MetricSettings `mapstructure:"elasticsearch.cluster.health"`
-	ElasticsearchClusterInFlightFetch                         MetricSettings `mapstructure:"elasticsearch.cluster.in_flight_fetch"`
-	ElasticsearchClusterIndicesCacheEvictions                 MetricSettings `mapstructure:"elasticsearch.cluster.indices.cache.evictions"`
-	ElasticsearchClusterNodes                                 MetricSettings `mapstructure:"elasticsearch.cluster.nodes"`
-	ElasticsearchClusterPendingTasks                          MetricSettings `mapstructure:"elasticsearch.cluster.pending_tasks"`
-	ElasticsearchClusterPublishedStatesDifferences            MetricSettings `mapstructure:"elasticsearch.cluster.published_states.differences"`
-	ElasticsearchClusterPublishedStatesFull                   MetricSettings `mapstructure:"elasticsearch.cluster.published_states.full"`
-	ElasticsearchClusterShards                                MetricSettings `mapstructure:"elasticsearch.cluster.shards"`
-	ElasticsearchClusterStateQueue                            MetricSettings `mapstructure:"elasticsearch.cluster.state_queue"`
-	ElasticsearchClusterStateUpdateCount                      MetricSettings `mapstructure:"elasticsearch.cluster.state_update.count"`
-	ElasticsearchClusterStateUpdateTime                       MetricSettings `mapstructure:"elasticsearch.cluster.state_update.time"`
-	ElasticsearchIndexCacheEvictions                          MetricSettings `mapstructure:"elasticsearch.index.cache.evictions"`
-	ElasticsearchIndexCacheMemoryUsage                        MetricSettings `mapstructure:"elasticsearch.index.cache.memory.usage"`
-	ElasticsearchIndexCacheSize                               MetricSettings `mapstructure:"elasticsearch.index.cache.size"`
-	ElasticsearchIndexDocuments                               MetricSettings `mapstructure:"elasticsearch.index.documents"`
-	ElasticsearchIndexOperationsCompleted                     MetricSettings `mapstructure:"elasticsearch.index.operations.completed"`
-	ElasticsearchIndexOperationsMergeDocsCount                MetricSettings `mapstructure:"elasticsearch.index.operations.merge.docs_count"`
-	ElasticsearchIndexOperationsMergeSize                     MetricSettings `mapstructure:"elasticsearch.index.operations.merge.size"`
-	ElasticsearchIndexOperationsTime                          MetricSettings `mapstructure:"elasticsearch.index.operations.time"`
-	ElasticsearchIndexSegmentsCount                           MetricSettings `mapstructure:"elasticsearch.index.segments.count"`
-	ElasticsearchIndexSegmentsMemory                          MetricSettings `mapstructure:"elasticsearch.index.segments.memory"`
-	ElasticsearchIndexSegmentsSize                            MetricSettings `mapstructure:"elasticsearch.index.segments.size"`
-	ElasticsearchIndexShardsSize                              MetricSettings `mapstructure:"elasticsearch.index.shards.size"`
-	ElasticsearchIndexTranslogOperations                      MetricSettings `mapstructure:"elasticsearch.index.translog.operations"`
-	ElasticsearchIndexTranslogSize                            MetricSettings `mapstructure:"elasticsearch.index.translog.size"`
-	ElasticsearchIndexingPressureMemoryLimit                  MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.limit"`
-	ElasticsearchIndexingPressureMemoryTotalPrimaryRejections MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.total.primary_rejections"`
-	ElasticsearchIndexingPressureMemoryTotalReplicaRejections MetricSettings `mapstructure:"elasticsearch.indexing_pressure.memory.total.replica_rejections"`
-	ElasticsearchMemoryIndexingPressure                       MetricSettings `mapstructure:"elasticsearch.memory.indexing_pressure"`
-	ElasticsearchNodeCacheCount                               MetricSettings `mapstructure:"elasticsearch.node.cache.count"`
-	ElasticsearchNodeCacheEvictions                           MetricSettings `mapstructure:"elasticsearch.node.cache.evictions"`
-	ElasticsearchNodeCacheMemoryUsage                         MetricSettings `mapstructure:"elasticsearch.node.cache.memory.usage"`
-	ElasticsearchNodeCacheSize                                MetricSettings `mapstructure:"elasticsearch.node.cache.size"`
-	ElasticsearchNodeClusterConnections                       MetricSettings `mapstructure:"elasticsearch.node.cluster.connections"`
-	ElasticsearchNodeClusterIo                                MetricSettings `mapstructure:"elasticsearch.node.cluster.io"`
-	ElasticsearchNodeDiskIoRead                               MetricSettings `mapstructure:"elasticsearch.node.disk.io.read"`
-	ElasticsearchNodeDiskIoWrite                              MetricSettings `mapstructure:"elasticsearch.node.disk.io.write"`
-	ElasticsearchNodeDocuments                                MetricSettings `mapstructure:"elasticsearch.node.documents"`
-	ElasticsearchNodeFsDiskAvailable                          MetricSettings `mapstructure:"elasticsearch.node.fs.disk.available"`
-	ElasticsearchNodeFsDiskFree                               MetricSettings `mapstructure:"elasticsearch.node.fs.disk.free"`
-	ElasticsearchNodeFsDiskTotal                              MetricSettings `mapstructure:"elasticsearch.node.fs.disk.total"`
-	ElasticsearchNodeHTTPConnections                          MetricSettings `mapstructure:"elasticsearch.node.http.connections"`
-	ElasticsearchNodeIngestDocuments                          MetricSettings `mapstructure:"elasticsearch.node.ingest.documents"`
-	ElasticsearchNodeIngestDocumentsCurrent                   MetricSettings `mapstructure:"elasticsearch.node.ingest.documents.current"`
-	ElasticsearchNodeIngestOperationsFailed                   MetricSettings `mapstructure:"elasticsearch.node.ingest.operations.failed"`
-	ElasticsearchNodeOpenFiles                                MetricSettings `mapstructure:"elasticsearch.node.open_files"`
-	ElasticsearchNodeOperationsCompleted                      MetricSettings `mapstructure:"elasticsearch.node.operations.completed"`
-	ElasticsearchNodeOperationsCurrent                        MetricSettings `mapstructure:"elasticsearch.node.operations.current"`
-	ElasticsearchNodeOperationsGetCompleted                   MetricSettings `mapstructure:"elasticsearch.node.operations.get.completed"`
-	ElasticsearchNodeOperationsGetTime                        MetricSettings `mapstructure:"elasticsearch.node.operations.get.time"`
-	ElasticsearchNodeOperationsTime                           MetricSettings `mapstructure:"elasticsearch.node.operations.time"`
-	ElasticsearchNodePipelineIngestDocumentsCurrent           MetricSettings `mapstructure:"elasticsearch.node.pipeline.ingest.documents.current"`
-	ElasticsearchNodePipelineIngestDocumentsPreprocessed      MetricSettings `mapstructure:"elasticsearch.node.pipeline.ingest.documents.preprocessed"`
-	ElasticsearchNodePipelineIngestOperationsFailed           MetricSettings `mapstructure:"elasticsearch.node.pipeline.ingest.operations.failed"`
-	ElasticsearchNodeScriptCacheEvictions                     MetricSettings `mapstructure:"elasticsearch.node.script.cache_evictions"`
-	ElasticsearchNodeScriptCompilationLimitTriggered          MetricSettings `mapstructure:"elasticsearch.node.script.compilation_limit_triggered"`
-	ElasticsearchNodeScriptCompilations                       MetricSettings `mapstructure:"elasticsearch.node.script.compilations"`
-	ElasticsearchNodeSegmentsMemory                           MetricSettings `mapstructure:"elasticsearch.node.segments.memory"`
-	ElasticsearchNodeShardsDataSetSize                        MetricSettings `mapstructure:"elasticsearch.node.shards.data_set.size"`
-	ElasticsearchNodeShardsReservedSize                       MetricSettings `mapstructure:"elasticsearch.node.shards.reserved.size"`
-	ElasticsearchNodeShardsSize                               MetricSettings `mapstructure:"elasticsearch.node.shards.size"`
-	ElasticsearchNodeThreadPoolTasksFinished                  MetricSettings `mapstructure:"elasticsearch.node.thread_pool.tasks.finished"`
-	ElasticsearchNodeThreadPoolTasksQueued                    MetricSettings `mapstructure:"elasticsearch.node.thread_pool.tasks.queued"`
-	ElasticsearchNodeThreadPoolThreads                        MetricSettings `mapstructure:"elasticsearch.node.thread_pool.threads"`
-	ElasticsearchNodeTranslogOperations                       MetricSettings `mapstructure:"elasticsearch.node.translog.operations"`
-	ElasticsearchNodeTranslogSize                             MetricSettings `mapstructure:"elasticsearch.node.translog.size"`
-	ElasticsearchNodeTranslogUncommittedSize                  MetricSettings `mapstructure:"elasticsearch.node.translog.uncommitted.size"`
-	ElasticsearchOsCPULoadAvg15m                              MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.15m"`
-	ElasticsearchOsCPULoadAvg1m                               MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.1m"`
-	ElasticsearchOsCPULoadAvg5m                               MetricSettings `mapstructure:"elasticsearch.os.cpu.load_avg.5m"`
-	ElasticsearchOsCPUUsage                                   MetricSettings `mapstructure:"elasticsearch.os.cpu.usage"`
-	ElasticsearchOsMemory                                     MetricSettings `mapstructure:"elasticsearch.os.memory"`
-	ElasticsearchProcessCPUTime                               MetricSettings `mapstructure:"elasticsearch.process.cpu.time"`
-	ElasticsearchProcessCPUUsage                              MetricSettings `mapstructure:"elasticsearch.process.cpu.usage"`
-	ElasticsearchProcessMemoryVirtual                         MetricSettings `mapstructure:"elasticsearch.process.memory.virtual"`
-	JvmClassesLoaded                                          MetricSettings `mapstructure:"jvm.classes.loaded"`
-	JvmGcCollectionsCount                                     MetricSettings `mapstructure:"jvm.gc.collections.count"`
-	JvmGcCollectionsElapsed                                   MetricSettings `mapstructure:"jvm.gc.collections.elapsed"`
-	JvmMemoryHeapCommitted                                    MetricSettings `mapstructure:"jvm.memory.heap.committed"`
-	JvmMemoryHeapMax                                          MetricSettings `mapstructure:"jvm.memory.heap.max"`
-	JvmMemoryHeapUsed                                         MetricSettings `mapstructure:"jvm.memory.heap.used"`
-	JvmMemoryHeapUtilization                                  MetricSettings `mapstructure:"jvm.memory.heap.utilization"`
-	JvmMemoryNonheapCommitted                                 MetricSettings `mapstructure:"jvm.memory.nonheap.committed"`
-	JvmMemoryNonheapUsed                                      MetricSettings `mapstructure:"jvm.memory.nonheap.used"`
-	JvmMemoryPoolMax                                          MetricSettings `mapstructure:"jvm.memory.pool.max"`
-	JvmMemoryPoolUsed                                         MetricSettings `mapstructure:"jvm.memory.pool.used"`
-	JvmThreadsCount                                           MetricSettings `mapstructure:"jvm.threads.count"`
+// MetricsConfig provides config for elasticsearchreceiver metrics.
+type MetricsConfig struct {
+	ElasticsearchBreakerMemoryEstimated                       MetricConfig `mapstructure:"elasticsearch.breaker.memory.estimated"`
+	ElasticsearchBreakerMemoryLimit                           MetricConfig `mapstructure:"elasticsearch.breaker.memory.limit"`
+	ElasticsearchBreakerTripped                               MetricConfig `mapstructure:"elasticsearch.breaker.tripped"`
+	ElasticsearchClusterDataNodes                             MetricConfig `mapstructure:"elasticsearch.cluster.data_nodes"`
+	ElasticsearchClusterHealth                                MetricConfig `mapstructure:"elasticsearch.cluster.health"`
+	ElasticsearchClusterInFlightFetch                         MetricConfig `mapstructure:"elasticsearch.cluster.in_flight_fetch"`
+	ElasticsearchClusterIndicesCacheEvictions                 MetricConfig `mapstructure:"elasticsearch.cluster.indices.cache.evictions"`
+	ElasticsearchClusterNodes                                 MetricConfig `mapstructure:"elasticsearch.cluster.nodes"`
+	ElasticsearchClusterPendingTasks                          MetricConfig `mapstructure:"elasticsearch.cluster.pending_tasks"`
+	ElasticsearchClusterPublishedStatesDifferences            MetricConfig `mapstructure:"elasticsearch.cluster.published_states.differences"`
+	ElasticsearchClusterPublishedStatesFull                   MetricConfig `mapstructure:"elasticsearch.cluster.published_states.full"`
+	ElasticsearchClusterShards                                MetricConfig `mapstructure:"elasticsearch.cluster.shards"`
+	ElasticsearchClusterStateQueue                            MetricConfig `mapstructure:"elasticsearch.cluster.state_queue"`
+	ElasticsearchClusterStateUpdateCount                      MetricConfig `mapstructure:"elasticsearch.cluster.state_update.count"`
+	ElasticsearchClusterStateUpdateTime                       MetricConfig `mapstructure:"elasticsearch.cluster.state_update.time"`
+	ElasticsearchIndexCacheEvictions                          MetricConfig `mapstructure:"elasticsearch.index.cache.evictions"`
+	ElasticsearchIndexCacheMemoryUsage                        MetricConfig `mapstructure:"elasticsearch.index.cache.memory.usage"`
+	ElasticsearchIndexCacheSize                               MetricConfig `mapstructure:"elasticsearch.index.cache.size"`
+	ElasticsearchIndexDocuments                               MetricConfig `mapstructure:"elasticsearch.index.documents"`
+	ElasticsearchIndexOperationsCompleted                     MetricConfig `mapstructure:"elasticsearch.index.operations.completed"`
+	ElasticsearchIndexOperationsMergeDocsCount                MetricConfig `mapstructure:"elasticsearch.index.operations.merge.docs_count"`
+	ElasticsearchIndexOperationsMergeSize                     MetricConfig `mapstructure:"elasticsearch.index.operations.merge.size"`
+	ElasticsearchIndexOperationsTime                          MetricConfig `mapstructure:"elasticsearch.index.operations.time"`
+	ElasticsearchIndexSegmentsCount                           MetricConfig `mapstructure:"elasticsearch.index.segments.count"`
+	ElasticsearchIndexSegmentsMemory                          MetricConfig `mapstructure:"elasticsearch.index.segments.memory"`
+	ElasticsearchIndexSegmentsSize                            MetricConfig `mapstructure:"elasticsearch.index.segments.size"`
+	ElasticsearchIndexShardsSize                              MetricConfig `mapstructure:"elasticsearch.index.shards.size"`
+	ElasticsearchIndexTranslogOperations                      MetricConfig `mapstructure:"elasticsearch.index.translog.operations"`
+	ElasticsearchIndexTranslogSize                            MetricConfig `mapstructure:"elasticsearch.index.translog.size"`
+	ElasticsearchIndexingPressureMemoryLimit                  MetricConfig `mapstructure:"elasticsearch.indexing_pressure.memory.limit"`
+	ElasticsearchIndexingPressureMemoryTotalPrimaryRejections MetricConfig `mapstructure:"elasticsearch.indexing_pressure.memory.total.primary_rejections"`
+	ElasticsearchIndexingPressureMemoryTotalReplicaRejections MetricConfig `mapstructure:"elasticsearch.indexing_pressure.memory.total.replica_rejections"`
+	ElasticsearchMemoryIndexingPressure                       MetricConfig `mapstructure:"elasticsearch.memory.indexing_pressure"`
+	ElasticsearchNodeCacheCount                               MetricConfig `mapstructure:"elasticsearch.node.cache.count"`
+	ElasticsearchNodeCacheEvictions                           MetricConfig `mapstructure:"elasticsearch.node.cache.evictions"`
+	ElasticsearchNodeCacheMemoryUsage                         MetricConfig `mapstructure:"elasticsearch.node.cache.memory.usage"`
+	ElasticsearchNodeCacheSize                                MetricConfig `mapstructure:"elasticsearch.node.cache.size"`
+	ElasticsearchNodeClusterConnections                       MetricConfig `mapstructure:"elasticsearch.node.cluster.connections"`
+	ElasticsearchNodeClusterIo                                MetricConfig `mapstructure:"elasticsearch.node.cluster.io"`
+	ElasticsearchNodeDiskIoRead                               MetricConfig `mapstructure:"elasticsearch.node.disk.io.read"`
+	ElasticsearchNodeDiskIoWrite                              MetricConfig `mapstructure:"elasticsearch.node.disk.io.write"`
+	ElasticsearchNodeDocuments                                MetricConfig `mapstructure:"elasticsearch.node.documents"`
+	ElasticsearchNodeFsDiskAvailable                          MetricConfig `mapstructure:"elasticsearch.node.fs.disk.available"`
+	ElasticsearchNodeFsDiskFree                               MetricConfig `mapstructure:"elasticsearch.node.fs.disk.free"`
+	ElasticsearchNodeFsDiskTotal                              MetricConfig `mapstructure:"elasticsearch.node.fs.disk.total"`
+	ElasticsearchNodeHTTPConnections                          MetricConfig `mapstructure:"elasticsearch.node.http.connections"`
+	ElasticsearchNodeIngestDocuments                          MetricConfig `mapstructure:"elasticsearch.node.ingest.documents"`
+	ElasticsearchNodeIngestDocumentsCurrent                   MetricConfig `mapstructure:"elasticsearch.node.ingest.documents.current"`
+	ElasticsearchNodeIngestOperationsFailed                   MetricConfig `mapstructure:"elasticsearch.node.ingest.operations.failed"`
+	ElasticsearchNodeOpenFiles                                MetricConfig `mapstructure:"elasticsearch.node.open_files"`
+	ElasticsearchNodeOperationsCompleted                      MetricConfig `mapstructure:"elasticsearch.node.operations.completed"`
+	ElasticsearchNodeOperationsCurrent                        MetricConfig `mapstructure:"elasticsearch.node.operations.current"`
+	ElasticsearchNodeOperationsGetCompleted                   MetricConfig `mapstructure:"elasticsearch.node.operations.get.completed"`
+	ElasticsearchNodeOperationsGetTime                        MetricConfig `mapstructure:"elasticsearch.node.operations.get.time"`
+	ElasticsearchNodeOperationsTime                           MetricConfig `mapstructure:"elasticsearch.node.operations.time"`
+	ElasticsearchNodePipelineIngestDocumentsCurrent           MetricConfig `mapstructure:"elasticsearch.node.pipeline.ingest.documents.current"`
+	ElasticsearchNodePipelineIngestDocumentsPreprocessed      MetricConfig `mapstructure:"elasticsearch.node.pipeline.ingest.documents.preprocessed"`
+	ElasticsearchNodePipelineIngestOperationsFailed           MetricConfig `mapstructure:"elasticsearch.node.pipeline.ingest.operations.failed"`
+	ElasticsearchNodeScriptCacheEvictions                     MetricConfig `mapstructure:"elasticsearch.node.script.cache_evictions"`
+	ElasticsearchNodeScriptCompilationLimitTriggered          MetricConfig `mapstructure:"elasticsearch.node.script.compilation_limit_triggered"`
+	ElasticsearchNodeScriptCompilations                       MetricConfig `mapstructure:"elasticsearch.node.script.compilations"`
+	ElasticsearchNodeSegmentsMemory                           MetricConfig `mapstructure:"elasticsearch.node.segments.memory"`
+	ElasticsearchNodeShardsDataSetSize                        MetricConfig `mapstructure:"elasticsearch.node.shards.data_set.size"`
+	ElasticsearchNodeShardsReservedSize                       MetricConfig `mapstructure:"elasticsearch.node.shards.reserved.size"`
+	ElasticsearchNodeShardsSize                               MetricConfig `mapstructure:"elasticsearch.node.shards.size"`
+	ElasticsearchNodeThreadPoolTasksFinished                  MetricConfig `mapstructure:"elasticsearch.node.thread_pool.tasks.finished"`
+	ElasticsearchNodeThreadPoolTasksQueued                    MetricConfig `mapstructure:"elasticsearch.node.thread_pool.tasks.queued"`
+	ElasticsearchNodeThreadPoolThreads                        MetricConfig `mapstructure:"elasticsearch.node.thread_pool.threads"`
+	ElasticsearchNodeTranslogOperations                       MetricConfig `mapstructure:"elasticsearch.node.translog.operations"`
+	ElasticsearchNodeTranslogSize                             MetricConfig `mapstructure:"elasticsearch.node.translog.size"`
+	ElasticsearchNodeTranslogUncommittedSize                  MetricConfig `mapstructure:"elasticsearch.node.translog.uncommitted.size"`
+	ElasticsearchOsCPULoadAvg15m                              MetricConfig `mapstructure:"elasticsearch.os.cpu.load_avg.15m"`
+	ElasticsearchOsCPULoadAvg1m                               MetricConfig `mapstructure:"elasticsearch.os.cpu.load_avg.1m"`
+	ElasticsearchOsCPULoadAvg5m                               MetricConfig `mapstructure:"elasticsearch.os.cpu.load_avg.5m"`
+	ElasticsearchOsCPUUsage                                   MetricConfig `mapstructure:"elasticsearch.os.cpu.usage"`
+	ElasticsearchOsMemory                                     MetricConfig `mapstructure:"elasticsearch.os.memory"`
+	ElasticsearchProcessCPUTime                               MetricConfig `mapstructure:"elasticsearch.process.cpu.time"`
+	ElasticsearchProcessCPUUsage                              MetricConfig `mapstructure:"elasticsearch.process.cpu.usage"`
+	ElasticsearchProcessMemoryVirtual                         MetricConfig `mapstructure:"elasticsearch.process.memory.virtual"`
+	JvmClassesLoaded                                          MetricConfig `mapstructure:"jvm.classes.loaded"`
+	JvmGcCollectionsCount                                     MetricConfig `mapstructure:"jvm.gc.collections.count"`
+	JvmGcCollectionsElapsed                                   MetricConfig `mapstructure:"jvm.gc.collections.elapsed"`
+	JvmMemoryHeapCommitted                                    MetricConfig `mapstructure:"jvm.memory.heap.committed"`
+	JvmMemoryHeapMax                                          MetricConfig `mapstructure:"jvm.memory.heap.max"`
+	JvmMemoryHeapUsed                                         MetricConfig `mapstructure:"jvm.memory.heap.used"`
+	JvmMemoryHeapUtilization                                  MetricConfig `mapstructure:"jvm.memory.heap.utilization"`
+	JvmMemoryNonheapCommitted                                 MetricConfig `mapstructure:"jvm.memory.nonheap.committed"`
+	JvmMemoryNonheapUsed                                      MetricConfig `mapstructure:"jvm.memory.nonheap.used"`
+	JvmMemoryPoolMax                                          MetricConfig `mapstructure:"jvm.memory.pool.max"`
+	JvmMemoryPoolUsed                                         MetricConfig `mapstructure:"jvm.memory.pool.used"`
+	JvmThreadsCount                                           MetricConfig `mapstructure:"jvm.threads.count"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		ElasticsearchBreakerMemoryEstimated: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		ElasticsearchBreakerMemoryEstimated: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchBreakerMemoryLimit: MetricSettings{
+		ElasticsearchBreakerMemoryLimit: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchBreakerTripped: MetricSettings{
+		ElasticsearchBreakerTripped: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchClusterDataNodes: MetricSettings{
+		ElasticsearchClusterDataNodes: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchClusterHealth: MetricSettings{
+		ElasticsearchClusterHealth: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchClusterInFlightFetch: MetricSettings{
+		ElasticsearchClusterInFlightFetch: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchClusterIndicesCacheEvictions: MetricSettings{
+		ElasticsearchClusterIndicesCacheEvictions: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchClusterNodes: MetricSettings{
+		ElasticsearchClusterNodes: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchClusterPendingTasks: MetricSettings{
+		ElasticsearchClusterPendingTasks: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchClusterPublishedStatesDifferences: MetricSettings{
+		ElasticsearchClusterPublishedStatesDifferences: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchClusterPublishedStatesFull: MetricSettings{
+		ElasticsearchClusterPublishedStatesFull: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchClusterShards: MetricSettings{
+		ElasticsearchClusterShards: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchClusterStateQueue: MetricSettings{
+		ElasticsearchClusterStateQueue: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchClusterStateUpdateCount: MetricSettings{
+		ElasticsearchClusterStateUpdateCount: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchClusterStateUpdateTime: MetricSettings{
+		ElasticsearchClusterStateUpdateTime: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchIndexCacheEvictions: MetricSettings{
+		ElasticsearchIndexCacheEvictions: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchIndexCacheMemoryUsage: MetricSettings{
+		ElasticsearchIndexCacheMemoryUsage: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchIndexCacheSize: MetricSettings{
+		ElasticsearchIndexCacheSize: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchIndexDocuments: MetricSettings{
+		ElasticsearchIndexDocuments: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchIndexOperationsCompleted: MetricSettings{
+		ElasticsearchIndexOperationsCompleted: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchIndexOperationsMergeDocsCount: MetricSettings{
+		ElasticsearchIndexOperationsMergeDocsCount: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchIndexOperationsMergeSize: MetricSettings{
+		ElasticsearchIndexOperationsMergeSize: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchIndexOperationsTime: MetricSettings{
+		ElasticsearchIndexOperationsTime: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchIndexSegmentsCount: MetricSettings{
+		ElasticsearchIndexSegmentsCount: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchIndexSegmentsMemory: MetricSettings{
+		ElasticsearchIndexSegmentsMemory: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchIndexSegmentsSize: MetricSettings{
+		ElasticsearchIndexSegmentsSize: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchIndexShardsSize: MetricSettings{
+		ElasticsearchIndexShardsSize: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchIndexTranslogOperations: MetricSettings{
+		ElasticsearchIndexTranslogOperations: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchIndexTranslogSize: MetricSettings{
+		ElasticsearchIndexTranslogSize: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchIndexingPressureMemoryLimit: MetricSettings{
+		ElasticsearchIndexingPressureMemoryLimit: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchIndexingPressureMemoryTotalPrimaryRejections: MetricSettings{
+		ElasticsearchIndexingPressureMemoryTotalPrimaryRejections: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchIndexingPressureMemoryTotalReplicaRejections: MetricSettings{
+		ElasticsearchIndexingPressureMemoryTotalReplicaRejections: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchMemoryIndexingPressure: MetricSettings{
+		ElasticsearchMemoryIndexingPressure: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeCacheCount: MetricSettings{
+		ElasticsearchNodeCacheCount: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeCacheEvictions: MetricSettings{
+		ElasticsearchNodeCacheEvictions: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeCacheMemoryUsage: MetricSettings{
+		ElasticsearchNodeCacheMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeCacheSize: MetricSettings{
+		ElasticsearchNodeCacheSize: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchNodeClusterConnections: MetricSettings{
+		ElasticsearchNodeClusterConnections: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeClusterIo: MetricSettings{
+		ElasticsearchNodeClusterIo: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeDiskIoRead: MetricSettings{
+		ElasticsearchNodeDiskIoRead: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeDiskIoWrite: MetricSettings{
+		ElasticsearchNodeDiskIoWrite: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeDocuments: MetricSettings{
+		ElasticsearchNodeDocuments: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeFsDiskAvailable: MetricSettings{
+		ElasticsearchNodeFsDiskAvailable: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeFsDiskFree: MetricSettings{
+		ElasticsearchNodeFsDiskFree: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeFsDiskTotal: MetricSettings{
+		ElasticsearchNodeFsDiskTotal: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeHTTPConnections: MetricSettings{
+		ElasticsearchNodeHTTPConnections: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeIngestDocuments: MetricSettings{
+		ElasticsearchNodeIngestDocuments: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeIngestDocumentsCurrent: MetricSettings{
+		ElasticsearchNodeIngestDocumentsCurrent: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeIngestOperationsFailed: MetricSettings{
+		ElasticsearchNodeIngestOperationsFailed: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeOpenFiles: MetricSettings{
+		ElasticsearchNodeOpenFiles: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeOperationsCompleted: MetricSettings{
+		ElasticsearchNodeOperationsCompleted: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeOperationsCurrent: MetricSettings{
+		ElasticsearchNodeOperationsCurrent: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchNodeOperationsGetCompleted: MetricSettings{
+		ElasticsearchNodeOperationsGetCompleted: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchNodeOperationsGetTime: MetricSettings{
+		ElasticsearchNodeOperationsGetTime: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchNodeOperationsTime: MetricSettings{
+		ElasticsearchNodeOperationsTime: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodePipelineIngestDocumentsCurrent: MetricSettings{
+		ElasticsearchNodePipelineIngestDocumentsCurrent: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodePipelineIngestDocumentsPreprocessed: MetricSettings{
+		ElasticsearchNodePipelineIngestDocumentsPreprocessed: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodePipelineIngestOperationsFailed: MetricSettings{
+		ElasticsearchNodePipelineIngestOperationsFailed: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeScriptCacheEvictions: MetricSettings{
+		ElasticsearchNodeScriptCacheEvictions: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeScriptCompilationLimitTriggered: MetricSettings{
+		ElasticsearchNodeScriptCompilationLimitTriggered: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeScriptCompilations: MetricSettings{
+		ElasticsearchNodeScriptCompilations: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeSegmentsMemory: MetricSettings{
+		ElasticsearchNodeSegmentsMemory: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchNodeShardsDataSetSize: MetricSettings{
+		ElasticsearchNodeShardsDataSetSize: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeShardsReservedSize: MetricSettings{
+		ElasticsearchNodeShardsReservedSize: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeShardsSize: MetricSettings{
+		ElasticsearchNodeShardsSize: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeThreadPoolTasksFinished: MetricSettings{
+		ElasticsearchNodeThreadPoolTasksFinished: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeThreadPoolTasksQueued: MetricSettings{
+		ElasticsearchNodeThreadPoolTasksQueued: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeThreadPoolThreads: MetricSettings{
+		ElasticsearchNodeThreadPoolThreads: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeTranslogOperations: MetricSettings{
+		ElasticsearchNodeTranslogOperations: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeTranslogSize: MetricSettings{
+		ElasticsearchNodeTranslogSize: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeTranslogUncommittedSize: MetricSettings{
+		ElasticsearchNodeTranslogUncommittedSize: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchOsCPULoadAvg15m: MetricSettings{
+		ElasticsearchOsCPULoadAvg15m: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchOsCPULoadAvg1m: MetricSettings{
+		ElasticsearchOsCPULoadAvg1m: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchOsCPULoadAvg5m: MetricSettings{
+		ElasticsearchOsCPULoadAvg5m: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchOsCPUUsage: MetricSettings{
+		ElasticsearchOsCPUUsage: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchOsMemory: MetricSettings{
+		ElasticsearchOsMemory: MetricConfig{
 			Enabled: true,
 		},
-		ElasticsearchProcessCPUTime: MetricSettings{
+		ElasticsearchProcessCPUTime: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchProcessCPUUsage: MetricSettings{
+		ElasticsearchProcessCPUUsage: MetricConfig{
 			Enabled: false,
 		},
-		ElasticsearchProcessMemoryVirtual: MetricSettings{
+		ElasticsearchProcessMemoryVirtual: MetricConfig{
 			Enabled: false,
 		},
-		JvmClassesLoaded: MetricSettings{
+		JvmClassesLoaded: MetricConfig{
 			Enabled: true,
 		},
-		JvmGcCollectionsCount: MetricSettings{
+		JvmGcCollectionsCount: MetricConfig{
 			Enabled: true,
 		},
-		JvmGcCollectionsElapsed: MetricSettings{
+		JvmGcCollectionsElapsed: MetricConfig{
 			Enabled: true,
 		},
-		JvmMemoryHeapCommitted: MetricSettings{
+		JvmMemoryHeapCommitted: MetricConfig{
 			Enabled: true,
 		},
-		JvmMemoryHeapMax: MetricSettings{
+		JvmMemoryHeapMax: MetricConfig{
 			Enabled: true,
 		},
-		JvmMemoryHeapUsed: MetricSettings{
+		JvmMemoryHeapUsed: MetricConfig{
 			Enabled: true,
 		},
-		JvmMemoryHeapUtilization: MetricSettings{
+		JvmMemoryHeapUtilization: MetricConfig{
 			Enabled: false,
 		},
-		JvmMemoryNonheapCommitted: MetricSettings{
+		JvmMemoryNonheapCommitted: MetricConfig{
 			Enabled: true,
 		},
-		JvmMemoryNonheapUsed: MetricSettings{
+		JvmMemoryNonheapUsed: MetricConfig{
 			Enabled: true,
 		},
-		JvmMemoryPoolMax: MetricSettings{
+		JvmMemoryPoolMax: MetricConfig{
 			Enabled: true,
 		},
-		JvmMemoryPoolUsed: MetricSettings{
+		JvmMemoryPoolUsed: MetricConfig{
 			Enabled: true,
 		},
-		JvmThreadsCount: MetricSettings{
+		JvmThreadsCount: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for elasticsearchreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	ElasticsearchClusterName ResourceAttributeSettings `mapstructure:"elasticsearch.cluster.name"`
-	ElasticsearchIndexName   ResourceAttributeSettings `mapstructure:"elasticsearch.index.name"`
-	ElasticsearchNodeName    ResourceAttributeSettings `mapstructure:"elasticsearch.node.name"`
-	ElasticsearchNodeVersion ResourceAttributeSettings `mapstructure:"elasticsearch.node.version"`
+// ResourceAttributesConfig provides config for elasticsearchreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	ElasticsearchClusterName ResourceAttributeConfig `mapstructure:"elasticsearch.cluster.name"`
+	ElasticsearchIndexName   ResourceAttributeConfig `mapstructure:"elasticsearch.index.name"`
+	ElasticsearchNodeName    ResourceAttributeConfig `mapstructure:"elasticsearch.node.name"`
+	ElasticsearchNodeVersion ResourceAttributeConfig `mapstructure:"elasticsearch.node.version"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		ElasticsearchClusterName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		ElasticsearchClusterName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ElasticsearchIndexName: ResourceAttributeSettings{
+		ElasticsearchIndexName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeName: ResourceAttributeSettings{
+		ElasticsearchNodeName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ElasticsearchNodeVersion: ResourceAttributeSettings{
+		ElasticsearchNodeVersion: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -962,7 +962,7 @@ var MapAttributeThreadState = map[string]AttributeThreadState{
 
 type metricElasticsearchBreakerMemoryEstimated struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -976,7 +976,7 @@ func (m *metricElasticsearchBreakerMemoryEstimated) init() {
 }
 
 func (m *metricElasticsearchBreakerMemoryEstimated) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, circuitBreakerNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -995,16 +995,16 @@ func (m *metricElasticsearchBreakerMemoryEstimated) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchBreakerMemoryEstimated) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchBreakerMemoryEstimated(settings MetricSettings) metricElasticsearchBreakerMemoryEstimated {
-	m := metricElasticsearchBreakerMemoryEstimated{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchBreakerMemoryEstimated(cfg MetricConfig) metricElasticsearchBreakerMemoryEstimated {
+	m := metricElasticsearchBreakerMemoryEstimated{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1013,7 +1013,7 @@ func newMetricElasticsearchBreakerMemoryEstimated(settings MetricSettings) metri
 
 type metricElasticsearchBreakerMemoryLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1029,7 +1029,7 @@ func (m *metricElasticsearchBreakerMemoryLimit) init() {
 }
 
 func (m *metricElasticsearchBreakerMemoryLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, circuitBreakerNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1048,16 +1048,16 @@ func (m *metricElasticsearchBreakerMemoryLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchBreakerMemoryLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchBreakerMemoryLimit(settings MetricSettings) metricElasticsearchBreakerMemoryLimit {
-	m := metricElasticsearchBreakerMemoryLimit{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchBreakerMemoryLimit(cfg MetricConfig) metricElasticsearchBreakerMemoryLimit {
+	m := metricElasticsearchBreakerMemoryLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1066,7 +1066,7 @@ func newMetricElasticsearchBreakerMemoryLimit(settings MetricSettings) metricEla
 
 type metricElasticsearchBreakerTripped struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1082,7 +1082,7 @@ func (m *metricElasticsearchBreakerTripped) init() {
 }
 
 func (m *metricElasticsearchBreakerTripped) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, circuitBreakerNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1101,16 +1101,16 @@ func (m *metricElasticsearchBreakerTripped) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchBreakerTripped) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchBreakerTripped(settings MetricSettings) metricElasticsearchBreakerTripped {
-	m := metricElasticsearchBreakerTripped{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchBreakerTripped(cfg MetricConfig) metricElasticsearchBreakerTripped {
+	m := metricElasticsearchBreakerTripped{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1119,7 +1119,7 @@ func newMetricElasticsearchBreakerTripped(settings MetricSettings) metricElastic
 
 type metricElasticsearchClusterDataNodes struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1134,7 +1134,7 @@ func (m *metricElasticsearchClusterDataNodes) init() {
 }
 
 func (m *metricElasticsearchClusterDataNodes) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1152,16 +1152,16 @@ func (m *metricElasticsearchClusterDataNodes) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterDataNodes) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterDataNodes(settings MetricSettings) metricElasticsearchClusterDataNodes {
-	m := metricElasticsearchClusterDataNodes{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterDataNodes(cfg MetricConfig) metricElasticsearchClusterDataNodes {
+	m := metricElasticsearchClusterDataNodes{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1170,7 +1170,7 @@ func newMetricElasticsearchClusterDataNodes(settings MetricSettings) metricElast
 
 type metricElasticsearchClusterHealth struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1186,7 +1186,7 @@ func (m *metricElasticsearchClusterHealth) init() {
 }
 
 func (m *metricElasticsearchClusterHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, healthStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1205,16 +1205,16 @@ func (m *metricElasticsearchClusterHealth) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterHealth) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterHealth(settings MetricSettings) metricElasticsearchClusterHealth {
-	m := metricElasticsearchClusterHealth{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterHealth(cfg MetricConfig) metricElasticsearchClusterHealth {
+	m := metricElasticsearchClusterHealth{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1223,7 +1223,7 @@ func newMetricElasticsearchClusterHealth(settings MetricSettings) metricElastics
 
 type metricElasticsearchClusterInFlightFetch struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1238,7 +1238,7 @@ func (m *metricElasticsearchClusterInFlightFetch) init() {
 }
 
 func (m *metricElasticsearchClusterInFlightFetch) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1256,16 +1256,16 @@ func (m *metricElasticsearchClusterInFlightFetch) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterInFlightFetch) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterInFlightFetch(settings MetricSettings) metricElasticsearchClusterInFlightFetch {
-	m := metricElasticsearchClusterInFlightFetch{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterInFlightFetch(cfg MetricConfig) metricElasticsearchClusterInFlightFetch {
+	m := metricElasticsearchClusterInFlightFetch{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1274,7 +1274,7 @@ func newMetricElasticsearchClusterInFlightFetch(settings MetricSettings) metricE
 
 type metricElasticsearchClusterIndicesCacheEvictions struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1290,7 +1290,7 @@ func (m *metricElasticsearchClusterIndicesCacheEvictions) init() {
 }
 
 func (m *metricElasticsearchClusterIndicesCacheEvictions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cacheNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1309,16 +1309,16 @@ func (m *metricElasticsearchClusterIndicesCacheEvictions) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterIndicesCacheEvictions) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterIndicesCacheEvictions(settings MetricSettings) metricElasticsearchClusterIndicesCacheEvictions {
-	m := metricElasticsearchClusterIndicesCacheEvictions{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterIndicesCacheEvictions(cfg MetricConfig) metricElasticsearchClusterIndicesCacheEvictions {
+	m := metricElasticsearchClusterIndicesCacheEvictions{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1327,7 +1327,7 @@ func newMetricElasticsearchClusterIndicesCacheEvictions(settings MetricSettings)
 
 type metricElasticsearchClusterNodes struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1342,7 +1342,7 @@ func (m *metricElasticsearchClusterNodes) init() {
 }
 
 func (m *metricElasticsearchClusterNodes) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1360,16 +1360,16 @@ func (m *metricElasticsearchClusterNodes) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterNodes) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterNodes(settings MetricSettings) metricElasticsearchClusterNodes {
-	m := metricElasticsearchClusterNodes{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterNodes(cfg MetricConfig) metricElasticsearchClusterNodes {
+	m := metricElasticsearchClusterNodes{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1378,7 +1378,7 @@ func newMetricElasticsearchClusterNodes(settings MetricSettings) metricElasticse
 
 type metricElasticsearchClusterPendingTasks struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1393,7 +1393,7 @@ func (m *metricElasticsearchClusterPendingTasks) init() {
 }
 
 func (m *metricElasticsearchClusterPendingTasks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1411,16 +1411,16 @@ func (m *metricElasticsearchClusterPendingTasks) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterPendingTasks) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterPendingTasks(settings MetricSettings) metricElasticsearchClusterPendingTasks {
-	m := metricElasticsearchClusterPendingTasks{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterPendingTasks(cfg MetricConfig) metricElasticsearchClusterPendingTasks {
+	m := metricElasticsearchClusterPendingTasks{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1429,7 +1429,7 @@ func newMetricElasticsearchClusterPendingTasks(settings MetricSettings) metricEl
 
 type metricElasticsearchClusterPublishedStatesDifferences struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1445,7 +1445,7 @@ func (m *metricElasticsearchClusterPublishedStatesDifferences) init() {
 }
 
 func (m *metricElasticsearchClusterPublishedStatesDifferences) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterPublishedDifferenceStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1464,16 +1464,16 @@ func (m *metricElasticsearchClusterPublishedStatesDifferences) updateCapacity() 
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterPublishedStatesDifferences) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterPublishedStatesDifferences(settings MetricSettings) metricElasticsearchClusterPublishedStatesDifferences {
-	m := metricElasticsearchClusterPublishedStatesDifferences{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterPublishedStatesDifferences(cfg MetricConfig) metricElasticsearchClusterPublishedStatesDifferences {
+	m := metricElasticsearchClusterPublishedStatesDifferences{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1482,7 +1482,7 @@ func newMetricElasticsearchClusterPublishedStatesDifferences(settings MetricSett
 
 type metricElasticsearchClusterPublishedStatesFull struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1497,7 +1497,7 @@ func (m *metricElasticsearchClusterPublishedStatesFull) init() {
 }
 
 func (m *metricElasticsearchClusterPublishedStatesFull) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1515,16 +1515,16 @@ func (m *metricElasticsearchClusterPublishedStatesFull) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterPublishedStatesFull) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterPublishedStatesFull(settings MetricSettings) metricElasticsearchClusterPublishedStatesFull {
-	m := metricElasticsearchClusterPublishedStatesFull{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterPublishedStatesFull(cfg MetricConfig) metricElasticsearchClusterPublishedStatesFull {
+	m := metricElasticsearchClusterPublishedStatesFull{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1533,7 +1533,7 @@ func newMetricElasticsearchClusterPublishedStatesFull(settings MetricSettings) m
 
 type metricElasticsearchClusterShards struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1549,7 +1549,7 @@ func (m *metricElasticsearchClusterShards) init() {
 }
 
 func (m *metricElasticsearchClusterShards) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, shardStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1568,16 +1568,16 @@ func (m *metricElasticsearchClusterShards) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterShards) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterShards(settings MetricSettings) metricElasticsearchClusterShards {
-	m := metricElasticsearchClusterShards{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterShards(cfg MetricConfig) metricElasticsearchClusterShards {
+	m := metricElasticsearchClusterShards{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1586,7 +1586,7 @@ func newMetricElasticsearchClusterShards(settings MetricSettings) metricElastics
 
 type metricElasticsearchClusterStateQueue struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1602,7 +1602,7 @@ func (m *metricElasticsearchClusterStateQueue) init() {
 }
 
 func (m *metricElasticsearchClusterStateQueue) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateQueueStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1621,16 +1621,16 @@ func (m *metricElasticsearchClusterStateQueue) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterStateQueue) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterStateQueue(settings MetricSettings) metricElasticsearchClusterStateQueue {
-	m := metricElasticsearchClusterStateQueue{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterStateQueue(cfg MetricConfig) metricElasticsearchClusterStateQueue {
+	m := metricElasticsearchClusterStateQueue{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1639,7 +1639,7 @@ func newMetricElasticsearchClusterStateQueue(settings MetricSettings) metricElas
 
 type metricElasticsearchClusterStateUpdateCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1655,7 +1655,7 @@ func (m *metricElasticsearchClusterStateUpdateCount) init() {
 }
 
 func (m *metricElasticsearchClusterStateUpdateCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1674,16 +1674,16 @@ func (m *metricElasticsearchClusterStateUpdateCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterStateUpdateCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterStateUpdateCount(settings MetricSettings) metricElasticsearchClusterStateUpdateCount {
-	m := metricElasticsearchClusterStateUpdateCount{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterStateUpdateCount(cfg MetricConfig) metricElasticsearchClusterStateUpdateCount {
+	m := metricElasticsearchClusterStateUpdateCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1692,7 +1692,7 @@ func newMetricElasticsearchClusterStateUpdateCount(settings MetricSettings) metr
 
 type metricElasticsearchClusterStateUpdateTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1708,7 +1708,7 @@ func (m *metricElasticsearchClusterStateUpdateTime) init() {
 }
 
 func (m *metricElasticsearchClusterStateUpdateTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, clusterStateUpdateStateAttributeValue string, clusterStateUpdateTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1728,16 +1728,16 @@ func (m *metricElasticsearchClusterStateUpdateTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchClusterStateUpdateTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchClusterStateUpdateTime(settings MetricSettings) metricElasticsearchClusterStateUpdateTime {
-	m := metricElasticsearchClusterStateUpdateTime{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchClusterStateUpdateTime(cfg MetricConfig) metricElasticsearchClusterStateUpdateTime {
+	m := metricElasticsearchClusterStateUpdateTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1746,7 +1746,7 @@ func newMetricElasticsearchClusterStateUpdateTime(settings MetricSettings) metri
 
 type metricElasticsearchIndexCacheEvictions struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1762,7 +1762,7 @@ func (m *metricElasticsearchIndexCacheEvictions) init() {
 }
 
 func (m *metricElasticsearchIndexCacheEvictions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cacheNameAttributeValue string, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1782,16 +1782,16 @@ func (m *metricElasticsearchIndexCacheEvictions) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexCacheEvictions) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexCacheEvictions(settings MetricSettings) metricElasticsearchIndexCacheEvictions {
-	m := metricElasticsearchIndexCacheEvictions{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexCacheEvictions(cfg MetricConfig) metricElasticsearchIndexCacheEvictions {
+	m := metricElasticsearchIndexCacheEvictions{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1800,7 +1800,7 @@ func newMetricElasticsearchIndexCacheEvictions(settings MetricSettings) metricEl
 
 type metricElasticsearchIndexCacheMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1816,7 +1816,7 @@ func (m *metricElasticsearchIndexCacheMemoryUsage) init() {
 }
 
 func (m *metricElasticsearchIndexCacheMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cacheNameAttributeValue string, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1836,16 +1836,16 @@ func (m *metricElasticsearchIndexCacheMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexCacheMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexCacheMemoryUsage(settings MetricSettings) metricElasticsearchIndexCacheMemoryUsage {
-	m := metricElasticsearchIndexCacheMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexCacheMemoryUsage(cfg MetricConfig) metricElasticsearchIndexCacheMemoryUsage {
+	m := metricElasticsearchIndexCacheMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1854,7 +1854,7 @@ func newMetricElasticsearchIndexCacheMemoryUsage(settings MetricSettings) metric
 
 type metricElasticsearchIndexCacheSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1870,7 +1870,7 @@ func (m *metricElasticsearchIndexCacheSize) init() {
 }
 
 func (m *metricElasticsearchIndexCacheSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1889,16 +1889,16 @@ func (m *metricElasticsearchIndexCacheSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexCacheSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexCacheSize(settings MetricSettings) metricElasticsearchIndexCacheSize {
-	m := metricElasticsearchIndexCacheSize{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexCacheSize(cfg MetricConfig) metricElasticsearchIndexCacheSize {
+	m := metricElasticsearchIndexCacheSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1907,7 +1907,7 @@ func newMetricElasticsearchIndexCacheSize(settings MetricSettings) metricElastic
 
 type metricElasticsearchIndexDocuments struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1923,7 +1923,7 @@ func (m *metricElasticsearchIndexDocuments) init() {
 }
 
 func (m *metricElasticsearchIndexDocuments) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, documentStateAttributeValue string, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1943,16 +1943,16 @@ func (m *metricElasticsearchIndexDocuments) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexDocuments) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexDocuments(settings MetricSettings) metricElasticsearchIndexDocuments {
-	m := metricElasticsearchIndexDocuments{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexDocuments(cfg MetricConfig) metricElasticsearchIndexDocuments {
+	m := metricElasticsearchIndexDocuments{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1961,7 +1961,7 @@ func newMetricElasticsearchIndexDocuments(settings MetricSettings) metricElastic
 
 type metricElasticsearchIndexOperationsCompleted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1977,7 +1977,7 @@ func (m *metricElasticsearchIndexOperationsCompleted) init() {
 }
 
 func (m *metricElasticsearchIndexOperationsCompleted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1997,16 +1997,16 @@ func (m *metricElasticsearchIndexOperationsCompleted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexOperationsCompleted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexOperationsCompleted(settings MetricSettings) metricElasticsearchIndexOperationsCompleted {
-	m := metricElasticsearchIndexOperationsCompleted{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexOperationsCompleted(cfg MetricConfig) metricElasticsearchIndexOperationsCompleted {
+	m := metricElasticsearchIndexOperationsCompleted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2015,7 +2015,7 @@ func newMetricElasticsearchIndexOperationsCompleted(settings MetricSettings) met
 
 type metricElasticsearchIndexOperationsMergeDocsCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2031,7 +2031,7 @@ func (m *metricElasticsearchIndexOperationsMergeDocsCount) init() {
 }
 
 func (m *metricElasticsearchIndexOperationsMergeDocsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2050,16 +2050,16 @@ func (m *metricElasticsearchIndexOperationsMergeDocsCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexOperationsMergeDocsCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexOperationsMergeDocsCount(settings MetricSettings) metricElasticsearchIndexOperationsMergeDocsCount {
-	m := metricElasticsearchIndexOperationsMergeDocsCount{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexOperationsMergeDocsCount(cfg MetricConfig) metricElasticsearchIndexOperationsMergeDocsCount {
+	m := metricElasticsearchIndexOperationsMergeDocsCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2068,7 +2068,7 @@ func newMetricElasticsearchIndexOperationsMergeDocsCount(settings MetricSettings
 
 type metricElasticsearchIndexOperationsMergeSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2084,7 +2084,7 @@ func (m *metricElasticsearchIndexOperationsMergeSize) init() {
 }
 
 func (m *metricElasticsearchIndexOperationsMergeSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2103,16 +2103,16 @@ func (m *metricElasticsearchIndexOperationsMergeSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexOperationsMergeSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexOperationsMergeSize(settings MetricSettings) metricElasticsearchIndexOperationsMergeSize {
-	m := metricElasticsearchIndexOperationsMergeSize{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexOperationsMergeSize(cfg MetricConfig) metricElasticsearchIndexOperationsMergeSize {
+	m := metricElasticsearchIndexOperationsMergeSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2121,7 +2121,7 @@ func newMetricElasticsearchIndexOperationsMergeSize(settings MetricSettings) met
 
 type metricElasticsearchIndexOperationsTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2137,7 +2137,7 @@ func (m *metricElasticsearchIndexOperationsTime) init() {
 }
 
 func (m *metricElasticsearchIndexOperationsTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2157,16 +2157,16 @@ func (m *metricElasticsearchIndexOperationsTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexOperationsTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexOperationsTime(settings MetricSettings) metricElasticsearchIndexOperationsTime {
-	m := metricElasticsearchIndexOperationsTime{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexOperationsTime(cfg MetricConfig) metricElasticsearchIndexOperationsTime {
+	m := metricElasticsearchIndexOperationsTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2175,7 +2175,7 @@ func newMetricElasticsearchIndexOperationsTime(settings MetricSettings) metricEl
 
 type metricElasticsearchIndexSegmentsCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2191,7 +2191,7 @@ func (m *metricElasticsearchIndexSegmentsCount) init() {
 }
 
 func (m *metricElasticsearchIndexSegmentsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2210,16 +2210,16 @@ func (m *metricElasticsearchIndexSegmentsCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexSegmentsCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexSegmentsCount(settings MetricSettings) metricElasticsearchIndexSegmentsCount {
-	m := metricElasticsearchIndexSegmentsCount{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexSegmentsCount(cfg MetricConfig) metricElasticsearchIndexSegmentsCount {
+	m := metricElasticsearchIndexSegmentsCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2228,7 +2228,7 @@ func newMetricElasticsearchIndexSegmentsCount(settings MetricSettings) metricEla
 
 type metricElasticsearchIndexSegmentsMemory struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2244,7 +2244,7 @@ func (m *metricElasticsearchIndexSegmentsMemory) init() {
 }
 
 func (m *metricElasticsearchIndexSegmentsMemory) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexAggregationTypeAttributeValue string, segmentsMemoryObjectTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2264,16 +2264,16 @@ func (m *metricElasticsearchIndexSegmentsMemory) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexSegmentsMemory) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexSegmentsMemory(settings MetricSettings) metricElasticsearchIndexSegmentsMemory {
-	m := metricElasticsearchIndexSegmentsMemory{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexSegmentsMemory(cfg MetricConfig) metricElasticsearchIndexSegmentsMemory {
+	m := metricElasticsearchIndexSegmentsMemory{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2282,7 +2282,7 @@ func newMetricElasticsearchIndexSegmentsMemory(settings MetricSettings) metricEl
 
 type metricElasticsearchIndexSegmentsSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2298,7 +2298,7 @@ func (m *metricElasticsearchIndexSegmentsSize) init() {
 }
 
 func (m *metricElasticsearchIndexSegmentsSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2317,16 +2317,16 @@ func (m *metricElasticsearchIndexSegmentsSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexSegmentsSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexSegmentsSize(settings MetricSettings) metricElasticsearchIndexSegmentsSize {
-	m := metricElasticsearchIndexSegmentsSize{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexSegmentsSize(cfg MetricConfig) metricElasticsearchIndexSegmentsSize {
+	m := metricElasticsearchIndexSegmentsSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2335,7 +2335,7 @@ func newMetricElasticsearchIndexSegmentsSize(settings MetricSettings) metricElas
 
 type metricElasticsearchIndexShardsSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2351,7 +2351,7 @@ func (m *metricElasticsearchIndexShardsSize) init() {
 }
 
 func (m *metricElasticsearchIndexShardsSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2370,16 +2370,16 @@ func (m *metricElasticsearchIndexShardsSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexShardsSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexShardsSize(settings MetricSettings) metricElasticsearchIndexShardsSize {
-	m := metricElasticsearchIndexShardsSize{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexShardsSize(cfg MetricConfig) metricElasticsearchIndexShardsSize {
+	m := metricElasticsearchIndexShardsSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2388,7 +2388,7 @@ func newMetricElasticsearchIndexShardsSize(settings MetricSettings) metricElasti
 
 type metricElasticsearchIndexTranslogOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2404,7 +2404,7 @@ func (m *metricElasticsearchIndexTranslogOperations) init() {
 }
 
 func (m *metricElasticsearchIndexTranslogOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2423,16 +2423,16 @@ func (m *metricElasticsearchIndexTranslogOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexTranslogOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexTranslogOperations(settings MetricSettings) metricElasticsearchIndexTranslogOperations {
-	m := metricElasticsearchIndexTranslogOperations{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexTranslogOperations(cfg MetricConfig) metricElasticsearchIndexTranslogOperations {
+	m := metricElasticsearchIndexTranslogOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2441,7 +2441,7 @@ func newMetricElasticsearchIndexTranslogOperations(settings MetricSettings) metr
 
 type metricElasticsearchIndexTranslogSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2457,7 +2457,7 @@ func (m *metricElasticsearchIndexTranslogSize) init() {
 }
 
 func (m *metricElasticsearchIndexTranslogSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexAggregationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2476,16 +2476,16 @@ func (m *metricElasticsearchIndexTranslogSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexTranslogSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexTranslogSize(settings MetricSettings) metricElasticsearchIndexTranslogSize {
-	m := metricElasticsearchIndexTranslogSize{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexTranslogSize(cfg MetricConfig) metricElasticsearchIndexTranslogSize {
+	m := metricElasticsearchIndexTranslogSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2494,7 +2494,7 @@ func newMetricElasticsearchIndexTranslogSize(settings MetricSettings) metricElas
 
 type metricElasticsearchIndexingPressureMemoryLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2507,7 +2507,7 @@ func (m *metricElasticsearchIndexingPressureMemoryLimit) init() {
 }
 
 func (m *metricElasticsearchIndexingPressureMemoryLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2525,16 +2525,16 @@ func (m *metricElasticsearchIndexingPressureMemoryLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexingPressureMemoryLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexingPressureMemoryLimit(settings MetricSettings) metricElasticsearchIndexingPressureMemoryLimit {
-	m := metricElasticsearchIndexingPressureMemoryLimit{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexingPressureMemoryLimit(cfg MetricConfig) metricElasticsearchIndexingPressureMemoryLimit {
+	m := metricElasticsearchIndexingPressureMemoryLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2543,7 +2543,7 @@ func newMetricElasticsearchIndexingPressureMemoryLimit(settings MetricSettings) 
 
 type metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2558,7 +2558,7 @@ func (m *metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections) init()
 }
 
 func (m *metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2576,16 +2576,16 @@ func (m *metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections) update
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexingPressureMemoryTotalPrimaryRejections(settings MetricSettings) metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections {
-	m := metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexingPressureMemoryTotalPrimaryRejections(cfg MetricConfig) metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections {
+	m := metricElasticsearchIndexingPressureMemoryTotalPrimaryRejections{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2594,7 +2594,7 @@ func newMetricElasticsearchIndexingPressureMemoryTotalPrimaryRejections(settings
 
 type metricElasticsearchIndexingPressureMemoryTotalReplicaRejections struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2609,7 +2609,7 @@ func (m *metricElasticsearchIndexingPressureMemoryTotalReplicaRejections) init()
 }
 
 func (m *metricElasticsearchIndexingPressureMemoryTotalReplicaRejections) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2627,16 +2627,16 @@ func (m *metricElasticsearchIndexingPressureMemoryTotalReplicaRejections) update
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchIndexingPressureMemoryTotalReplicaRejections) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchIndexingPressureMemoryTotalReplicaRejections(settings MetricSettings) metricElasticsearchIndexingPressureMemoryTotalReplicaRejections {
-	m := metricElasticsearchIndexingPressureMemoryTotalReplicaRejections{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchIndexingPressureMemoryTotalReplicaRejections(cfg MetricConfig) metricElasticsearchIndexingPressureMemoryTotalReplicaRejections {
+	m := metricElasticsearchIndexingPressureMemoryTotalReplicaRejections{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2645,7 +2645,7 @@ func newMetricElasticsearchIndexingPressureMemoryTotalReplicaRejections(settings
 
 type metricElasticsearchMemoryIndexingPressure struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2661,7 +2661,7 @@ func (m *metricElasticsearchMemoryIndexingPressure) init() {
 }
 
 func (m *metricElasticsearchMemoryIndexingPressure) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, indexingPressureStageAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2680,16 +2680,16 @@ func (m *metricElasticsearchMemoryIndexingPressure) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchMemoryIndexingPressure) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchMemoryIndexingPressure(settings MetricSettings) metricElasticsearchMemoryIndexingPressure {
-	m := metricElasticsearchMemoryIndexingPressure{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchMemoryIndexingPressure(cfg MetricConfig) metricElasticsearchMemoryIndexingPressure {
+	m := metricElasticsearchMemoryIndexingPressure{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2698,7 +2698,7 @@ func newMetricElasticsearchMemoryIndexingPressure(settings MetricSettings) metri
 
 type metricElasticsearchNodeCacheCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2714,7 +2714,7 @@ func (m *metricElasticsearchNodeCacheCount) init() {
 }
 
 func (m *metricElasticsearchNodeCacheCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, queryCacheCountTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2733,16 +2733,16 @@ func (m *metricElasticsearchNodeCacheCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeCacheCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeCacheCount(settings MetricSettings) metricElasticsearchNodeCacheCount {
-	m := metricElasticsearchNodeCacheCount{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeCacheCount(cfg MetricConfig) metricElasticsearchNodeCacheCount {
+	m := metricElasticsearchNodeCacheCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2751,7 +2751,7 @@ func newMetricElasticsearchNodeCacheCount(settings MetricSettings) metricElastic
 
 type metricElasticsearchNodeCacheEvictions struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2767,7 +2767,7 @@ func (m *metricElasticsearchNodeCacheEvictions) init() {
 }
 
 func (m *metricElasticsearchNodeCacheEvictions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cacheNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2786,16 +2786,16 @@ func (m *metricElasticsearchNodeCacheEvictions) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeCacheEvictions) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeCacheEvictions(settings MetricSettings) metricElasticsearchNodeCacheEvictions {
-	m := metricElasticsearchNodeCacheEvictions{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeCacheEvictions(cfg MetricConfig) metricElasticsearchNodeCacheEvictions {
+	m := metricElasticsearchNodeCacheEvictions{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2804,7 +2804,7 @@ func newMetricElasticsearchNodeCacheEvictions(settings MetricSettings) metricEla
 
 type metricElasticsearchNodeCacheMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2820,7 +2820,7 @@ func (m *metricElasticsearchNodeCacheMemoryUsage) init() {
 }
 
 func (m *metricElasticsearchNodeCacheMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cacheNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2839,16 +2839,16 @@ func (m *metricElasticsearchNodeCacheMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeCacheMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeCacheMemoryUsage(settings MetricSettings) metricElasticsearchNodeCacheMemoryUsage {
-	m := metricElasticsearchNodeCacheMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeCacheMemoryUsage(cfg MetricConfig) metricElasticsearchNodeCacheMemoryUsage {
+	m := metricElasticsearchNodeCacheMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2857,7 +2857,7 @@ func newMetricElasticsearchNodeCacheMemoryUsage(settings MetricSettings) metricE
 
 type metricElasticsearchNodeCacheSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2872,7 +2872,7 @@ func (m *metricElasticsearchNodeCacheSize) init() {
 }
 
 func (m *metricElasticsearchNodeCacheSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2890,16 +2890,16 @@ func (m *metricElasticsearchNodeCacheSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeCacheSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeCacheSize(settings MetricSettings) metricElasticsearchNodeCacheSize {
-	m := metricElasticsearchNodeCacheSize{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeCacheSize(cfg MetricConfig) metricElasticsearchNodeCacheSize {
+	m := metricElasticsearchNodeCacheSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2908,7 +2908,7 @@ func newMetricElasticsearchNodeCacheSize(settings MetricSettings) metricElastics
 
 type metricElasticsearchNodeClusterConnections struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2923,7 +2923,7 @@ func (m *metricElasticsearchNodeClusterConnections) init() {
 }
 
 func (m *metricElasticsearchNodeClusterConnections) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2941,16 +2941,16 @@ func (m *metricElasticsearchNodeClusterConnections) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeClusterConnections) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeClusterConnections(settings MetricSettings) metricElasticsearchNodeClusterConnections {
-	m := metricElasticsearchNodeClusterConnections{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeClusterConnections(cfg MetricConfig) metricElasticsearchNodeClusterConnections {
+	m := metricElasticsearchNodeClusterConnections{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2959,7 +2959,7 @@ func newMetricElasticsearchNodeClusterConnections(settings MetricSettings) metri
 
 type metricElasticsearchNodeClusterIo struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2975,7 +2975,7 @@ func (m *metricElasticsearchNodeClusterIo) init() {
 }
 
 func (m *metricElasticsearchNodeClusterIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2994,16 +2994,16 @@ func (m *metricElasticsearchNodeClusterIo) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeClusterIo) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeClusterIo(settings MetricSettings) metricElasticsearchNodeClusterIo {
-	m := metricElasticsearchNodeClusterIo{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeClusterIo(cfg MetricConfig) metricElasticsearchNodeClusterIo {
+	m := metricElasticsearchNodeClusterIo{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3012,7 +3012,7 @@ func newMetricElasticsearchNodeClusterIo(settings MetricSettings) metricElastics
 
 type metricElasticsearchNodeDiskIoRead struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3027,7 +3027,7 @@ func (m *metricElasticsearchNodeDiskIoRead) init() {
 }
 
 func (m *metricElasticsearchNodeDiskIoRead) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3045,16 +3045,16 @@ func (m *metricElasticsearchNodeDiskIoRead) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeDiskIoRead) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeDiskIoRead(settings MetricSettings) metricElasticsearchNodeDiskIoRead {
-	m := metricElasticsearchNodeDiskIoRead{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeDiskIoRead(cfg MetricConfig) metricElasticsearchNodeDiskIoRead {
+	m := metricElasticsearchNodeDiskIoRead{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3063,7 +3063,7 @@ func newMetricElasticsearchNodeDiskIoRead(settings MetricSettings) metricElastic
 
 type metricElasticsearchNodeDiskIoWrite struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3078,7 +3078,7 @@ func (m *metricElasticsearchNodeDiskIoWrite) init() {
 }
 
 func (m *metricElasticsearchNodeDiskIoWrite) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3096,16 +3096,16 @@ func (m *metricElasticsearchNodeDiskIoWrite) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeDiskIoWrite) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeDiskIoWrite(settings MetricSettings) metricElasticsearchNodeDiskIoWrite {
-	m := metricElasticsearchNodeDiskIoWrite{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeDiskIoWrite(cfg MetricConfig) metricElasticsearchNodeDiskIoWrite {
+	m := metricElasticsearchNodeDiskIoWrite{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3114,7 +3114,7 @@ func newMetricElasticsearchNodeDiskIoWrite(settings MetricSettings) metricElasti
 
 type metricElasticsearchNodeDocuments struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3130,7 +3130,7 @@ func (m *metricElasticsearchNodeDocuments) init() {
 }
 
 func (m *metricElasticsearchNodeDocuments) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, documentStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3149,16 +3149,16 @@ func (m *metricElasticsearchNodeDocuments) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeDocuments) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeDocuments(settings MetricSettings) metricElasticsearchNodeDocuments {
-	m := metricElasticsearchNodeDocuments{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeDocuments(cfg MetricConfig) metricElasticsearchNodeDocuments {
+	m := metricElasticsearchNodeDocuments{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3167,7 +3167,7 @@ func newMetricElasticsearchNodeDocuments(settings MetricSettings) metricElastics
 
 type metricElasticsearchNodeFsDiskAvailable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3182,7 +3182,7 @@ func (m *metricElasticsearchNodeFsDiskAvailable) init() {
 }
 
 func (m *metricElasticsearchNodeFsDiskAvailable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3200,16 +3200,16 @@ func (m *metricElasticsearchNodeFsDiskAvailable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeFsDiskAvailable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeFsDiskAvailable(settings MetricSettings) metricElasticsearchNodeFsDiskAvailable {
-	m := metricElasticsearchNodeFsDiskAvailable{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeFsDiskAvailable(cfg MetricConfig) metricElasticsearchNodeFsDiskAvailable {
+	m := metricElasticsearchNodeFsDiskAvailable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3218,7 +3218,7 @@ func newMetricElasticsearchNodeFsDiskAvailable(settings MetricSettings) metricEl
 
 type metricElasticsearchNodeFsDiskFree struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3233,7 +3233,7 @@ func (m *metricElasticsearchNodeFsDiskFree) init() {
 }
 
 func (m *metricElasticsearchNodeFsDiskFree) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3251,16 +3251,16 @@ func (m *metricElasticsearchNodeFsDiskFree) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeFsDiskFree) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeFsDiskFree(settings MetricSettings) metricElasticsearchNodeFsDiskFree {
-	m := metricElasticsearchNodeFsDiskFree{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeFsDiskFree(cfg MetricConfig) metricElasticsearchNodeFsDiskFree {
+	m := metricElasticsearchNodeFsDiskFree{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3269,7 +3269,7 @@ func newMetricElasticsearchNodeFsDiskFree(settings MetricSettings) metricElastic
 
 type metricElasticsearchNodeFsDiskTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3284,7 +3284,7 @@ func (m *metricElasticsearchNodeFsDiskTotal) init() {
 }
 
 func (m *metricElasticsearchNodeFsDiskTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3302,16 +3302,16 @@ func (m *metricElasticsearchNodeFsDiskTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeFsDiskTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeFsDiskTotal(settings MetricSettings) metricElasticsearchNodeFsDiskTotal {
-	m := metricElasticsearchNodeFsDiskTotal{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeFsDiskTotal(cfg MetricConfig) metricElasticsearchNodeFsDiskTotal {
+	m := metricElasticsearchNodeFsDiskTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3320,7 +3320,7 @@ func newMetricElasticsearchNodeFsDiskTotal(settings MetricSettings) metricElasti
 
 type metricElasticsearchNodeHTTPConnections struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3335,7 +3335,7 @@ func (m *metricElasticsearchNodeHTTPConnections) init() {
 }
 
 func (m *metricElasticsearchNodeHTTPConnections) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3353,16 +3353,16 @@ func (m *metricElasticsearchNodeHTTPConnections) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeHTTPConnections) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeHTTPConnections(settings MetricSettings) metricElasticsearchNodeHTTPConnections {
-	m := metricElasticsearchNodeHTTPConnections{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeHTTPConnections(cfg MetricConfig) metricElasticsearchNodeHTTPConnections {
+	m := metricElasticsearchNodeHTTPConnections{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3371,7 +3371,7 @@ func newMetricElasticsearchNodeHTTPConnections(settings MetricSettings) metricEl
 
 type metricElasticsearchNodeIngestDocuments struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3386,7 +3386,7 @@ func (m *metricElasticsearchNodeIngestDocuments) init() {
 }
 
 func (m *metricElasticsearchNodeIngestDocuments) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3404,16 +3404,16 @@ func (m *metricElasticsearchNodeIngestDocuments) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeIngestDocuments) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeIngestDocuments(settings MetricSettings) metricElasticsearchNodeIngestDocuments {
-	m := metricElasticsearchNodeIngestDocuments{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeIngestDocuments(cfg MetricConfig) metricElasticsearchNodeIngestDocuments {
+	m := metricElasticsearchNodeIngestDocuments{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3422,7 +3422,7 @@ func newMetricElasticsearchNodeIngestDocuments(settings MetricSettings) metricEl
 
 type metricElasticsearchNodeIngestDocumentsCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3437,7 +3437,7 @@ func (m *metricElasticsearchNodeIngestDocumentsCurrent) init() {
 }
 
 func (m *metricElasticsearchNodeIngestDocumentsCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3455,16 +3455,16 @@ func (m *metricElasticsearchNodeIngestDocumentsCurrent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeIngestDocumentsCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeIngestDocumentsCurrent(settings MetricSettings) metricElasticsearchNodeIngestDocumentsCurrent {
-	m := metricElasticsearchNodeIngestDocumentsCurrent{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeIngestDocumentsCurrent(cfg MetricConfig) metricElasticsearchNodeIngestDocumentsCurrent {
+	m := metricElasticsearchNodeIngestDocumentsCurrent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3473,7 +3473,7 @@ func newMetricElasticsearchNodeIngestDocumentsCurrent(settings MetricSettings) m
 
 type metricElasticsearchNodeIngestOperationsFailed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3488,7 +3488,7 @@ func (m *metricElasticsearchNodeIngestOperationsFailed) init() {
 }
 
 func (m *metricElasticsearchNodeIngestOperationsFailed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3506,16 +3506,16 @@ func (m *metricElasticsearchNodeIngestOperationsFailed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeIngestOperationsFailed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeIngestOperationsFailed(settings MetricSettings) metricElasticsearchNodeIngestOperationsFailed {
-	m := metricElasticsearchNodeIngestOperationsFailed{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeIngestOperationsFailed(cfg MetricConfig) metricElasticsearchNodeIngestOperationsFailed {
+	m := metricElasticsearchNodeIngestOperationsFailed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3524,7 +3524,7 @@ func newMetricElasticsearchNodeIngestOperationsFailed(settings MetricSettings) m
 
 type metricElasticsearchNodeOpenFiles struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3539,7 +3539,7 @@ func (m *metricElasticsearchNodeOpenFiles) init() {
 }
 
 func (m *metricElasticsearchNodeOpenFiles) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3557,16 +3557,16 @@ func (m *metricElasticsearchNodeOpenFiles) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeOpenFiles) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeOpenFiles(settings MetricSettings) metricElasticsearchNodeOpenFiles {
-	m := metricElasticsearchNodeOpenFiles{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeOpenFiles(cfg MetricConfig) metricElasticsearchNodeOpenFiles {
+	m := metricElasticsearchNodeOpenFiles{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3575,7 +3575,7 @@ func newMetricElasticsearchNodeOpenFiles(settings MetricSettings) metricElastics
 
 type metricElasticsearchNodeOperationsCompleted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3591,7 +3591,7 @@ func (m *metricElasticsearchNodeOperationsCompleted) init() {
 }
 
 func (m *metricElasticsearchNodeOperationsCompleted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3610,16 +3610,16 @@ func (m *metricElasticsearchNodeOperationsCompleted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeOperationsCompleted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeOperationsCompleted(settings MetricSettings) metricElasticsearchNodeOperationsCompleted {
-	m := metricElasticsearchNodeOperationsCompleted{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeOperationsCompleted(cfg MetricConfig) metricElasticsearchNodeOperationsCompleted {
+	m := metricElasticsearchNodeOperationsCompleted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3628,7 +3628,7 @@ func newMetricElasticsearchNodeOperationsCompleted(settings MetricSettings) metr
 
 type metricElasticsearchNodeOperationsCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3642,7 +3642,7 @@ func (m *metricElasticsearchNodeOperationsCurrent) init() {
 }
 
 func (m *metricElasticsearchNodeOperationsCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3661,16 +3661,16 @@ func (m *metricElasticsearchNodeOperationsCurrent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeOperationsCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeOperationsCurrent(settings MetricSettings) metricElasticsearchNodeOperationsCurrent {
-	m := metricElasticsearchNodeOperationsCurrent{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeOperationsCurrent(cfg MetricConfig) metricElasticsearchNodeOperationsCurrent {
+	m := metricElasticsearchNodeOperationsCurrent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3679,7 +3679,7 @@ func newMetricElasticsearchNodeOperationsCurrent(settings MetricSettings) metric
 
 type metricElasticsearchNodeOperationsGetCompleted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3695,7 +3695,7 @@ func (m *metricElasticsearchNodeOperationsGetCompleted) init() {
 }
 
 func (m *metricElasticsearchNodeOperationsGetCompleted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, getResultAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3714,16 +3714,16 @@ func (m *metricElasticsearchNodeOperationsGetCompleted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeOperationsGetCompleted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeOperationsGetCompleted(settings MetricSettings) metricElasticsearchNodeOperationsGetCompleted {
-	m := metricElasticsearchNodeOperationsGetCompleted{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeOperationsGetCompleted(cfg MetricConfig) metricElasticsearchNodeOperationsGetCompleted {
+	m := metricElasticsearchNodeOperationsGetCompleted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3732,7 +3732,7 @@ func newMetricElasticsearchNodeOperationsGetCompleted(settings MetricSettings) m
 
 type metricElasticsearchNodeOperationsGetTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3748,7 +3748,7 @@ func (m *metricElasticsearchNodeOperationsGetTime) init() {
 }
 
 func (m *metricElasticsearchNodeOperationsGetTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, getResultAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3767,16 +3767,16 @@ func (m *metricElasticsearchNodeOperationsGetTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeOperationsGetTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeOperationsGetTime(settings MetricSettings) metricElasticsearchNodeOperationsGetTime {
-	m := metricElasticsearchNodeOperationsGetTime{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeOperationsGetTime(cfg MetricConfig) metricElasticsearchNodeOperationsGetTime {
+	m := metricElasticsearchNodeOperationsGetTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3785,7 +3785,7 @@ func newMetricElasticsearchNodeOperationsGetTime(settings MetricSettings) metric
 
 type metricElasticsearchNodeOperationsTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3801,7 +3801,7 @@ func (m *metricElasticsearchNodeOperationsTime) init() {
 }
 
 func (m *metricElasticsearchNodeOperationsTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3820,16 +3820,16 @@ func (m *metricElasticsearchNodeOperationsTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeOperationsTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeOperationsTime(settings MetricSettings) metricElasticsearchNodeOperationsTime {
-	m := metricElasticsearchNodeOperationsTime{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeOperationsTime(cfg MetricConfig) metricElasticsearchNodeOperationsTime {
+	m := metricElasticsearchNodeOperationsTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3838,7 +3838,7 @@ func newMetricElasticsearchNodeOperationsTime(settings MetricSettings) metricEla
 
 type metricElasticsearchNodePipelineIngestDocumentsCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3854,7 +3854,7 @@ func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) init() {
 }
 
 func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3873,16 +3873,16 @@ func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) updateCapacity()
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodePipelineIngestDocumentsCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodePipelineIngestDocumentsCurrent(settings MetricSettings) metricElasticsearchNodePipelineIngestDocumentsCurrent {
-	m := metricElasticsearchNodePipelineIngestDocumentsCurrent{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodePipelineIngestDocumentsCurrent(cfg MetricConfig) metricElasticsearchNodePipelineIngestDocumentsCurrent {
+	m := metricElasticsearchNodePipelineIngestDocumentsCurrent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3891,7 +3891,7 @@ func newMetricElasticsearchNodePipelineIngestDocumentsCurrent(settings MetricSet
 
 type metricElasticsearchNodePipelineIngestDocumentsPreprocessed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3907,7 +3907,7 @@ func (m *metricElasticsearchNodePipelineIngestDocumentsPreprocessed) init() {
 }
 
 func (m *metricElasticsearchNodePipelineIngestDocumentsPreprocessed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3926,16 +3926,16 @@ func (m *metricElasticsearchNodePipelineIngestDocumentsPreprocessed) updateCapac
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodePipelineIngestDocumentsPreprocessed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodePipelineIngestDocumentsPreprocessed(settings MetricSettings) metricElasticsearchNodePipelineIngestDocumentsPreprocessed {
-	m := metricElasticsearchNodePipelineIngestDocumentsPreprocessed{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodePipelineIngestDocumentsPreprocessed(cfg MetricConfig) metricElasticsearchNodePipelineIngestDocumentsPreprocessed {
+	m := metricElasticsearchNodePipelineIngestDocumentsPreprocessed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3944,7 +3944,7 @@ func newMetricElasticsearchNodePipelineIngestDocumentsPreprocessed(settings Metr
 
 type metricElasticsearchNodePipelineIngestOperationsFailed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3960,7 +3960,7 @@ func (m *metricElasticsearchNodePipelineIngestOperationsFailed) init() {
 }
 
 func (m *metricElasticsearchNodePipelineIngestOperationsFailed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ingestPipelineNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3979,16 +3979,16 @@ func (m *metricElasticsearchNodePipelineIngestOperationsFailed) updateCapacity()
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodePipelineIngestOperationsFailed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodePipelineIngestOperationsFailed(settings MetricSettings) metricElasticsearchNodePipelineIngestOperationsFailed {
-	m := metricElasticsearchNodePipelineIngestOperationsFailed{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodePipelineIngestOperationsFailed(cfg MetricConfig) metricElasticsearchNodePipelineIngestOperationsFailed {
+	m := metricElasticsearchNodePipelineIngestOperationsFailed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3997,7 +3997,7 @@ func newMetricElasticsearchNodePipelineIngestOperationsFailed(settings MetricSet
 
 type metricElasticsearchNodeScriptCacheEvictions struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4012,7 +4012,7 @@ func (m *metricElasticsearchNodeScriptCacheEvictions) init() {
 }
 
 func (m *metricElasticsearchNodeScriptCacheEvictions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4030,16 +4030,16 @@ func (m *metricElasticsearchNodeScriptCacheEvictions) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeScriptCacheEvictions) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeScriptCacheEvictions(settings MetricSettings) metricElasticsearchNodeScriptCacheEvictions {
-	m := metricElasticsearchNodeScriptCacheEvictions{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeScriptCacheEvictions(cfg MetricConfig) metricElasticsearchNodeScriptCacheEvictions {
+	m := metricElasticsearchNodeScriptCacheEvictions{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4048,7 +4048,7 @@ func newMetricElasticsearchNodeScriptCacheEvictions(settings MetricSettings) met
 
 type metricElasticsearchNodeScriptCompilationLimitTriggered struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4063,7 +4063,7 @@ func (m *metricElasticsearchNodeScriptCompilationLimitTriggered) init() {
 }
 
 func (m *metricElasticsearchNodeScriptCompilationLimitTriggered) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4081,16 +4081,16 @@ func (m *metricElasticsearchNodeScriptCompilationLimitTriggered) updateCapacity(
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeScriptCompilationLimitTriggered) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeScriptCompilationLimitTriggered(settings MetricSettings) metricElasticsearchNodeScriptCompilationLimitTriggered {
-	m := metricElasticsearchNodeScriptCompilationLimitTriggered{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeScriptCompilationLimitTriggered(cfg MetricConfig) metricElasticsearchNodeScriptCompilationLimitTriggered {
+	m := metricElasticsearchNodeScriptCompilationLimitTriggered{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4099,7 +4099,7 @@ func newMetricElasticsearchNodeScriptCompilationLimitTriggered(settings MetricSe
 
 type metricElasticsearchNodeScriptCompilations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4114,7 +4114,7 @@ func (m *metricElasticsearchNodeScriptCompilations) init() {
 }
 
 func (m *metricElasticsearchNodeScriptCompilations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4132,16 +4132,16 @@ func (m *metricElasticsearchNodeScriptCompilations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeScriptCompilations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeScriptCompilations(settings MetricSettings) metricElasticsearchNodeScriptCompilations {
-	m := metricElasticsearchNodeScriptCompilations{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeScriptCompilations(cfg MetricConfig) metricElasticsearchNodeScriptCompilations {
+	m := metricElasticsearchNodeScriptCompilations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4150,7 +4150,7 @@ func newMetricElasticsearchNodeScriptCompilations(settings MetricSettings) metri
 
 type metricElasticsearchNodeSegmentsMemory struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4166,7 +4166,7 @@ func (m *metricElasticsearchNodeSegmentsMemory) init() {
 }
 
 func (m *metricElasticsearchNodeSegmentsMemory) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, segmentsMemoryObjectTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4185,16 +4185,16 @@ func (m *metricElasticsearchNodeSegmentsMemory) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeSegmentsMemory) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeSegmentsMemory(settings MetricSettings) metricElasticsearchNodeSegmentsMemory {
-	m := metricElasticsearchNodeSegmentsMemory{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeSegmentsMemory(cfg MetricConfig) metricElasticsearchNodeSegmentsMemory {
+	m := metricElasticsearchNodeSegmentsMemory{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4203,7 +4203,7 @@ func newMetricElasticsearchNodeSegmentsMemory(settings MetricSettings) metricEla
 
 type metricElasticsearchNodeShardsDataSetSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4218,7 +4218,7 @@ func (m *metricElasticsearchNodeShardsDataSetSize) init() {
 }
 
 func (m *metricElasticsearchNodeShardsDataSetSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4236,16 +4236,16 @@ func (m *metricElasticsearchNodeShardsDataSetSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeShardsDataSetSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeShardsDataSetSize(settings MetricSettings) metricElasticsearchNodeShardsDataSetSize {
-	m := metricElasticsearchNodeShardsDataSetSize{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeShardsDataSetSize(cfg MetricConfig) metricElasticsearchNodeShardsDataSetSize {
+	m := metricElasticsearchNodeShardsDataSetSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4254,7 +4254,7 @@ func newMetricElasticsearchNodeShardsDataSetSize(settings MetricSettings) metric
 
 type metricElasticsearchNodeShardsReservedSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4269,7 +4269,7 @@ func (m *metricElasticsearchNodeShardsReservedSize) init() {
 }
 
 func (m *metricElasticsearchNodeShardsReservedSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4287,16 +4287,16 @@ func (m *metricElasticsearchNodeShardsReservedSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeShardsReservedSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeShardsReservedSize(settings MetricSettings) metricElasticsearchNodeShardsReservedSize {
-	m := metricElasticsearchNodeShardsReservedSize{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeShardsReservedSize(cfg MetricConfig) metricElasticsearchNodeShardsReservedSize {
+	m := metricElasticsearchNodeShardsReservedSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4305,7 +4305,7 @@ func newMetricElasticsearchNodeShardsReservedSize(settings MetricSettings) metri
 
 type metricElasticsearchNodeShardsSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4320,7 +4320,7 @@ func (m *metricElasticsearchNodeShardsSize) init() {
 }
 
 func (m *metricElasticsearchNodeShardsSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4338,16 +4338,16 @@ func (m *metricElasticsearchNodeShardsSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeShardsSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeShardsSize(settings MetricSettings) metricElasticsearchNodeShardsSize {
-	m := metricElasticsearchNodeShardsSize{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeShardsSize(cfg MetricConfig) metricElasticsearchNodeShardsSize {
+	m := metricElasticsearchNodeShardsSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4356,7 +4356,7 @@ func newMetricElasticsearchNodeShardsSize(settings MetricSettings) metricElastic
 
 type metricElasticsearchNodeThreadPoolTasksFinished struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4372,7 +4372,7 @@ func (m *metricElasticsearchNodeThreadPoolTasksFinished) init() {
 }
 
 func (m *metricElasticsearchNodeThreadPoolTasksFinished) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, threadPoolNameAttributeValue string, taskStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4392,16 +4392,16 @@ func (m *metricElasticsearchNodeThreadPoolTasksFinished) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeThreadPoolTasksFinished) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeThreadPoolTasksFinished(settings MetricSettings) metricElasticsearchNodeThreadPoolTasksFinished {
-	m := metricElasticsearchNodeThreadPoolTasksFinished{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeThreadPoolTasksFinished(cfg MetricConfig) metricElasticsearchNodeThreadPoolTasksFinished {
+	m := metricElasticsearchNodeThreadPoolTasksFinished{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4410,7 +4410,7 @@ func newMetricElasticsearchNodeThreadPoolTasksFinished(settings MetricSettings) 
 
 type metricElasticsearchNodeThreadPoolTasksQueued struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4426,7 +4426,7 @@ func (m *metricElasticsearchNodeThreadPoolTasksQueued) init() {
 }
 
 func (m *metricElasticsearchNodeThreadPoolTasksQueued) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, threadPoolNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4445,16 +4445,16 @@ func (m *metricElasticsearchNodeThreadPoolTasksQueued) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeThreadPoolTasksQueued) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeThreadPoolTasksQueued(settings MetricSettings) metricElasticsearchNodeThreadPoolTasksQueued {
-	m := metricElasticsearchNodeThreadPoolTasksQueued{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeThreadPoolTasksQueued(cfg MetricConfig) metricElasticsearchNodeThreadPoolTasksQueued {
+	m := metricElasticsearchNodeThreadPoolTasksQueued{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4463,7 +4463,7 @@ func newMetricElasticsearchNodeThreadPoolTasksQueued(settings MetricSettings) me
 
 type metricElasticsearchNodeThreadPoolThreads struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4479,7 +4479,7 @@ func (m *metricElasticsearchNodeThreadPoolThreads) init() {
 }
 
 func (m *metricElasticsearchNodeThreadPoolThreads) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, threadPoolNameAttributeValue string, threadStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4499,16 +4499,16 @@ func (m *metricElasticsearchNodeThreadPoolThreads) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeThreadPoolThreads) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeThreadPoolThreads(settings MetricSettings) metricElasticsearchNodeThreadPoolThreads {
-	m := metricElasticsearchNodeThreadPoolThreads{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeThreadPoolThreads(cfg MetricConfig) metricElasticsearchNodeThreadPoolThreads {
+	m := metricElasticsearchNodeThreadPoolThreads{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4517,7 +4517,7 @@ func newMetricElasticsearchNodeThreadPoolThreads(settings MetricSettings) metric
 
 type metricElasticsearchNodeTranslogOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4532,7 +4532,7 @@ func (m *metricElasticsearchNodeTranslogOperations) init() {
 }
 
 func (m *metricElasticsearchNodeTranslogOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4550,16 +4550,16 @@ func (m *metricElasticsearchNodeTranslogOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeTranslogOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeTranslogOperations(settings MetricSettings) metricElasticsearchNodeTranslogOperations {
-	m := metricElasticsearchNodeTranslogOperations{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeTranslogOperations(cfg MetricConfig) metricElasticsearchNodeTranslogOperations {
+	m := metricElasticsearchNodeTranslogOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4568,7 +4568,7 @@ func newMetricElasticsearchNodeTranslogOperations(settings MetricSettings) metri
 
 type metricElasticsearchNodeTranslogSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4583,7 +4583,7 @@ func (m *metricElasticsearchNodeTranslogSize) init() {
 }
 
 func (m *metricElasticsearchNodeTranslogSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4601,16 +4601,16 @@ func (m *metricElasticsearchNodeTranslogSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeTranslogSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeTranslogSize(settings MetricSettings) metricElasticsearchNodeTranslogSize {
-	m := metricElasticsearchNodeTranslogSize{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeTranslogSize(cfg MetricConfig) metricElasticsearchNodeTranslogSize {
+	m := metricElasticsearchNodeTranslogSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4619,7 +4619,7 @@ func newMetricElasticsearchNodeTranslogSize(settings MetricSettings) metricElast
 
 type metricElasticsearchNodeTranslogUncommittedSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4634,7 +4634,7 @@ func (m *metricElasticsearchNodeTranslogUncommittedSize) init() {
 }
 
 func (m *metricElasticsearchNodeTranslogUncommittedSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4652,16 +4652,16 @@ func (m *metricElasticsearchNodeTranslogUncommittedSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchNodeTranslogUncommittedSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchNodeTranslogUncommittedSize(settings MetricSettings) metricElasticsearchNodeTranslogUncommittedSize {
-	m := metricElasticsearchNodeTranslogUncommittedSize{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchNodeTranslogUncommittedSize(cfg MetricConfig) metricElasticsearchNodeTranslogUncommittedSize {
+	m := metricElasticsearchNodeTranslogUncommittedSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4670,7 +4670,7 @@ func newMetricElasticsearchNodeTranslogUncommittedSize(settings MetricSettings) 
 
 type metricElasticsearchOsCPULoadAvg15m struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4683,7 +4683,7 @@ func (m *metricElasticsearchOsCPULoadAvg15m) init() {
 }
 
 func (m *metricElasticsearchOsCPULoadAvg15m) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -4701,16 +4701,16 @@ func (m *metricElasticsearchOsCPULoadAvg15m) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchOsCPULoadAvg15m) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchOsCPULoadAvg15m(settings MetricSettings) metricElasticsearchOsCPULoadAvg15m {
-	m := metricElasticsearchOsCPULoadAvg15m{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchOsCPULoadAvg15m(cfg MetricConfig) metricElasticsearchOsCPULoadAvg15m {
+	m := metricElasticsearchOsCPULoadAvg15m{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4719,7 +4719,7 @@ func newMetricElasticsearchOsCPULoadAvg15m(settings MetricSettings) metricElasti
 
 type metricElasticsearchOsCPULoadAvg1m struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4732,7 +4732,7 @@ func (m *metricElasticsearchOsCPULoadAvg1m) init() {
 }
 
 func (m *metricElasticsearchOsCPULoadAvg1m) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -4750,16 +4750,16 @@ func (m *metricElasticsearchOsCPULoadAvg1m) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchOsCPULoadAvg1m) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchOsCPULoadAvg1m(settings MetricSettings) metricElasticsearchOsCPULoadAvg1m {
-	m := metricElasticsearchOsCPULoadAvg1m{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchOsCPULoadAvg1m(cfg MetricConfig) metricElasticsearchOsCPULoadAvg1m {
+	m := metricElasticsearchOsCPULoadAvg1m{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4768,7 +4768,7 @@ func newMetricElasticsearchOsCPULoadAvg1m(settings MetricSettings) metricElastic
 
 type metricElasticsearchOsCPULoadAvg5m struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4781,7 +4781,7 @@ func (m *metricElasticsearchOsCPULoadAvg5m) init() {
 }
 
 func (m *metricElasticsearchOsCPULoadAvg5m) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -4799,16 +4799,16 @@ func (m *metricElasticsearchOsCPULoadAvg5m) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchOsCPULoadAvg5m) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchOsCPULoadAvg5m(settings MetricSettings) metricElasticsearchOsCPULoadAvg5m {
-	m := metricElasticsearchOsCPULoadAvg5m{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchOsCPULoadAvg5m(cfg MetricConfig) metricElasticsearchOsCPULoadAvg5m {
+	m := metricElasticsearchOsCPULoadAvg5m{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4817,7 +4817,7 @@ func newMetricElasticsearchOsCPULoadAvg5m(settings MetricSettings) metricElastic
 
 type metricElasticsearchOsCPUUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4830,7 +4830,7 @@ func (m *metricElasticsearchOsCPUUsage) init() {
 }
 
 func (m *metricElasticsearchOsCPUUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -4848,16 +4848,16 @@ func (m *metricElasticsearchOsCPUUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchOsCPUUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchOsCPUUsage(settings MetricSettings) metricElasticsearchOsCPUUsage {
-	m := metricElasticsearchOsCPUUsage{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchOsCPUUsage(cfg MetricConfig) metricElasticsearchOsCPUUsage {
+	m := metricElasticsearchOsCPUUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4866,7 +4866,7 @@ func newMetricElasticsearchOsCPUUsage(settings MetricSettings) metricElasticsear
 
 type metricElasticsearchOsMemory struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4880,7 +4880,7 @@ func (m *metricElasticsearchOsMemory) init() {
 }
 
 func (m *metricElasticsearchOsMemory) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, memoryStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -4899,16 +4899,16 @@ func (m *metricElasticsearchOsMemory) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchOsMemory) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchOsMemory(settings MetricSettings) metricElasticsearchOsMemory {
-	m := metricElasticsearchOsMemory{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchOsMemory(cfg MetricConfig) metricElasticsearchOsMemory {
+	m := metricElasticsearchOsMemory{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4917,7 +4917,7 @@ func newMetricElasticsearchOsMemory(settings MetricSettings) metricElasticsearch
 
 type metricElasticsearchProcessCPUTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4932,7 +4932,7 @@ func (m *metricElasticsearchProcessCPUTime) init() {
 }
 
 func (m *metricElasticsearchProcessCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -4950,16 +4950,16 @@ func (m *metricElasticsearchProcessCPUTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchProcessCPUTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchProcessCPUTime(settings MetricSettings) metricElasticsearchProcessCPUTime {
-	m := metricElasticsearchProcessCPUTime{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchProcessCPUTime(cfg MetricConfig) metricElasticsearchProcessCPUTime {
+	m := metricElasticsearchProcessCPUTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4968,7 +4968,7 @@ func newMetricElasticsearchProcessCPUTime(settings MetricSettings) metricElastic
 
 type metricElasticsearchProcessCPUUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4981,7 +4981,7 @@ func (m *metricElasticsearchProcessCPUUsage) init() {
 }
 
 func (m *metricElasticsearchProcessCPUUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -4999,16 +4999,16 @@ func (m *metricElasticsearchProcessCPUUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchProcessCPUUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchProcessCPUUsage(settings MetricSettings) metricElasticsearchProcessCPUUsage {
-	m := metricElasticsearchProcessCPUUsage{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchProcessCPUUsage(cfg MetricConfig) metricElasticsearchProcessCPUUsage {
+	m := metricElasticsearchProcessCPUUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5017,7 +5017,7 @@ func newMetricElasticsearchProcessCPUUsage(settings MetricSettings) metricElasti
 
 type metricElasticsearchProcessMemoryVirtual struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5032,7 +5032,7 @@ func (m *metricElasticsearchProcessMemoryVirtual) init() {
 }
 
 func (m *metricElasticsearchProcessMemoryVirtual) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -5050,16 +5050,16 @@ func (m *metricElasticsearchProcessMemoryVirtual) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricElasticsearchProcessMemoryVirtual) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricElasticsearchProcessMemoryVirtual(settings MetricSettings) metricElasticsearchProcessMemoryVirtual {
-	m := metricElasticsearchProcessMemoryVirtual{settings: settings}
-	if settings.Enabled {
+func newMetricElasticsearchProcessMemoryVirtual(cfg MetricConfig) metricElasticsearchProcessMemoryVirtual {
+	m := metricElasticsearchProcessMemoryVirtual{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5068,7 +5068,7 @@ func newMetricElasticsearchProcessMemoryVirtual(settings MetricSettings) metricE
 
 type metricJvmClassesLoaded struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5081,7 +5081,7 @@ func (m *metricJvmClassesLoaded) init() {
 }
 
 func (m *metricJvmClassesLoaded) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -5099,16 +5099,16 @@ func (m *metricJvmClassesLoaded) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmClassesLoaded) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmClassesLoaded(settings MetricSettings) metricJvmClassesLoaded {
-	m := metricJvmClassesLoaded{settings: settings}
-	if settings.Enabled {
+func newMetricJvmClassesLoaded(cfg MetricConfig) metricJvmClassesLoaded {
+	m := metricJvmClassesLoaded{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5117,7 +5117,7 @@ func newMetricJvmClassesLoaded(settings MetricSettings) metricJvmClassesLoaded {
 
 type metricJvmGcCollectionsCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5133,7 +5133,7 @@ func (m *metricJvmGcCollectionsCount) init() {
 }
 
 func (m *metricJvmGcCollectionsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, collectorNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -5152,16 +5152,16 @@ func (m *metricJvmGcCollectionsCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmGcCollectionsCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmGcCollectionsCount(settings MetricSettings) metricJvmGcCollectionsCount {
-	m := metricJvmGcCollectionsCount{settings: settings}
-	if settings.Enabled {
+func newMetricJvmGcCollectionsCount(cfg MetricConfig) metricJvmGcCollectionsCount {
+	m := metricJvmGcCollectionsCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5170,7 +5170,7 @@ func newMetricJvmGcCollectionsCount(settings MetricSettings) metricJvmGcCollecti
 
 type metricJvmGcCollectionsElapsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5186,7 +5186,7 @@ func (m *metricJvmGcCollectionsElapsed) init() {
 }
 
 func (m *metricJvmGcCollectionsElapsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, collectorNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -5205,16 +5205,16 @@ func (m *metricJvmGcCollectionsElapsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmGcCollectionsElapsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmGcCollectionsElapsed(settings MetricSettings) metricJvmGcCollectionsElapsed {
-	m := metricJvmGcCollectionsElapsed{settings: settings}
-	if settings.Enabled {
+func newMetricJvmGcCollectionsElapsed(cfg MetricConfig) metricJvmGcCollectionsElapsed {
+	m := metricJvmGcCollectionsElapsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5223,7 +5223,7 @@ func newMetricJvmGcCollectionsElapsed(settings MetricSettings) metricJvmGcCollec
 
 type metricJvmMemoryHeapCommitted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5236,7 +5236,7 @@ func (m *metricJvmMemoryHeapCommitted) init() {
 }
 
 func (m *metricJvmMemoryHeapCommitted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -5254,16 +5254,16 @@ func (m *metricJvmMemoryHeapCommitted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmMemoryHeapCommitted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmMemoryHeapCommitted(settings MetricSettings) metricJvmMemoryHeapCommitted {
-	m := metricJvmMemoryHeapCommitted{settings: settings}
-	if settings.Enabled {
+func newMetricJvmMemoryHeapCommitted(cfg MetricConfig) metricJvmMemoryHeapCommitted {
+	m := metricJvmMemoryHeapCommitted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5272,7 +5272,7 @@ func newMetricJvmMemoryHeapCommitted(settings MetricSettings) metricJvmMemoryHea
 
 type metricJvmMemoryHeapMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5285,7 +5285,7 @@ func (m *metricJvmMemoryHeapMax) init() {
 }
 
 func (m *metricJvmMemoryHeapMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -5303,16 +5303,16 @@ func (m *metricJvmMemoryHeapMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmMemoryHeapMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmMemoryHeapMax(settings MetricSettings) metricJvmMemoryHeapMax {
-	m := metricJvmMemoryHeapMax{settings: settings}
-	if settings.Enabled {
+func newMetricJvmMemoryHeapMax(cfg MetricConfig) metricJvmMemoryHeapMax {
+	m := metricJvmMemoryHeapMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5321,7 +5321,7 @@ func newMetricJvmMemoryHeapMax(settings MetricSettings) metricJvmMemoryHeapMax {
 
 type metricJvmMemoryHeapUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5334,7 +5334,7 @@ func (m *metricJvmMemoryHeapUsed) init() {
 }
 
 func (m *metricJvmMemoryHeapUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -5352,16 +5352,16 @@ func (m *metricJvmMemoryHeapUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmMemoryHeapUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmMemoryHeapUsed(settings MetricSettings) metricJvmMemoryHeapUsed {
-	m := metricJvmMemoryHeapUsed{settings: settings}
-	if settings.Enabled {
+func newMetricJvmMemoryHeapUsed(cfg MetricConfig) metricJvmMemoryHeapUsed {
+	m := metricJvmMemoryHeapUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5370,7 +5370,7 @@ func newMetricJvmMemoryHeapUsed(settings MetricSettings) metricJvmMemoryHeapUsed
 
 type metricJvmMemoryHeapUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5383,7 +5383,7 @@ func (m *metricJvmMemoryHeapUtilization) init() {
 }
 
 func (m *metricJvmMemoryHeapUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -5401,16 +5401,16 @@ func (m *metricJvmMemoryHeapUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmMemoryHeapUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmMemoryHeapUtilization(settings MetricSettings) metricJvmMemoryHeapUtilization {
-	m := metricJvmMemoryHeapUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricJvmMemoryHeapUtilization(cfg MetricConfig) metricJvmMemoryHeapUtilization {
+	m := metricJvmMemoryHeapUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5419,7 +5419,7 @@ func newMetricJvmMemoryHeapUtilization(settings MetricSettings) metricJvmMemoryH
 
 type metricJvmMemoryNonheapCommitted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5432,7 +5432,7 @@ func (m *metricJvmMemoryNonheapCommitted) init() {
 }
 
 func (m *metricJvmMemoryNonheapCommitted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -5450,16 +5450,16 @@ func (m *metricJvmMemoryNonheapCommitted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmMemoryNonheapCommitted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmMemoryNonheapCommitted(settings MetricSettings) metricJvmMemoryNonheapCommitted {
-	m := metricJvmMemoryNonheapCommitted{settings: settings}
-	if settings.Enabled {
+func newMetricJvmMemoryNonheapCommitted(cfg MetricConfig) metricJvmMemoryNonheapCommitted {
+	m := metricJvmMemoryNonheapCommitted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5468,7 +5468,7 @@ func newMetricJvmMemoryNonheapCommitted(settings MetricSettings) metricJvmMemory
 
 type metricJvmMemoryNonheapUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5481,7 +5481,7 @@ func (m *metricJvmMemoryNonheapUsed) init() {
 }
 
 func (m *metricJvmMemoryNonheapUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -5499,16 +5499,16 @@ func (m *metricJvmMemoryNonheapUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmMemoryNonheapUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmMemoryNonheapUsed(settings MetricSettings) metricJvmMemoryNonheapUsed {
-	m := metricJvmMemoryNonheapUsed{settings: settings}
-	if settings.Enabled {
+func newMetricJvmMemoryNonheapUsed(cfg MetricConfig) metricJvmMemoryNonheapUsed {
+	m := metricJvmMemoryNonheapUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5517,7 +5517,7 @@ func newMetricJvmMemoryNonheapUsed(settings MetricSettings) metricJvmMemoryNonhe
 
 type metricJvmMemoryPoolMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5531,7 +5531,7 @@ func (m *metricJvmMemoryPoolMax) init() {
 }
 
 func (m *metricJvmMemoryPoolMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, memoryPoolNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -5550,16 +5550,16 @@ func (m *metricJvmMemoryPoolMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmMemoryPoolMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmMemoryPoolMax(settings MetricSettings) metricJvmMemoryPoolMax {
-	m := metricJvmMemoryPoolMax{settings: settings}
-	if settings.Enabled {
+func newMetricJvmMemoryPoolMax(cfg MetricConfig) metricJvmMemoryPoolMax {
+	m := metricJvmMemoryPoolMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5568,7 +5568,7 @@ func newMetricJvmMemoryPoolMax(settings MetricSettings) metricJvmMemoryPoolMax {
 
 type metricJvmMemoryPoolUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5582,7 +5582,7 @@ func (m *metricJvmMemoryPoolUsed) init() {
 }
 
 func (m *metricJvmMemoryPoolUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, memoryPoolNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -5601,16 +5601,16 @@ func (m *metricJvmMemoryPoolUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmMemoryPoolUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmMemoryPoolUsed(settings MetricSettings) metricJvmMemoryPoolUsed {
-	m := metricJvmMemoryPoolUsed{settings: settings}
-	if settings.Enabled {
+func newMetricJvmMemoryPoolUsed(cfg MetricConfig) metricJvmMemoryPoolUsed {
+	m := metricJvmMemoryPoolUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5619,7 +5619,7 @@ func newMetricJvmMemoryPoolUsed(settings MetricSettings) metricJvmMemoryPoolUsed
 
 type metricJvmThreadsCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -5632,7 +5632,7 @@ func (m *metricJvmThreadsCount) init() {
 }
 
 func (m *metricJvmThreadsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -5650,16 +5650,16 @@ func (m *metricJvmThreadsCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricJvmThreadsCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricJvmThreadsCount(settings MetricSettings) metricJvmThreadsCount {
-	m := metricJvmThreadsCount{settings: settings}
-	if settings.Enabled {
+func newMetricJvmThreadsCount(cfg MetricConfig) metricJvmThreadsCount {
+	m := metricJvmThreadsCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -5668,19 +5668,19 @@ func newMetricJvmThreadsCount(settings MetricSettings) metricJvmThreadsCount {
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                                       pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                                                 int                 // maximum observed number of metrics per resource.
 	resourceCapacity                                                int                 // maximum observed number of resource attributes.
 	metricsBuffer                                                   pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                                                       component.BuildInfo // contains version information
-	resourceAttributesSettings                                      ResourceAttributesSettings
+	resourceAttributesConfig                                        ResourceAttributesConfig
 	metricElasticsearchBreakerMemoryEstimated                       metricElasticsearchBreakerMemoryEstimated
 	metricElasticsearchBreakerMemoryLimit                           metricElasticsearchBreakerMemoryLimit
 	metricElasticsearchBreakerTripped                               metricElasticsearchBreakerTripped
@@ -5786,17 +5786,17 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		startTime:                  pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:              pmetric.NewMetrics(),
-		buildInfo:                  settings.BuildInfo,
-		resourceAttributesSettings: mbc.ResourceAttributes,
+		startTime:                pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:            pmetric.NewMetrics(),
+		buildInfo:                settings.BuildInfo,
+		resourceAttributesConfig: mbc.ResourceAttributes,
 		metricElasticsearchBreakerMemoryEstimated:                       newMetricElasticsearchBreakerMemoryEstimated(mbc.Metrics.ElasticsearchBreakerMemoryEstimated),
 		metricElasticsearchBreakerMemoryLimit:                           newMetricElasticsearchBreakerMemoryLimit(mbc.Metrics.ElasticsearchBreakerMemoryLimit),
 		metricElasticsearchBreakerTripped:                               newMetricElasticsearchBreakerTripped(mbc.Metrics.ElasticsearchBreakerTripped),
@@ -5906,12 +5906,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithElasticsearchClusterName sets provided value as "elasticsearch.cluster.name" attribute for current resource.
 func WithElasticsearchClusterName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ElasticsearchClusterName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ElasticsearchClusterName.Enabled {
 			rm.Resource().Attributes().PutStr("elasticsearch.cluster.name", val)
 		}
 	}
@@ -5919,8 +5919,8 @@ func WithElasticsearchClusterName(val string) ResourceMetricsOption {
 
 // WithElasticsearchIndexName sets provided value as "elasticsearch.index.name" attribute for current resource.
 func WithElasticsearchIndexName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ElasticsearchIndexName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ElasticsearchIndexName.Enabled {
 			rm.Resource().Attributes().PutStr("elasticsearch.index.name", val)
 		}
 	}
@@ -5928,8 +5928,8 @@ func WithElasticsearchIndexName(val string) ResourceMetricsOption {
 
 // WithElasticsearchNodeName sets provided value as "elasticsearch.node.name" attribute for current resource.
 func WithElasticsearchNodeName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ElasticsearchNodeName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ElasticsearchNodeName.Enabled {
 			rm.Resource().Attributes().PutStr("elasticsearch.node.name", val)
 		}
 	}
@@ -5937,8 +5937,8 @@ func WithElasticsearchNodeName(val string) ResourceMetricsOption {
 
 // WithElasticsearchNodeVersion sets provided value as "elasticsearch.node.version" attribute for current resource.
 func WithElasticsearchNodeVersion(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ElasticsearchNodeVersion.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ElasticsearchNodeVersion.Enabled {
 			rm.Resource().Attributes().PutStr("elasticsearch.node.version", val)
 		}
 	}
@@ -5947,7 +5947,7 @@ func WithElasticsearchNodeVersion(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -6069,7 +6069,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricJvmThreadsCount.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -6079,7 +6079,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_test.go
@@ -414,29 +414,29 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("elasticsearch.cluster.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ElasticsearchClusterName.Enabled, ok)
-			if mb.resourceAttributesSettings.ElasticsearchClusterName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ElasticsearchClusterName.Enabled, ok)
+			if mb.resourceAttributesConfig.ElasticsearchClusterName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("elasticsearch.index.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ElasticsearchIndexName.Enabled, ok)
-			if mb.resourceAttributesSettings.ElasticsearchIndexName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ElasticsearchIndexName.Enabled, ok)
+			if mb.resourceAttributesConfig.ElasticsearchIndexName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("elasticsearch.node.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ElasticsearchNodeName.Enabled, ok)
-			if mb.resourceAttributesSettings.ElasticsearchNodeName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ElasticsearchNodeName.Enabled, ok)
+			if mb.resourceAttributesConfig.ElasticsearchNodeName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("elasticsearch.node.version")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ElasticsearchNodeVersion.Enabled, ok)
-			if mb.resourceAttributesSettings.ElasticsearchNodeVersion.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ElasticsearchNodeVersion.Enabled, ok)
+			if mb.resourceAttributesConfig.ElasticsearchNodeVersion.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/expvarreceiver/config_test.go
+++ b/receiver/expvarreceiver/config_test.go
@@ -92,7 +92,7 @@ func TestLoadConfig(t *testing.T) {
 				return
 			}
 			assert.NoError(t, component.ValidateConfig(cfg))
-			if diff := cmp.Diff(tt.expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricSettings{})); diff != "" {
+			if diff := cmp.Diff(tt.expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricConfig{})); diff != "" {
 				t.Errorf("Config mismatch (-expected +actual):\n%s", diff)
 			}
 		})

--- a/receiver/expvarreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/expvarreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,114 +31,114 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for expvarreceiver metrics.
-type MetricsSettings struct {
-	ProcessRuntimeMemstatsBuckHashSys   MetricSettings `mapstructure:"process.runtime.memstats.buck_hash_sys"`
-	ProcessRuntimeMemstatsFrees         MetricSettings `mapstructure:"process.runtime.memstats.frees"`
-	ProcessRuntimeMemstatsGcCPUFraction MetricSettings `mapstructure:"process.runtime.memstats.gc_cpu_fraction"`
-	ProcessRuntimeMemstatsGcSys         MetricSettings `mapstructure:"process.runtime.memstats.gc_sys"`
-	ProcessRuntimeMemstatsHeapAlloc     MetricSettings `mapstructure:"process.runtime.memstats.heap_alloc"`
-	ProcessRuntimeMemstatsHeapIdle      MetricSettings `mapstructure:"process.runtime.memstats.heap_idle"`
-	ProcessRuntimeMemstatsHeapInuse     MetricSettings `mapstructure:"process.runtime.memstats.heap_inuse"`
-	ProcessRuntimeMemstatsHeapObjects   MetricSettings `mapstructure:"process.runtime.memstats.heap_objects"`
-	ProcessRuntimeMemstatsHeapReleased  MetricSettings `mapstructure:"process.runtime.memstats.heap_released"`
-	ProcessRuntimeMemstatsHeapSys       MetricSettings `mapstructure:"process.runtime.memstats.heap_sys"`
-	ProcessRuntimeMemstatsLastPause     MetricSettings `mapstructure:"process.runtime.memstats.last_pause"`
-	ProcessRuntimeMemstatsLookups       MetricSettings `mapstructure:"process.runtime.memstats.lookups"`
-	ProcessRuntimeMemstatsMallocs       MetricSettings `mapstructure:"process.runtime.memstats.mallocs"`
-	ProcessRuntimeMemstatsMcacheInuse   MetricSettings `mapstructure:"process.runtime.memstats.mcache_inuse"`
-	ProcessRuntimeMemstatsMcacheSys     MetricSettings `mapstructure:"process.runtime.memstats.mcache_sys"`
-	ProcessRuntimeMemstatsMspanInuse    MetricSettings `mapstructure:"process.runtime.memstats.mspan_inuse"`
-	ProcessRuntimeMemstatsMspanSys      MetricSettings `mapstructure:"process.runtime.memstats.mspan_sys"`
-	ProcessRuntimeMemstatsNextGc        MetricSettings `mapstructure:"process.runtime.memstats.next_gc"`
-	ProcessRuntimeMemstatsNumForcedGc   MetricSettings `mapstructure:"process.runtime.memstats.num_forced_gc"`
-	ProcessRuntimeMemstatsNumGc         MetricSettings `mapstructure:"process.runtime.memstats.num_gc"`
-	ProcessRuntimeMemstatsOtherSys      MetricSettings `mapstructure:"process.runtime.memstats.other_sys"`
-	ProcessRuntimeMemstatsPauseTotal    MetricSettings `mapstructure:"process.runtime.memstats.pause_total"`
-	ProcessRuntimeMemstatsStackInuse    MetricSettings `mapstructure:"process.runtime.memstats.stack_inuse"`
-	ProcessRuntimeMemstatsStackSys      MetricSettings `mapstructure:"process.runtime.memstats.stack_sys"`
-	ProcessRuntimeMemstatsSys           MetricSettings `mapstructure:"process.runtime.memstats.sys"`
-	ProcessRuntimeMemstatsTotalAlloc    MetricSettings `mapstructure:"process.runtime.memstats.total_alloc"`
+// MetricsConfig provides config for expvarreceiver metrics.
+type MetricsConfig struct {
+	ProcessRuntimeMemstatsBuckHashSys   MetricConfig `mapstructure:"process.runtime.memstats.buck_hash_sys"`
+	ProcessRuntimeMemstatsFrees         MetricConfig `mapstructure:"process.runtime.memstats.frees"`
+	ProcessRuntimeMemstatsGcCPUFraction MetricConfig `mapstructure:"process.runtime.memstats.gc_cpu_fraction"`
+	ProcessRuntimeMemstatsGcSys         MetricConfig `mapstructure:"process.runtime.memstats.gc_sys"`
+	ProcessRuntimeMemstatsHeapAlloc     MetricConfig `mapstructure:"process.runtime.memstats.heap_alloc"`
+	ProcessRuntimeMemstatsHeapIdle      MetricConfig `mapstructure:"process.runtime.memstats.heap_idle"`
+	ProcessRuntimeMemstatsHeapInuse     MetricConfig `mapstructure:"process.runtime.memstats.heap_inuse"`
+	ProcessRuntimeMemstatsHeapObjects   MetricConfig `mapstructure:"process.runtime.memstats.heap_objects"`
+	ProcessRuntimeMemstatsHeapReleased  MetricConfig `mapstructure:"process.runtime.memstats.heap_released"`
+	ProcessRuntimeMemstatsHeapSys       MetricConfig `mapstructure:"process.runtime.memstats.heap_sys"`
+	ProcessRuntimeMemstatsLastPause     MetricConfig `mapstructure:"process.runtime.memstats.last_pause"`
+	ProcessRuntimeMemstatsLookups       MetricConfig `mapstructure:"process.runtime.memstats.lookups"`
+	ProcessRuntimeMemstatsMallocs       MetricConfig `mapstructure:"process.runtime.memstats.mallocs"`
+	ProcessRuntimeMemstatsMcacheInuse   MetricConfig `mapstructure:"process.runtime.memstats.mcache_inuse"`
+	ProcessRuntimeMemstatsMcacheSys     MetricConfig `mapstructure:"process.runtime.memstats.mcache_sys"`
+	ProcessRuntimeMemstatsMspanInuse    MetricConfig `mapstructure:"process.runtime.memstats.mspan_inuse"`
+	ProcessRuntimeMemstatsMspanSys      MetricConfig `mapstructure:"process.runtime.memstats.mspan_sys"`
+	ProcessRuntimeMemstatsNextGc        MetricConfig `mapstructure:"process.runtime.memstats.next_gc"`
+	ProcessRuntimeMemstatsNumForcedGc   MetricConfig `mapstructure:"process.runtime.memstats.num_forced_gc"`
+	ProcessRuntimeMemstatsNumGc         MetricConfig `mapstructure:"process.runtime.memstats.num_gc"`
+	ProcessRuntimeMemstatsOtherSys      MetricConfig `mapstructure:"process.runtime.memstats.other_sys"`
+	ProcessRuntimeMemstatsPauseTotal    MetricConfig `mapstructure:"process.runtime.memstats.pause_total"`
+	ProcessRuntimeMemstatsStackInuse    MetricConfig `mapstructure:"process.runtime.memstats.stack_inuse"`
+	ProcessRuntimeMemstatsStackSys      MetricConfig `mapstructure:"process.runtime.memstats.stack_sys"`
+	ProcessRuntimeMemstatsSys           MetricConfig `mapstructure:"process.runtime.memstats.sys"`
+	ProcessRuntimeMemstatsTotalAlloc    MetricConfig `mapstructure:"process.runtime.memstats.total_alloc"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		ProcessRuntimeMemstatsBuckHashSys: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		ProcessRuntimeMemstatsBuckHashSys: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsFrees: MetricSettings{
+		ProcessRuntimeMemstatsFrees: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsGcCPUFraction: MetricSettings{
+		ProcessRuntimeMemstatsGcCPUFraction: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsGcSys: MetricSettings{
+		ProcessRuntimeMemstatsGcSys: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsHeapAlloc: MetricSettings{
+		ProcessRuntimeMemstatsHeapAlloc: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsHeapIdle: MetricSettings{
+		ProcessRuntimeMemstatsHeapIdle: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsHeapInuse: MetricSettings{
+		ProcessRuntimeMemstatsHeapInuse: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsHeapObjects: MetricSettings{
+		ProcessRuntimeMemstatsHeapObjects: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsHeapReleased: MetricSettings{
+		ProcessRuntimeMemstatsHeapReleased: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsHeapSys: MetricSettings{
+		ProcessRuntimeMemstatsHeapSys: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsLastPause: MetricSettings{
+		ProcessRuntimeMemstatsLastPause: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsLookups: MetricSettings{
+		ProcessRuntimeMemstatsLookups: MetricConfig{
 			Enabled: false,
 		},
-		ProcessRuntimeMemstatsMallocs: MetricSettings{
+		ProcessRuntimeMemstatsMallocs: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsMcacheInuse: MetricSettings{
+		ProcessRuntimeMemstatsMcacheInuse: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsMcacheSys: MetricSettings{
+		ProcessRuntimeMemstatsMcacheSys: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsMspanInuse: MetricSettings{
+		ProcessRuntimeMemstatsMspanInuse: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsMspanSys: MetricSettings{
+		ProcessRuntimeMemstatsMspanSys: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsNextGc: MetricSettings{
+		ProcessRuntimeMemstatsNextGc: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsNumForcedGc: MetricSettings{
+		ProcessRuntimeMemstatsNumForcedGc: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsNumGc: MetricSettings{
+		ProcessRuntimeMemstatsNumGc: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsOtherSys: MetricSettings{
+		ProcessRuntimeMemstatsOtherSys: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsPauseTotal: MetricSettings{
+		ProcessRuntimeMemstatsPauseTotal: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsStackInuse: MetricSettings{
+		ProcessRuntimeMemstatsStackInuse: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsStackSys: MetricSettings{
+		ProcessRuntimeMemstatsStackSys: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsSys: MetricSettings{
+		ProcessRuntimeMemstatsSys: MetricConfig{
 			Enabled: true,
 		},
-		ProcessRuntimeMemstatsTotalAlloc: MetricSettings{
+		ProcessRuntimeMemstatsTotalAlloc: MetricConfig{
 			Enabled: false,
 		},
 	}
@@ -146,7 +146,7 @@ func DefaultMetricsSettings() MetricsSettings {
 
 type metricProcessRuntimeMemstatsBuckHashSys struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -161,7 +161,7 @@ func (m *metricProcessRuntimeMemstatsBuckHashSys) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsBuckHashSys) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -179,16 +179,16 @@ func (m *metricProcessRuntimeMemstatsBuckHashSys) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsBuckHashSys) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsBuckHashSys(settings MetricSettings) metricProcessRuntimeMemstatsBuckHashSys {
-	m := metricProcessRuntimeMemstatsBuckHashSys{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsBuckHashSys(cfg MetricConfig) metricProcessRuntimeMemstatsBuckHashSys {
+	m := metricProcessRuntimeMemstatsBuckHashSys{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -197,7 +197,7 @@ func newMetricProcessRuntimeMemstatsBuckHashSys(settings MetricSettings) metricP
 
 type metricProcessRuntimeMemstatsFrees struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -212,7 +212,7 @@ func (m *metricProcessRuntimeMemstatsFrees) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsFrees) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -230,16 +230,16 @@ func (m *metricProcessRuntimeMemstatsFrees) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsFrees) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsFrees(settings MetricSettings) metricProcessRuntimeMemstatsFrees {
-	m := metricProcessRuntimeMemstatsFrees{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsFrees(cfg MetricConfig) metricProcessRuntimeMemstatsFrees {
+	m := metricProcessRuntimeMemstatsFrees{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -248,7 +248,7 @@ func newMetricProcessRuntimeMemstatsFrees(settings MetricSettings) metricProcess
 
 type metricProcessRuntimeMemstatsGcCPUFraction struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -261,7 +261,7 @@ func (m *metricProcessRuntimeMemstatsGcCPUFraction) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsGcCPUFraction) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -279,16 +279,16 @@ func (m *metricProcessRuntimeMemstatsGcCPUFraction) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsGcCPUFraction) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsGcCPUFraction(settings MetricSettings) metricProcessRuntimeMemstatsGcCPUFraction {
-	m := metricProcessRuntimeMemstatsGcCPUFraction{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsGcCPUFraction(cfg MetricConfig) metricProcessRuntimeMemstatsGcCPUFraction {
+	m := metricProcessRuntimeMemstatsGcCPUFraction{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -297,7 +297,7 @@ func newMetricProcessRuntimeMemstatsGcCPUFraction(settings MetricSettings) metri
 
 type metricProcessRuntimeMemstatsGcSys struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -312,7 +312,7 @@ func (m *metricProcessRuntimeMemstatsGcSys) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsGcSys) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -330,16 +330,16 @@ func (m *metricProcessRuntimeMemstatsGcSys) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsGcSys) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsGcSys(settings MetricSettings) metricProcessRuntimeMemstatsGcSys {
-	m := metricProcessRuntimeMemstatsGcSys{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsGcSys(cfg MetricConfig) metricProcessRuntimeMemstatsGcSys {
+	m := metricProcessRuntimeMemstatsGcSys{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -348,7 +348,7 @@ func newMetricProcessRuntimeMemstatsGcSys(settings MetricSettings) metricProcess
 
 type metricProcessRuntimeMemstatsHeapAlloc struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -363,7 +363,7 @@ func (m *metricProcessRuntimeMemstatsHeapAlloc) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsHeapAlloc) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -381,16 +381,16 @@ func (m *metricProcessRuntimeMemstatsHeapAlloc) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsHeapAlloc) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsHeapAlloc(settings MetricSettings) metricProcessRuntimeMemstatsHeapAlloc {
-	m := metricProcessRuntimeMemstatsHeapAlloc{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsHeapAlloc(cfg MetricConfig) metricProcessRuntimeMemstatsHeapAlloc {
+	m := metricProcessRuntimeMemstatsHeapAlloc{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -399,7 +399,7 @@ func newMetricProcessRuntimeMemstatsHeapAlloc(settings MetricSettings) metricPro
 
 type metricProcessRuntimeMemstatsHeapIdle struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -414,7 +414,7 @@ func (m *metricProcessRuntimeMemstatsHeapIdle) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsHeapIdle) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -432,16 +432,16 @@ func (m *metricProcessRuntimeMemstatsHeapIdle) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsHeapIdle) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsHeapIdle(settings MetricSettings) metricProcessRuntimeMemstatsHeapIdle {
-	m := metricProcessRuntimeMemstatsHeapIdle{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsHeapIdle(cfg MetricConfig) metricProcessRuntimeMemstatsHeapIdle {
+	m := metricProcessRuntimeMemstatsHeapIdle{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -450,7 +450,7 @@ func newMetricProcessRuntimeMemstatsHeapIdle(settings MetricSettings) metricProc
 
 type metricProcessRuntimeMemstatsHeapInuse struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -465,7 +465,7 @@ func (m *metricProcessRuntimeMemstatsHeapInuse) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsHeapInuse) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -483,16 +483,16 @@ func (m *metricProcessRuntimeMemstatsHeapInuse) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsHeapInuse) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsHeapInuse(settings MetricSettings) metricProcessRuntimeMemstatsHeapInuse {
-	m := metricProcessRuntimeMemstatsHeapInuse{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsHeapInuse(cfg MetricConfig) metricProcessRuntimeMemstatsHeapInuse {
+	m := metricProcessRuntimeMemstatsHeapInuse{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -501,7 +501,7 @@ func newMetricProcessRuntimeMemstatsHeapInuse(settings MetricSettings) metricPro
 
 type metricProcessRuntimeMemstatsHeapObjects struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -516,7 +516,7 @@ func (m *metricProcessRuntimeMemstatsHeapObjects) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsHeapObjects) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -534,16 +534,16 @@ func (m *metricProcessRuntimeMemstatsHeapObjects) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsHeapObjects) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsHeapObjects(settings MetricSettings) metricProcessRuntimeMemstatsHeapObjects {
-	m := metricProcessRuntimeMemstatsHeapObjects{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsHeapObjects(cfg MetricConfig) metricProcessRuntimeMemstatsHeapObjects {
+	m := metricProcessRuntimeMemstatsHeapObjects{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -552,7 +552,7 @@ func newMetricProcessRuntimeMemstatsHeapObjects(settings MetricSettings) metricP
 
 type metricProcessRuntimeMemstatsHeapReleased struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -567,7 +567,7 @@ func (m *metricProcessRuntimeMemstatsHeapReleased) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsHeapReleased) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -585,16 +585,16 @@ func (m *metricProcessRuntimeMemstatsHeapReleased) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsHeapReleased) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsHeapReleased(settings MetricSettings) metricProcessRuntimeMemstatsHeapReleased {
-	m := metricProcessRuntimeMemstatsHeapReleased{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsHeapReleased(cfg MetricConfig) metricProcessRuntimeMemstatsHeapReleased {
+	m := metricProcessRuntimeMemstatsHeapReleased{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -603,7 +603,7 @@ func newMetricProcessRuntimeMemstatsHeapReleased(settings MetricSettings) metric
 
 type metricProcessRuntimeMemstatsHeapSys struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -618,7 +618,7 @@ func (m *metricProcessRuntimeMemstatsHeapSys) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsHeapSys) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -636,16 +636,16 @@ func (m *metricProcessRuntimeMemstatsHeapSys) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsHeapSys) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsHeapSys(settings MetricSettings) metricProcessRuntimeMemstatsHeapSys {
-	m := metricProcessRuntimeMemstatsHeapSys{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsHeapSys(cfg MetricConfig) metricProcessRuntimeMemstatsHeapSys {
+	m := metricProcessRuntimeMemstatsHeapSys{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -654,7 +654,7 @@ func newMetricProcessRuntimeMemstatsHeapSys(settings MetricSettings) metricProce
 
 type metricProcessRuntimeMemstatsLastPause struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -667,7 +667,7 @@ func (m *metricProcessRuntimeMemstatsLastPause) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsLastPause) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -685,16 +685,16 @@ func (m *metricProcessRuntimeMemstatsLastPause) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsLastPause) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsLastPause(settings MetricSettings) metricProcessRuntimeMemstatsLastPause {
-	m := metricProcessRuntimeMemstatsLastPause{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsLastPause(cfg MetricConfig) metricProcessRuntimeMemstatsLastPause {
+	m := metricProcessRuntimeMemstatsLastPause{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -703,7 +703,7 @@ func newMetricProcessRuntimeMemstatsLastPause(settings MetricSettings) metricPro
 
 type metricProcessRuntimeMemstatsLookups struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -718,7 +718,7 @@ func (m *metricProcessRuntimeMemstatsLookups) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsLookups) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -736,16 +736,16 @@ func (m *metricProcessRuntimeMemstatsLookups) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsLookups) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsLookups(settings MetricSettings) metricProcessRuntimeMemstatsLookups {
-	m := metricProcessRuntimeMemstatsLookups{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsLookups(cfg MetricConfig) metricProcessRuntimeMemstatsLookups {
+	m := metricProcessRuntimeMemstatsLookups{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -754,7 +754,7 @@ func newMetricProcessRuntimeMemstatsLookups(settings MetricSettings) metricProce
 
 type metricProcessRuntimeMemstatsMallocs struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -769,7 +769,7 @@ func (m *metricProcessRuntimeMemstatsMallocs) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsMallocs) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -787,16 +787,16 @@ func (m *metricProcessRuntimeMemstatsMallocs) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsMallocs) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsMallocs(settings MetricSettings) metricProcessRuntimeMemstatsMallocs {
-	m := metricProcessRuntimeMemstatsMallocs{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsMallocs(cfg MetricConfig) metricProcessRuntimeMemstatsMallocs {
+	m := metricProcessRuntimeMemstatsMallocs{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -805,7 +805,7 @@ func newMetricProcessRuntimeMemstatsMallocs(settings MetricSettings) metricProce
 
 type metricProcessRuntimeMemstatsMcacheInuse struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -820,7 +820,7 @@ func (m *metricProcessRuntimeMemstatsMcacheInuse) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsMcacheInuse) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -838,16 +838,16 @@ func (m *metricProcessRuntimeMemstatsMcacheInuse) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsMcacheInuse) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsMcacheInuse(settings MetricSettings) metricProcessRuntimeMemstatsMcacheInuse {
-	m := metricProcessRuntimeMemstatsMcacheInuse{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsMcacheInuse(cfg MetricConfig) metricProcessRuntimeMemstatsMcacheInuse {
+	m := metricProcessRuntimeMemstatsMcacheInuse{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -856,7 +856,7 @@ func newMetricProcessRuntimeMemstatsMcacheInuse(settings MetricSettings) metricP
 
 type metricProcessRuntimeMemstatsMcacheSys struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -871,7 +871,7 @@ func (m *metricProcessRuntimeMemstatsMcacheSys) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsMcacheSys) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -889,16 +889,16 @@ func (m *metricProcessRuntimeMemstatsMcacheSys) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsMcacheSys) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsMcacheSys(settings MetricSettings) metricProcessRuntimeMemstatsMcacheSys {
-	m := metricProcessRuntimeMemstatsMcacheSys{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsMcacheSys(cfg MetricConfig) metricProcessRuntimeMemstatsMcacheSys {
+	m := metricProcessRuntimeMemstatsMcacheSys{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -907,7 +907,7 @@ func newMetricProcessRuntimeMemstatsMcacheSys(settings MetricSettings) metricPro
 
 type metricProcessRuntimeMemstatsMspanInuse struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -922,7 +922,7 @@ func (m *metricProcessRuntimeMemstatsMspanInuse) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsMspanInuse) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -940,16 +940,16 @@ func (m *metricProcessRuntimeMemstatsMspanInuse) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsMspanInuse) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsMspanInuse(settings MetricSettings) metricProcessRuntimeMemstatsMspanInuse {
-	m := metricProcessRuntimeMemstatsMspanInuse{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsMspanInuse(cfg MetricConfig) metricProcessRuntimeMemstatsMspanInuse {
+	m := metricProcessRuntimeMemstatsMspanInuse{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -958,7 +958,7 @@ func newMetricProcessRuntimeMemstatsMspanInuse(settings MetricSettings) metricPr
 
 type metricProcessRuntimeMemstatsMspanSys struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -973,7 +973,7 @@ func (m *metricProcessRuntimeMemstatsMspanSys) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsMspanSys) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -991,16 +991,16 @@ func (m *metricProcessRuntimeMemstatsMspanSys) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsMspanSys) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsMspanSys(settings MetricSettings) metricProcessRuntimeMemstatsMspanSys {
-	m := metricProcessRuntimeMemstatsMspanSys{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsMspanSys(cfg MetricConfig) metricProcessRuntimeMemstatsMspanSys {
+	m := metricProcessRuntimeMemstatsMspanSys{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1009,7 +1009,7 @@ func newMetricProcessRuntimeMemstatsMspanSys(settings MetricSettings) metricProc
 
 type metricProcessRuntimeMemstatsNextGc struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1024,7 +1024,7 @@ func (m *metricProcessRuntimeMemstatsNextGc) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsNextGc) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1042,16 +1042,16 @@ func (m *metricProcessRuntimeMemstatsNextGc) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsNextGc) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsNextGc(settings MetricSettings) metricProcessRuntimeMemstatsNextGc {
-	m := metricProcessRuntimeMemstatsNextGc{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsNextGc(cfg MetricConfig) metricProcessRuntimeMemstatsNextGc {
+	m := metricProcessRuntimeMemstatsNextGc{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1060,7 +1060,7 @@ func newMetricProcessRuntimeMemstatsNextGc(settings MetricSettings) metricProces
 
 type metricProcessRuntimeMemstatsNumForcedGc struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1075,7 +1075,7 @@ func (m *metricProcessRuntimeMemstatsNumForcedGc) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsNumForcedGc) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1093,16 +1093,16 @@ func (m *metricProcessRuntimeMemstatsNumForcedGc) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsNumForcedGc) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsNumForcedGc(settings MetricSettings) metricProcessRuntimeMemstatsNumForcedGc {
-	m := metricProcessRuntimeMemstatsNumForcedGc{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsNumForcedGc(cfg MetricConfig) metricProcessRuntimeMemstatsNumForcedGc {
+	m := metricProcessRuntimeMemstatsNumForcedGc{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1111,7 +1111,7 @@ func newMetricProcessRuntimeMemstatsNumForcedGc(settings MetricSettings) metricP
 
 type metricProcessRuntimeMemstatsNumGc struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1126,7 +1126,7 @@ func (m *metricProcessRuntimeMemstatsNumGc) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsNumGc) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1144,16 +1144,16 @@ func (m *metricProcessRuntimeMemstatsNumGc) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsNumGc) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsNumGc(settings MetricSettings) metricProcessRuntimeMemstatsNumGc {
-	m := metricProcessRuntimeMemstatsNumGc{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsNumGc(cfg MetricConfig) metricProcessRuntimeMemstatsNumGc {
+	m := metricProcessRuntimeMemstatsNumGc{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1162,7 +1162,7 @@ func newMetricProcessRuntimeMemstatsNumGc(settings MetricSettings) metricProcess
 
 type metricProcessRuntimeMemstatsOtherSys struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1177,7 +1177,7 @@ func (m *metricProcessRuntimeMemstatsOtherSys) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsOtherSys) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1195,16 +1195,16 @@ func (m *metricProcessRuntimeMemstatsOtherSys) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsOtherSys) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsOtherSys(settings MetricSettings) metricProcessRuntimeMemstatsOtherSys {
-	m := metricProcessRuntimeMemstatsOtherSys{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsOtherSys(cfg MetricConfig) metricProcessRuntimeMemstatsOtherSys {
+	m := metricProcessRuntimeMemstatsOtherSys{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1213,7 +1213,7 @@ func newMetricProcessRuntimeMemstatsOtherSys(settings MetricSettings) metricProc
 
 type metricProcessRuntimeMemstatsPauseTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1228,7 +1228,7 @@ func (m *metricProcessRuntimeMemstatsPauseTotal) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsPauseTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1246,16 +1246,16 @@ func (m *metricProcessRuntimeMemstatsPauseTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsPauseTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsPauseTotal(settings MetricSettings) metricProcessRuntimeMemstatsPauseTotal {
-	m := metricProcessRuntimeMemstatsPauseTotal{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsPauseTotal(cfg MetricConfig) metricProcessRuntimeMemstatsPauseTotal {
+	m := metricProcessRuntimeMemstatsPauseTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1264,7 +1264,7 @@ func newMetricProcessRuntimeMemstatsPauseTotal(settings MetricSettings) metricPr
 
 type metricProcessRuntimeMemstatsStackInuse struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1279,7 +1279,7 @@ func (m *metricProcessRuntimeMemstatsStackInuse) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsStackInuse) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1297,16 +1297,16 @@ func (m *metricProcessRuntimeMemstatsStackInuse) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsStackInuse) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsStackInuse(settings MetricSettings) metricProcessRuntimeMemstatsStackInuse {
-	m := metricProcessRuntimeMemstatsStackInuse{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsStackInuse(cfg MetricConfig) metricProcessRuntimeMemstatsStackInuse {
+	m := metricProcessRuntimeMemstatsStackInuse{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1315,7 +1315,7 @@ func newMetricProcessRuntimeMemstatsStackInuse(settings MetricSettings) metricPr
 
 type metricProcessRuntimeMemstatsStackSys struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1330,7 +1330,7 @@ func (m *metricProcessRuntimeMemstatsStackSys) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsStackSys) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1348,16 +1348,16 @@ func (m *metricProcessRuntimeMemstatsStackSys) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsStackSys) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsStackSys(settings MetricSettings) metricProcessRuntimeMemstatsStackSys {
-	m := metricProcessRuntimeMemstatsStackSys{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsStackSys(cfg MetricConfig) metricProcessRuntimeMemstatsStackSys {
+	m := metricProcessRuntimeMemstatsStackSys{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1366,7 +1366,7 @@ func newMetricProcessRuntimeMemstatsStackSys(settings MetricSettings) metricProc
 
 type metricProcessRuntimeMemstatsSys struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1381,7 +1381,7 @@ func (m *metricProcessRuntimeMemstatsSys) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsSys) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1399,16 +1399,16 @@ func (m *metricProcessRuntimeMemstatsSys) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsSys) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsSys(settings MetricSettings) metricProcessRuntimeMemstatsSys {
-	m := metricProcessRuntimeMemstatsSys{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsSys(cfg MetricConfig) metricProcessRuntimeMemstatsSys {
+	m := metricProcessRuntimeMemstatsSys{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1417,7 +1417,7 @@ func newMetricProcessRuntimeMemstatsSys(settings MetricSettings) metricProcessRu
 
 type metricProcessRuntimeMemstatsTotalAlloc struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1432,7 +1432,7 @@ func (m *metricProcessRuntimeMemstatsTotalAlloc) init() {
 }
 
 func (m *metricProcessRuntimeMemstatsTotalAlloc) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1450,16 +1450,16 @@ func (m *metricProcessRuntimeMemstatsTotalAlloc) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessRuntimeMemstatsTotalAlloc) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessRuntimeMemstatsTotalAlloc(settings MetricSettings) metricProcessRuntimeMemstatsTotalAlloc {
-	m := metricProcessRuntimeMemstatsTotalAlloc{settings: settings}
-	if settings.Enabled {
+func newMetricProcessRuntimeMemstatsTotalAlloc(cfg MetricConfig) metricProcessRuntimeMemstatsTotalAlloc {
+	m := metricProcessRuntimeMemstatsTotalAlloc{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1468,11 +1468,11 @@ func newMetricProcessRuntimeMemstatsTotalAlloc(settings MetricSettings) metricPr
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics MetricsSettings `mapstructure:"metrics"`
+	Metrics MetricsConfig `mapstructure:"metrics"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                 pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                           int                 // maximum observed number of metrics per resource.
@@ -1519,7 +1519,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics: DefaultMetricsSettings(),
+		Metrics: DefaultMetricsConfig(),
 	}
 }
 
@@ -1644,7 +1644,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/expvarreceiver/scraper_test.go
+++ b/receiver/expvarreceiver/scraper_test.go
@@ -33,9 +33,9 @@ import (
 )
 
 var (
-	metricEnabled     = metadata.MetricSettings{Enabled: true}
-	metricDisabled    = metadata.MetricSettings{Enabled: false}
-	allMetricsEnabled = metadata.MetricsSettings{
+	metricEnabled     = metadata.MetricConfig{Enabled: true}
+	metricDisabled    = metadata.MetricConfig{Enabled: false}
+	allMetricsEnabled = metadata.MetricsConfig{
 		ProcessRuntimeMemstatsBuckHashSys:   metricEnabled,
 		ProcessRuntimeMemstatsFrees:         metricEnabled,
 		ProcessRuntimeMemstatsGcCPUFraction: metricEnabled,
@@ -63,7 +63,7 @@ var (
 		ProcessRuntimeMemstatsSys:           metricEnabled,
 		ProcessRuntimeMemstatsTotalAlloc:    metricEnabled,
 	}
-	allMetricsDisabled = metadata.MetricsSettings{
+	allMetricsDisabled = metadata.MetricsConfig{
 		ProcessRuntimeMemstatsBuckHashSys:   metricDisabled,
 		ProcessRuntimeMemstatsFrees:         metricDisabled,
 		ProcessRuntimeMemstatsGcCPUFraction: metricDisabled,

--- a/receiver/filestatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/filestatsreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,48 +31,48 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for filestats metrics.
-type MetricsSettings struct {
-	FileAtime MetricSettings `mapstructure:"file.atime"`
-	FileCtime MetricSettings `mapstructure:"file.ctime"`
-	FileMtime MetricSettings `mapstructure:"file.mtime"`
-	FileSize  MetricSettings `mapstructure:"file.size"`
+// MetricsConfig provides config for filestats metrics.
+type MetricsConfig struct {
+	FileAtime MetricConfig `mapstructure:"file.atime"`
+	FileCtime MetricConfig `mapstructure:"file.ctime"`
+	FileMtime MetricConfig `mapstructure:"file.mtime"`
+	FileSize  MetricConfig `mapstructure:"file.size"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		FileAtime: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		FileAtime: MetricConfig{
 			Enabled: false,
 		},
-		FileCtime: MetricSettings{
+		FileCtime: MetricConfig{
 			Enabled: false,
 		},
-		FileMtime: MetricSettings{
+		FileMtime: MetricConfig{
 			Enabled: true,
 		},
-		FileSize: MetricSettings{
+		FileSize: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for filestats resource attributes.
-type ResourceAttributesSettings struct {
-	FileName ResourceAttributeSettings `mapstructure:"file.name"`
-	FilePath ResourceAttributeSettings `mapstructure:"file.path"`
+// ResourceAttributesConfig provides config for filestats resource attributes.
+type ResourceAttributesConfig struct {
+	FileName ResourceAttributeConfig `mapstructure:"file.name"`
+	FilePath ResourceAttributeConfig `mapstructure:"file.path"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		FileName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		FileName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		FilePath: ResourceAttributeSettings{
+		FilePath: ResourceAttributeConfig{
 			Enabled: false,
 		},
 	}
@@ -80,7 +80,7 @@ func DefaultResourceAttributesSettings() ResourceAttributesSettings {
 
 type metricFileAtime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -95,7 +95,7 @@ func (m *metricFileAtime) init() {
 }
 
 func (m *metricFileAtime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -113,16 +113,16 @@ func (m *metricFileAtime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFileAtime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFileAtime(settings MetricSettings) metricFileAtime {
-	m := metricFileAtime{settings: settings}
-	if settings.Enabled {
+func newMetricFileAtime(cfg MetricConfig) metricFileAtime {
+	m := metricFileAtime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -131,7 +131,7 @@ func newMetricFileAtime(settings MetricSettings) metricFileAtime {
 
 type metricFileCtime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -147,7 +147,7 @@ func (m *metricFileCtime) init() {
 }
 
 func (m *metricFileCtime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, filePermissionsAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -166,16 +166,16 @@ func (m *metricFileCtime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFileCtime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFileCtime(settings MetricSettings) metricFileCtime {
-	m := metricFileCtime{settings: settings}
-	if settings.Enabled {
+func newMetricFileCtime(cfg MetricConfig) metricFileCtime {
+	m := metricFileCtime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -184,7 +184,7 @@ func newMetricFileCtime(settings MetricSettings) metricFileCtime {
 
 type metricFileMtime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -199,7 +199,7 @@ func (m *metricFileMtime) init() {
 }
 
 func (m *metricFileMtime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -217,16 +217,16 @@ func (m *metricFileMtime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFileMtime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFileMtime(settings MetricSettings) metricFileMtime {
-	m := metricFileMtime{settings: settings}
-	if settings.Enabled {
+func newMetricFileMtime(cfg MetricConfig) metricFileMtime {
+	m := metricFileMtime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -235,7 +235,7 @@ func newMetricFileMtime(settings MetricSettings) metricFileMtime {
 
 type metricFileSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -248,7 +248,7 @@ func (m *metricFileSize) init() {
 }
 
 func (m *metricFileSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -266,16 +266,16 @@ func (m *metricFileSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFileSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFileSize(settings MetricSettings) metricFileSize {
-	m := metricFileSize{settings: settings}
-	if settings.Enabled {
+func newMetricFileSize(cfg MetricConfig) metricFileSize {
+	m := metricFileSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -284,23 +284,23 @@ func newMetricFileSize(settings MetricSettings) metricFileSize {
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	startTime                  pcommon.Timestamp   // start time that will be applied to all recorded data points.
-	metricsCapacity            int                 // maximum observed number of metrics per resource.
-	resourceCapacity           int                 // maximum observed number of resource attributes.
-	metricsBuffer              pmetric.Metrics     // accumulates metrics data before emitting.
-	buildInfo                  component.BuildInfo // contains version information
-	resourceAttributesSettings ResourceAttributesSettings
-	metricFileAtime            metricFileAtime
-	metricFileCtime            metricFileCtime
-	metricFileMtime            metricFileMtime
-	metricFileSize             metricFileSize
+	startTime                pcommon.Timestamp   // start time that will be applied to all recorded data points.
+	metricsCapacity          int                 // maximum observed number of metrics per resource.
+	resourceCapacity         int                 // maximum observed number of resource attributes.
+	metricsBuffer            pmetric.Metrics     // accumulates metrics data before emitting.
+	buildInfo                component.BuildInfo // contains version information
+	resourceAttributesConfig ResourceAttributesConfig
+	metricFileAtime          metricFileAtime
+	metricFileCtime          metricFileCtime
+	metricFileMtime          metricFileMtime
+	metricFileSize           metricFileSize
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -315,21 +315,21 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		startTime:                  pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:              pmetric.NewMetrics(),
-		buildInfo:                  settings.BuildInfo,
-		resourceAttributesSettings: mbc.ResourceAttributes,
-		metricFileAtime:            newMetricFileAtime(mbc.Metrics.FileAtime),
-		metricFileCtime:            newMetricFileCtime(mbc.Metrics.FileCtime),
-		metricFileMtime:            newMetricFileMtime(mbc.Metrics.FileMtime),
-		metricFileSize:             newMetricFileSize(mbc.Metrics.FileSize),
+		startTime:                pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:            pmetric.NewMetrics(),
+		buildInfo:                settings.BuildInfo,
+		resourceAttributesConfig: mbc.ResourceAttributes,
+		metricFileAtime:          newMetricFileAtime(mbc.Metrics.FileAtime),
+		metricFileCtime:          newMetricFileCtime(mbc.Metrics.FileCtime),
+		metricFileMtime:          newMetricFileMtime(mbc.Metrics.FileMtime),
+		metricFileSize:           newMetricFileSize(mbc.Metrics.FileSize),
 	}
 	for _, op := range options {
 		op(mb)
@@ -348,12 +348,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithFileName sets provided value as "file.name" attribute for current resource.
 func WithFileName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.FileName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.FileName.Enabled {
 			rm.Resource().Attributes().PutStr("file.name", val)
 		}
 	}
@@ -361,8 +361,8 @@ func WithFileName(val string) ResourceMetricsOption {
 
 // WithFilePath sets provided value as "file.path" attribute for current resource.
 func WithFilePath(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.FilePath.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.FilePath.Enabled {
 			rm.Resource().Attributes().PutStr("file.path", val)
 		}
 	}
@@ -371,7 +371,7 @@ func WithFilePath(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -406,7 +406,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricFileSize.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -416,7 +416,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/filestatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/filestatsreceiver/internal/metadata/generated_metrics_test.go
@@ -85,15 +85,15 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("file.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.FileName.Enabled, ok)
-			if mb.resourceAttributesSettings.FileName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.FileName.Enabled, ok)
+			if mb.resourceAttributesConfig.FileName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("file.path")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.FilePath.Enabled, ok)
-			if mb.resourceAttributesSettings.FilePath.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.FilePath.Enabled, ok)
+			if mb.resourceAttributesConfig.FilePath.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics.go
@@ -14,14 +14,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -33,164 +33,164 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for flinkmetricsreceiver metrics.
-type MetricsSettings struct {
-	FlinkJobCheckpointCount           MetricSettings `mapstructure:"flink.job.checkpoint.count"`
-	FlinkJobCheckpointInProgress      MetricSettings `mapstructure:"flink.job.checkpoint.in_progress"`
-	FlinkJobLastCheckpointSize        MetricSettings `mapstructure:"flink.job.last_checkpoint.size"`
-	FlinkJobLastCheckpointTime        MetricSettings `mapstructure:"flink.job.last_checkpoint.time"`
-	FlinkJobRestartCount              MetricSettings `mapstructure:"flink.job.restart.count"`
-	FlinkJvmClassLoaderClassesLoaded  MetricSettings `mapstructure:"flink.jvm.class_loader.classes_loaded"`
-	FlinkJvmCPULoad                   MetricSettings `mapstructure:"flink.jvm.cpu.load"`
-	FlinkJvmCPUTime                   MetricSettings `mapstructure:"flink.jvm.cpu.time"`
-	FlinkJvmGcCollectionsCount        MetricSettings `mapstructure:"flink.jvm.gc.collections.count"`
-	FlinkJvmGcCollectionsTime         MetricSettings `mapstructure:"flink.jvm.gc.collections.time"`
-	FlinkJvmMemoryDirectTotalCapacity MetricSettings `mapstructure:"flink.jvm.memory.direct.total_capacity"`
-	FlinkJvmMemoryDirectUsed          MetricSettings `mapstructure:"flink.jvm.memory.direct.used"`
-	FlinkJvmMemoryHeapCommitted       MetricSettings `mapstructure:"flink.jvm.memory.heap.committed"`
-	FlinkJvmMemoryHeapMax             MetricSettings `mapstructure:"flink.jvm.memory.heap.max"`
-	FlinkJvmMemoryHeapUsed            MetricSettings `mapstructure:"flink.jvm.memory.heap.used"`
-	FlinkJvmMemoryMappedTotalCapacity MetricSettings `mapstructure:"flink.jvm.memory.mapped.total_capacity"`
-	FlinkJvmMemoryMappedUsed          MetricSettings `mapstructure:"flink.jvm.memory.mapped.used"`
-	FlinkJvmMemoryMetaspaceCommitted  MetricSettings `mapstructure:"flink.jvm.memory.metaspace.committed"`
-	FlinkJvmMemoryMetaspaceMax        MetricSettings `mapstructure:"flink.jvm.memory.metaspace.max"`
-	FlinkJvmMemoryMetaspaceUsed       MetricSettings `mapstructure:"flink.jvm.memory.metaspace.used"`
-	FlinkJvmMemoryNonheapCommitted    MetricSettings `mapstructure:"flink.jvm.memory.nonheap.committed"`
-	FlinkJvmMemoryNonheapMax          MetricSettings `mapstructure:"flink.jvm.memory.nonheap.max"`
-	FlinkJvmMemoryNonheapUsed         MetricSettings `mapstructure:"flink.jvm.memory.nonheap.used"`
-	FlinkJvmThreadsCount              MetricSettings `mapstructure:"flink.jvm.threads.count"`
-	FlinkMemoryManagedTotal           MetricSettings `mapstructure:"flink.memory.managed.total"`
-	FlinkMemoryManagedUsed            MetricSettings `mapstructure:"flink.memory.managed.used"`
-	FlinkOperatorRecordCount          MetricSettings `mapstructure:"flink.operator.record.count"`
-	FlinkOperatorWatermarkOutput      MetricSettings `mapstructure:"flink.operator.watermark.output"`
-	FlinkTaskRecordCount              MetricSettings `mapstructure:"flink.task.record.count"`
+// MetricsConfig provides config for flinkmetricsreceiver metrics.
+type MetricsConfig struct {
+	FlinkJobCheckpointCount           MetricConfig `mapstructure:"flink.job.checkpoint.count"`
+	FlinkJobCheckpointInProgress      MetricConfig `mapstructure:"flink.job.checkpoint.in_progress"`
+	FlinkJobLastCheckpointSize        MetricConfig `mapstructure:"flink.job.last_checkpoint.size"`
+	FlinkJobLastCheckpointTime        MetricConfig `mapstructure:"flink.job.last_checkpoint.time"`
+	FlinkJobRestartCount              MetricConfig `mapstructure:"flink.job.restart.count"`
+	FlinkJvmClassLoaderClassesLoaded  MetricConfig `mapstructure:"flink.jvm.class_loader.classes_loaded"`
+	FlinkJvmCPULoad                   MetricConfig `mapstructure:"flink.jvm.cpu.load"`
+	FlinkJvmCPUTime                   MetricConfig `mapstructure:"flink.jvm.cpu.time"`
+	FlinkJvmGcCollectionsCount        MetricConfig `mapstructure:"flink.jvm.gc.collections.count"`
+	FlinkJvmGcCollectionsTime         MetricConfig `mapstructure:"flink.jvm.gc.collections.time"`
+	FlinkJvmMemoryDirectTotalCapacity MetricConfig `mapstructure:"flink.jvm.memory.direct.total_capacity"`
+	FlinkJvmMemoryDirectUsed          MetricConfig `mapstructure:"flink.jvm.memory.direct.used"`
+	FlinkJvmMemoryHeapCommitted       MetricConfig `mapstructure:"flink.jvm.memory.heap.committed"`
+	FlinkJvmMemoryHeapMax             MetricConfig `mapstructure:"flink.jvm.memory.heap.max"`
+	FlinkJvmMemoryHeapUsed            MetricConfig `mapstructure:"flink.jvm.memory.heap.used"`
+	FlinkJvmMemoryMappedTotalCapacity MetricConfig `mapstructure:"flink.jvm.memory.mapped.total_capacity"`
+	FlinkJvmMemoryMappedUsed          MetricConfig `mapstructure:"flink.jvm.memory.mapped.used"`
+	FlinkJvmMemoryMetaspaceCommitted  MetricConfig `mapstructure:"flink.jvm.memory.metaspace.committed"`
+	FlinkJvmMemoryMetaspaceMax        MetricConfig `mapstructure:"flink.jvm.memory.metaspace.max"`
+	FlinkJvmMemoryMetaspaceUsed       MetricConfig `mapstructure:"flink.jvm.memory.metaspace.used"`
+	FlinkJvmMemoryNonheapCommitted    MetricConfig `mapstructure:"flink.jvm.memory.nonheap.committed"`
+	FlinkJvmMemoryNonheapMax          MetricConfig `mapstructure:"flink.jvm.memory.nonheap.max"`
+	FlinkJvmMemoryNonheapUsed         MetricConfig `mapstructure:"flink.jvm.memory.nonheap.used"`
+	FlinkJvmThreadsCount              MetricConfig `mapstructure:"flink.jvm.threads.count"`
+	FlinkMemoryManagedTotal           MetricConfig `mapstructure:"flink.memory.managed.total"`
+	FlinkMemoryManagedUsed            MetricConfig `mapstructure:"flink.memory.managed.used"`
+	FlinkOperatorRecordCount          MetricConfig `mapstructure:"flink.operator.record.count"`
+	FlinkOperatorWatermarkOutput      MetricConfig `mapstructure:"flink.operator.watermark.output"`
+	FlinkTaskRecordCount              MetricConfig `mapstructure:"flink.task.record.count"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		FlinkJobCheckpointCount: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		FlinkJobCheckpointCount: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJobCheckpointInProgress: MetricSettings{
+		FlinkJobCheckpointInProgress: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJobLastCheckpointSize: MetricSettings{
+		FlinkJobLastCheckpointSize: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJobLastCheckpointTime: MetricSettings{
+		FlinkJobLastCheckpointTime: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJobRestartCount: MetricSettings{
+		FlinkJobRestartCount: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmClassLoaderClassesLoaded: MetricSettings{
+		FlinkJvmClassLoaderClassesLoaded: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmCPULoad: MetricSettings{
+		FlinkJvmCPULoad: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmCPUTime: MetricSettings{
+		FlinkJvmCPUTime: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmGcCollectionsCount: MetricSettings{
+		FlinkJvmGcCollectionsCount: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmGcCollectionsTime: MetricSettings{
+		FlinkJvmGcCollectionsTime: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryDirectTotalCapacity: MetricSettings{
+		FlinkJvmMemoryDirectTotalCapacity: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryDirectUsed: MetricSettings{
+		FlinkJvmMemoryDirectUsed: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryHeapCommitted: MetricSettings{
+		FlinkJvmMemoryHeapCommitted: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryHeapMax: MetricSettings{
+		FlinkJvmMemoryHeapMax: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryHeapUsed: MetricSettings{
+		FlinkJvmMemoryHeapUsed: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryMappedTotalCapacity: MetricSettings{
+		FlinkJvmMemoryMappedTotalCapacity: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryMappedUsed: MetricSettings{
+		FlinkJvmMemoryMappedUsed: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryMetaspaceCommitted: MetricSettings{
+		FlinkJvmMemoryMetaspaceCommitted: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryMetaspaceMax: MetricSettings{
+		FlinkJvmMemoryMetaspaceMax: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryMetaspaceUsed: MetricSettings{
+		FlinkJvmMemoryMetaspaceUsed: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryNonheapCommitted: MetricSettings{
+		FlinkJvmMemoryNonheapCommitted: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryNonheapMax: MetricSettings{
+		FlinkJvmMemoryNonheapMax: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmMemoryNonheapUsed: MetricSettings{
+		FlinkJvmMemoryNonheapUsed: MetricConfig{
 			Enabled: true,
 		},
-		FlinkJvmThreadsCount: MetricSettings{
+		FlinkJvmThreadsCount: MetricConfig{
 			Enabled: true,
 		},
-		FlinkMemoryManagedTotal: MetricSettings{
+		FlinkMemoryManagedTotal: MetricConfig{
 			Enabled: true,
 		},
-		FlinkMemoryManagedUsed: MetricSettings{
+		FlinkMemoryManagedUsed: MetricConfig{
 			Enabled: true,
 		},
-		FlinkOperatorRecordCount: MetricSettings{
+		FlinkOperatorRecordCount: MetricConfig{
 			Enabled: true,
 		},
-		FlinkOperatorWatermarkOutput: MetricSettings{
+		FlinkOperatorWatermarkOutput: MetricConfig{
 			Enabled: true,
 		},
-		FlinkTaskRecordCount: MetricSettings{
+		FlinkTaskRecordCount: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for flinkmetricsreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	FlinkJobName       ResourceAttributeSettings `mapstructure:"flink.job.name"`
-	FlinkResourceType  ResourceAttributeSettings `mapstructure:"flink.resource.type"`
-	FlinkSubtaskIndex  ResourceAttributeSettings `mapstructure:"flink.subtask.index"`
-	FlinkTaskName      ResourceAttributeSettings `mapstructure:"flink.task.name"`
-	FlinkTaskmanagerID ResourceAttributeSettings `mapstructure:"flink.taskmanager.id"`
-	HostName           ResourceAttributeSettings `mapstructure:"host.name"`
+// ResourceAttributesConfig provides config for flinkmetricsreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	FlinkJobName       ResourceAttributeConfig `mapstructure:"flink.job.name"`
+	FlinkResourceType  ResourceAttributeConfig `mapstructure:"flink.resource.type"`
+	FlinkSubtaskIndex  ResourceAttributeConfig `mapstructure:"flink.subtask.index"`
+	FlinkTaskName      ResourceAttributeConfig `mapstructure:"flink.task.name"`
+	FlinkTaskmanagerID ResourceAttributeConfig `mapstructure:"flink.taskmanager.id"`
+	HostName           ResourceAttributeConfig `mapstructure:"host.name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		FlinkJobName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		FlinkJobName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		FlinkResourceType: ResourceAttributeSettings{
+		FlinkResourceType: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		FlinkSubtaskIndex: ResourceAttributeSettings{
+		FlinkSubtaskIndex: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		FlinkTaskName: ResourceAttributeSettings{
+		FlinkTaskName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		FlinkTaskmanagerID: ResourceAttributeSettings{
+		FlinkTaskmanagerID: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		HostName: ResourceAttributeSettings{
+		HostName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -288,7 +288,7 @@ var MapAttributeRecord = map[string]AttributeRecord{
 
 type metricFlinkJobCheckpointCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -304,7 +304,7 @@ func (m *metricFlinkJobCheckpointCount) init() {
 }
 
 func (m *metricFlinkJobCheckpointCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, checkpointAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -323,16 +323,16 @@ func (m *metricFlinkJobCheckpointCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJobCheckpointCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJobCheckpointCount(settings MetricSettings) metricFlinkJobCheckpointCount {
-	m := metricFlinkJobCheckpointCount{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJobCheckpointCount(cfg MetricConfig) metricFlinkJobCheckpointCount {
+	m := metricFlinkJobCheckpointCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -341,7 +341,7 @@ func newMetricFlinkJobCheckpointCount(settings MetricSettings) metricFlinkJobChe
 
 type metricFlinkJobCheckpointInProgress struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -356,7 +356,7 @@ func (m *metricFlinkJobCheckpointInProgress) init() {
 }
 
 func (m *metricFlinkJobCheckpointInProgress) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -374,16 +374,16 @@ func (m *metricFlinkJobCheckpointInProgress) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJobCheckpointInProgress) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJobCheckpointInProgress(settings MetricSettings) metricFlinkJobCheckpointInProgress {
-	m := metricFlinkJobCheckpointInProgress{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJobCheckpointInProgress(cfg MetricConfig) metricFlinkJobCheckpointInProgress {
+	m := metricFlinkJobCheckpointInProgress{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -392,7 +392,7 @@ func newMetricFlinkJobCheckpointInProgress(settings MetricSettings) metricFlinkJ
 
 type metricFlinkJobLastCheckpointSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -407,7 +407,7 @@ func (m *metricFlinkJobLastCheckpointSize) init() {
 }
 
 func (m *metricFlinkJobLastCheckpointSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -425,16 +425,16 @@ func (m *metricFlinkJobLastCheckpointSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJobLastCheckpointSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJobLastCheckpointSize(settings MetricSettings) metricFlinkJobLastCheckpointSize {
-	m := metricFlinkJobLastCheckpointSize{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJobLastCheckpointSize(cfg MetricConfig) metricFlinkJobLastCheckpointSize {
+	m := metricFlinkJobLastCheckpointSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -443,7 +443,7 @@ func newMetricFlinkJobLastCheckpointSize(settings MetricSettings) metricFlinkJob
 
 type metricFlinkJobLastCheckpointTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -456,7 +456,7 @@ func (m *metricFlinkJobLastCheckpointTime) init() {
 }
 
 func (m *metricFlinkJobLastCheckpointTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -474,16 +474,16 @@ func (m *metricFlinkJobLastCheckpointTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJobLastCheckpointTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJobLastCheckpointTime(settings MetricSettings) metricFlinkJobLastCheckpointTime {
-	m := metricFlinkJobLastCheckpointTime{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJobLastCheckpointTime(cfg MetricConfig) metricFlinkJobLastCheckpointTime {
+	m := metricFlinkJobLastCheckpointTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -492,7 +492,7 @@ func newMetricFlinkJobLastCheckpointTime(settings MetricSettings) metricFlinkJob
 
 type metricFlinkJobRestartCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -507,7 +507,7 @@ func (m *metricFlinkJobRestartCount) init() {
 }
 
 func (m *metricFlinkJobRestartCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -525,16 +525,16 @@ func (m *metricFlinkJobRestartCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJobRestartCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJobRestartCount(settings MetricSettings) metricFlinkJobRestartCount {
-	m := metricFlinkJobRestartCount{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJobRestartCount(cfg MetricConfig) metricFlinkJobRestartCount {
+	m := metricFlinkJobRestartCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -543,7 +543,7 @@ func newMetricFlinkJobRestartCount(settings MetricSettings) metricFlinkJobRestar
 
 type metricFlinkJvmClassLoaderClassesLoaded struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -558,7 +558,7 @@ func (m *metricFlinkJvmClassLoaderClassesLoaded) init() {
 }
 
 func (m *metricFlinkJvmClassLoaderClassesLoaded) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -576,16 +576,16 @@ func (m *metricFlinkJvmClassLoaderClassesLoaded) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmClassLoaderClassesLoaded) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmClassLoaderClassesLoaded(settings MetricSettings) metricFlinkJvmClassLoaderClassesLoaded {
-	m := metricFlinkJvmClassLoaderClassesLoaded{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmClassLoaderClassesLoaded(cfg MetricConfig) metricFlinkJvmClassLoaderClassesLoaded {
+	m := metricFlinkJvmClassLoaderClassesLoaded{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -594,7 +594,7 @@ func newMetricFlinkJvmClassLoaderClassesLoaded(settings MetricSettings) metricFl
 
 type metricFlinkJvmCPULoad struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -607,7 +607,7 @@ func (m *metricFlinkJvmCPULoad) init() {
 }
 
 func (m *metricFlinkJvmCPULoad) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -625,16 +625,16 @@ func (m *metricFlinkJvmCPULoad) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmCPULoad) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmCPULoad(settings MetricSettings) metricFlinkJvmCPULoad {
-	m := metricFlinkJvmCPULoad{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmCPULoad(cfg MetricConfig) metricFlinkJvmCPULoad {
+	m := metricFlinkJvmCPULoad{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -643,7 +643,7 @@ func newMetricFlinkJvmCPULoad(settings MetricSettings) metricFlinkJvmCPULoad {
 
 type metricFlinkJvmCPUTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -658,7 +658,7 @@ func (m *metricFlinkJvmCPUTime) init() {
 }
 
 func (m *metricFlinkJvmCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -676,16 +676,16 @@ func (m *metricFlinkJvmCPUTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmCPUTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmCPUTime(settings MetricSettings) metricFlinkJvmCPUTime {
-	m := metricFlinkJvmCPUTime{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmCPUTime(cfg MetricConfig) metricFlinkJvmCPUTime {
+	m := metricFlinkJvmCPUTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -694,7 +694,7 @@ func newMetricFlinkJvmCPUTime(settings MetricSettings) metricFlinkJvmCPUTime {
 
 type metricFlinkJvmGcCollectionsCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -710,7 +710,7 @@ func (m *metricFlinkJvmGcCollectionsCount) init() {
 }
 
 func (m *metricFlinkJvmGcCollectionsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, garbageCollectorNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -729,16 +729,16 @@ func (m *metricFlinkJvmGcCollectionsCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmGcCollectionsCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmGcCollectionsCount(settings MetricSettings) metricFlinkJvmGcCollectionsCount {
-	m := metricFlinkJvmGcCollectionsCount{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmGcCollectionsCount(cfg MetricConfig) metricFlinkJvmGcCollectionsCount {
+	m := metricFlinkJvmGcCollectionsCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -747,7 +747,7 @@ func newMetricFlinkJvmGcCollectionsCount(settings MetricSettings) metricFlinkJvm
 
 type metricFlinkJvmGcCollectionsTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -763,7 +763,7 @@ func (m *metricFlinkJvmGcCollectionsTime) init() {
 }
 
 func (m *metricFlinkJvmGcCollectionsTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, garbageCollectorNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -782,16 +782,16 @@ func (m *metricFlinkJvmGcCollectionsTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmGcCollectionsTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmGcCollectionsTime(settings MetricSettings) metricFlinkJvmGcCollectionsTime {
-	m := metricFlinkJvmGcCollectionsTime{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmGcCollectionsTime(cfg MetricConfig) metricFlinkJvmGcCollectionsTime {
+	m := metricFlinkJvmGcCollectionsTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -800,7 +800,7 @@ func newMetricFlinkJvmGcCollectionsTime(settings MetricSettings) metricFlinkJvmG
 
 type metricFlinkJvmMemoryDirectTotalCapacity struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -815,7 +815,7 @@ func (m *metricFlinkJvmMemoryDirectTotalCapacity) init() {
 }
 
 func (m *metricFlinkJvmMemoryDirectTotalCapacity) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -833,16 +833,16 @@ func (m *metricFlinkJvmMemoryDirectTotalCapacity) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryDirectTotalCapacity) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryDirectTotalCapacity(settings MetricSettings) metricFlinkJvmMemoryDirectTotalCapacity {
-	m := metricFlinkJvmMemoryDirectTotalCapacity{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryDirectTotalCapacity(cfg MetricConfig) metricFlinkJvmMemoryDirectTotalCapacity {
+	m := metricFlinkJvmMemoryDirectTotalCapacity{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -851,7 +851,7 @@ func newMetricFlinkJvmMemoryDirectTotalCapacity(settings MetricSettings) metricF
 
 type metricFlinkJvmMemoryDirectUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -866,7 +866,7 @@ func (m *metricFlinkJvmMemoryDirectUsed) init() {
 }
 
 func (m *metricFlinkJvmMemoryDirectUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -884,16 +884,16 @@ func (m *metricFlinkJvmMemoryDirectUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryDirectUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryDirectUsed(settings MetricSettings) metricFlinkJvmMemoryDirectUsed {
-	m := metricFlinkJvmMemoryDirectUsed{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryDirectUsed(cfg MetricConfig) metricFlinkJvmMemoryDirectUsed {
+	m := metricFlinkJvmMemoryDirectUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -902,7 +902,7 @@ func newMetricFlinkJvmMemoryDirectUsed(settings MetricSettings) metricFlinkJvmMe
 
 type metricFlinkJvmMemoryHeapCommitted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -917,7 +917,7 @@ func (m *metricFlinkJvmMemoryHeapCommitted) init() {
 }
 
 func (m *metricFlinkJvmMemoryHeapCommitted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -935,16 +935,16 @@ func (m *metricFlinkJvmMemoryHeapCommitted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryHeapCommitted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryHeapCommitted(settings MetricSettings) metricFlinkJvmMemoryHeapCommitted {
-	m := metricFlinkJvmMemoryHeapCommitted{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryHeapCommitted(cfg MetricConfig) metricFlinkJvmMemoryHeapCommitted {
+	m := metricFlinkJvmMemoryHeapCommitted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -953,7 +953,7 @@ func newMetricFlinkJvmMemoryHeapCommitted(settings MetricSettings) metricFlinkJv
 
 type metricFlinkJvmMemoryHeapMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -968,7 +968,7 @@ func (m *metricFlinkJvmMemoryHeapMax) init() {
 }
 
 func (m *metricFlinkJvmMemoryHeapMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -986,16 +986,16 @@ func (m *metricFlinkJvmMemoryHeapMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryHeapMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryHeapMax(settings MetricSettings) metricFlinkJvmMemoryHeapMax {
-	m := metricFlinkJvmMemoryHeapMax{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryHeapMax(cfg MetricConfig) metricFlinkJvmMemoryHeapMax {
+	m := metricFlinkJvmMemoryHeapMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1004,7 +1004,7 @@ func newMetricFlinkJvmMemoryHeapMax(settings MetricSettings) metricFlinkJvmMemor
 
 type metricFlinkJvmMemoryHeapUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1019,7 +1019,7 @@ func (m *metricFlinkJvmMemoryHeapUsed) init() {
 }
 
 func (m *metricFlinkJvmMemoryHeapUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1037,16 +1037,16 @@ func (m *metricFlinkJvmMemoryHeapUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryHeapUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryHeapUsed(settings MetricSettings) metricFlinkJvmMemoryHeapUsed {
-	m := metricFlinkJvmMemoryHeapUsed{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryHeapUsed(cfg MetricConfig) metricFlinkJvmMemoryHeapUsed {
+	m := metricFlinkJvmMemoryHeapUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1055,7 +1055,7 @@ func newMetricFlinkJvmMemoryHeapUsed(settings MetricSettings) metricFlinkJvmMemo
 
 type metricFlinkJvmMemoryMappedTotalCapacity struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1070,7 +1070,7 @@ func (m *metricFlinkJvmMemoryMappedTotalCapacity) init() {
 }
 
 func (m *metricFlinkJvmMemoryMappedTotalCapacity) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1088,16 +1088,16 @@ func (m *metricFlinkJvmMemoryMappedTotalCapacity) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryMappedTotalCapacity) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryMappedTotalCapacity(settings MetricSettings) metricFlinkJvmMemoryMappedTotalCapacity {
-	m := metricFlinkJvmMemoryMappedTotalCapacity{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryMappedTotalCapacity(cfg MetricConfig) metricFlinkJvmMemoryMappedTotalCapacity {
+	m := metricFlinkJvmMemoryMappedTotalCapacity{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1106,7 +1106,7 @@ func newMetricFlinkJvmMemoryMappedTotalCapacity(settings MetricSettings) metricF
 
 type metricFlinkJvmMemoryMappedUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1121,7 +1121,7 @@ func (m *metricFlinkJvmMemoryMappedUsed) init() {
 }
 
 func (m *metricFlinkJvmMemoryMappedUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1139,16 +1139,16 @@ func (m *metricFlinkJvmMemoryMappedUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryMappedUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryMappedUsed(settings MetricSettings) metricFlinkJvmMemoryMappedUsed {
-	m := metricFlinkJvmMemoryMappedUsed{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryMappedUsed(cfg MetricConfig) metricFlinkJvmMemoryMappedUsed {
+	m := metricFlinkJvmMemoryMappedUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1157,7 +1157,7 @@ func newMetricFlinkJvmMemoryMappedUsed(settings MetricSettings) metricFlinkJvmMe
 
 type metricFlinkJvmMemoryMetaspaceCommitted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1172,7 +1172,7 @@ func (m *metricFlinkJvmMemoryMetaspaceCommitted) init() {
 }
 
 func (m *metricFlinkJvmMemoryMetaspaceCommitted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1190,16 +1190,16 @@ func (m *metricFlinkJvmMemoryMetaspaceCommitted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryMetaspaceCommitted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryMetaspaceCommitted(settings MetricSettings) metricFlinkJvmMemoryMetaspaceCommitted {
-	m := metricFlinkJvmMemoryMetaspaceCommitted{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryMetaspaceCommitted(cfg MetricConfig) metricFlinkJvmMemoryMetaspaceCommitted {
+	m := metricFlinkJvmMemoryMetaspaceCommitted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1208,7 +1208,7 @@ func newMetricFlinkJvmMemoryMetaspaceCommitted(settings MetricSettings) metricFl
 
 type metricFlinkJvmMemoryMetaspaceMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1223,7 +1223,7 @@ func (m *metricFlinkJvmMemoryMetaspaceMax) init() {
 }
 
 func (m *metricFlinkJvmMemoryMetaspaceMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1241,16 +1241,16 @@ func (m *metricFlinkJvmMemoryMetaspaceMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryMetaspaceMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryMetaspaceMax(settings MetricSettings) metricFlinkJvmMemoryMetaspaceMax {
-	m := metricFlinkJvmMemoryMetaspaceMax{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryMetaspaceMax(cfg MetricConfig) metricFlinkJvmMemoryMetaspaceMax {
+	m := metricFlinkJvmMemoryMetaspaceMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1259,7 +1259,7 @@ func newMetricFlinkJvmMemoryMetaspaceMax(settings MetricSettings) metricFlinkJvm
 
 type metricFlinkJvmMemoryMetaspaceUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1274,7 +1274,7 @@ func (m *metricFlinkJvmMemoryMetaspaceUsed) init() {
 }
 
 func (m *metricFlinkJvmMemoryMetaspaceUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1292,16 +1292,16 @@ func (m *metricFlinkJvmMemoryMetaspaceUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryMetaspaceUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryMetaspaceUsed(settings MetricSettings) metricFlinkJvmMemoryMetaspaceUsed {
-	m := metricFlinkJvmMemoryMetaspaceUsed{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryMetaspaceUsed(cfg MetricConfig) metricFlinkJvmMemoryMetaspaceUsed {
+	m := metricFlinkJvmMemoryMetaspaceUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1310,7 +1310,7 @@ func newMetricFlinkJvmMemoryMetaspaceUsed(settings MetricSettings) metricFlinkJv
 
 type metricFlinkJvmMemoryNonheapCommitted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1325,7 +1325,7 @@ func (m *metricFlinkJvmMemoryNonheapCommitted) init() {
 }
 
 func (m *metricFlinkJvmMemoryNonheapCommitted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1343,16 +1343,16 @@ func (m *metricFlinkJvmMemoryNonheapCommitted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryNonheapCommitted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryNonheapCommitted(settings MetricSettings) metricFlinkJvmMemoryNonheapCommitted {
-	m := metricFlinkJvmMemoryNonheapCommitted{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryNonheapCommitted(cfg MetricConfig) metricFlinkJvmMemoryNonheapCommitted {
+	m := metricFlinkJvmMemoryNonheapCommitted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1361,7 +1361,7 @@ func newMetricFlinkJvmMemoryNonheapCommitted(settings MetricSettings) metricFlin
 
 type metricFlinkJvmMemoryNonheapMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1376,7 +1376,7 @@ func (m *metricFlinkJvmMemoryNonheapMax) init() {
 }
 
 func (m *metricFlinkJvmMemoryNonheapMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1394,16 +1394,16 @@ func (m *metricFlinkJvmMemoryNonheapMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryNonheapMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryNonheapMax(settings MetricSettings) metricFlinkJvmMemoryNonheapMax {
-	m := metricFlinkJvmMemoryNonheapMax{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryNonheapMax(cfg MetricConfig) metricFlinkJvmMemoryNonheapMax {
+	m := metricFlinkJvmMemoryNonheapMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1412,7 +1412,7 @@ func newMetricFlinkJvmMemoryNonheapMax(settings MetricSettings) metricFlinkJvmMe
 
 type metricFlinkJvmMemoryNonheapUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1427,7 +1427,7 @@ func (m *metricFlinkJvmMemoryNonheapUsed) init() {
 }
 
 func (m *metricFlinkJvmMemoryNonheapUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1445,16 +1445,16 @@ func (m *metricFlinkJvmMemoryNonheapUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmMemoryNonheapUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmMemoryNonheapUsed(settings MetricSettings) metricFlinkJvmMemoryNonheapUsed {
-	m := metricFlinkJvmMemoryNonheapUsed{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmMemoryNonheapUsed(cfg MetricConfig) metricFlinkJvmMemoryNonheapUsed {
+	m := metricFlinkJvmMemoryNonheapUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1463,7 +1463,7 @@ func newMetricFlinkJvmMemoryNonheapUsed(settings MetricSettings) metricFlinkJvmM
 
 type metricFlinkJvmThreadsCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1478,7 +1478,7 @@ func (m *metricFlinkJvmThreadsCount) init() {
 }
 
 func (m *metricFlinkJvmThreadsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1496,16 +1496,16 @@ func (m *metricFlinkJvmThreadsCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkJvmThreadsCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkJvmThreadsCount(settings MetricSettings) metricFlinkJvmThreadsCount {
-	m := metricFlinkJvmThreadsCount{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkJvmThreadsCount(cfg MetricConfig) metricFlinkJvmThreadsCount {
+	m := metricFlinkJvmThreadsCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1514,7 +1514,7 @@ func newMetricFlinkJvmThreadsCount(settings MetricSettings) metricFlinkJvmThread
 
 type metricFlinkMemoryManagedTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1529,7 +1529,7 @@ func (m *metricFlinkMemoryManagedTotal) init() {
 }
 
 func (m *metricFlinkMemoryManagedTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1547,16 +1547,16 @@ func (m *metricFlinkMemoryManagedTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkMemoryManagedTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkMemoryManagedTotal(settings MetricSettings) metricFlinkMemoryManagedTotal {
-	m := metricFlinkMemoryManagedTotal{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkMemoryManagedTotal(cfg MetricConfig) metricFlinkMemoryManagedTotal {
+	m := metricFlinkMemoryManagedTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1565,7 +1565,7 @@ func newMetricFlinkMemoryManagedTotal(settings MetricSettings) metricFlinkMemory
 
 type metricFlinkMemoryManagedUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1580,7 +1580,7 @@ func (m *metricFlinkMemoryManagedUsed) init() {
 }
 
 func (m *metricFlinkMemoryManagedUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1598,16 +1598,16 @@ func (m *metricFlinkMemoryManagedUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkMemoryManagedUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkMemoryManagedUsed(settings MetricSettings) metricFlinkMemoryManagedUsed {
-	m := metricFlinkMemoryManagedUsed{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkMemoryManagedUsed(cfg MetricConfig) metricFlinkMemoryManagedUsed {
+	m := metricFlinkMemoryManagedUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1616,7 +1616,7 @@ func newMetricFlinkMemoryManagedUsed(settings MetricSettings) metricFlinkMemoryM
 
 type metricFlinkOperatorRecordCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1632,7 +1632,7 @@ func (m *metricFlinkOperatorRecordCount) init() {
 }
 
 func (m *metricFlinkOperatorRecordCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operatorNameAttributeValue string, recordAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1652,16 +1652,16 @@ func (m *metricFlinkOperatorRecordCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkOperatorRecordCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkOperatorRecordCount(settings MetricSettings) metricFlinkOperatorRecordCount {
-	m := metricFlinkOperatorRecordCount{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkOperatorRecordCount(cfg MetricConfig) metricFlinkOperatorRecordCount {
+	m := metricFlinkOperatorRecordCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1670,7 +1670,7 @@ func newMetricFlinkOperatorRecordCount(settings MetricSettings) metricFlinkOpera
 
 type metricFlinkOperatorWatermarkOutput struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1686,7 +1686,7 @@ func (m *metricFlinkOperatorWatermarkOutput) init() {
 }
 
 func (m *metricFlinkOperatorWatermarkOutput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operatorNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1705,16 +1705,16 @@ func (m *metricFlinkOperatorWatermarkOutput) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkOperatorWatermarkOutput) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkOperatorWatermarkOutput(settings MetricSettings) metricFlinkOperatorWatermarkOutput {
-	m := metricFlinkOperatorWatermarkOutput{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkOperatorWatermarkOutput(cfg MetricConfig) metricFlinkOperatorWatermarkOutput {
+	m := metricFlinkOperatorWatermarkOutput{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1723,7 +1723,7 @@ func newMetricFlinkOperatorWatermarkOutput(settings MetricSettings) metricFlinkO
 
 type metricFlinkTaskRecordCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1739,7 +1739,7 @@ func (m *metricFlinkTaskRecordCount) init() {
 }
 
 func (m *metricFlinkTaskRecordCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, recordAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1758,16 +1758,16 @@ func (m *metricFlinkTaskRecordCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricFlinkTaskRecordCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricFlinkTaskRecordCount(settings MetricSettings) metricFlinkTaskRecordCount {
-	m := metricFlinkTaskRecordCount{settings: settings}
-	if settings.Enabled {
+func newMetricFlinkTaskRecordCount(cfg MetricConfig) metricFlinkTaskRecordCount {
+	m := metricFlinkTaskRecordCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1776,19 +1776,19 @@ func newMetricFlinkTaskRecordCount(settings MetricSettings) metricFlinkTaskRecor
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                               pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                         int                 // maximum observed number of metrics per resource.
 	resourceCapacity                        int                 // maximum observed number of resource attributes.
 	metricsBuffer                           pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                               component.BuildInfo // contains version information
-	resourceAttributesSettings              ResourceAttributesSettings
+	resourceAttributesConfig                ResourceAttributesConfig
 	metricFlinkJobCheckpointCount           metricFlinkJobCheckpointCount
 	metricFlinkJobCheckpointInProgress      metricFlinkJobCheckpointInProgress
 	metricFlinkJobLastCheckpointSize        metricFlinkJobLastCheckpointSize
@@ -1832,8 +1832,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -1842,7 +1842,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                               pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                           pmetric.NewMetrics(),
 		buildInfo:                               settings.BuildInfo,
-		resourceAttributesSettings:              mbc.ResourceAttributes,
+		resourceAttributesConfig:                mbc.ResourceAttributes,
 		metricFlinkJobCheckpointCount:           newMetricFlinkJobCheckpointCount(mbc.Metrics.FlinkJobCheckpointCount),
 		metricFlinkJobCheckpointInProgress:      newMetricFlinkJobCheckpointInProgress(mbc.Metrics.FlinkJobCheckpointInProgress),
 		metricFlinkJobLastCheckpointSize:        newMetricFlinkJobLastCheckpointSize(mbc.Metrics.FlinkJobLastCheckpointSize),
@@ -1890,35 +1890,35 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithFlinkJobName sets provided value as "flink.job.name" attribute for current resource.
 func WithFlinkJobName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.FlinkJobName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.FlinkJobName.Enabled {
 			rm.Resource().Attributes().PutStr("flink.job.name", val)
 		}
 	}
 }
 
 // WithFlinkResourceTypeJobmanager sets "flink.resource.type=jobmanager" attribute for current resource.
-func WithFlinkResourceTypeJobmanager(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-	if ras.FlinkResourceType.Enabled {
+func WithFlinkResourceTypeJobmanager(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+	if rac.FlinkResourceType.Enabled {
 		rm.Resource().Attributes().PutStr("flink.resource.type", "jobmanager")
 	}
 }
 
 // WithFlinkResourceTypeTaskmanager sets "flink.resource.type=taskmanager" attribute for current resource.
-func WithFlinkResourceTypeTaskmanager(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-	if ras.FlinkResourceType.Enabled {
+func WithFlinkResourceTypeTaskmanager(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+	if rac.FlinkResourceType.Enabled {
 		rm.Resource().Attributes().PutStr("flink.resource.type", "taskmanager")
 	}
 }
 
 // WithFlinkSubtaskIndex sets provided value as "flink.subtask.index" attribute for current resource.
 func WithFlinkSubtaskIndex(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.FlinkSubtaskIndex.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.FlinkSubtaskIndex.Enabled {
 			rm.Resource().Attributes().PutStr("flink.subtask.index", val)
 		}
 	}
@@ -1926,8 +1926,8 @@ func WithFlinkSubtaskIndex(val string) ResourceMetricsOption {
 
 // WithFlinkTaskName sets provided value as "flink.task.name" attribute for current resource.
 func WithFlinkTaskName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.FlinkTaskName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.FlinkTaskName.Enabled {
 			rm.Resource().Attributes().PutStr("flink.task.name", val)
 		}
 	}
@@ -1935,8 +1935,8 @@ func WithFlinkTaskName(val string) ResourceMetricsOption {
 
 // WithFlinkTaskmanagerID sets provided value as "flink.taskmanager.id" attribute for current resource.
 func WithFlinkTaskmanagerID(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.FlinkTaskmanagerID.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.FlinkTaskmanagerID.Enabled {
 			rm.Resource().Attributes().PutStr("flink.taskmanager.id", val)
 		}
 	}
@@ -1944,8 +1944,8 @@ func WithFlinkTaskmanagerID(val string) ResourceMetricsOption {
 
 // WithHostName sets provided value as "host.name" attribute for current resource.
 func WithHostName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.HostName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.HostName.Enabled {
 			rm.Resource().Attributes().PutStr("host.name", val)
 		}
 	}
@@ -1954,7 +1954,7 @@ func WithHostName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -2014,7 +2014,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricFlinkTaskRecordCount.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -2024,7 +2024,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics_test.go
@@ -187,43 +187,43 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("flink.job.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.FlinkJobName.Enabled, ok)
-			if mb.resourceAttributesSettings.FlinkJobName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.FlinkJobName.Enabled, ok)
+			if mb.resourceAttributesConfig.FlinkJobName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("flink.resource.type")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.FlinkResourceType.Enabled, ok)
-			if mb.resourceAttributesSettings.FlinkResourceType.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.FlinkResourceType.Enabled, ok)
+			if mb.resourceAttributesConfig.FlinkResourceType.Enabled {
 				enabledAttrCount++
 				assert.Equal(t, "jobmanager", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("flink.subtask.index")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.FlinkSubtaskIndex.Enabled, ok)
-			if mb.resourceAttributesSettings.FlinkSubtaskIndex.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.FlinkSubtaskIndex.Enabled, ok)
+			if mb.resourceAttributesConfig.FlinkSubtaskIndex.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("flink.task.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.FlinkTaskName.Enabled, ok)
-			if mb.resourceAttributesSettings.FlinkTaskName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.FlinkTaskName.Enabled, ok)
+			if mb.resourceAttributesConfig.FlinkTaskName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("flink.taskmanager.id")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.FlinkTaskmanagerID.Enabled, ok)
-			if mb.resourceAttributesSettings.FlinkTaskmanagerID.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.FlinkTaskmanagerID.Enabled, ok)
+			if mb.resourceAttributesConfig.FlinkTaskmanagerID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("host.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.HostName.Enabled, ok)
-			if mb.resourceAttributesSettings.HostName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.HostName.Enabled, ok)
+			if mb.resourceAttributesConfig.HostName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/haproxyreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/haproxyreceiver/internal/metadata/generated_metrics.go
@@ -14,14 +14,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -33,164 +33,164 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for haproxyreceiver metrics.
-type MetricsSettings struct {
-	HaproxyBytesInput           MetricSettings `mapstructure:"haproxy.bytes.input"`
-	HaproxyBytesOutput          MetricSettings `mapstructure:"haproxy.bytes.output"`
-	HaproxyClientsCanceled      MetricSettings `mapstructure:"haproxy.clients.canceled"`
-	HaproxyCompressionBypass    MetricSettings `mapstructure:"haproxy.compression.bypass"`
-	HaproxyCompressionCount     MetricSettings `mapstructure:"haproxy.compression.count"`
-	HaproxyCompressionInput     MetricSettings `mapstructure:"haproxy.compression.input"`
-	HaproxyCompressionOutput    MetricSettings `mapstructure:"haproxy.compression.output"`
-	HaproxyConnectionsErrors    MetricSettings `mapstructure:"haproxy.connections.errors"`
-	HaproxyConnectionsRate      MetricSettings `mapstructure:"haproxy.connections.rate"`
-	HaproxyConnectionsRetries   MetricSettings `mapstructure:"haproxy.connections.retries"`
-	HaproxyConnectionsTotal     MetricSettings `mapstructure:"haproxy.connections.total"`
-	HaproxyDowntime             MetricSettings `mapstructure:"haproxy.downtime"`
-	HaproxyFailedChecks         MetricSettings `mapstructure:"haproxy.failed_checks"`
-	HaproxyRequestsDenied       MetricSettings `mapstructure:"haproxy.requests.denied"`
-	HaproxyRequestsErrors       MetricSettings `mapstructure:"haproxy.requests.errors"`
-	HaproxyRequestsQueued       MetricSettings `mapstructure:"haproxy.requests.queued"`
-	HaproxyRequestsRate         MetricSettings `mapstructure:"haproxy.requests.rate"`
-	HaproxyRequestsRedispatched MetricSettings `mapstructure:"haproxy.requests.redispatched"`
-	HaproxyRequestsTotal        MetricSettings `mapstructure:"haproxy.requests.total"`
-	HaproxyResponsesDenied      MetricSettings `mapstructure:"haproxy.responses.denied"`
-	HaproxyResponsesErrors      MetricSettings `mapstructure:"haproxy.responses.errors"`
-	HaproxyServerSelectedTotal  MetricSettings `mapstructure:"haproxy.server_selected.total"`
-	HaproxySessionsAverage      MetricSettings `mapstructure:"haproxy.sessions.average"`
-	HaproxySessionsCount        MetricSettings `mapstructure:"haproxy.sessions.count"`
-	HaproxySessionsRate         MetricSettings `mapstructure:"haproxy.sessions.rate"`
-	HaproxySessionsTotal        MetricSettings `mapstructure:"haproxy.sessions.total"`
+// MetricsConfig provides config for haproxyreceiver metrics.
+type MetricsConfig struct {
+	HaproxyBytesInput           MetricConfig `mapstructure:"haproxy.bytes.input"`
+	HaproxyBytesOutput          MetricConfig `mapstructure:"haproxy.bytes.output"`
+	HaproxyClientsCanceled      MetricConfig `mapstructure:"haproxy.clients.canceled"`
+	HaproxyCompressionBypass    MetricConfig `mapstructure:"haproxy.compression.bypass"`
+	HaproxyCompressionCount     MetricConfig `mapstructure:"haproxy.compression.count"`
+	HaproxyCompressionInput     MetricConfig `mapstructure:"haproxy.compression.input"`
+	HaproxyCompressionOutput    MetricConfig `mapstructure:"haproxy.compression.output"`
+	HaproxyConnectionsErrors    MetricConfig `mapstructure:"haproxy.connections.errors"`
+	HaproxyConnectionsRate      MetricConfig `mapstructure:"haproxy.connections.rate"`
+	HaproxyConnectionsRetries   MetricConfig `mapstructure:"haproxy.connections.retries"`
+	HaproxyConnectionsTotal     MetricConfig `mapstructure:"haproxy.connections.total"`
+	HaproxyDowntime             MetricConfig `mapstructure:"haproxy.downtime"`
+	HaproxyFailedChecks         MetricConfig `mapstructure:"haproxy.failed_checks"`
+	HaproxyRequestsDenied       MetricConfig `mapstructure:"haproxy.requests.denied"`
+	HaproxyRequestsErrors       MetricConfig `mapstructure:"haproxy.requests.errors"`
+	HaproxyRequestsQueued       MetricConfig `mapstructure:"haproxy.requests.queued"`
+	HaproxyRequestsRate         MetricConfig `mapstructure:"haproxy.requests.rate"`
+	HaproxyRequestsRedispatched MetricConfig `mapstructure:"haproxy.requests.redispatched"`
+	HaproxyRequestsTotal        MetricConfig `mapstructure:"haproxy.requests.total"`
+	HaproxyResponsesDenied      MetricConfig `mapstructure:"haproxy.responses.denied"`
+	HaproxyResponsesErrors      MetricConfig `mapstructure:"haproxy.responses.errors"`
+	HaproxyServerSelectedTotal  MetricConfig `mapstructure:"haproxy.server_selected.total"`
+	HaproxySessionsAverage      MetricConfig `mapstructure:"haproxy.sessions.average"`
+	HaproxySessionsCount        MetricConfig `mapstructure:"haproxy.sessions.count"`
+	HaproxySessionsRate         MetricConfig `mapstructure:"haproxy.sessions.rate"`
+	HaproxySessionsTotal        MetricConfig `mapstructure:"haproxy.sessions.total"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		HaproxyBytesInput: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		HaproxyBytesInput: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyBytesOutput: MetricSettings{
+		HaproxyBytesOutput: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyClientsCanceled: MetricSettings{
+		HaproxyClientsCanceled: MetricConfig{
 			Enabled: false,
 		},
-		HaproxyCompressionBypass: MetricSettings{
+		HaproxyCompressionBypass: MetricConfig{
 			Enabled: false,
 		},
-		HaproxyCompressionCount: MetricSettings{
+		HaproxyCompressionCount: MetricConfig{
 			Enabled: false,
 		},
-		HaproxyCompressionInput: MetricSettings{
+		HaproxyCompressionInput: MetricConfig{
 			Enabled: false,
 		},
-		HaproxyCompressionOutput: MetricSettings{
+		HaproxyCompressionOutput: MetricConfig{
 			Enabled: false,
 		},
-		HaproxyConnectionsErrors: MetricSettings{
+		HaproxyConnectionsErrors: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyConnectionsRate: MetricSettings{
+		HaproxyConnectionsRate: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyConnectionsRetries: MetricSettings{
+		HaproxyConnectionsRetries: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyConnectionsTotal: MetricSettings{
+		HaproxyConnectionsTotal: MetricConfig{
 			Enabled: false,
 		},
-		HaproxyDowntime: MetricSettings{
+		HaproxyDowntime: MetricConfig{
 			Enabled: false,
 		},
-		HaproxyFailedChecks: MetricSettings{
+		HaproxyFailedChecks: MetricConfig{
 			Enabled: false,
 		},
-		HaproxyRequestsDenied: MetricSettings{
+		HaproxyRequestsDenied: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyRequestsErrors: MetricSettings{
+		HaproxyRequestsErrors: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyRequestsQueued: MetricSettings{
+		HaproxyRequestsQueued: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyRequestsRate: MetricSettings{
+		HaproxyRequestsRate: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyRequestsRedispatched: MetricSettings{
+		HaproxyRequestsRedispatched: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyRequestsTotal: MetricSettings{
+		HaproxyRequestsTotal: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyResponsesDenied: MetricSettings{
+		HaproxyResponsesDenied: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyResponsesErrors: MetricSettings{
+		HaproxyResponsesErrors: MetricConfig{
 			Enabled: true,
 		},
-		HaproxyServerSelectedTotal: MetricSettings{
+		HaproxyServerSelectedTotal: MetricConfig{
 			Enabled: true,
 		},
-		HaproxySessionsAverage: MetricSettings{
+		HaproxySessionsAverage: MetricConfig{
 			Enabled: true,
 		},
-		HaproxySessionsCount: MetricSettings{
+		HaproxySessionsCount: MetricConfig{
 			Enabled: true,
 		},
-		HaproxySessionsRate: MetricSettings{
+		HaproxySessionsRate: MetricConfig{
 			Enabled: true,
 		},
-		HaproxySessionsTotal: MetricSettings{
+		HaproxySessionsTotal: MetricConfig{
 			Enabled: false,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for haproxyreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	HaproxyAddr ResourceAttributeSettings `mapstructure:"haproxy.addr"`
-	HaproxyAlgo ResourceAttributeSettings `mapstructure:"haproxy.algo"`
-	HaproxyIid  ResourceAttributeSettings `mapstructure:"haproxy.iid"`
-	HaproxyPid  ResourceAttributeSettings `mapstructure:"haproxy.pid"`
-	HaproxySid  ResourceAttributeSettings `mapstructure:"haproxy.sid"`
-	HaproxyType ResourceAttributeSettings `mapstructure:"haproxy.type"`
-	HaproxyURL  ResourceAttributeSettings `mapstructure:"haproxy.url"`
-	ProxyName   ResourceAttributeSettings `mapstructure:"proxy_name"`
-	ServiceName ResourceAttributeSettings `mapstructure:"service_name"`
+// ResourceAttributesConfig provides config for haproxyreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	HaproxyAddr ResourceAttributeConfig `mapstructure:"haproxy.addr"`
+	HaproxyAlgo ResourceAttributeConfig `mapstructure:"haproxy.algo"`
+	HaproxyIid  ResourceAttributeConfig `mapstructure:"haproxy.iid"`
+	HaproxyPid  ResourceAttributeConfig `mapstructure:"haproxy.pid"`
+	HaproxySid  ResourceAttributeConfig `mapstructure:"haproxy.sid"`
+	HaproxyType ResourceAttributeConfig `mapstructure:"haproxy.type"`
+	HaproxyURL  ResourceAttributeConfig `mapstructure:"haproxy.url"`
+	ProxyName   ResourceAttributeConfig `mapstructure:"proxy_name"`
+	ServiceName ResourceAttributeConfig `mapstructure:"service_name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		HaproxyAddr: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		HaproxyAddr: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		HaproxyAlgo: ResourceAttributeSettings{
+		HaproxyAlgo: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		HaproxyIid: ResourceAttributeSettings{
+		HaproxyIid: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		HaproxyPid: ResourceAttributeSettings{
+		HaproxyPid: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		HaproxySid: ResourceAttributeSettings{
+		HaproxySid: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		HaproxyType: ResourceAttributeSettings{
+		HaproxyType: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		HaproxyURL: ResourceAttributeSettings{
+		HaproxyURL: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ProxyName: ResourceAttributeSettings{
+		ProxyName: ResourceAttributeConfig{
 			Enabled: false,
 		},
-		ServiceName: ResourceAttributeSettings{
+		ServiceName: ResourceAttributeConfig{
 			Enabled: false,
 		},
 	}
@@ -240,7 +240,7 @@ var MapAttributeStatusCode = map[string]AttributeStatusCode{
 
 type metricHaproxyBytesInput struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -255,7 +255,7 @@ func (m *metricHaproxyBytesInput) init() {
 }
 
 func (m *metricHaproxyBytesInput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -273,16 +273,16 @@ func (m *metricHaproxyBytesInput) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyBytesInput) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyBytesInput(settings MetricSettings) metricHaproxyBytesInput {
-	m := metricHaproxyBytesInput{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyBytesInput(cfg MetricConfig) metricHaproxyBytesInput {
+	m := metricHaproxyBytesInput{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -291,7 +291,7 @@ func newMetricHaproxyBytesInput(settings MetricSettings) metricHaproxyBytesInput
 
 type metricHaproxyBytesOutput struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -306,7 +306,7 @@ func (m *metricHaproxyBytesOutput) init() {
 }
 
 func (m *metricHaproxyBytesOutput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -324,16 +324,16 @@ func (m *metricHaproxyBytesOutput) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyBytesOutput) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyBytesOutput(settings MetricSettings) metricHaproxyBytesOutput {
-	m := metricHaproxyBytesOutput{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyBytesOutput(cfg MetricConfig) metricHaproxyBytesOutput {
+	m := metricHaproxyBytesOutput{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -342,7 +342,7 @@ func newMetricHaproxyBytesOutput(settings MetricSettings) metricHaproxyBytesOutp
 
 type metricHaproxyClientsCanceled struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -357,7 +357,7 @@ func (m *metricHaproxyClientsCanceled) init() {
 }
 
 func (m *metricHaproxyClientsCanceled) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -375,16 +375,16 @@ func (m *metricHaproxyClientsCanceled) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyClientsCanceled) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyClientsCanceled(settings MetricSettings) metricHaproxyClientsCanceled {
-	m := metricHaproxyClientsCanceled{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyClientsCanceled(cfg MetricConfig) metricHaproxyClientsCanceled {
+	m := metricHaproxyClientsCanceled{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -393,7 +393,7 @@ func newMetricHaproxyClientsCanceled(settings MetricSettings) metricHaproxyClien
 
 type metricHaproxyCompressionBypass struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -408,7 +408,7 @@ func (m *metricHaproxyCompressionBypass) init() {
 }
 
 func (m *metricHaproxyCompressionBypass) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -426,16 +426,16 @@ func (m *metricHaproxyCompressionBypass) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyCompressionBypass) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyCompressionBypass(settings MetricSettings) metricHaproxyCompressionBypass {
-	m := metricHaproxyCompressionBypass{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyCompressionBypass(cfg MetricConfig) metricHaproxyCompressionBypass {
+	m := metricHaproxyCompressionBypass{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -444,7 +444,7 @@ func newMetricHaproxyCompressionBypass(settings MetricSettings) metricHaproxyCom
 
 type metricHaproxyCompressionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -459,7 +459,7 @@ func (m *metricHaproxyCompressionCount) init() {
 }
 
 func (m *metricHaproxyCompressionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -477,16 +477,16 @@ func (m *metricHaproxyCompressionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyCompressionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyCompressionCount(settings MetricSettings) metricHaproxyCompressionCount {
-	m := metricHaproxyCompressionCount{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyCompressionCount(cfg MetricConfig) metricHaproxyCompressionCount {
+	m := metricHaproxyCompressionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -495,7 +495,7 @@ func newMetricHaproxyCompressionCount(settings MetricSettings) metricHaproxyComp
 
 type metricHaproxyCompressionInput struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -510,7 +510,7 @@ func (m *metricHaproxyCompressionInput) init() {
 }
 
 func (m *metricHaproxyCompressionInput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -528,16 +528,16 @@ func (m *metricHaproxyCompressionInput) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyCompressionInput) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyCompressionInput(settings MetricSettings) metricHaproxyCompressionInput {
-	m := metricHaproxyCompressionInput{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyCompressionInput(cfg MetricConfig) metricHaproxyCompressionInput {
+	m := metricHaproxyCompressionInput{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -546,7 +546,7 @@ func newMetricHaproxyCompressionInput(settings MetricSettings) metricHaproxyComp
 
 type metricHaproxyCompressionOutput struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -561,7 +561,7 @@ func (m *metricHaproxyCompressionOutput) init() {
 }
 
 func (m *metricHaproxyCompressionOutput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -579,16 +579,16 @@ func (m *metricHaproxyCompressionOutput) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyCompressionOutput) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyCompressionOutput(settings MetricSettings) metricHaproxyCompressionOutput {
-	m := metricHaproxyCompressionOutput{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyCompressionOutput(cfg MetricConfig) metricHaproxyCompressionOutput {
+	m := metricHaproxyCompressionOutput{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -597,7 +597,7 @@ func newMetricHaproxyCompressionOutput(settings MetricSettings) metricHaproxyCom
 
 type metricHaproxyConnectionsErrors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -612,7 +612,7 @@ func (m *metricHaproxyConnectionsErrors) init() {
 }
 
 func (m *metricHaproxyConnectionsErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -630,16 +630,16 @@ func (m *metricHaproxyConnectionsErrors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyConnectionsErrors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyConnectionsErrors(settings MetricSettings) metricHaproxyConnectionsErrors {
-	m := metricHaproxyConnectionsErrors{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyConnectionsErrors(cfg MetricConfig) metricHaproxyConnectionsErrors {
+	m := metricHaproxyConnectionsErrors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -648,7 +648,7 @@ func newMetricHaproxyConnectionsErrors(settings MetricSettings) metricHaproxyCon
 
 type metricHaproxyConnectionsRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -661,7 +661,7 @@ func (m *metricHaproxyConnectionsRate) init() {
 }
 
 func (m *metricHaproxyConnectionsRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -679,16 +679,16 @@ func (m *metricHaproxyConnectionsRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyConnectionsRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyConnectionsRate(settings MetricSettings) metricHaproxyConnectionsRate {
-	m := metricHaproxyConnectionsRate{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyConnectionsRate(cfg MetricConfig) metricHaproxyConnectionsRate {
+	m := metricHaproxyConnectionsRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -697,7 +697,7 @@ func newMetricHaproxyConnectionsRate(settings MetricSettings) metricHaproxyConne
 
 type metricHaproxyConnectionsRetries struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -712,7 +712,7 @@ func (m *metricHaproxyConnectionsRetries) init() {
 }
 
 func (m *metricHaproxyConnectionsRetries) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -730,16 +730,16 @@ func (m *metricHaproxyConnectionsRetries) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyConnectionsRetries) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyConnectionsRetries(settings MetricSettings) metricHaproxyConnectionsRetries {
-	m := metricHaproxyConnectionsRetries{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyConnectionsRetries(cfg MetricConfig) metricHaproxyConnectionsRetries {
+	m := metricHaproxyConnectionsRetries{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -748,7 +748,7 @@ func newMetricHaproxyConnectionsRetries(settings MetricSettings) metricHaproxyCo
 
 type metricHaproxyConnectionsTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -763,7 +763,7 @@ func (m *metricHaproxyConnectionsTotal) init() {
 }
 
 func (m *metricHaproxyConnectionsTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -781,16 +781,16 @@ func (m *metricHaproxyConnectionsTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyConnectionsTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyConnectionsTotal(settings MetricSettings) metricHaproxyConnectionsTotal {
-	m := metricHaproxyConnectionsTotal{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyConnectionsTotal(cfg MetricConfig) metricHaproxyConnectionsTotal {
+	m := metricHaproxyConnectionsTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -799,7 +799,7 @@ func newMetricHaproxyConnectionsTotal(settings MetricSettings) metricHaproxyConn
 
 type metricHaproxyDowntime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -814,7 +814,7 @@ func (m *metricHaproxyDowntime) init() {
 }
 
 func (m *metricHaproxyDowntime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -832,16 +832,16 @@ func (m *metricHaproxyDowntime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyDowntime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyDowntime(settings MetricSettings) metricHaproxyDowntime {
-	m := metricHaproxyDowntime{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyDowntime(cfg MetricConfig) metricHaproxyDowntime {
+	m := metricHaproxyDowntime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -850,7 +850,7 @@ func newMetricHaproxyDowntime(settings MetricSettings) metricHaproxyDowntime {
 
 type metricHaproxyFailedChecks struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -865,7 +865,7 @@ func (m *metricHaproxyFailedChecks) init() {
 }
 
 func (m *metricHaproxyFailedChecks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -883,16 +883,16 @@ func (m *metricHaproxyFailedChecks) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyFailedChecks) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyFailedChecks(settings MetricSettings) metricHaproxyFailedChecks {
-	m := metricHaproxyFailedChecks{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyFailedChecks(cfg MetricConfig) metricHaproxyFailedChecks {
+	m := metricHaproxyFailedChecks{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -901,7 +901,7 @@ func newMetricHaproxyFailedChecks(settings MetricSettings) metricHaproxyFailedCh
 
 type metricHaproxyRequestsDenied struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -916,7 +916,7 @@ func (m *metricHaproxyRequestsDenied) init() {
 }
 
 func (m *metricHaproxyRequestsDenied) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -934,16 +934,16 @@ func (m *metricHaproxyRequestsDenied) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyRequestsDenied) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyRequestsDenied(settings MetricSettings) metricHaproxyRequestsDenied {
-	m := metricHaproxyRequestsDenied{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyRequestsDenied(cfg MetricConfig) metricHaproxyRequestsDenied {
+	m := metricHaproxyRequestsDenied{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -952,7 +952,7 @@ func newMetricHaproxyRequestsDenied(settings MetricSettings) metricHaproxyReques
 
 type metricHaproxyRequestsErrors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -967,7 +967,7 @@ func (m *metricHaproxyRequestsErrors) init() {
 }
 
 func (m *metricHaproxyRequestsErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -985,16 +985,16 @@ func (m *metricHaproxyRequestsErrors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyRequestsErrors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyRequestsErrors(settings MetricSettings) metricHaproxyRequestsErrors {
-	m := metricHaproxyRequestsErrors{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyRequestsErrors(cfg MetricConfig) metricHaproxyRequestsErrors {
+	m := metricHaproxyRequestsErrors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1003,7 +1003,7 @@ func newMetricHaproxyRequestsErrors(settings MetricSettings) metricHaproxyReques
 
 type metricHaproxyRequestsQueued struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1018,7 +1018,7 @@ func (m *metricHaproxyRequestsQueued) init() {
 }
 
 func (m *metricHaproxyRequestsQueued) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1036,16 +1036,16 @@ func (m *metricHaproxyRequestsQueued) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyRequestsQueued) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyRequestsQueued(settings MetricSettings) metricHaproxyRequestsQueued {
-	m := metricHaproxyRequestsQueued{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyRequestsQueued(cfg MetricConfig) metricHaproxyRequestsQueued {
+	m := metricHaproxyRequestsQueued{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1054,7 +1054,7 @@ func newMetricHaproxyRequestsQueued(settings MetricSettings) metricHaproxyReques
 
 type metricHaproxyRequestsRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1067,7 +1067,7 @@ func (m *metricHaproxyRequestsRate) init() {
 }
 
 func (m *metricHaproxyRequestsRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1085,16 +1085,16 @@ func (m *metricHaproxyRequestsRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyRequestsRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyRequestsRate(settings MetricSettings) metricHaproxyRequestsRate {
-	m := metricHaproxyRequestsRate{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyRequestsRate(cfg MetricConfig) metricHaproxyRequestsRate {
+	m := metricHaproxyRequestsRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1103,7 +1103,7 @@ func newMetricHaproxyRequestsRate(settings MetricSettings) metricHaproxyRequests
 
 type metricHaproxyRequestsRedispatched struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1118,7 +1118,7 @@ func (m *metricHaproxyRequestsRedispatched) init() {
 }
 
 func (m *metricHaproxyRequestsRedispatched) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1136,16 +1136,16 @@ func (m *metricHaproxyRequestsRedispatched) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyRequestsRedispatched) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyRequestsRedispatched(settings MetricSettings) metricHaproxyRequestsRedispatched {
-	m := metricHaproxyRequestsRedispatched{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyRequestsRedispatched(cfg MetricConfig) metricHaproxyRequestsRedispatched {
+	m := metricHaproxyRequestsRedispatched{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1154,7 +1154,7 @@ func newMetricHaproxyRequestsRedispatched(settings MetricSettings) metricHaproxy
 
 type metricHaproxyRequestsTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1170,7 +1170,7 @@ func (m *metricHaproxyRequestsTotal) init() {
 }
 
 func (m *metricHaproxyRequestsTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, statusCodeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1189,16 +1189,16 @@ func (m *metricHaproxyRequestsTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyRequestsTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyRequestsTotal(settings MetricSettings) metricHaproxyRequestsTotal {
-	m := metricHaproxyRequestsTotal{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyRequestsTotal(cfg MetricConfig) metricHaproxyRequestsTotal {
+	m := metricHaproxyRequestsTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1207,7 +1207,7 @@ func newMetricHaproxyRequestsTotal(settings MetricSettings) metricHaproxyRequest
 
 type metricHaproxyResponsesDenied struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1222,7 +1222,7 @@ func (m *metricHaproxyResponsesDenied) init() {
 }
 
 func (m *metricHaproxyResponsesDenied) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1240,16 +1240,16 @@ func (m *metricHaproxyResponsesDenied) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyResponsesDenied) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyResponsesDenied(settings MetricSettings) metricHaproxyResponsesDenied {
-	m := metricHaproxyResponsesDenied{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyResponsesDenied(cfg MetricConfig) metricHaproxyResponsesDenied {
+	m := metricHaproxyResponsesDenied{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1258,7 +1258,7 @@ func newMetricHaproxyResponsesDenied(settings MetricSettings) metricHaproxyRespo
 
 type metricHaproxyResponsesErrors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1273,7 +1273,7 @@ func (m *metricHaproxyResponsesErrors) init() {
 }
 
 func (m *metricHaproxyResponsesErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1291,16 +1291,16 @@ func (m *metricHaproxyResponsesErrors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyResponsesErrors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyResponsesErrors(settings MetricSettings) metricHaproxyResponsesErrors {
-	m := metricHaproxyResponsesErrors{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyResponsesErrors(cfg MetricConfig) metricHaproxyResponsesErrors {
+	m := metricHaproxyResponsesErrors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1309,7 +1309,7 @@ func newMetricHaproxyResponsesErrors(settings MetricSettings) metricHaproxyRespo
 
 type metricHaproxyServerSelectedTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1324,7 +1324,7 @@ func (m *metricHaproxyServerSelectedTotal) init() {
 }
 
 func (m *metricHaproxyServerSelectedTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1342,16 +1342,16 @@ func (m *metricHaproxyServerSelectedTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxyServerSelectedTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxyServerSelectedTotal(settings MetricSettings) metricHaproxyServerSelectedTotal {
-	m := metricHaproxyServerSelectedTotal{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxyServerSelectedTotal(cfg MetricConfig) metricHaproxyServerSelectedTotal {
+	m := metricHaproxyServerSelectedTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1360,7 +1360,7 @@ func newMetricHaproxyServerSelectedTotal(settings MetricSettings) metricHaproxyS
 
 type metricHaproxySessionsAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1373,7 +1373,7 @@ func (m *metricHaproxySessionsAverage) init() {
 }
 
 func (m *metricHaproxySessionsAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1391,16 +1391,16 @@ func (m *metricHaproxySessionsAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxySessionsAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxySessionsAverage(settings MetricSettings) metricHaproxySessionsAverage {
-	m := metricHaproxySessionsAverage{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxySessionsAverage(cfg MetricConfig) metricHaproxySessionsAverage {
+	m := metricHaproxySessionsAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1409,7 +1409,7 @@ func newMetricHaproxySessionsAverage(settings MetricSettings) metricHaproxySessi
 
 type metricHaproxySessionsCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1422,7 +1422,7 @@ func (m *metricHaproxySessionsCount) init() {
 }
 
 func (m *metricHaproxySessionsCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1440,16 +1440,16 @@ func (m *metricHaproxySessionsCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxySessionsCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxySessionsCount(settings MetricSettings) metricHaproxySessionsCount {
-	m := metricHaproxySessionsCount{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxySessionsCount(cfg MetricConfig) metricHaproxySessionsCount {
+	m := metricHaproxySessionsCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1458,7 +1458,7 @@ func newMetricHaproxySessionsCount(settings MetricSettings) metricHaproxySession
 
 type metricHaproxySessionsRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1471,7 +1471,7 @@ func (m *metricHaproxySessionsRate) init() {
 }
 
 func (m *metricHaproxySessionsRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1489,16 +1489,16 @@ func (m *metricHaproxySessionsRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxySessionsRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxySessionsRate(settings MetricSettings) metricHaproxySessionsRate {
-	m := metricHaproxySessionsRate{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxySessionsRate(cfg MetricConfig) metricHaproxySessionsRate {
+	m := metricHaproxySessionsRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1507,7 +1507,7 @@ func newMetricHaproxySessionsRate(settings MetricSettings) metricHaproxySessions
 
 type metricHaproxySessionsTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1522,7 +1522,7 @@ func (m *metricHaproxySessionsTotal) init() {
 }
 
 func (m *metricHaproxySessionsTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1540,16 +1540,16 @@ func (m *metricHaproxySessionsTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHaproxySessionsTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHaproxySessionsTotal(settings MetricSettings) metricHaproxySessionsTotal {
-	m := metricHaproxySessionsTotal{settings: settings}
-	if settings.Enabled {
+func newMetricHaproxySessionsTotal(cfg MetricConfig) metricHaproxySessionsTotal {
+	m := metricHaproxySessionsTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1558,19 +1558,19 @@ func newMetricHaproxySessionsTotal(settings MetricSettings) metricHaproxySession
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                         pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                   int                 // maximum observed number of metrics per resource.
 	resourceCapacity                  int                 // maximum observed number of resource attributes.
 	metricsBuffer                     pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                         component.BuildInfo // contains version information
-	resourceAttributesSettings        ResourceAttributesSettings
+	resourceAttributesConfig          ResourceAttributesConfig
 	metricHaproxyBytesInput           metricHaproxyBytesInput
 	metricHaproxyBytesOutput          metricHaproxyBytesOutput
 	metricHaproxyClientsCanceled      metricHaproxyClientsCanceled
@@ -1611,8 +1611,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -1621,7 +1621,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                         pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                     pmetric.NewMetrics(),
 		buildInfo:                         settings.BuildInfo,
-		resourceAttributesSettings:        mbc.ResourceAttributes,
+		resourceAttributesConfig:          mbc.ResourceAttributes,
 		metricHaproxyBytesInput:           newMetricHaproxyBytesInput(mbc.Metrics.HaproxyBytesInput),
 		metricHaproxyBytesOutput:          newMetricHaproxyBytesOutput(mbc.Metrics.HaproxyBytesOutput),
 		metricHaproxyClientsCanceled:      newMetricHaproxyClientsCanceled(mbc.Metrics.HaproxyClientsCanceled),
@@ -1666,12 +1666,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithHaproxyAddr sets provided value as "haproxy.addr" attribute for current resource.
 func WithHaproxyAddr(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.HaproxyAddr.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.HaproxyAddr.Enabled {
 			rm.Resource().Attributes().PutStr("haproxy.addr", val)
 		}
 	}
@@ -1679,8 +1679,8 @@ func WithHaproxyAddr(val string) ResourceMetricsOption {
 
 // WithHaproxyAlgo sets provided value as "haproxy.algo" attribute for current resource.
 func WithHaproxyAlgo(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.HaproxyAlgo.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.HaproxyAlgo.Enabled {
 			rm.Resource().Attributes().PutStr("haproxy.algo", val)
 		}
 	}
@@ -1688,8 +1688,8 @@ func WithHaproxyAlgo(val string) ResourceMetricsOption {
 
 // WithHaproxyIid sets provided value as "haproxy.iid" attribute for current resource.
 func WithHaproxyIid(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.HaproxyIid.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.HaproxyIid.Enabled {
 			rm.Resource().Attributes().PutStr("haproxy.iid", val)
 		}
 	}
@@ -1697,8 +1697,8 @@ func WithHaproxyIid(val string) ResourceMetricsOption {
 
 // WithHaproxyPid sets provided value as "haproxy.pid" attribute for current resource.
 func WithHaproxyPid(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.HaproxyPid.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.HaproxyPid.Enabled {
 			rm.Resource().Attributes().PutStr("haproxy.pid", val)
 		}
 	}
@@ -1706,8 +1706,8 @@ func WithHaproxyPid(val string) ResourceMetricsOption {
 
 // WithHaproxySid sets provided value as "haproxy.sid" attribute for current resource.
 func WithHaproxySid(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.HaproxySid.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.HaproxySid.Enabled {
 			rm.Resource().Attributes().PutStr("haproxy.sid", val)
 		}
 	}
@@ -1715,8 +1715,8 @@ func WithHaproxySid(val string) ResourceMetricsOption {
 
 // WithHaproxyType sets provided value as "haproxy.type" attribute for current resource.
 func WithHaproxyType(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.HaproxyType.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.HaproxyType.Enabled {
 			rm.Resource().Attributes().PutStr("haproxy.type", val)
 		}
 	}
@@ -1724,8 +1724,8 @@ func WithHaproxyType(val string) ResourceMetricsOption {
 
 // WithHaproxyURL sets provided value as "haproxy.url" attribute for current resource.
 func WithHaproxyURL(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.HaproxyURL.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.HaproxyURL.Enabled {
 			rm.Resource().Attributes().PutStr("haproxy.url", val)
 		}
 	}
@@ -1733,8 +1733,8 @@ func WithHaproxyURL(val string) ResourceMetricsOption {
 
 // WithProxyName sets provided value as "proxy_name" attribute for current resource.
 func WithProxyName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ProxyName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ProxyName.Enabled {
 			rm.Resource().Attributes().PutStr("proxy_name", val)
 		}
 	}
@@ -1742,8 +1742,8 @@ func WithProxyName(val string) ResourceMetricsOption {
 
 // WithServiceName sets provided value as "service_name" attribute for current resource.
 func WithServiceName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ServiceName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ServiceName.Enabled {
 			rm.Resource().Attributes().PutStr("service_name", val)
 		}
 	}
@@ -1752,7 +1752,7 @@ func WithServiceName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -1809,7 +1809,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricHaproxySessionsTotal.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -1819,7 +1819,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/haproxyreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/haproxyreceiver/internal/metadata/generated_metrics_test.go
@@ -166,64 +166,64 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("haproxy.addr")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.HaproxyAddr.Enabled, ok)
-			if mb.resourceAttributesSettings.HaproxyAddr.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.HaproxyAddr.Enabled, ok)
+			if mb.resourceAttributesConfig.HaproxyAddr.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("haproxy.algo")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.HaproxyAlgo.Enabled, ok)
-			if mb.resourceAttributesSettings.HaproxyAlgo.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.HaproxyAlgo.Enabled, ok)
+			if mb.resourceAttributesConfig.HaproxyAlgo.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("haproxy.iid")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.HaproxyIid.Enabled, ok)
-			if mb.resourceAttributesSettings.HaproxyIid.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.HaproxyIid.Enabled, ok)
+			if mb.resourceAttributesConfig.HaproxyIid.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("haproxy.pid")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.HaproxyPid.Enabled, ok)
-			if mb.resourceAttributesSettings.HaproxyPid.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.HaproxyPid.Enabled, ok)
+			if mb.resourceAttributesConfig.HaproxyPid.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("haproxy.sid")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.HaproxySid.Enabled, ok)
-			if mb.resourceAttributesSettings.HaproxySid.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.HaproxySid.Enabled, ok)
+			if mb.resourceAttributesConfig.HaproxySid.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("haproxy.type")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.HaproxyType.Enabled, ok)
-			if mb.resourceAttributesSettings.HaproxyType.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.HaproxyType.Enabled, ok)
+			if mb.resourceAttributesConfig.HaproxyType.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("haproxy.url")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.HaproxyURL.Enabled, ok)
-			if mb.resourceAttributesSettings.HaproxyURL.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.HaproxyURL.Enabled, ok)
+			if mb.resourceAttributesConfig.HaproxyURL.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("proxy_name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ProxyName.Enabled, ok)
-			if mb.resourceAttributesSettings.ProxyName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ProxyName.Enabled, ok)
+			if mb.resourceAttributesConfig.ProxyName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("service_name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ServiceName.Enabled, ok)
-			if mb.resourceAttributesSettings.ServiceName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ServiceName.Enabled, ok)
+			if mb.resourceAttributesConfig.ServiceName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -178,7 +178,7 @@ func TestScrape_CpuUtilization(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			settings := test.metricsConfig
-			if test.metricsConfig.Metrics == (metadata.MetricsSettings{}) {
+			if test.metricsConfig.Metrics == (metadata.MetricsConfig{}) {
 				settings = metadata.DefaultMetricsBuilderConfig()
 				settings.Metrics.SystemCPUTime.Enabled = test.times
 				settings.Metrics.SystemCPUUtilization.Enabled = test.utilization

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
@@ -13,14 +13,14 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -32,18 +32,18 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for hostmetricsreceiver/cpu metrics.
-type MetricsSettings struct {
-	SystemCPUTime        MetricSettings `mapstructure:"system.cpu.time"`
-	SystemCPUUtilization MetricSettings `mapstructure:"system.cpu.utilization"`
+// MetricsConfig provides config for hostmetricsreceiver/cpu metrics.
+type MetricsConfig struct {
+	SystemCPUTime        MetricConfig `mapstructure:"system.cpu.time"`
+	SystemCPUUtilization MetricConfig `mapstructure:"system.cpu.utilization"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		SystemCPUTime: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		SystemCPUTime: MetricConfig{
 			Enabled: true,
 		},
-		SystemCPUUtilization: MetricSettings{
+		SystemCPUUtilization: MetricConfig{
 			Enabled: false,
 		},
 	}
@@ -101,7 +101,7 @@ var MapAttributeState = map[string]AttributeState{
 
 type metricSystemCPUTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -117,7 +117,7 @@ func (m *metricSystemCPUTime) init() {
 }
 
 func (m *metricSystemCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -137,16 +137,16 @@ func (m *metricSystemCPUTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemCPUTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemCPUTime(settings MetricSettings) metricSystemCPUTime {
-	m := metricSystemCPUTime{settings: settings}
-	if settings.Enabled {
+func newMetricSystemCPUTime(cfg MetricConfig) metricSystemCPUTime {
+	m := metricSystemCPUTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -155,7 +155,7 @@ func newMetricSystemCPUTime(settings MetricSettings) metricSystemCPUTime {
 
 type metricSystemCPUUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -169,7 +169,7 @@ func (m *metricSystemCPUUtilization) init() {
 }
 
 func (m *metricSystemCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuAttributeValue string, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -189,16 +189,16 @@ func (m *metricSystemCPUUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemCPUUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemCPUUtilization(settings MetricSettings) metricSystemCPUUtilization {
-	m := metricSystemCPUUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricSystemCPUUtilization(cfg MetricConfig) metricSystemCPUUtilization {
+	m := metricSystemCPUUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -207,11 +207,11 @@ func newMetricSystemCPUUtilization(settings MetricSettings) metricSystemCPUUtili
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics MetricsSettings `mapstructure:"metrics"`
+	Metrics MetricsConfig `mapstructure:"metrics"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                  pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity            int                 // maximum observed number of metrics per resource.
@@ -234,7 +234,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics: DefaultMetricsSettings(),
+		Metrics: DefaultMetricsConfig(),
 	}
 }
 
@@ -312,7 +312,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
@@ -13,14 +13,14 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -32,22 +32,22 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for hostmetricsreceiver/filesystem metrics.
-type MetricsSettings struct {
-	SystemFilesystemInodesUsage MetricSettings `mapstructure:"system.filesystem.inodes.usage"`
-	SystemFilesystemUsage       MetricSettings `mapstructure:"system.filesystem.usage"`
-	SystemFilesystemUtilization MetricSettings `mapstructure:"system.filesystem.utilization"`
+// MetricsConfig provides config for hostmetricsreceiver/filesystem metrics.
+type MetricsConfig struct {
+	SystemFilesystemInodesUsage MetricConfig `mapstructure:"system.filesystem.inodes.usage"`
+	SystemFilesystemUsage       MetricConfig `mapstructure:"system.filesystem.usage"`
+	SystemFilesystemUtilization MetricConfig `mapstructure:"system.filesystem.utilization"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		SystemFilesystemInodesUsage: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		SystemFilesystemInodesUsage: MetricConfig{
 			Enabled: true,
 		},
-		SystemFilesystemUsage: MetricSettings{
+		SystemFilesystemUsage: MetricConfig{
 			Enabled: true,
 		},
-		SystemFilesystemUtilization: MetricSettings{
+		SystemFilesystemUtilization: MetricConfig{
 			Enabled: false,
 		},
 	}
@@ -85,7 +85,7 @@ var MapAttributeState = map[string]AttributeState{
 
 type metricSystemFilesystemInodesUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -101,7 +101,7 @@ func (m *metricSystemFilesystemInodesUsage) init() {
 }
 
 func (m *metricSystemFilesystemInodesUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceAttributeValue string, modeAttributeValue string, mountpointAttributeValue string, typeAttributeValue string, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -124,16 +124,16 @@ func (m *metricSystemFilesystemInodesUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemFilesystemInodesUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemFilesystemInodesUsage(settings MetricSettings) metricSystemFilesystemInodesUsage {
-	m := metricSystemFilesystemInodesUsage{settings: settings}
-	if settings.Enabled {
+func newMetricSystemFilesystemInodesUsage(cfg MetricConfig) metricSystemFilesystemInodesUsage {
+	m := metricSystemFilesystemInodesUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -142,7 +142,7 @@ func newMetricSystemFilesystemInodesUsage(settings MetricSettings) metricSystemF
 
 type metricSystemFilesystemUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -158,7 +158,7 @@ func (m *metricSystemFilesystemUsage) init() {
 }
 
 func (m *metricSystemFilesystemUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceAttributeValue string, modeAttributeValue string, mountpointAttributeValue string, typeAttributeValue string, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -181,16 +181,16 @@ func (m *metricSystemFilesystemUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemFilesystemUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemFilesystemUsage(settings MetricSettings) metricSystemFilesystemUsage {
-	m := metricSystemFilesystemUsage{settings: settings}
-	if settings.Enabled {
+func newMetricSystemFilesystemUsage(cfg MetricConfig) metricSystemFilesystemUsage {
+	m := metricSystemFilesystemUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -199,7 +199,7 @@ func newMetricSystemFilesystemUsage(settings MetricSettings) metricSystemFilesys
 
 type metricSystemFilesystemUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -213,7 +213,7 @@ func (m *metricSystemFilesystemUtilization) init() {
 }
 
 func (m *metricSystemFilesystemUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, deviceAttributeValue string, modeAttributeValue string, mountpointAttributeValue string, typeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -235,16 +235,16 @@ func (m *metricSystemFilesystemUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemFilesystemUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemFilesystemUtilization(settings MetricSettings) metricSystemFilesystemUtilization {
-	m := metricSystemFilesystemUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricSystemFilesystemUtilization(cfg MetricConfig) metricSystemFilesystemUtilization {
+	m := metricSystemFilesystemUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -253,11 +253,11 @@ func newMetricSystemFilesystemUtilization(settings MetricSettings) metricSystemF
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics MetricsSettings `mapstructure:"metrics"`
+	Metrics MetricsConfig `mapstructure:"metrics"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                         pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                   int                 // maximum observed number of metrics per resource.
@@ -281,7 +281,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics: DefaultMetricsSettings(),
+		Metrics: DefaultMetricsConfig(),
 	}
 }
 
@@ -361,7 +361,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
@@ -13,14 +13,14 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -32,22 +32,22 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for hostmetricsreceiver/load metrics.
-type MetricsSettings struct {
-	SystemCPULoadAverage15m MetricSettings `mapstructure:"system.cpu.load_average.15m"`
-	SystemCPULoadAverage1m  MetricSettings `mapstructure:"system.cpu.load_average.1m"`
-	SystemCPULoadAverage5m  MetricSettings `mapstructure:"system.cpu.load_average.5m"`
+// MetricsConfig provides config for hostmetricsreceiver/load metrics.
+type MetricsConfig struct {
+	SystemCPULoadAverage15m MetricConfig `mapstructure:"system.cpu.load_average.15m"`
+	SystemCPULoadAverage1m  MetricConfig `mapstructure:"system.cpu.load_average.1m"`
+	SystemCPULoadAverage5m  MetricConfig `mapstructure:"system.cpu.load_average.5m"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		SystemCPULoadAverage15m: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		SystemCPULoadAverage15m: MetricConfig{
 			Enabled: true,
 		},
-		SystemCPULoadAverage1m: MetricSettings{
+		SystemCPULoadAverage1m: MetricConfig{
 			Enabled: true,
 		},
-		SystemCPULoadAverage5m: MetricSettings{
+		SystemCPULoadAverage5m: MetricConfig{
 			Enabled: true,
 		},
 	}
@@ -55,7 +55,7 @@ func DefaultMetricsSettings() MetricsSettings {
 
 type metricSystemCPULoadAverage15m struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -68,7 +68,7 @@ func (m *metricSystemCPULoadAverage15m) init() {
 }
 
 func (m *metricSystemCPULoadAverage15m) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -86,16 +86,16 @@ func (m *metricSystemCPULoadAverage15m) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemCPULoadAverage15m) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemCPULoadAverage15m(settings MetricSettings) metricSystemCPULoadAverage15m {
-	m := metricSystemCPULoadAverage15m{settings: settings}
-	if settings.Enabled {
+func newMetricSystemCPULoadAverage15m(cfg MetricConfig) metricSystemCPULoadAverage15m {
+	m := metricSystemCPULoadAverage15m{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -104,7 +104,7 @@ func newMetricSystemCPULoadAverage15m(settings MetricSettings) metricSystemCPULo
 
 type metricSystemCPULoadAverage1m struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -117,7 +117,7 @@ func (m *metricSystemCPULoadAverage1m) init() {
 }
 
 func (m *metricSystemCPULoadAverage1m) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -135,16 +135,16 @@ func (m *metricSystemCPULoadAverage1m) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemCPULoadAverage1m) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemCPULoadAverage1m(settings MetricSettings) metricSystemCPULoadAverage1m {
-	m := metricSystemCPULoadAverage1m{settings: settings}
-	if settings.Enabled {
+func newMetricSystemCPULoadAverage1m(cfg MetricConfig) metricSystemCPULoadAverage1m {
+	m := metricSystemCPULoadAverage1m{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -153,7 +153,7 @@ func newMetricSystemCPULoadAverage1m(settings MetricSettings) metricSystemCPULoa
 
 type metricSystemCPULoadAverage5m struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -166,7 +166,7 @@ func (m *metricSystemCPULoadAverage5m) init() {
 }
 
 func (m *metricSystemCPULoadAverage5m) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -184,16 +184,16 @@ func (m *metricSystemCPULoadAverage5m) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemCPULoadAverage5m) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemCPULoadAverage5m(settings MetricSettings) metricSystemCPULoadAverage5m {
-	m := metricSystemCPULoadAverage5m{settings: settings}
-	if settings.Enabled {
+func newMetricSystemCPULoadAverage5m(cfg MetricConfig) metricSystemCPULoadAverage5m {
+	m := metricSystemCPULoadAverage5m{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -202,11 +202,11 @@ func newMetricSystemCPULoadAverage5m(settings MetricSettings) metricSystemCPULoa
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics MetricsSettings `mapstructure:"metrics"`
+	Metrics MetricsConfig `mapstructure:"metrics"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                     pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity               int                 // maximum observed number of metrics per resource.
@@ -230,7 +230,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics: DefaultMetricsSettings(),
+		Metrics: DefaultMetricsConfig(),
 	}
 }
 
@@ -310,7 +310,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
@@ -13,14 +13,14 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -32,18 +32,18 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for hostmetricsreceiver/memory metrics.
-type MetricsSettings struct {
-	SystemMemoryUsage       MetricSettings `mapstructure:"system.memory.usage"`
-	SystemMemoryUtilization MetricSettings `mapstructure:"system.memory.utilization"`
+// MetricsConfig provides config for hostmetricsreceiver/memory metrics.
+type MetricsConfig struct {
+	SystemMemoryUsage       MetricConfig `mapstructure:"system.memory.usage"`
+	SystemMemoryUtilization MetricConfig `mapstructure:"system.memory.utilization"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		SystemMemoryUsage: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		SystemMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		SystemMemoryUtilization: MetricSettings{
+		SystemMemoryUtilization: MetricConfig{
 			Enabled: false,
 		},
 	}
@@ -97,7 +97,7 @@ var MapAttributeState = map[string]AttributeState{
 
 type metricSystemMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -113,7 +113,7 @@ func (m *metricSystemMemoryUsage) init() {
 }
 
 func (m *metricSystemMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -132,16 +132,16 @@ func (m *metricSystemMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemMemoryUsage(settings MetricSettings) metricSystemMemoryUsage {
-	m := metricSystemMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricSystemMemoryUsage(cfg MetricConfig) metricSystemMemoryUsage {
+	m := metricSystemMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -150,7 +150,7 @@ func newMetricSystemMemoryUsage(settings MetricSettings) metricSystemMemoryUsage
 
 type metricSystemMemoryUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -164,7 +164,7 @@ func (m *metricSystemMemoryUtilization) init() {
 }
 
 func (m *metricSystemMemoryUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -183,16 +183,16 @@ func (m *metricSystemMemoryUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemMemoryUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemMemoryUtilization(settings MetricSettings) metricSystemMemoryUtilization {
-	m := metricSystemMemoryUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricSystemMemoryUtilization(cfg MetricConfig) metricSystemMemoryUtilization {
+	m := metricSystemMemoryUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -201,11 +201,11 @@ func newMetricSystemMemoryUtilization(settings MetricSettings) metricSystemMemor
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics MetricsSettings `mapstructure:"metrics"`
+	Metrics MetricsConfig `mapstructure:"metrics"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                     pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity               int                 // maximum observed number of metrics per resource.
@@ -228,7 +228,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics: DefaultMetricsSettings(),
+		Metrics: DefaultMetricsConfig(),
 	}
 }
 
@@ -306,7 +306,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -56,11 +56,11 @@ func TestScrape(t *testing.T) {
 			name: "All metrics enabled",
 			config: &Config{
 				MetricsBuilderConfig: metadata.MetricsBuilderConfig{
-					Metrics: metadata.MetricsSettings{
-						SystemMemoryUtilization: metadata.MetricSettings{
+					Metrics: metadata.MetricsConfig{
+						SystemMemoryUtilization: metadata.MetricConfig{
 							Enabled: true,
 						},
-						SystemMemoryUsage: metadata.MetricSettings{
+						SystemMemoryUsage: metadata.MetricConfig{
 							Enabled: true,
 						},
 					},

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
@@ -13,14 +13,14 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -32,38 +32,38 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for hostmetricsreceiver/network metrics.
-type MetricsSettings struct {
-	SystemNetworkConnections    MetricSettings `mapstructure:"system.network.connections"`
-	SystemNetworkConntrackCount MetricSettings `mapstructure:"system.network.conntrack.count"`
-	SystemNetworkConntrackMax   MetricSettings `mapstructure:"system.network.conntrack.max"`
-	SystemNetworkDropped        MetricSettings `mapstructure:"system.network.dropped"`
-	SystemNetworkErrors         MetricSettings `mapstructure:"system.network.errors"`
-	SystemNetworkIo             MetricSettings `mapstructure:"system.network.io"`
-	SystemNetworkPackets        MetricSettings `mapstructure:"system.network.packets"`
+// MetricsConfig provides config for hostmetricsreceiver/network metrics.
+type MetricsConfig struct {
+	SystemNetworkConnections    MetricConfig `mapstructure:"system.network.connections"`
+	SystemNetworkConntrackCount MetricConfig `mapstructure:"system.network.conntrack.count"`
+	SystemNetworkConntrackMax   MetricConfig `mapstructure:"system.network.conntrack.max"`
+	SystemNetworkDropped        MetricConfig `mapstructure:"system.network.dropped"`
+	SystemNetworkErrors         MetricConfig `mapstructure:"system.network.errors"`
+	SystemNetworkIo             MetricConfig `mapstructure:"system.network.io"`
+	SystemNetworkPackets        MetricConfig `mapstructure:"system.network.packets"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		SystemNetworkConnections: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		SystemNetworkConnections: MetricConfig{
 			Enabled: true,
 		},
-		SystemNetworkConntrackCount: MetricSettings{
+		SystemNetworkConntrackCount: MetricConfig{
 			Enabled: false,
 		},
-		SystemNetworkConntrackMax: MetricSettings{
+		SystemNetworkConntrackMax: MetricConfig{
 			Enabled: false,
 		},
-		SystemNetworkDropped: MetricSettings{
+		SystemNetworkDropped: MetricConfig{
 			Enabled: true,
 		},
-		SystemNetworkErrors: MetricSettings{
+		SystemNetworkErrors: MetricConfig{
 			Enabled: true,
 		},
-		SystemNetworkIo: MetricSettings{
+		SystemNetworkIo: MetricConfig{
 			Enabled: true,
 		},
-		SystemNetworkPackets: MetricSettings{
+		SystemNetworkPackets: MetricConfig{
 			Enabled: true,
 		},
 	}
@@ -119,7 +119,7 @@ var MapAttributeProtocol = map[string]AttributeProtocol{
 
 type metricSystemNetworkConnections struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -135,7 +135,7 @@ func (m *metricSystemNetworkConnections) init() {
 }
 
 func (m *metricSystemNetworkConnections) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, protocolAttributeValue string, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -155,16 +155,16 @@ func (m *metricSystemNetworkConnections) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemNetworkConnections) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemNetworkConnections(settings MetricSettings) metricSystemNetworkConnections {
-	m := metricSystemNetworkConnections{settings: settings}
-	if settings.Enabled {
+func newMetricSystemNetworkConnections(cfg MetricConfig) metricSystemNetworkConnections {
+	m := metricSystemNetworkConnections{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -173,7 +173,7 @@ func newMetricSystemNetworkConnections(settings MetricSettings) metricSystemNetw
 
 type metricSystemNetworkConntrackCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -188,7 +188,7 @@ func (m *metricSystemNetworkConntrackCount) init() {
 }
 
 func (m *metricSystemNetworkConntrackCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -206,16 +206,16 @@ func (m *metricSystemNetworkConntrackCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemNetworkConntrackCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemNetworkConntrackCount(settings MetricSettings) metricSystemNetworkConntrackCount {
-	m := metricSystemNetworkConntrackCount{settings: settings}
-	if settings.Enabled {
+func newMetricSystemNetworkConntrackCount(cfg MetricConfig) metricSystemNetworkConntrackCount {
+	m := metricSystemNetworkConntrackCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -224,7 +224,7 @@ func newMetricSystemNetworkConntrackCount(settings MetricSettings) metricSystemN
 
 type metricSystemNetworkConntrackMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -239,7 +239,7 @@ func (m *metricSystemNetworkConntrackMax) init() {
 }
 
 func (m *metricSystemNetworkConntrackMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -257,16 +257,16 @@ func (m *metricSystemNetworkConntrackMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemNetworkConntrackMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemNetworkConntrackMax(settings MetricSettings) metricSystemNetworkConntrackMax {
-	m := metricSystemNetworkConntrackMax{settings: settings}
-	if settings.Enabled {
+func newMetricSystemNetworkConntrackMax(cfg MetricConfig) metricSystemNetworkConntrackMax {
+	m := metricSystemNetworkConntrackMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -275,7 +275,7 @@ func newMetricSystemNetworkConntrackMax(settings MetricSettings) metricSystemNet
 
 type metricSystemNetworkDropped struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -291,7 +291,7 @@ func (m *metricSystemNetworkDropped) init() {
 }
 
 func (m *metricSystemNetworkDropped) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceAttributeValue string, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -311,16 +311,16 @@ func (m *metricSystemNetworkDropped) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemNetworkDropped) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemNetworkDropped(settings MetricSettings) metricSystemNetworkDropped {
-	m := metricSystemNetworkDropped{settings: settings}
-	if settings.Enabled {
+func newMetricSystemNetworkDropped(cfg MetricConfig) metricSystemNetworkDropped {
+	m := metricSystemNetworkDropped{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -329,7 +329,7 @@ func newMetricSystemNetworkDropped(settings MetricSettings) metricSystemNetworkD
 
 type metricSystemNetworkErrors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -345,7 +345,7 @@ func (m *metricSystemNetworkErrors) init() {
 }
 
 func (m *metricSystemNetworkErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceAttributeValue string, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -365,16 +365,16 @@ func (m *metricSystemNetworkErrors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemNetworkErrors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemNetworkErrors(settings MetricSettings) metricSystemNetworkErrors {
-	m := metricSystemNetworkErrors{settings: settings}
-	if settings.Enabled {
+func newMetricSystemNetworkErrors(cfg MetricConfig) metricSystemNetworkErrors {
+	m := metricSystemNetworkErrors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -383,7 +383,7 @@ func newMetricSystemNetworkErrors(settings MetricSettings) metricSystemNetworkEr
 
 type metricSystemNetworkIo struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -399,7 +399,7 @@ func (m *metricSystemNetworkIo) init() {
 }
 
 func (m *metricSystemNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceAttributeValue string, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -419,16 +419,16 @@ func (m *metricSystemNetworkIo) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemNetworkIo) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemNetworkIo(settings MetricSettings) metricSystemNetworkIo {
-	m := metricSystemNetworkIo{settings: settings}
-	if settings.Enabled {
+func newMetricSystemNetworkIo(cfg MetricConfig) metricSystemNetworkIo {
+	m := metricSystemNetworkIo{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -437,7 +437,7 @@ func newMetricSystemNetworkIo(settings MetricSettings) metricSystemNetworkIo {
 
 type metricSystemNetworkPackets struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -453,7 +453,7 @@ func (m *metricSystemNetworkPackets) init() {
 }
 
 func (m *metricSystemNetworkPackets) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceAttributeValue string, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -473,16 +473,16 @@ func (m *metricSystemNetworkPackets) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemNetworkPackets) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemNetworkPackets(settings MetricSettings) metricSystemNetworkPackets {
-	m := metricSystemNetworkPackets{settings: settings}
-	if settings.Enabled {
+func newMetricSystemNetworkPackets(cfg MetricConfig) metricSystemNetworkPackets {
+	m := metricSystemNetworkPackets{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -491,11 +491,11 @@ func newMetricSystemNetworkPackets(settings MetricSettings) metricSystemNetworkP
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics MetricsSettings `mapstructure:"metrics"`
+	Metrics MetricsConfig `mapstructure:"metrics"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                         pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                   int                 // maximum observed number of metrics per resource.
@@ -523,7 +523,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics: DefaultMetricsSettings(),
+		Metrics: DefaultMetricsConfig(),
 	}
 }
 
@@ -611,7 +611,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
@@ -13,14 +13,14 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -32,26 +32,26 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for hostmetricsreceiver/paging metrics.
-type MetricsSettings struct {
-	SystemPagingFaults      MetricSettings `mapstructure:"system.paging.faults"`
-	SystemPagingOperations  MetricSettings `mapstructure:"system.paging.operations"`
-	SystemPagingUsage       MetricSettings `mapstructure:"system.paging.usage"`
-	SystemPagingUtilization MetricSettings `mapstructure:"system.paging.utilization"`
+// MetricsConfig provides config for hostmetricsreceiver/paging metrics.
+type MetricsConfig struct {
+	SystemPagingFaults      MetricConfig `mapstructure:"system.paging.faults"`
+	SystemPagingOperations  MetricConfig `mapstructure:"system.paging.operations"`
+	SystemPagingUsage       MetricConfig `mapstructure:"system.paging.usage"`
+	SystemPagingUtilization MetricConfig `mapstructure:"system.paging.utilization"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		SystemPagingFaults: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		SystemPagingFaults: MetricConfig{
 			Enabled: true,
 		},
-		SystemPagingOperations: MetricSettings{
+		SystemPagingOperations: MetricConfig{
 			Enabled: true,
 		},
-		SystemPagingUsage: MetricSettings{
+		SystemPagingUsage: MetricConfig{
 			Enabled: true,
 		},
-		SystemPagingUtilization: MetricSettings{
+		SystemPagingUtilization: MetricConfig{
 			Enabled: false,
 		},
 	}
@@ -141,7 +141,7 @@ var MapAttributeType = map[string]AttributeType{
 
 type metricSystemPagingFaults struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -157,7 +157,7 @@ func (m *metricSystemPagingFaults) init() {
 }
 
 func (m *metricSystemPagingFaults) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, typeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -176,16 +176,16 @@ func (m *metricSystemPagingFaults) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemPagingFaults) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemPagingFaults(settings MetricSettings) metricSystemPagingFaults {
-	m := metricSystemPagingFaults{settings: settings}
-	if settings.Enabled {
+func newMetricSystemPagingFaults(cfg MetricConfig) metricSystemPagingFaults {
+	m := metricSystemPagingFaults{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -194,7 +194,7 @@ func newMetricSystemPagingFaults(settings MetricSettings) metricSystemPagingFaul
 
 type metricSystemPagingOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -210,7 +210,7 @@ func (m *metricSystemPagingOperations) init() {
 }
 
 func (m *metricSystemPagingOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string, typeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -230,16 +230,16 @@ func (m *metricSystemPagingOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemPagingOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemPagingOperations(settings MetricSettings) metricSystemPagingOperations {
-	m := metricSystemPagingOperations{settings: settings}
-	if settings.Enabled {
+func newMetricSystemPagingOperations(cfg MetricConfig) metricSystemPagingOperations {
+	m := metricSystemPagingOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -248,7 +248,7 @@ func newMetricSystemPagingOperations(settings MetricSettings) metricSystemPaging
 
 type metricSystemPagingUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -264,7 +264,7 @@ func (m *metricSystemPagingUsage) init() {
 }
 
 func (m *metricSystemPagingUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, deviceAttributeValue string, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -284,16 +284,16 @@ func (m *metricSystemPagingUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemPagingUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemPagingUsage(settings MetricSettings) metricSystemPagingUsage {
-	m := metricSystemPagingUsage{settings: settings}
-	if settings.Enabled {
+func newMetricSystemPagingUsage(cfg MetricConfig) metricSystemPagingUsage {
+	m := metricSystemPagingUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -302,7 +302,7 @@ func newMetricSystemPagingUsage(settings MetricSettings) metricSystemPagingUsage
 
 type metricSystemPagingUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -316,7 +316,7 @@ func (m *metricSystemPagingUtilization) init() {
 }
 
 func (m *metricSystemPagingUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, deviceAttributeValue string, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -336,16 +336,16 @@ func (m *metricSystemPagingUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemPagingUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemPagingUtilization(settings MetricSettings) metricSystemPagingUtilization {
-	m := metricSystemPagingUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricSystemPagingUtilization(cfg MetricConfig) metricSystemPagingUtilization {
+	m := metricSystemPagingUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -354,11 +354,11 @@ func newMetricSystemPagingUtilization(settings MetricSettings) metricSystemPagin
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics MetricsSettings `mapstructure:"metrics"`
+	Metrics MetricsConfig `mapstructure:"metrics"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                     pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity               int                 // maximum observed number of metrics per resource.
@@ -383,7 +383,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics: DefaultMetricsSettings(),
+		Metrics: DefaultMetricsConfig(),
 	}
 }
 
@@ -465,7 +465,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
@@ -13,14 +13,14 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -32,18 +32,18 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for hostmetricsreceiver/processes metrics.
-type MetricsSettings struct {
-	SystemProcessesCount   MetricSettings `mapstructure:"system.processes.count"`
-	SystemProcessesCreated MetricSettings `mapstructure:"system.processes.created"`
+// MetricsConfig provides config for hostmetricsreceiver/processes metrics.
+type MetricsConfig struct {
+	SystemProcessesCount   MetricConfig `mapstructure:"system.processes.count"`
+	SystemProcessesCreated MetricConfig `mapstructure:"system.processes.created"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		SystemProcessesCount: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		SystemProcessesCount: MetricConfig{
 			Enabled: true,
 		},
-		SystemProcessesCreated: MetricSettings{
+		SystemProcessesCreated: MetricConfig{
 			Enabled: true,
 		},
 	}
@@ -121,7 +121,7 @@ var MapAttributeStatus = map[string]AttributeStatus{
 
 type metricSystemProcessesCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -137,7 +137,7 @@ func (m *metricSystemProcessesCount) init() {
 }
 
 func (m *metricSystemProcessesCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, statusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -156,16 +156,16 @@ func (m *metricSystemProcessesCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemProcessesCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemProcessesCount(settings MetricSettings) metricSystemProcessesCount {
-	m := metricSystemProcessesCount{settings: settings}
-	if settings.Enabled {
+func newMetricSystemProcessesCount(cfg MetricConfig) metricSystemProcessesCount {
+	m := metricSystemProcessesCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -174,7 +174,7 @@ func newMetricSystemProcessesCount(settings MetricSettings) metricSystemProcesse
 
 type metricSystemProcessesCreated struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -189,7 +189,7 @@ func (m *metricSystemProcessesCreated) init() {
 }
 
 func (m *metricSystemProcessesCreated) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -207,16 +207,16 @@ func (m *metricSystemProcessesCreated) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSystemProcessesCreated) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSystemProcessesCreated(settings MetricSettings) metricSystemProcessesCreated {
-	m := metricSystemProcessesCreated{settings: settings}
-	if settings.Enabled {
+func newMetricSystemProcessesCreated(cfg MetricConfig) metricSystemProcessesCreated {
+	m := metricSystemProcessesCreated{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -225,11 +225,11 @@ func newMetricSystemProcessesCreated(settings MetricSettings) metricSystemProces
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics MetricsSettings `mapstructure:"metrics"`
+	Metrics MetricsConfig `mapstructure:"metrics"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                    pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity              int                 // maximum observed number of metrics per resource.
@@ -252,7 +252,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics: DefaultMetricsSettings(),
+		Metrics: DefaultMetricsConfig(),
 	}
 }
 
@@ -330,7 +330,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
@@ -13,14 +13,14 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -32,100 +32,100 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for hostmetricsreceiver/process metrics.
-type MetricsSettings struct {
-	ProcessContextSwitches     MetricSettings `mapstructure:"process.context_switches"`
-	ProcessCPUTime             MetricSettings `mapstructure:"process.cpu.time"`
-	ProcessCPUUtilization      MetricSettings `mapstructure:"process.cpu.utilization"`
-	ProcessDiskIo              MetricSettings `mapstructure:"process.disk.io"`
-	ProcessDiskOperations      MetricSettings `mapstructure:"process.disk.operations"`
-	ProcessMemoryUsage         MetricSettings `mapstructure:"process.memory.usage"`
-	ProcessMemoryUtilization   MetricSettings `mapstructure:"process.memory.utilization"`
-	ProcessMemoryVirtual       MetricSettings `mapstructure:"process.memory.virtual"`
-	ProcessOpenFileDescriptors MetricSettings `mapstructure:"process.open_file_descriptors"`
-	ProcessPagingFaults        MetricSettings `mapstructure:"process.paging.faults"`
-	ProcessSignalsPending      MetricSettings `mapstructure:"process.signals_pending"`
-	ProcessThreads             MetricSettings `mapstructure:"process.threads"`
+// MetricsConfig provides config for hostmetricsreceiver/process metrics.
+type MetricsConfig struct {
+	ProcessContextSwitches     MetricConfig `mapstructure:"process.context_switches"`
+	ProcessCPUTime             MetricConfig `mapstructure:"process.cpu.time"`
+	ProcessCPUUtilization      MetricConfig `mapstructure:"process.cpu.utilization"`
+	ProcessDiskIo              MetricConfig `mapstructure:"process.disk.io"`
+	ProcessDiskOperations      MetricConfig `mapstructure:"process.disk.operations"`
+	ProcessMemoryUsage         MetricConfig `mapstructure:"process.memory.usage"`
+	ProcessMemoryUtilization   MetricConfig `mapstructure:"process.memory.utilization"`
+	ProcessMemoryVirtual       MetricConfig `mapstructure:"process.memory.virtual"`
+	ProcessOpenFileDescriptors MetricConfig `mapstructure:"process.open_file_descriptors"`
+	ProcessPagingFaults        MetricConfig `mapstructure:"process.paging.faults"`
+	ProcessSignalsPending      MetricConfig `mapstructure:"process.signals_pending"`
+	ProcessThreads             MetricConfig `mapstructure:"process.threads"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		ProcessContextSwitches: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		ProcessContextSwitches: MetricConfig{
 			Enabled: false,
 		},
-		ProcessCPUTime: MetricSettings{
+		ProcessCPUTime: MetricConfig{
 			Enabled: true,
 		},
-		ProcessCPUUtilization: MetricSettings{
+		ProcessCPUUtilization: MetricConfig{
 			Enabled: false,
 		},
-		ProcessDiskIo: MetricSettings{
+		ProcessDiskIo: MetricConfig{
 			Enabled: true,
 		},
-		ProcessDiskOperations: MetricSettings{
+		ProcessDiskOperations: MetricConfig{
 			Enabled: false,
 		},
-		ProcessMemoryUsage: MetricSettings{
+		ProcessMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		ProcessMemoryUtilization: MetricSettings{
+		ProcessMemoryUtilization: MetricConfig{
 			Enabled: false,
 		},
-		ProcessMemoryVirtual: MetricSettings{
+		ProcessMemoryVirtual: MetricConfig{
 			Enabled: true,
 		},
-		ProcessOpenFileDescriptors: MetricSettings{
+		ProcessOpenFileDescriptors: MetricConfig{
 			Enabled: false,
 		},
-		ProcessPagingFaults: MetricSettings{
+		ProcessPagingFaults: MetricConfig{
 			Enabled: false,
 		},
-		ProcessSignalsPending: MetricSettings{
+		ProcessSignalsPending: MetricConfig{
 			Enabled: false,
 		},
-		ProcessThreads: MetricSettings{
+		ProcessThreads: MetricConfig{
 			Enabled: false,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for hostmetricsreceiver/process resource attributes.
-type ResourceAttributesSettings struct {
-	ProcessCommand        ResourceAttributeSettings `mapstructure:"process.command"`
-	ProcessCommandLine    ResourceAttributeSettings `mapstructure:"process.command_line"`
-	ProcessExecutableName ResourceAttributeSettings `mapstructure:"process.executable.name"`
-	ProcessExecutablePath ResourceAttributeSettings `mapstructure:"process.executable.path"`
-	ProcessOwner          ResourceAttributeSettings `mapstructure:"process.owner"`
-	ProcessParentPid      ResourceAttributeSettings `mapstructure:"process.parent_pid"`
-	ProcessPid            ResourceAttributeSettings `mapstructure:"process.pid"`
+// ResourceAttributesConfig provides config for hostmetricsreceiver/process resource attributes.
+type ResourceAttributesConfig struct {
+	ProcessCommand        ResourceAttributeConfig `mapstructure:"process.command"`
+	ProcessCommandLine    ResourceAttributeConfig `mapstructure:"process.command_line"`
+	ProcessExecutableName ResourceAttributeConfig `mapstructure:"process.executable.name"`
+	ProcessExecutablePath ResourceAttributeConfig `mapstructure:"process.executable.path"`
+	ProcessOwner          ResourceAttributeConfig `mapstructure:"process.owner"`
+	ProcessParentPid      ResourceAttributeConfig `mapstructure:"process.parent_pid"`
+	ProcessPid            ResourceAttributeConfig `mapstructure:"process.pid"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		ProcessCommand: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		ProcessCommand: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ProcessCommandLine: ResourceAttributeSettings{
+		ProcessCommandLine: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ProcessExecutableName: ResourceAttributeSettings{
+		ProcessExecutableName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ProcessExecutablePath: ResourceAttributeSettings{
+		ProcessExecutablePath: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ProcessOwner: ResourceAttributeSettings{
+		ProcessOwner: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ProcessParentPid: ResourceAttributeSettings{
+		ProcessParentPid: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ProcessPid: ResourceAttributeSettings{
+		ProcessPid: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -241,7 +241,7 @@ var MapAttributeState = map[string]AttributeState{
 
 type metricProcessContextSwitches struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -257,7 +257,7 @@ func (m *metricProcessContextSwitches) init() {
 }
 
 func (m *metricProcessContextSwitches) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, contextSwitchTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -276,16 +276,16 @@ func (m *metricProcessContextSwitches) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessContextSwitches) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessContextSwitches(settings MetricSettings) metricProcessContextSwitches {
-	m := metricProcessContextSwitches{settings: settings}
-	if settings.Enabled {
+func newMetricProcessContextSwitches(cfg MetricConfig) metricProcessContextSwitches {
+	m := metricProcessContextSwitches{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -294,7 +294,7 @@ func newMetricProcessContextSwitches(settings MetricSettings) metricProcessConte
 
 type metricProcessCPUTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -310,7 +310,7 @@ func (m *metricProcessCPUTime) init() {
 }
 
 func (m *metricProcessCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -329,16 +329,16 @@ func (m *metricProcessCPUTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessCPUTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessCPUTime(settings MetricSettings) metricProcessCPUTime {
-	m := metricProcessCPUTime{settings: settings}
-	if settings.Enabled {
+func newMetricProcessCPUTime(cfg MetricConfig) metricProcessCPUTime {
+	m := metricProcessCPUTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -347,7 +347,7 @@ func newMetricProcessCPUTime(settings MetricSettings) metricProcessCPUTime {
 
 type metricProcessCPUUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -361,7 +361,7 @@ func (m *metricProcessCPUUtilization) init() {
 }
 
 func (m *metricProcessCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -380,16 +380,16 @@ func (m *metricProcessCPUUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessCPUUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessCPUUtilization(settings MetricSettings) metricProcessCPUUtilization {
-	m := metricProcessCPUUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricProcessCPUUtilization(cfg MetricConfig) metricProcessCPUUtilization {
+	m := metricProcessCPUUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -398,7 +398,7 @@ func newMetricProcessCPUUtilization(settings MetricSettings) metricProcessCPUUti
 
 type metricProcessDiskIo struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -414,7 +414,7 @@ func (m *metricProcessDiskIo) init() {
 }
 
 func (m *metricProcessDiskIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -433,16 +433,16 @@ func (m *metricProcessDiskIo) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessDiskIo) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessDiskIo(settings MetricSettings) metricProcessDiskIo {
-	m := metricProcessDiskIo{settings: settings}
-	if settings.Enabled {
+func newMetricProcessDiskIo(cfg MetricConfig) metricProcessDiskIo {
+	m := metricProcessDiskIo{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -451,7 +451,7 @@ func newMetricProcessDiskIo(settings MetricSettings) metricProcessDiskIo {
 
 type metricProcessDiskOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -467,7 +467,7 @@ func (m *metricProcessDiskOperations) init() {
 }
 
 func (m *metricProcessDiskOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -486,16 +486,16 @@ func (m *metricProcessDiskOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessDiskOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessDiskOperations(settings MetricSettings) metricProcessDiskOperations {
-	m := metricProcessDiskOperations{settings: settings}
-	if settings.Enabled {
+func newMetricProcessDiskOperations(cfg MetricConfig) metricProcessDiskOperations {
+	m := metricProcessDiskOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -504,7 +504,7 @@ func newMetricProcessDiskOperations(settings MetricSettings) metricProcessDiskOp
 
 type metricProcessMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -519,7 +519,7 @@ func (m *metricProcessMemoryUsage) init() {
 }
 
 func (m *metricProcessMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -537,16 +537,16 @@ func (m *metricProcessMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessMemoryUsage(settings MetricSettings) metricProcessMemoryUsage {
-	m := metricProcessMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricProcessMemoryUsage(cfg MetricConfig) metricProcessMemoryUsage {
+	m := metricProcessMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -555,7 +555,7 @@ func newMetricProcessMemoryUsage(settings MetricSettings) metricProcessMemoryUsa
 
 type metricProcessMemoryUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -568,7 +568,7 @@ func (m *metricProcessMemoryUtilization) init() {
 }
 
 func (m *metricProcessMemoryUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -586,16 +586,16 @@ func (m *metricProcessMemoryUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessMemoryUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessMemoryUtilization(settings MetricSettings) metricProcessMemoryUtilization {
-	m := metricProcessMemoryUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricProcessMemoryUtilization(cfg MetricConfig) metricProcessMemoryUtilization {
+	m := metricProcessMemoryUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -604,7 +604,7 @@ func newMetricProcessMemoryUtilization(settings MetricSettings) metricProcessMem
 
 type metricProcessMemoryVirtual struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -619,7 +619,7 @@ func (m *metricProcessMemoryVirtual) init() {
 }
 
 func (m *metricProcessMemoryVirtual) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -637,16 +637,16 @@ func (m *metricProcessMemoryVirtual) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessMemoryVirtual) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessMemoryVirtual(settings MetricSettings) metricProcessMemoryVirtual {
-	m := metricProcessMemoryVirtual{settings: settings}
-	if settings.Enabled {
+func newMetricProcessMemoryVirtual(cfg MetricConfig) metricProcessMemoryVirtual {
+	m := metricProcessMemoryVirtual{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -655,7 +655,7 @@ func newMetricProcessMemoryVirtual(settings MetricSettings) metricProcessMemoryV
 
 type metricProcessOpenFileDescriptors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -670,7 +670,7 @@ func (m *metricProcessOpenFileDescriptors) init() {
 }
 
 func (m *metricProcessOpenFileDescriptors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -688,16 +688,16 @@ func (m *metricProcessOpenFileDescriptors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessOpenFileDescriptors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessOpenFileDescriptors(settings MetricSettings) metricProcessOpenFileDescriptors {
-	m := metricProcessOpenFileDescriptors{settings: settings}
-	if settings.Enabled {
+func newMetricProcessOpenFileDescriptors(cfg MetricConfig) metricProcessOpenFileDescriptors {
+	m := metricProcessOpenFileDescriptors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -706,7 +706,7 @@ func newMetricProcessOpenFileDescriptors(settings MetricSettings) metricProcessO
 
 type metricProcessPagingFaults struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -722,7 +722,7 @@ func (m *metricProcessPagingFaults) init() {
 }
 
 func (m *metricProcessPagingFaults) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, pagingFaultTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -741,16 +741,16 @@ func (m *metricProcessPagingFaults) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessPagingFaults) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessPagingFaults(settings MetricSettings) metricProcessPagingFaults {
-	m := metricProcessPagingFaults{settings: settings}
-	if settings.Enabled {
+func newMetricProcessPagingFaults(cfg MetricConfig) metricProcessPagingFaults {
+	m := metricProcessPagingFaults{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -759,7 +759,7 @@ func newMetricProcessPagingFaults(settings MetricSettings) metricProcessPagingFa
 
 type metricProcessSignalsPending struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -774,7 +774,7 @@ func (m *metricProcessSignalsPending) init() {
 }
 
 func (m *metricProcessSignalsPending) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -792,16 +792,16 @@ func (m *metricProcessSignalsPending) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessSignalsPending) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessSignalsPending(settings MetricSettings) metricProcessSignalsPending {
-	m := metricProcessSignalsPending{settings: settings}
-	if settings.Enabled {
+func newMetricProcessSignalsPending(cfg MetricConfig) metricProcessSignalsPending {
+	m := metricProcessSignalsPending{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -810,7 +810,7 @@ func newMetricProcessSignalsPending(settings MetricSettings) metricProcessSignal
 
 type metricProcessThreads struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -825,7 +825,7 @@ func (m *metricProcessThreads) init() {
 }
 
 func (m *metricProcessThreads) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -843,16 +843,16 @@ func (m *metricProcessThreads) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricProcessThreads) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricProcessThreads(settings MetricSettings) metricProcessThreads {
-	m := metricProcessThreads{settings: settings}
-	if settings.Enabled {
+func newMetricProcessThreads(cfg MetricConfig) metricProcessThreads {
+	m := metricProcessThreads{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -861,19 +861,19 @@ func newMetricProcessThreads(settings MetricSettings) metricProcessThreads {
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                        pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                  int                 // maximum observed number of metrics per resource.
 	resourceCapacity                 int                 // maximum observed number of resource attributes.
 	metricsBuffer                    pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                        component.BuildInfo // contains version information
-	resourceAttributesSettings       ResourceAttributesSettings
+	resourceAttributesConfig         ResourceAttributesConfig
 	metricProcessContextSwitches     metricProcessContextSwitches
 	metricProcessCPUTime             metricProcessCPUTime
 	metricProcessCPUUtilization      metricProcessCPUUtilization
@@ -900,8 +900,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -910,7 +910,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                        pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                    pmetric.NewMetrics(),
 		buildInfo:                        settings.BuildInfo,
-		resourceAttributesSettings:       mbc.ResourceAttributes,
+		resourceAttributesConfig:         mbc.ResourceAttributes,
 		metricProcessContextSwitches:     newMetricProcessContextSwitches(mbc.Metrics.ProcessContextSwitches),
 		metricProcessCPUTime:             newMetricProcessCPUTime(mbc.Metrics.ProcessCPUTime),
 		metricProcessCPUUtilization:      newMetricProcessCPUUtilization(mbc.Metrics.ProcessCPUUtilization),
@@ -941,12 +941,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithProcessCommand sets provided value as "process.command" attribute for current resource.
 func WithProcessCommand(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ProcessCommand.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ProcessCommand.Enabled {
 			rm.Resource().Attributes().PutStr("process.command", val)
 		}
 	}
@@ -954,8 +954,8 @@ func WithProcessCommand(val string) ResourceMetricsOption {
 
 // WithProcessCommandLine sets provided value as "process.command_line" attribute for current resource.
 func WithProcessCommandLine(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ProcessCommandLine.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ProcessCommandLine.Enabled {
 			rm.Resource().Attributes().PutStr("process.command_line", val)
 		}
 	}
@@ -963,8 +963,8 @@ func WithProcessCommandLine(val string) ResourceMetricsOption {
 
 // WithProcessExecutableName sets provided value as "process.executable.name" attribute for current resource.
 func WithProcessExecutableName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ProcessExecutableName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ProcessExecutableName.Enabled {
 			rm.Resource().Attributes().PutStr("process.executable.name", val)
 		}
 	}
@@ -972,8 +972,8 @@ func WithProcessExecutableName(val string) ResourceMetricsOption {
 
 // WithProcessExecutablePath sets provided value as "process.executable.path" attribute for current resource.
 func WithProcessExecutablePath(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ProcessExecutablePath.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ProcessExecutablePath.Enabled {
 			rm.Resource().Attributes().PutStr("process.executable.path", val)
 		}
 	}
@@ -981,8 +981,8 @@ func WithProcessExecutablePath(val string) ResourceMetricsOption {
 
 // WithProcessOwner sets provided value as "process.owner" attribute for current resource.
 func WithProcessOwner(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ProcessOwner.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ProcessOwner.Enabled {
 			rm.Resource().Attributes().PutStr("process.owner", val)
 		}
 	}
@@ -990,8 +990,8 @@ func WithProcessOwner(val string) ResourceMetricsOption {
 
 // WithProcessParentPid sets provided value as "process.parent_pid" attribute for current resource.
 func WithProcessParentPid(val int64) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ProcessParentPid.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ProcessParentPid.Enabled {
 			rm.Resource().Attributes().PutInt("process.parent_pid", val)
 		}
 	}
@@ -999,8 +999,8 @@ func WithProcessParentPid(val int64) ResourceMetricsOption {
 
 // WithProcessPid sets provided value as "process.pid" attribute for current resource.
 func WithProcessPid(val int64) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ProcessPid.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ProcessPid.Enabled {
 			rm.Resource().Attributes().PutInt("process.pid", val)
 		}
 	}
@@ -1009,7 +1009,7 @@ func WithProcessPid(val int64) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -1053,7 +1053,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricProcessThreads.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -1063,7 +1063,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics_test.go
@@ -111,50 +111,50 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("process.command")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ProcessCommand.Enabled, ok)
-			if mb.resourceAttributesSettings.ProcessCommand.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ProcessCommand.Enabled, ok)
+			if mb.resourceAttributesConfig.ProcessCommand.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("process.command_line")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ProcessCommandLine.Enabled, ok)
-			if mb.resourceAttributesSettings.ProcessCommandLine.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ProcessCommandLine.Enabled, ok)
+			if mb.resourceAttributesConfig.ProcessCommandLine.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("process.executable.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ProcessExecutableName.Enabled, ok)
-			if mb.resourceAttributesSettings.ProcessExecutableName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ProcessExecutableName.Enabled, ok)
+			if mb.resourceAttributesConfig.ProcessExecutableName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("process.executable.path")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ProcessExecutablePath.Enabled, ok)
-			if mb.resourceAttributesSettings.ProcessExecutablePath.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ProcessExecutablePath.Enabled, ok)
+			if mb.resourceAttributesConfig.ProcessExecutablePath.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("process.owner")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ProcessOwner.Enabled, ok)
-			if mb.resourceAttributesSettings.ProcessOwner.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ProcessOwner.Enabled, ok)
+			if mb.resourceAttributesConfig.ProcessOwner.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("process.parent_pid")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ProcessParentPid.Enabled, ok)
-			if mb.resourceAttributesSettings.ProcessParentPid.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ProcessParentPid.Enabled, ok)
+			if mb.resourceAttributesConfig.ProcessParentPid.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, 1, attrVal.Int())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("process.pid")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ProcessPid.Enabled, ok)
-			if mb.resourceAttributesSettings.ProcessPid.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ProcessPid.Enabled, ok)
+			if mb.resourceAttributesConfig.ProcessPid.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, 1, attrVal.Int())
 			}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -45,7 +45,7 @@ func skipTestOnUnsupportedOS(t *testing.T) {
 	}
 }
 
-func enableLinuxOnlyMetrics(ms *metadata.MetricsSettings) {
+func enableLinuxOnlyMetrics(ms *metadata.MetricsConfig) {
 	if runtime.GOOS != "linux" {
 		return
 	}
@@ -59,9 +59,9 @@ func enableLinuxOnlyMetrics(ms *metadata.MetricsSettings) {
 func TestScrape(t *testing.T) {
 	skipTestOnUnsupportedOS(t)
 	type testCase struct {
-		name                  string
-		mutateScraper         func(*scraper)
-		mutateMetricsSettings func(*testing.T, *metadata.MetricsSettings)
+		name                string
+		mutateScraper       func(*scraper)
+		mutateMetricsConfig func(*testing.T, *metadata.MetricsConfig)
 	}
 	testCases := []testCase{
 		{
@@ -69,7 +69,7 @@ func TestScrape(t *testing.T) {
 		},
 		{
 			name: "Enable Linux-only metrics",
-			mutateMetricsSettings: func(t *testing.T, ms *metadata.MetricsSettings) {
+			mutateMetricsConfig: func(t *testing.T, ms *metadata.MetricsConfig) {
 				if runtime.GOOS != "linux" {
 					t.Skipf("skipping test on %v", runtime.GOOS)
 				}
@@ -79,7 +79,7 @@ func TestScrape(t *testing.T) {
 		},
 		{
 			name: "Enable memory utilization",
-			mutateMetricsSettings: func(t *testing.T, ms *metadata.MetricsSettings) {
+			mutateMetricsConfig: func(t *testing.T, ms *metadata.MetricsConfig) {
 				ms.ProcessMemoryUtilization.Enabled = true
 			},
 		},
@@ -96,8 +96,8 @@ func TestScrape(t *testing.T) {
 				metricsBuilderConfig.Metrics.ProcessDiskIo.Enabled = false
 			}
 
-			if test.mutateMetricsSettings != nil {
-				test.mutateMetricsSettings(t, &metricsBuilderConfig.Metrics)
+			if test.mutateMetricsConfig != nil {
+				test.mutateMetricsConfig(t, &metricsBuilderConfig.Metrics)
 			}
 			scraper, err := newProcessScraper(receivertest.NewNopCreateSettings(), &Config{MetricsBuilderConfig: metricsBuilderConfig})
 			if test.mutateScraper != nil {
@@ -628,7 +628,7 @@ func TestScrapeMetrics_Filtered(t *testing.T) {
 	}
 }
 
-func enableOptionalMetrics(ms *metadata.MetricsSettings) {
+func enableOptionalMetrics(ms *metadata.MetricsConfig) {
 	ms.ProcessMemoryUtilization.Enabled = true
 	ms.ProcessThreads.Enabled = true
 	ms.ProcessPagingFaults.Enabled = true

--- a/receiver/httpcheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,22 +31,22 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for httpcheckreceiver metrics.
-type MetricsSettings struct {
-	HttpcheckDuration MetricSettings `mapstructure:"httpcheck.duration"`
-	HttpcheckError    MetricSettings `mapstructure:"httpcheck.error"`
-	HttpcheckStatus   MetricSettings `mapstructure:"httpcheck.status"`
+// MetricsConfig provides config for httpcheckreceiver metrics.
+type MetricsConfig struct {
+	HttpcheckDuration MetricConfig `mapstructure:"httpcheck.duration"`
+	HttpcheckError    MetricConfig `mapstructure:"httpcheck.error"`
+	HttpcheckStatus   MetricConfig `mapstructure:"httpcheck.status"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		HttpcheckDuration: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		HttpcheckDuration: MetricConfig{
 			Enabled: true,
 		},
-		HttpcheckError: MetricSettings{
+		HttpcheckError: MetricConfig{
 			Enabled: true,
 		},
-		HttpcheckStatus: MetricSettings{
+		HttpcheckStatus: MetricConfig{
 			Enabled: true,
 		},
 	}
@@ -54,7 +54,7 @@ func DefaultMetricsSettings() MetricsSettings {
 
 type metricHttpcheckDuration struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -68,7 +68,7 @@ func (m *metricHttpcheckDuration) init() {
 }
 
 func (m *metricHttpcheckDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -87,16 +87,16 @@ func (m *metricHttpcheckDuration) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckDuration) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckDuration(settings MetricSettings) metricHttpcheckDuration {
-	m := metricHttpcheckDuration{settings: settings}
-	if settings.Enabled {
+func newMetricHttpcheckDuration(cfg MetricConfig) metricHttpcheckDuration {
+	m := metricHttpcheckDuration{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -105,7 +105,7 @@ func newMetricHttpcheckDuration(settings MetricSettings) metricHttpcheckDuration
 
 type metricHttpcheckError struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -121,7 +121,7 @@ func (m *metricHttpcheckError) init() {
 }
 
 func (m *metricHttpcheckError) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string, errorMessageAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -141,16 +141,16 @@ func (m *metricHttpcheckError) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckError) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckError(settings MetricSettings) metricHttpcheckError {
-	m := metricHttpcheckError{settings: settings}
-	if settings.Enabled {
+func newMetricHttpcheckError(cfg MetricConfig) metricHttpcheckError {
+	m := metricHttpcheckError{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -159,7 +159,7 @@ func newMetricHttpcheckError(settings MetricSettings) metricHttpcheckError {
 
 type metricHttpcheckStatus struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -175,7 +175,7 @@ func (m *metricHttpcheckStatus) init() {
 }
 
 func (m *metricHttpcheckStatus) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string, httpStatusCodeAttributeValue int64, httpMethodAttributeValue string, httpStatusClassAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -197,16 +197,16 @@ func (m *metricHttpcheckStatus) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricHttpcheckStatus) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricHttpcheckStatus(settings MetricSettings) metricHttpcheckStatus {
-	m := metricHttpcheckStatus{settings: settings}
-	if settings.Enabled {
+func newMetricHttpcheckStatus(cfg MetricConfig) metricHttpcheckStatus {
+	m := metricHttpcheckStatus{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -215,11 +215,11 @@ func newMetricHttpcheckStatus(settings MetricSettings) metricHttpcheckStatus {
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics MetricsSettings `mapstructure:"metrics"`
+	Metrics MetricsConfig `mapstructure:"metrics"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime               pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity         int                 // maximum observed number of metrics per resource.
@@ -243,7 +243,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics: DefaultMetricsSettings(),
+		Metrics: DefaultMetricsConfig(),
 	}
 }
 
@@ -322,7 +322,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/iisreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/iisreceiver/internal/metadata/generated_metrics_test.go
@@ -119,15 +119,15 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("iis.application_pool")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.IisApplicationPool.Enabled, ok)
-			if mb.resourceAttributesSettings.IisApplicationPool.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.IisApplicationPool.Enabled, ok)
+			if mb.resourceAttributesConfig.IisApplicationPool.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("iis.site")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.IisSite.Enabled, ok)
-			if mb.resourceAttributesSettings.IisSite.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.IisSite.Enabled, ok)
+			if mb.resourceAttributesConfig.IisSite.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/kafkametricsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kafkametricsreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,54 +31,54 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for kafkametricsreceiver metrics.
-type MetricsSettings struct {
-	KafkaBrokers                 MetricSettings `mapstructure:"kafka.brokers"`
-	KafkaConsumerGroupLag        MetricSettings `mapstructure:"kafka.consumer_group.lag"`
-	KafkaConsumerGroupLagSum     MetricSettings `mapstructure:"kafka.consumer_group.lag_sum"`
-	KafkaConsumerGroupMembers    MetricSettings `mapstructure:"kafka.consumer_group.members"`
-	KafkaConsumerGroupOffset     MetricSettings `mapstructure:"kafka.consumer_group.offset"`
-	KafkaConsumerGroupOffsetSum  MetricSettings `mapstructure:"kafka.consumer_group.offset_sum"`
-	KafkaPartitionCurrentOffset  MetricSettings `mapstructure:"kafka.partition.current_offset"`
-	KafkaPartitionOldestOffset   MetricSettings `mapstructure:"kafka.partition.oldest_offset"`
-	KafkaPartitionReplicas       MetricSettings `mapstructure:"kafka.partition.replicas"`
-	KafkaPartitionReplicasInSync MetricSettings `mapstructure:"kafka.partition.replicas_in_sync"`
-	KafkaTopicPartitions         MetricSettings `mapstructure:"kafka.topic.partitions"`
+// MetricsConfig provides config for kafkametricsreceiver metrics.
+type MetricsConfig struct {
+	KafkaBrokers                 MetricConfig `mapstructure:"kafka.brokers"`
+	KafkaConsumerGroupLag        MetricConfig `mapstructure:"kafka.consumer_group.lag"`
+	KafkaConsumerGroupLagSum     MetricConfig `mapstructure:"kafka.consumer_group.lag_sum"`
+	KafkaConsumerGroupMembers    MetricConfig `mapstructure:"kafka.consumer_group.members"`
+	KafkaConsumerGroupOffset     MetricConfig `mapstructure:"kafka.consumer_group.offset"`
+	KafkaConsumerGroupOffsetSum  MetricConfig `mapstructure:"kafka.consumer_group.offset_sum"`
+	KafkaPartitionCurrentOffset  MetricConfig `mapstructure:"kafka.partition.current_offset"`
+	KafkaPartitionOldestOffset   MetricConfig `mapstructure:"kafka.partition.oldest_offset"`
+	KafkaPartitionReplicas       MetricConfig `mapstructure:"kafka.partition.replicas"`
+	KafkaPartitionReplicasInSync MetricConfig `mapstructure:"kafka.partition.replicas_in_sync"`
+	KafkaTopicPartitions         MetricConfig `mapstructure:"kafka.topic.partitions"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		KafkaBrokers: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		KafkaBrokers: MetricConfig{
 			Enabled: true,
 		},
-		KafkaConsumerGroupLag: MetricSettings{
+		KafkaConsumerGroupLag: MetricConfig{
 			Enabled: true,
 		},
-		KafkaConsumerGroupLagSum: MetricSettings{
+		KafkaConsumerGroupLagSum: MetricConfig{
 			Enabled: true,
 		},
-		KafkaConsumerGroupMembers: MetricSettings{
+		KafkaConsumerGroupMembers: MetricConfig{
 			Enabled: true,
 		},
-		KafkaConsumerGroupOffset: MetricSettings{
+		KafkaConsumerGroupOffset: MetricConfig{
 			Enabled: true,
 		},
-		KafkaConsumerGroupOffsetSum: MetricSettings{
+		KafkaConsumerGroupOffsetSum: MetricConfig{
 			Enabled: true,
 		},
-		KafkaPartitionCurrentOffset: MetricSettings{
+		KafkaPartitionCurrentOffset: MetricConfig{
 			Enabled: true,
 		},
-		KafkaPartitionOldestOffset: MetricSettings{
+		KafkaPartitionOldestOffset: MetricConfig{
 			Enabled: true,
 		},
-		KafkaPartitionReplicas: MetricSettings{
+		KafkaPartitionReplicas: MetricConfig{
 			Enabled: true,
 		},
-		KafkaPartitionReplicasInSync: MetricSettings{
+		KafkaPartitionReplicasInSync: MetricConfig{
 			Enabled: true,
 		},
-		KafkaTopicPartitions: MetricSettings{
+		KafkaTopicPartitions: MetricConfig{
 			Enabled: true,
 		},
 	}
@@ -86,7 +86,7 @@ func DefaultMetricsSettings() MetricsSettings {
 
 type metricKafkaBrokers struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -99,7 +99,7 @@ func (m *metricKafkaBrokers) init() {
 }
 
 func (m *metricKafkaBrokers) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -117,16 +117,16 @@ func (m *metricKafkaBrokers) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricKafkaBrokers) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricKafkaBrokers(settings MetricSettings) metricKafkaBrokers {
-	m := metricKafkaBrokers{settings: settings}
-	if settings.Enabled {
+func newMetricKafkaBrokers(cfg MetricConfig) metricKafkaBrokers {
+	m := metricKafkaBrokers{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -135,7 +135,7 @@ func newMetricKafkaBrokers(settings MetricSettings) metricKafkaBrokers {
 
 type metricKafkaConsumerGroupLag struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -149,7 +149,7 @@ func (m *metricKafkaConsumerGroupLag) init() {
 }
 
 func (m *metricKafkaConsumerGroupLag) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, groupAttributeValue string, topicAttributeValue string, partitionAttributeValue int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -170,16 +170,16 @@ func (m *metricKafkaConsumerGroupLag) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricKafkaConsumerGroupLag) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricKafkaConsumerGroupLag(settings MetricSettings) metricKafkaConsumerGroupLag {
-	m := metricKafkaConsumerGroupLag{settings: settings}
-	if settings.Enabled {
+func newMetricKafkaConsumerGroupLag(cfg MetricConfig) metricKafkaConsumerGroupLag {
+	m := metricKafkaConsumerGroupLag{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -188,7 +188,7 @@ func newMetricKafkaConsumerGroupLag(settings MetricSettings) metricKafkaConsumer
 
 type metricKafkaConsumerGroupLagSum struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -202,7 +202,7 @@ func (m *metricKafkaConsumerGroupLagSum) init() {
 }
 
 func (m *metricKafkaConsumerGroupLagSum) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, groupAttributeValue string, topicAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -222,16 +222,16 @@ func (m *metricKafkaConsumerGroupLagSum) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricKafkaConsumerGroupLagSum) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricKafkaConsumerGroupLagSum(settings MetricSettings) metricKafkaConsumerGroupLagSum {
-	m := metricKafkaConsumerGroupLagSum{settings: settings}
-	if settings.Enabled {
+func newMetricKafkaConsumerGroupLagSum(cfg MetricConfig) metricKafkaConsumerGroupLagSum {
+	m := metricKafkaConsumerGroupLagSum{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -240,7 +240,7 @@ func newMetricKafkaConsumerGroupLagSum(settings MetricSettings) metricKafkaConsu
 
 type metricKafkaConsumerGroupMembers struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -254,7 +254,7 @@ func (m *metricKafkaConsumerGroupMembers) init() {
 }
 
 func (m *metricKafkaConsumerGroupMembers) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, groupAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -273,16 +273,16 @@ func (m *metricKafkaConsumerGroupMembers) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricKafkaConsumerGroupMembers) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricKafkaConsumerGroupMembers(settings MetricSettings) metricKafkaConsumerGroupMembers {
-	m := metricKafkaConsumerGroupMembers{settings: settings}
-	if settings.Enabled {
+func newMetricKafkaConsumerGroupMembers(cfg MetricConfig) metricKafkaConsumerGroupMembers {
+	m := metricKafkaConsumerGroupMembers{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -291,7 +291,7 @@ func newMetricKafkaConsumerGroupMembers(settings MetricSettings) metricKafkaCons
 
 type metricKafkaConsumerGroupOffset struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -305,7 +305,7 @@ func (m *metricKafkaConsumerGroupOffset) init() {
 }
 
 func (m *metricKafkaConsumerGroupOffset) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, groupAttributeValue string, topicAttributeValue string, partitionAttributeValue int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -326,16 +326,16 @@ func (m *metricKafkaConsumerGroupOffset) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricKafkaConsumerGroupOffset) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricKafkaConsumerGroupOffset(settings MetricSettings) metricKafkaConsumerGroupOffset {
-	m := metricKafkaConsumerGroupOffset{settings: settings}
-	if settings.Enabled {
+func newMetricKafkaConsumerGroupOffset(cfg MetricConfig) metricKafkaConsumerGroupOffset {
+	m := metricKafkaConsumerGroupOffset{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -344,7 +344,7 @@ func newMetricKafkaConsumerGroupOffset(settings MetricSettings) metricKafkaConsu
 
 type metricKafkaConsumerGroupOffsetSum struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -358,7 +358,7 @@ func (m *metricKafkaConsumerGroupOffsetSum) init() {
 }
 
 func (m *metricKafkaConsumerGroupOffsetSum) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, groupAttributeValue string, topicAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -378,16 +378,16 @@ func (m *metricKafkaConsumerGroupOffsetSum) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricKafkaConsumerGroupOffsetSum) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricKafkaConsumerGroupOffsetSum(settings MetricSettings) metricKafkaConsumerGroupOffsetSum {
-	m := metricKafkaConsumerGroupOffsetSum{settings: settings}
-	if settings.Enabled {
+func newMetricKafkaConsumerGroupOffsetSum(cfg MetricConfig) metricKafkaConsumerGroupOffsetSum {
+	m := metricKafkaConsumerGroupOffsetSum{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -396,7 +396,7 @@ func newMetricKafkaConsumerGroupOffsetSum(settings MetricSettings) metricKafkaCo
 
 type metricKafkaPartitionCurrentOffset struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -410,7 +410,7 @@ func (m *metricKafkaPartitionCurrentOffset) init() {
 }
 
 func (m *metricKafkaPartitionCurrentOffset) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, topicAttributeValue string, partitionAttributeValue int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -430,16 +430,16 @@ func (m *metricKafkaPartitionCurrentOffset) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricKafkaPartitionCurrentOffset) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricKafkaPartitionCurrentOffset(settings MetricSettings) metricKafkaPartitionCurrentOffset {
-	m := metricKafkaPartitionCurrentOffset{settings: settings}
-	if settings.Enabled {
+func newMetricKafkaPartitionCurrentOffset(cfg MetricConfig) metricKafkaPartitionCurrentOffset {
+	m := metricKafkaPartitionCurrentOffset{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -448,7 +448,7 @@ func newMetricKafkaPartitionCurrentOffset(settings MetricSettings) metricKafkaPa
 
 type metricKafkaPartitionOldestOffset struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -462,7 +462,7 @@ func (m *metricKafkaPartitionOldestOffset) init() {
 }
 
 func (m *metricKafkaPartitionOldestOffset) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, topicAttributeValue string, partitionAttributeValue int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -482,16 +482,16 @@ func (m *metricKafkaPartitionOldestOffset) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricKafkaPartitionOldestOffset) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricKafkaPartitionOldestOffset(settings MetricSettings) metricKafkaPartitionOldestOffset {
-	m := metricKafkaPartitionOldestOffset{settings: settings}
-	if settings.Enabled {
+func newMetricKafkaPartitionOldestOffset(cfg MetricConfig) metricKafkaPartitionOldestOffset {
+	m := metricKafkaPartitionOldestOffset{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -500,7 +500,7 @@ func newMetricKafkaPartitionOldestOffset(settings MetricSettings) metricKafkaPar
 
 type metricKafkaPartitionReplicas struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -514,7 +514,7 @@ func (m *metricKafkaPartitionReplicas) init() {
 }
 
 func (m *metricKafkaPartitionReplicas) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, topicAttributeValue string, partitionAttributeValue int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -534,16 +534,16 @@ func (m *metricKafkaPartitionReplicas) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricKafkaPartitionReplicas) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricKafkaPartitionReplicas(settings MetricSettings) metricKafkaPartitionReplicas {
-	m := metricKafkaPartitionReplicas{settings: settings}
-	if settings.Enabled {
+func newMetricKafkaPartitionReplicas(cfg MetricConfig) metricKafkaPartitionReplicas {
+	m := metricKafkaPartitionReplicas{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -552,7 +552,7 @@ func newMetricKafkaPartitionReplicas(settings MetricSettings) metricKafkaPartiti
 
 type metricKafkaPartitionReplicasInSync struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -566,7 +566,7 @@ func (m *metricKafkaPartitionReplicasInSync) init() {
 }
 
 func (m *metricKafkaPartitionReplicasInSync) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, topicAttributeValue string, partitionAttributeValue int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -586,16 +586,16 @@ func (m *metricKafkaPartitionReplicasInSync) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricKafkaPartitionReplicasInSync) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricKafkaPartitionReplicasInSync(settings MetricSettings) metricKafkaPartitionReplicasInSync {
-	m := metricKafkaPartitionReplicasInSync{settings: settings}
-	if settings.Enabled {
+func newMetricKafkaPartitionReplicasInSync(cfg MetricConfig) metricKafkaPartitionReplicasInSync {
+	m := metricKafkaPartitionReplicasInSync{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -604,7 +604,7 @@ func newMetricKafkaPartitionReplicasInSync(settings MetricSettings) metricKafkaP
 
 type metricKafkaTopicPartitions struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -618,7 +618,7 @@ func (m *metricKafkaTopicPartitions) init() {
 }
 
 func (m *metricKafkaTopicPartitions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, topicAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -637,16 +637,16 @@ func (m *metricKafkaTopicPartitions) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricKafkaTopicPartitions) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricKafkaTopicPartitions(settings MetricSettings) metricKafkaTopicPartitions {
-	m := metricKafkaTopicPartitions{settings: settings}
-	if settings.Enabled {
+func newMetricKafkaTopicPartitions(cfg MetricConfig) metricKafkaTopicPartitions {
+	m := metricKafkaTopicPartitions{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -655,11 +655,11 @@ func newMetricKafkaTopicPartitions(settings MetricSettings) metricKafkaTopicPart
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics MetricsSettings `mapstructure:"metrics"`
+	Metrics MetricsConfig `mapstructure:"metrics"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                          pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                    int                 // maximum observed number of metrics per resource.
@@ -691,7 +691,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics: DefaultMetricsSettings(),
+		Metrics: DefaultMetricsConfig(),
 	}
 }
 
@@ -786,7 +786,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metadata_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metadata_test.go
@@ -229,9 +229,9 @@ func TestSetExtraLabels(t *testing.T) {
 			ro, err := tt.metadata.getExtraResources(stats.PodReference{UID: tt.args[0]}, MetadataLabel(tt.args[1]), tt.args[2])
 
 			r := pmetric.NewResourceMetrics()
-			ras := metadata.DefaultResourceAttributesSettings()
+			rac := metadata.DefaultResourceAttributesConfig()
 			for _, op := range ro {
-				op(ras, r)
+				op(rac, r)
 			}
 
 			if tt.wantError == "" {
@@ -375,7 +375,7 @@ func TestSetExtraLabelsForVolumeTypes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			volName := "volume0"
-			ras := metadata.DefaultResourceAttributesSettings()
+			rac := metadata.DefaultResourceAttributesConfig()
 			metadata := NewMetadata([]MetadataLabel{MetadataLabelVolumeType}, &v1.PodList{
 				Items: []v1.Pod{
 					{
@@ -399,7 +399,7 @@ func TestSetExtraLabelsForVolumeTypes(t *testing.T) {
 
 			rm := pmetric.NewResourceMetrics()
 			for _, op := range ro {
-				op(ras, rm)
+				op(rac, rm)
 			}
 
 			assert.Equal(t, tt.want, rm.Resource().Attributes().AsRaw())

--- a/receiver/kubeletstatsreceiver/internal/kubelet/volume_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/volume_test.go
@@ -170,7 +170,7 @@ func TestDetailedPVCLabels(t *testing.T) {
 					Namespace: tt.pod.namespace,
 				},
 			}
-			ras := metadata.DefaultResourceAttributesSettings()
+			rac := metadata.DefaultResourceAttributesConfig()
 			metadata := NewMetadata([]MetadataLabel{MetadataLabelVolumeType}, &v1.PodList{
 				Items: []v1.Pod{
 					{
@@ -197,7 +197,7 @@ func TestDetailedPVCLabels(t *testing.T) {
 
 			volumeResourceMetrics := pmetric.NewResourceMetrics()
 			for _, op := range ro {
-				op(ras, volumeResourceMetrics)
+				op(rac, volumeResourceMetrics)
 			}
 
 			require.Equal(t, tt.want, volumeResourceMetrics.Resource().Attributes().AsRaw())

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,252 +31,252 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for kubeletstatsreceiver metrics.
-type MetricsSettings struct {
-	ContainerCPUTime               MetricSettings `mapstructure:"container.cpu.time"`
-	ContainerCPUUtilization        MetricSettings `mapstructure:"container.cpu.utilization"`
-	ContainerFilesystemAvailable   MetricSettings `mapstructure:"container.filesystem.available"`
-	ContainerFilesystemCapacity    MetricSettings `mapstructure:"container.filesystem.capacity"`
-	ContainerFilesystemUsage       MetricSettings `mapstructure:"container.filesystem.usage"`
-	ContainerMemoryAvailable       MetricSettings `mapstructure:"container.memory.available"`
-	ContainerMemoryMajorPageFaults MetricSettings `mapstructure:"container.memory.major_page_faults"`
-	ContainerMemoryPageFaults      MetricSettings `mapstructure:"container.memory.page_faults"`
-	ContainerMemoryRss             MetricSettings `mapstructure:"container.memory.rss"`
-	ContainerMemoryUsage           MetricSettings `mapstructure:"container.memory.usage"`
-	ContainerMemoryWorkingSet      MetricSettings `mapstructure:"container.memory.working_set"`
-	K8sNodeCPUTime                 MetricSettings `mapstructure:"k8s.node.cpu.time"`
-	K8sNodeCPUUtilization          MetricSettings `mapstructure:"k8s.node.cpu.utilization"`
-	K8sNodeFilesystemAvailable     MetricSettings `mapstructure:"k8s.node.filesystem.available"`
-	K8sNodeFilesystemCapacity      MetricSettings `mapstructure:"k8s.node.filesystem.capacity"`
-	K8sNodeFilesystemUsage         MetricSettings `mapstructure:"k8s.node.filesystem.usage"`
-	K8sNodeMemoryAvailable         MetricSettings `mapstructure:"k8s.node.memory.available"`
-	K8sNodeMemoryMajorPageFaults   MetricSettings `mapstructure:"k8s.node.memory.major_page_faults"`
-	K8sNodeMemoryPageFaults        MetricSettings `mapstructure:"k8s.node.memory.page_faults"`
-	K8sNodeMemoryRss               MetricSettings `mapstructure:"k8s.node.memory.rss"`
-	K8sNodeMemoryUsage             MetricSettings `mapstructure:"k8s.node.memory.usage"`
-	K8sNodeMemoryWorkingSet        MetricSettings `mapstructure:"k8s.node.memory.working_set"`
-	K8sNodeNetworkErrors           MetricSettings `mapstructure:"k8s.node.network.errors"`
-	K8sNodeNetworkIo               MetricSettings `mapstructure:"k8s.node.network.io"`
-	K8sPodCPUTime                  MetricSettings `mapstructure:"k8s.pod.cpu.time"`
-	K8sPodCPUUtilization           MetricSettings `mapstructure:"k8s.pod.cpu.utilization"`
-	K8sPodFilesystemAvailable      MetricSettings `mapstructure:"k8s.pod.filesystem.available"`
-	K8sPodFilesystemCapacity       MetricSettings `mapstructure:"k8s.pod.filesystem.capacity"`
-	K8sPodFilesystemUsage          MetricSettings `mapstructure:"k8s.pod.filesystem.usage"`
-	K8sPodMemoryAvailable          MetricSettings `mapstructure:"k8s.pod.memory.available"`
-	K8sPodMemoryMajorPageFaults    MetricSettings `mapstructure:"k8s.pod.memory.major_page_faults"`
-	K8sPodMemoryPageFaults         MetricSettings `mapstructure:"k8s.pod.memory.page_faults"`
-	K8sPodMemoryRss                MetricSettings `mapstructure:"k8s.pod.memory.rss"`
-	K8sPodMemoryUsage              MetricSettings `mapstructure:"k8s.pod.memory.usage"`
-	K8sPodMemoryWorkingSet         MetricSettings `mapstructure:"k8s.pod.memory.working_set"`
-	K8sPodNetworkErrors            MetricSettings `mapstructure:"k8s.pod.network.errors"`
-	K8sPodNetworkIo                MetricSettings `mapstructure:"k8s.pod.network.io"`
-	K8sVolumeAvailable             MetricSettings `mapstructure:"k8s.volume.available"`
-	K8sVolumeCapacity              MetricSettings `mapstructure:"k8s.volume.capacity"`
-	K8sVolumeInodes                MetricSettings `mapstructure:"k8s.volume.inodes"`
-	K8sVolumeInodesFree            MetricSettings `mapstructure:"k8s.volume.inodes.free"`
-	K8sVolumeInodesUsed            MetricSettings `mapstructure:"k8s.volume.inodes.used"`
+// MetricsConfig provides config for kubeletstatsreceiver metrics.
+type MetricsConfig struct {
+	ContainerCPUTime               MetricConfig `mapstructure:"container.cpu.time"`
+	ContainerCPUUtilization        MetricConfig `mapstructure:"container.cpu.utilization"`
+	ContainerFilesystemAvailable   MetricConfig `mapstructure:"container.filesystem.available"`
+	ContainerFilesystemCapacity    MetricConfig `mapstructure:"container.filesystem.capacity"`
+	ContainerFilesystemUsage       MetricConfig `mapstructure:"container.filesystem.usage"`
+	ContainerMemoryAvailable       MetricConfig `mapstructure:"container.memory.available"`
+	ContainerMemoryMajorPageFaults MetricConfig `mapstructure:"container.memory.major_page_faults"`
+	ContainerMemoryPageFaults      MetricConfig `mapstructure:"container.memory.page_faults"`
+	ContainerMemoryRss             MetricConfig `mapstructure:"container.memory.rss"`
+	ContainerMemoryUsage           MetricConfig `mapstructure:"container.memory.usage"`
+	ContainerMemoryWorkingSet      MetricConfig `mapstructure:"container.memory.working_set"`
+	K8sNodeCPUTime                 MetricConfig `mapstructure:"k8s.node.cpu.time"`
+	K8sNodeCPUUtilization          MetricConfig `mapstructure:"k8s.node.cpu.utilization"`
+	K8sNodeFilesystemAvailable     MetricConfig `mapstructure:"k8s.node.filesystem.available"`
+	K8sNodeFilesystemCapacity      MetricConfig `mapstructure:"k8s.node.filesystem.capacity"`
+	K8sNodeFilesystemUsage         MetricConfig `mapstructure:"k8s.node.filesystem.usage"`
+	K8sNodeMemoryAvailable         MetricConfig `mapstructure:"k8s.node.memory.available"`
+	K8sNodeMemoryMajorPageFaults   MetricConfig `mapstructure:"k8s.node.memory.major_page_faults"`
+	K8sNodeMemoryPageFaults        MetricConfig `mapstructure:"k8s.node.memory.page_faults"`
+	K8sNodeMemoryRss               MetricConfig `mapstructure:"k8s.node.memory.rss"`
+	K8sNodeMemoryUsage             MetricConfig `mapstructure:"k8s.node.memory.usage"`
+	K8sNodeMemoryWorkingSet        MetricConfig `mapstructure:"k8s.node.memory.working_set"`
+	K8sNodeNetworkErrors           MetricConfig `mapstructure:"k8s.node.network.errors"`
+	K8sNodeNetworkIo               MetricConfig `mapstructure:"k8s.node.network.io"`
+	K8sPodCPUTime                  MetricConfig `mapstructure:"k8s.pod.cpu.time"`
+	K8sPodCPUUtilization           MetricConfig `mapstructure:"k8s.pod.cpu.utilization"`
+	K8sPodFilesystemAvailable      MetricConfig `mapstructure:"k8s.pod.filesystem.available"`
+	K8sPodFilesystemCapacity       MetricConfig `mapstructure:"k8s.pod.filesystem.capacity"`
+	K8sPodFilesystemUsage          MetricConfig `mapstructure:"k8s.pod.filesystem.usage"`
+	K8sPodMemoryAvailable          MetricConfig `mapstructure:"k8s.pod.memory.available"`
+	K8sPodMemoryMajorPageFaults    MetricConfig `mapstructure:"k8s.pod.memory.major_page_faults"`
+	K8sPodMemoryPageFaults         MetricConfig `mapstructure:"k8s.pod.memory.page_faults"`
+	K8sPodMemoryRss                MetricConfig `mapstructure:"k8s.pod.memory.rss"`
+	K8sPodMemoryUsage              MetricConfig `mapstructure:"k8s.pod.memory.usage"`
+	K8sPodMemoryWorkingSet         MetricConfig `mapstructure:"k8s.pod.memory.working_set"`
+	K8sPodNetworkErrors            MetricConfig `mapstructure:"k8s.pod.network.errors"`
+	K8sPodNetworkIo                MetricConfig `mapstructure:"k8s.pod.network.io"`
+	K8sVolumeAvailable             MetricConfig `mapstructure:"k8s.volume.available"`
+	K8sVolumeCapacity              MetricConfig `mapstructure:"k8s.volume.capacity"`
+	K8sVolumeInodes                MetricConfig `mapstructure:"k8s.volume.inodes"`
+	K8sVolumeInodesFree            MetricConfig `mapstructure:"k8s.volume.inodes.free"`
+	K8sVolumeInodesUsed            MetricConfig `mapstructure:"k8s.volume.inodes.used"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		ContainerCPUTime: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		ContainerCPUTime: MetricConfig{
 			Enabled: true,
 		},
-		ContainerCPUUtilization: MetricSettings{
+		ContainerCPUUtilization: MetricConfig{
 			Enabled: true,
 		},
-		ContainerFilesystemAvailable: MetricSettings{
+		ContainerFilesystemAvailable: MetricConfig{
 			Enabled: true,
 		},
-		ContainerFilesystemCapacity: MetricSettings{
+		ContainerFilesystemCapacity: MetricConfig{
 			Enabled: true,
 		},
-		ContainerFilesystemUsage: MetricSettings{
+		ContainerFilesystemUsage: MetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryAvailable: MetricSettings{
+		ContainerMemoryAvailable: MetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryMajorPageFaults: MetricSettings{
+		ContainerMemoryMajorPageFaults: MetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryPageFaults: MetricSettings{
+		ContainerMemoryPageFaults: MetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryRss: MetricSettings{
+		ContainerMemoryRss: MetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryUsage: MetricSettings{
+		ContainerMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		ContainerMemoryWorkingSet: MetricSettings{
+		ContainerMemoryWorkingSet: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeCPUTime: MetricSettings{
+		K8sNodeCPUTime: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeCPUUtilization: MetricSettings{
+		K8sNodeCPUUtilization: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeFilesystemAvailable: MetricSettings{
+		K8sNodeFilesystemAvailable: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeFilesystemCapacity: MetricSettings{
+		K8sNodeFilesystemCapacity: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeFilesystemUsage: MetricSettings{
+		K8sNodeFilesystemUsage: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeMemoryAvailable: MetricSettings{
+		K8sNodeMemoryAvailable: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeMemoryMajorPageFaults: MetricSettings{
+		K8sNodeMemoryMajorPageFaults: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeMemoryPageFaults: MetricSettings{
+		K8sNodeMemoryPageFaults: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeMemoryRss: MetricSettings{
+		K8sNodeMemoryRss: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeMemoryUsage: MetricSettings{
+		K8sNodeMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeMemoryWorkingSet: MetricSettings{
+		K8sNodeMemoryWorkingSet: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeNetworkErrors: MetricSettings{
+		K8sNodeNetworkErrors: MetricConfig{
 			Enabled: true,
 		},
-		K8sNodeNetworkIo: MetricSettings{
+		K8sNodeNetworkIo: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodCPUTime: MetricSettings{
+		K8sPodCPUTime: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodCPUUtilization: MetricSettings{
+		K8sPodCPUUtilization: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodFilesystemAvailable: MetricSettings{
+		K8sPodFilesystemAvailable: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodFilesystemCapacity: MetricSettings{
+		K8sPodFilesystemCapacity: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodFilesystemUsage: MetricSettings{
+		K8sPodFilesystemUsage: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodMemoryAvailable: MetricSettings{
+		K8sPodMemoryAvailable: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodMemoryMajorPageFaults: MetricSettings{
+		K8sPodMemoryMajorPageFaults: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodMemoryPageFaults: MetricSettings{
+		K8sPodMemoryPageFaults: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodMemoryRss: MetricSettings{
+		K8sPodMemoryRss: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodMemoryUsage: MetricSettings{
+		K8sPodMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodMemoryWorkingSet: MetricSettings{
+		K8sPodMemoryWorkingSet: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodNetworkErrors: MetricSettings{
+		K8sPodNetworkErrors: MetricConfig{
 			Enabled: true,
 		},
-		K8sPodNetworkIo: MetricSettings{
+		K8sPodNetworkIo: MetricConfig{
 			Enabled: true,
 		},
-		K8sVolumeAvailable: MetricSettings{
+		K8sVolumeAvailable: MetricConfig{
 			Enabled: true,
 		},
-		K8sVolumeCapacity: MetricSettings{
+		K8sVolumeCapacity: MetricConfig{
 			Enabled: true,
 		},
-		K8sVolumeInodes: MetricSettings{
+		K8sVolumeInodes: MetricConfig{
 			Enabled: true,
 		},
-		K8sVolumeInodesFree: MetricSettings{
+		K8sVolumeInodesFree: MetricConfig{
 			Enabled: true,
 		},
-		K8sVolumeInodesUsed: MetricSettings{
+		K8sVolumeInodesUsed: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for kubeletstatsreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	AwsVolumeID                  ResourceAttributeSettings `mapstructure:"aws.volume.id"`
-	ContainerID                  ResourceAttributeSettings `mapstructure:"container.id"`
-	FsType                       ResourceAttributeSettings `mapstructure:"fs.type"`
-	GcePdName                    ResourceAttributeSettings `mapstructure:"gce.pd.name"`
-	GlusterfsEndpointsName       ResourceAttributeSettings `mapstructure:"glusterfs.endpoints.name"`
-	GlusterfsPath                ResourceAttributeSettings `mapstructure:"glusterfs.path"`
-	K8sContainerName             ResourceAttributeSettings `mapstructure:"k8s.container.name"`
-	K8sNamespaceName             ResourceAttributeSettings `mapstructure:"k8s.namespace.name"`
-	K8sNodeName                  ResourceAttributeSettings `mapstructure:"k8s.node.name"`
-	K8sPersistentvolumeclaimName ResourceAttributeSettings `mapstructure:"k8s.persistentvolumeclaim.name"`
-	K8sPodName                   ResourceAttributeSettings `mapstructure:"k8s.pod.name"`
-	K8sPodUID                    ResourceAttributeSettings `mapstructure:"k8s.pod.uid"`
-	K8sVolumeName                ResourceAttributeSettings `mapstructure:"k8s.volume.name"`
-	K8sVolumeType                ResourceAttributeSettings `mapstructure:"k8s.volume.type"`
-	Partition                    ResourceAttributeSettings `mapstructure:"partition"`
+// ResourceAttributesConfig provides config for kubeletstatsreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	AwsVolumeID                  ResourceAttributeConfig `mapstructure:"aws.volume.id"`
+	ContainerID                  ResourceAttributeConfig `mapstructure:"container.id"`
+	FsType                       ResourceAttributeConfig `mapstructure:"fs.type"`
+	GcePdName                    ResourceAttributeConfig `mapstructure:"gce.pd.name"`
+	GlusterfsEndpointsName       ResourceAttributeConfig `mapstructure:"glusterfs.endpoints.name"`
+	GlusterfsPath                ResourceAttributeConfig `mapstructure:"glusterfs.path"`
+	K8sContainerName             ResourceAttributeConfig `mapstructure:"k8s.container.name"`
+	K8sNamespaceName             ResourceAttributeConfig `mapstructure:"k8s.namespace.name"`
+	K8sNodeName                  ResourceAttributeConfig `mapstructure:"k8s.node.name"`
+	K8sPersistentvolumeclaimName ResourceAttributeConfig `mapstructure:"k8s.persistentvolumeclaim.name"`
+	K8sPodName                   ResourceAttributeConfig `mapstructure:"k8s.pod.name"`
+	K8sPodUID                    ResourceAttributeConfig `mapstructure:"k8s.pod.uid"`
+	K8sVolumeName                ResourceAttributeConfig `mapstructure:"k8s.volume.name"`
+	K8sVolumeType                ResourceAttributeConfig `mapstructure:"k8s.volume.type"`
+	Partition                    ResourceAttributeConfig `mapstructure:"partition"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		AwsVolumeID: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		AwsVolumeID: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ContainerID: ResourceAttributeSettings{
+		ContainerID: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		FsType: ResourceAttributeSettings{
+		FsType: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		GcePdName: ResourceAttributeSettings{
+		GcePdName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		GlusterfsEndpointsName: ResourceAttributeSettings{
+		GlusterfsEndpointsName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		GlusterfsPath: ResourceAttributeSettings{
+		GlusterfsPath: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		K8sContainerName: ResourceAttributeSettings{
+		K8sContainerName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		K8sNamespaceName: ResourceAttributeSettings{
+		K8sNamespaceName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		K8sNodeName: ResourceAttributeSettings{
+		K8sNodeName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		K8sPersistentvolumeclaimName: ResourceAttributeSettings{
+		K8sPersistentvolumeclaimName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		K8sPodName: ResourceAttributeSettings{
+		K8sPodName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		K8sPodUID: ResourceAttributeSettings{
+		K8sPodUID: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		K8sVolumeName: ResourceAttributeSettings{
+		K8sVolumeName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		K8sVolumeType: ResourceAttributeSettings{
+		K8sVolumeType: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		Partition: ResourceAttributeSettings{
+		Partition: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -310,7 +310,7 @@ var MapAttributeDirection = map[string]AttributeDirection{
 
 type metricContainerCPUTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -325,7 +325,7 @@ func (m *metricContainerCPUTime) init() {
 }
 
 func (m *metricContainerCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -343,16 +343,16 @@ func (m *metricContainerCPUTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerCPUTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerCPUTime(settings MetricSettings) metricContainerCPUTime {
-	m := metricContainerCPUTime{settings: settings}
-	if settings.Enabled {
+func newMetricContainerCPUTime(cfg MetricConfig) metricContainerCPUTime {
+	m := metricContainerCPUTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -361,7 +361,7 @@ func newMetricContainerCPUTime(settings MetricSettings) metricContainerCPUTime {
 
 type metricContainerCPUUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -374,7 +374,7 @@ func (m *metricContainerCPUUtilization) init() {
 }
 
 func (m *metricContainerCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -392,16 +392,16 @@ func (m *metricContainerCPUUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerCPUUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerCPUUtilization(settings MetricSettings) metricContainerCPUUtilization {
-	m := metricContainerCPUUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricContainerCPUUtilization(cfg MetricConfig) metricContainerCPUUtilization {
+	m := metricContainerCPUUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -410,7 +410,7 @@ func newMetricContainerCPUUtilization(settings MetricSettings) metricContainerCP
 
 type metricContainerFilesystemAvailable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -423,7 +423,7 @@ func (m *metricContainerFilesystemAvailable) init() {
 }
 
 func (m *metricContainerFilesystemAvailable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -441,16 +441,16 @@ func (m *metricContainerFilesystemAvailable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerFilesystemAvailable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerFilesystemAvailable(settings MetricSettings) metricContainerFilesystemAvailable {
-	m := metricContainerFilesystemAvailable{settings: settings}
-	if settings.Enabled {
+func newMetricContainerFilesystemAvailable(cfg MetricConfig) metricContainerFilesystemAvailable {
+	m := metricContainerFilesystemAvailable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -459,7 +459,7 @@ func newMetricContainerFilesystemAvailable(settings MetricSettings) metricContai
 
 type metricContainerFilesystemCapacity struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -472,7 +472,7 @@ func (m *metricContainerFilesystemCapacity) init() {
 }
 
 func (m *metricContainerFilesystemCapacity) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -490,16 +490,16 @@ func (m *metricContainerFilesystemCapacity) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerFilesystemCapacity) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerFilesystemCapacity(settings MetricSettings) metricContainerFilesystemCapacity {
-	m := metricContainerFilesystemCapacity{settings: settings}
-	if settings.Enabled {
+func newMetricContainerFilesystemCapacity(cfg MetricConfig) metricContainerFilesystemCapacity {
+	m := metricContainerFilesystemCapacity{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -508,7 +508,7 @@ func newMetricContainerFilesystemCapacity(settings MetricSettings) metricContain
 
 type metricContainerFilesystemUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -521,7 +521,7 @@ func (m *metricContainerFilesystemUsage) init() {
 }
 
 func (m *metricContainerFilesystemUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -539,16 +539,16 @@ func (m *metricContainerFilesystemUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerFilesystemUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerFilesystemUsage(settings MetricSettings) metricContainerFilesystemUsage {
-	m := metricContainerFilesystemUsage{settings: settings}
-	if settings.Enabled {
+func newMetricContainerFilesystemUsage(cfg MetricConfig) metricContainerFilesystemUsage {
+	m := metricContainerFilesystemUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -557,7 +557,7 @@ func newMetricContainerFilesystemUsage(settings MetricSettings) metricContainerF
 
 type metricContainerMemoryAvailable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -570,7 +570,7 @@ func (m *metricContainerMemoryAvailable) init() {
 }
 
 func (m *metricContainerMemoryAvailable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -588,16 +588,16 @@ func (m *metricContainerMemoryAvailable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryAvailable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryAvailable(settings MetricSettings) metricContainerMemoryAvailable {
-	m := metricContainerMemoryAvailable{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryAvailable(cfg MetricConfig) metricContainerMemoryAvailable {
+	m := metricContainerMemoryAvailable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -606,7 +606,7 @@ func newMetricContainerMemoryAvailable(settings MetricSettings) metricContainerM
 
 type metricContainerMemoryMajorPageFaults struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -619,7 +619,7 @@ func (m *metricContainerMemoryMajorPageFaults) init() {
 }
 
 func (m *metricContainerMemoryMajorPageFaults) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -637,16 +637,16 @@ func (m *metricContainerMemoryMajorPageFaults) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryMajorPageFaults) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryMajorPageFaults(settings MetricSettings) metricContainerMemoryMajorPageFaults {
-	m := metricContainerMemoryMajorPageFaults{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryMajorPageFaults(cfg MetricConfig) metricContainerMemoryMajorPageFaults {
+	m := metricContainerMemoryMajorPageFaults{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -655,7 +655,7 @@ func newMetricContainerMemoryMajorPageFaults(settings MetricSettings) metricCont
 
 type metricContainerMemoryPageFaults struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -668,7 +668,7 @@ func (m *metricContainerMemoryPageFaults) init() {
 }
 
 func (m *metricContainerMemoryPageFaults) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -686,16 +686,16 @@ func (m *metricContainerMemoryPageFaults) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryPageFaults) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryPageFaults(settings MetricSettings) metricContainerMemoryPageFaults {
-	m := metricContainerMemoryPageFaults{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryPageFaults(cfg MetricConfig) metricContainerMemoryPageFaults {
+	m := metricContainerMemoryPageFaults{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -704,7 +704,7 @@ func newMetricContainerMemoryPageFaults(settings MetricSettings) metricContainer
 
 type metricContainerMemoryRss struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -717,7 +717,7 @@ func (m *metricContainerMemoryRss) init() {
 }
 
 func (m *metricContainerMemoryRss) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -735,16 +735,16 @@ func (m *metricContainerMemoryRss) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryRss) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryRss(settings MetricSettings) metricContainerMemoryRss {
-	m := metricContainerMemoryRss{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryRss(cfg MetricConfig) metricContainerMemoryRss {
+	m := metricContainerMemoryRss{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -753,7 +753,7 @@ func newMetricContainerMemoryRss(settings MetricSettings) metricContainerMemoryR
 
 type metricContainerMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -766,7 +766,7 @@ func (m *metricContainerMemoryUsage) init() {
 }
 
 func (m *metricContainerMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -784,16 +784,16 @@ func (m *metricContainerMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryUsage(settings MetricSettings) metricContainerMemoryUsage {
-	m := metricContainerMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryUsage(cfg MetricConfig) metricContainerMemoryUsage {
+	m := metricContainerMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -802,7 +802,7 @@ func newMetricContainerMemoryUsage(settings MetricSettings) metricContainerMemor
 
 type metricContainerMemoryWorkingSet struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -815,7 +815,7 @@ func (m *metricContainerMemoryWorkingSet) init() {
 }
 
 func (m *metricContainerMemoryWorkingSet) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -833,16 +833,16 @@ func (m *metricContainerMemoryWorkingSet) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricContainerMemoryWorkingSet) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricContainerMemoryWorkingSet(settings MetricSettings) metricContainerMemoryWorkingSet {
-	m := metricContainerMemoryWorkingSet{settings: settings}
-	if settings.Enabled {
+func newMetricContainerMemoryWorkingSet(cfg MetricConfig) metricContainerMemoryWorkingSet {
+	m := metricContainerMemoryWorkingSet{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -851,7 +851,7 @@ func newMetricContainerMemoryWorkingSet(settings MetricSettings) metricContainer
 
 type metricK8sNodeCPUTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -866,7 +866,7 @@ func (m *metricK8sNodeCPUTime) init() {
 }
 
 func (m *metricK8sNodeCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -884,16 +884,16 @@ func (m *metricK8sNodeCPUTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeCPUTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeCPUTime(settings MetricSettings) metricK8sNodeCPUTime {
-	m := metricK8sNodeCPUTime{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeCPUTime(cfg MetricConfig) metricK8sNodeCPUTime {
+	m := metricK8sNodeCPUTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -902,7 +902,7 @@ func newMetricK8sNodeCPUTime(settings MetricSettings) metricK8sNodeCPUTime {
 
 type metricK8sNodeCPUUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -915,7 +915,7 @@ func (m *metricK8sNodeCPUUtilization) init() {
 }
 
 func (m *metricK8sNodeCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -933,16 +933,16 @@ func (m *metricK8sNodeCPUUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeCPUUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeCPUUtilization(settings MetricSettings) metricK8sNodeCPUUtilization {
-	m := metricK8sNodeCPUUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeCPUUtilization(cfg MetricConfig) metricK8sNodeCPUUtilization {
+	m := metricK8sNodeCPUUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -951,7 +951,7 @@ func newMetricK8sNodeCPUUtilization(settings MetricSettings) metricK8sNodeCPUUti
 
 type metricK8sNodeFilesystemAvailable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -964,7 +964,7 @@ func (m *metricK8sNodeFilesystemAvailable) init() {
 }
 
 func (m *metricK8sNodeFilesystemAvailable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -982,16 +982,16 @@ func (m *metricK8sNodeFilesystemAvailable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeFilesystemAvailable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeFilesystemAvailable(settings MetricSettings) metricK8sNodeFilesystemAvailable {
-	m := metricK8sNodeFilesystemAvailable{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeFilesystemAvailable(cfg MetricConfig) metricK8sNodeFilesystemAvailable {
+	m := metricK8sNodeFilesystemAvailable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1000,7 +1000,7 @@ func newMetricK8sNodeFilesystemAvailable(settings MetricSettings) metricK8sNodeF
 
 type metricK8sNodeFilesystemCapacity struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1013,7 +1013,7 @@ func (m *metricK8sNodeFilesystemCapacity) init() {
 }
 
 func (m *metricK8sNodeFilesystemCapacity) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1031,16 +1031,16 @@ func (m *metricK8sNodeFilesystemCapacity) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeFilesystemCapacity) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeFilesystemCapacity(settings MetricSettings) metricK8sNodeFilesystemCapacity {
-	m := metricK8sNodeFilesystemCapacity{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeFilesystemCapacity(cfg MetricConfig) metricK8sNodeFilesystemCapacity {
+	m := metricK8sNodeFilesystemCapacity{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1049,7 +1049,7 @@ func newMetricK8sNodeFilesystemCapacity(settings MetricSettings) metricK8sNodeFi
 
 type metricK8sNodeFilesystemUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1062,7 +1062,7 @@ func (m *metricK8sNodeFilesystemUsage) init() {
 }
 
 func (m *metricK8sNodeFilesystemUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1080,16 +1080,16 @@ func (m *metricK8sNodeFilesystemUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeFilesystemUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeFilesystemUsage(settings MetricSettings) metricK8sNodeFilesystemUsage {
-	m := metricK8sNodeFilesystemUsage{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeFilesystemUsage(cfg MetricConfig) metricK8sNodeFilesystemUsage {
+	m := metricK8sNodeFilesystemUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1098,7 +1098,7 @@ func newMetricK8sNodeFilesystemUsage(settings MetricSettings) metricK8sNodeFiles
 
 type metricK8sNodeMemoryAvailable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1111,7 +1111,7 @@ func (m *metricK8sNodeMemoryAvailable) init() {
 }
 
 func (m *metricK8sNodeMemoryAvailable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1129,16 +1129,16 @@ func (m *metricK8sNodeMemoryAvailable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeMemoryAvailable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeMemoryAvailable(settings MetricSettings) metricK8sNodeMemoryAvailable {
-	m := metricK8sNodeMemoryAvailable{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeMemoryAvailable(cfg MetricConfig) metricK8sNodeMemoryAvailable {
+	m := metricK8sNodeMemoryAvailable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1147,7 +1147,7 @@ func newMetricK8sNodeMemoryAvailable(settings MetricSettings) metricK8sNodeMemor
 
 type metricK8sNodeMemoryMajorPageFaults struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1160,7 +1160,7 @@ func (m *metricK8sNodeMemoryMajorPageFaults) init() {
 }
 
 func (m *metricK8sNodeMemoryMajorPageFaults) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1178,16 +1178,16 @@ func (m *metricK8sNodeMemoryMajorPageFaults) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeMemoryMajorPageFaults) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeMemoryMajorPageFaults(settings MetricSettings) metricK8sNodeMemoryMajorPageFaults {
-	m := metricK8sNodeMemoryMajorPageFaults{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeMemoryMajorPageFaults(cfg MetricConfig) metricK8sNodeMemoryMajorPageFaults {
+	m := metricK8sNodeMemoryMajorPageFaults{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1196,7 +1196,7 @@ func newMetricK8sNodeMemoryMajorPageFaults(settings MetricSettings) metricK8sNod
 
 type metricK8sNodeMemoryPageFaults struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1209,7 +1209,7 @@ func (m *metricK8sNodeMemoryPageFaults) init() {
 }
 
 func (m *metricK8sNodeMemoryPageFaults) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1227,16 +1227,16 @@ func (m *metricK8sNodeMemoryPageFaults) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeMemoryPageFaults) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeMemoryPageFaults(settings MetricSettings) metricK8sNodeMemoryPageFaults {
-	m := metricK8sNodeMemoryPageFaults{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeMemoryPageFaults(cfg MetricConfig) metricK8sNodeMemoryPageFaults {
+	m := metricK8sNodeMemoryPageFaults{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1245,7 +1245,7 @@ func newMetricK8sNodeMemoryPageFaults(settings MetricSettings) metricK8sNodeMemo
 
 type metricK8sNodeMemoryRss struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1258,7 +1258,7 @@ func (m *metricK8sNodeMemoryRss) init() {
 }
 
 func (m *metricK8sNodeMemoryRss) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1276,16 +1276,16 @@ func (m *metricK8sNodeMemoryRss) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeMemoryRss) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeMemoryRss(settings MetricSettings) metricK8sNodeMemoryRss {
-	m := metricK8sNodeMemoryRss{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeMemoryRss(cfg MetricConfig) metricK8sNodeMemoryRss {
+	m := metricK8sNodeMemoryRss{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1294,7 +1294,7 @@ func newMetricK8sNodeMemoryRss(settings MetricSettings) metricK8sNodeMemoryRss {
 
 type metricK8sNodeMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1307,7 +1307,7 @@ func (m *metricK8sNodeMemoryUsage) init() {
 }
 
 func (m *metricK8sNodeMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1325,16 +1325,16 @@ func (m *metricK8sNodeMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeMemoryUsage(settings MetricSettings) metricK8sNodeMemoryUsage {
-	m := metricK8sNodeMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeMemoryUsage(cfg MetricConfig) metricK8sNodeMemoryUsage {
+	m := metricK8sNodeMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1343,7 +1343,7 @@ func newMetricK8sNodeMemoryUsage(settings MetricSettings) metricK8sNodeMemoryUsa
 
 type metricK8sNodeMemoryWorkingSet struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1356,7 +1356,7 @@ func (m *metricK8sNodeMemoryWorkingSet) init() {
 }
 
 func (m *metricK8sNodeMemoryWorkingSet) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1374,16 +1374,16 @@ func (m *metricK8sNodeMemoryWorkingSet) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeMemoryWorkingSet) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeMemoryWorkingSet(settings MetricSettings) metricK8sNodeMemoryWorkingSet {
-	m := metricK8sNodeMemoryWorkingSet{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeMemoryWorkingSet(cfg MetricConfig) metricK8sNodeMemoryWorkingSet {
+	m := metricK8sNodeMemoryWorkingSet{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1392,7 +1392,7 @@ func newMetricK8sNodeMemoryWorkingSet(settings MetricSettings) metricK8sNodeMemo
 
 type metricK8sNodeNetworkErrors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1408,7 +1408,7 @@ func (m *metricK8sNodeNetworkErrors) init() {
 }
 
 func (m *metricK8sNodeNetworkErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1428,16 +1428,16 @@ func (m *metricK8sNodeNetworkErrors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeNetworkErrors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeNetworkErrors(settings MetricSettings) metricK8sNodeNetworkErrors {
-	m := metricK8sNodeNetworkErrors{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeNetworkErrors(cfg MetricConfig) metricK8sNodeNetworkErrors {
+	m := metricK8sNodeNetworkErrors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1446,7 +1446,7 @@ func newMetricK8sNodeNetworkErrors(settings MetricSettings) metricK8sNodeNetwork
 
 type metricK8sNodeNetworkIo struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1462,7 +1462,7 @@ func (m *metricK8sNodeNetworkIo) init() {
 }
 
 func (m *metricK8sNodeNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1482,16 +1482,16 @@ func (m *metricK8sNodeNetworkIo) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sNodeNetworkIo) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sNodeNetworkIo(settings MetricSettings) metricK8sNodeNetworkIo {
-	m := metricK8sNodeNetworkIo{settings: settings}
-	if settings.Enabled {
+func newMetricK8sNodeNetworkIo(cfg MetricConfig) metricK8sNodeNetworkIo {
+	m := metricK8sNodeNetworkIo{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1500,7 +1500,7 @@ func newMetricK8sNodeNetworkIo(settings MetricSettings) metricK8sNodeNetworkIo {
 
 type metricK8sPodCPUTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1515,7 +1515,7 @@ func (m *metricK8sPodCPUTime) init() {
 }
 
 func (m *metricK8sPodCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1533,16 +1533,16 @@ func (m *metricK8sPodCPUTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodCPUTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodCPUTime(settings MetricSettings) metricK8sPodCPUTime {
-	m := metricK8sPodCPUTime{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodCPUTime(cfg MetricConfig) metricK8sPodCPUTime {
+	m := metricK8sPodCPUTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1551,7 +1551,7 @@ func newMetricK8sPodCPUTime(settings MetricSettings) metricK8sPodCPUTime {
 
 type metricK8sPodCPUUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1564,7 +1564,7 @@ func (m *metricK8sPodCPUUtilization) init() {
 }
 
 func (m *metricK8sPodCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1582,16 +1582,16 @@ func (m *metricK8sPodCPUUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodCPUUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodCPUUtilization(settings MetricSettings) metricK8sPodCPUUtilization {
-	m := metricK8sPodCPUUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodCPUUtilization(cfg MetricConfig) metricK8sPodCPUUtilization {
+	m := metricK8sPodCPUUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1600,7 +1600,7 @@ func newMetricK8sPodCPUUtilization(settings MetricSettings) metricK8sPodCPUUtili
 
 type metricK8sPodFilesystemAvailable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1613,7 +1613,7 @@ func (m *metricK8sPodFilesystemAvailable) init() {
 }
 
 func (m *metricK8sPodFilesystemAvailable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1631,16 +1631,16 @@ func (m *metricK8sPodFilesystemAvailable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodFilesystemAvailable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodFilesystemAvailable(settings MetricSettings) metricK8sPodFilesystemAvailable {
-	m := metricK8sPodFilesystemAvailable{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodFilesystemAvailable(cfg MetricConfig) metricK8sPodFilesystemAvailable {
+	m := metricK8sPodFilesystemAvailable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1649,7 +1649,7 @@ func newMetricK8sPodFilesystemAvailable(settings MetricSettings) metricK8sPodFil
 
 type metricK8sPodFilesystemCapacity struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1662,7 +1662,7 @@ func (m *metricK8sPodFilesystemCapacity) init() {
 }
 
 func (m *metricK8sPodFilesystemCapacity) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1680,16 +1680,16 @@ func (m *metricK8sPodFilesystemCapacity) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodFilesystemCapacity) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodFilesystemCapacity(settings MetricSettings) metricK8sPodFilesystemCapacity {
-	m := metricK8sPodFilesystemCapacity{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodFilesystemCapacity(cfg MetricConfig) metricK8sPodFilesystemCapacity {
+	m := metricK8sPodFilesystemCapacity{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1698,7 +1698,7 @@ func newMetricK8sPodFilesystemCapacity(settings MetricSettings) metricK8sPodFile
 
 type metricK8sPodFilesystemUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1711,7 +1711,7 @@ func (m *metricK8sPodFilesystemUsage) init() {
 }
 
 func (m *metricK8sPodFilesystemUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1729,16 +1729,16 @@ func (m *metricK8sPodFilesystemUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodFilesystemUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodFilesystemUsage(settings MetricSettings) metricK8sPodFilesystemUsage {
-	m := metricK8sPodFilesystemUsage{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodFilesystemUsage(cfg MetricConfig) metricK8sPodFilesystemUsage {
+	m := metricK8sPodFilesystemUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1747,7 +1747,7 @@ func newMetricK8sPodFilesystemUsage(settings MetricSettings) metricK8sPodFilesys
 
 type metricK8sPodMemoryAvailable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1760,7 +1760,7 @@ func (m *metricK8sPodMemoryAvailable) init() {
 }
 
 func (m *metricK8sPodMemoryAvailable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1778,16 +1778,16 @@ func (m *metricK8sPodMemoryAvailable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodMemoryAvailable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodMemoryAvailable(settings MetricSettings) metricK8sPodMemoryAvailable {
-	m := metricK8sPodMemoryAvailable{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodMemoryAvailable(cfg MetricConfig) metricK8sPodMemoryAvailable {
+	m := metricK8sPodMemoryAvailable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1796,7 +1796,7 @@ func newMetricK8sPodMemoryAvailable(settings MetricSettings) metricK8sPodMemoryA
 
 type metricK8sPodMemoryMajorPageFaults struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1809,7 +1809,7 @@ func (m *metricK8sPodMemoryMajorPageFaults) init() {
 }
 
 func (m *metricK8sPodMemoryMajorPageFaults) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1827,16 +1827,16 @@ func (m *metricK8sPodMemoryMajorPageFaults) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodMemoryMajorPageFaults) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodMemoryMajorPageFaults(settings MetricSettings) metricK8sPodMemoryMajorPageFaults {
-	m := metricK8sPodMemoryMajorPageFaults{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodMemoryMajorPageFaults(cfg MetricConfig) metricK8sPodMemoryMajorPageFaults {
+	m := metricK8sPodMemoryMajorPageFaults{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1845,7 +1845,7 @@ func newMetricK8sPodMemoryMajorPageFaults(settings MetricSettings) metricK8sPodM
 
 type metricK8sPodMemoryPageFaults struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1858,7 +1858,7 @@ func (m *metricK8sPodMemoryPageFaults) init() {
 }
 
 func (m *metricK8sPodMemoryPageFaults) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1876,16 +1876,16 @@ func (m *metricK8sPodMemoryPageFaults) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodMemoryPageFaults) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodMemoryPageFaults(settings MetricSettings) metricK8sPodMemoryPageFaults {
-	m := metricK8sPodMemoryPageFaults{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodMemoryPageFaults(cfg MetricConfig) metricK8sPodMemoryPageFaults {
+	m := metricK8sPodMemoryPageFaults{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1894,7 +1894,7 @@ func newMetricK8sPodMemoryPageFaults(settings MetricSettings) metricK8sPodMemory
 
 type metricK8sPodMemoryRss struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1907,7 +1907,7 @@ func (m *metricK8sPodMemoryRss) init() {
 }
 
 func (m *metricK8sPodMemoryRss) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1925,16 +1925,16 @@ func (m *metricK8sPodMemoryRss) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodMemoryRss) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodMemoryRss(settings MetricSettings) metricK8sPodMemoryRss {
-	m := metricK8sPodMemoryRss{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodMemoryRss(cfg MetricConfig) metricK8sPodMemoryRss {
+	m := metricK8sPodMemoryRss{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1943,7 +1943,7 @@ func newMetricK8sPodMemoryRss(settings MetricSettings) metricK8sPodMemoryRss {
 
 type metricK8sPodMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1956,7 +1956,7 @@ func (m *metricK8sPodMemoryUsage) init() {
 }
 
 func (m *metricK8sPodMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1974,16 +1974,16 @@ func (m *metricK8sPodMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodMemoryUsage(settings MetricSettings) metricK8sPodMemoryUsage {
-	m := metricK8sPodMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodMemoryUsage(cfg MetricConfig) metricK8sPodMemoryUsage {
+	m := metricK8sPodMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1992,7 +1992,7 @@ func newMetricK8sPodMemoryUsage(settings MetricSettings) metricK8sPodMemoryUsage
 
 type metricK8sPodMemoryWorkingSet struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2005,7 +2005,7 @@ func (m *metricK8sPodMemoryWorkingSet) init() {
 }
 
 func (m *metricK8sPodMemoryWorkingSet) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2023,16 +2023,16 @@ func (m *metricK8sPodMemoryWorkingSet) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodMemoryWorkingSet) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodMemoryWorkingSet(settings MetricSettings) metricK8sPodMemoryWorkingSet {
-	m := metricK8sPodMemoryWorkingSet{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodMemoryWorkingSet(cfg MetricConfig) metricK8sPodMemoryWorkingSet {
+	m := metricK8sPodMemoryWorkingSet{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2041,7 +2041,7 @@ func newMetricK8sPodMemoryWorkingSet(settings MetricSettings) metricK8sPodMemory
 
 type metricK8sPodNetworkErrors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2057,7 +2057,7 @@ func (m *metricK8sPodNetworkErrors) init() {
 }
 
 func (m *metricK8sPodNetworkErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2077,16 +2077,16 @@ func (m *metricK8sPodNetworkErrors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodNetworkErrors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodNetworkErrors(settings MetricSettings) metricK8sPodNetworkErrors {
-	m := metricK8sPodNetworkErrors{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodNetworkErrors(cfg MetricConfig) metricK8sPodNetworkErrors {
+	m := metricK8sPodNetworkErrors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2095,7 +2095,7 @@ func newMetricK8sPodNetworkErrors(settings MetricSettings) metricK8sPodNetworkEr
 
 type metricK8sPodNetworkIo struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2111,7 +2111,7 @@ func (m *metricK8sPodNetworkIo) init() {
 }
 
 func (m *metricK8sPodNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, interfaceAttributeValue string, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2131,16 +2131,16 @@ func (m *metricK8sPodNetworkIo) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sPodNetworkIo) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sPodNetworkIo(settings MetricSettings) metricK8sPodNetworkIo {
-	m := metricK8sPodNetworkIo{settings: settings}
-	if settings.Enabled {
+func newMetricK8sPodNetworkIo(cfg MetricConfig) metricK8sPodNetworkIo {
+	m := metricK8sPodNetworkIo{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2149,7 +2149,7 @@ func newMetricK8sPodNetworkIo(settings MetricSettings) metricK8sPodNetworkIo {
 
 type metricK8sVolumeAvailable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2162,7 +2162,7 @@ func (m *metricK8sVolumeAvailable) init() {
 }
 
 func (m *metricK8sVolumeAvailable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2180,16 +2180,16 @@ func (m *metricK8sVolumeAvailable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sVolumeAvailable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sVolumeAvailable(settings MetricSettings) metricK8sVolumeAvailable {
-	m := metricK8sVolumeAvailable{settings: settings}
-	if settings.Enabled {
+func newMetricK8sVolumeAvailable(cfg MetricConfig) metricK8sVolumeAvailable {
+	m := metricK8sVolumeAvailable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2198,7 +2198,7 @@ func newMetricK8sVolumeAvailable(settings MetricSettings) metricK8sVolumeAvailab
 
 type metricK8sVolumeCapacity struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2211,7 +2211,7 @@ func (m *metricK8sVolumeCapacity) init() {
 }
 
 func (m *metricK8sVolumeCapacity) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2229,16 +2229,16 @@ func (m *metricK8sVolumeCapacity) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sVolumeCapacity) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sVolumeCapacity(settings MetricSettings) metricK8sVolumeCapacity {
-	m := metricK8sVolumeCapacity{settings: settings}
-	if settings.Enabled {
+func newMetricK8sVolumeCapacity(cfg MetricConfig) metricK8sVolumeCapacity {
+	m := metricK8sVolumeCapacity{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2247,7 +2247,7 @@ func newMetricK8sVolumeCapacity(settings MetricSettings) metricK8sVolumeCapacity
 
 type metricK8sVolumeInodes struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2260,7 +2260,7 @@ func (m *metricK8sVolumeInodes) init() {
 }
 
 func (m *metricK8sVolumeInodes) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2278,16 +2278,16 @@ func (m *metricK8sVolumeInodes) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sVolumeInodes) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sVolumeInodes(settings MetricSettings) metricK8sVolumeInodes {
-	m := metricK8sVolumeInodes{settings: settings}
-	if settings.Enabled {
+func newMetricK8sVolumeInodes(cfg MetricConfig) metricK8sVolumeInodes {
+	m := metricK8sVolumeInodes{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2296,7 +2296,7 @@ func newMetricK8sVolumeInodes(settings MetricSettings) metricK8sVolumeInodes {
 
 type metricK8sVolumeInodesFree struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2309,7 +2309,7 @@ func (m *metricK8sVolumeInodesFree) init() {
 }
 
 func (m *metricK8sVolumeInodesFree) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2327,16 +2327,16 @@ func (m *metricK8sVolumeInodesFree) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sVolumeInodesFree) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sVolumeInodesFree(settings MetricSettings) metricK8sVolumeInodesFree {
-	m := metricK8sVolumeInodesFree{settings: settings}
-	if settings.Enabled {
+func newMetricK8sVolumeInodesFree(cfg MetricConfig) metricK8sVolumeInodesFree {
+	m := metricK8sVolumeInodesFree{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2345,7 +2345,7 @@ func newMetricK8sVolumeInodesFree(settings MetricSettings) metricK8sVolumeInodes
 
 type metricK8sVolumeInodesUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2358,7 +2358,7 @@ func (m *metricK8sVolumeInodesUsed) init() {
 }
 
 func (m *metricK8sVolumeInodesUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2376,16 +2376,16 @@ func (m *metricK8sVolumeInodesUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricK8sVolumeInodesUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricK8sVolumeInodesUsed(settings MetricSettings) metricK8sVolumeInodesUsed {
-	m := metricK8sVolumeInodesUsed{settings: settings}
-	if settings.Enabled {
+func newMetricK8sVolumeInodesUsed(cfg MetricConfig) metricK8sVolumeInodesUsed {
+	m := metricK8sVolumeInodesUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2394,19 +2394,19 @@ func newMetricK8sVolumeInodesUsed(settings MetricSettings) metricK8sVolumeInodes
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                            pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                      int                 // maximum observed number of metrics per resource.
 	resourceCapacity                     int                 // maximum observed number of resource attributes.
 	metricsBuffer                        pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                            component.BuildInfo // contains version information
-	resourceAttributesSettings           ResourceAttributesSettings
+	resourceAttributesConfig             ResourceAttributesConfig
 	metricContainerCPUTime               metricContainerCPUTime
 	metricContainerCPUUtilization        metricContainerCPUUtilization
 	metricContainerFilesystemAvailable   metricContainerFilesystemAvailable
@@ -2463,8 +2463,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -2473,7 +2473,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                            pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                        pmetric.NewMetrics(),
 		buildInfo:                            settings.BuildInfo,
-		resourceAttributesSettings:           mbc.ResourceAttributes,
+		resourceAttributesConfig:             mbc.ResourceAttributes,
 		metricContainerCPUTime:               newMetricContainerCPUTime(mbc.Metrics.ContainerCPUTime),
 		metricContainerCPUUtilization:        newMetricContainerCPUUtilization(mbc.Metrics.ContainerCPUUtilization),
 		metricContainerFilesystemAvailable:   newMetricContainerFilesystemAvailable(mbc.Metrics.ContainerFilesystemAvailable),
@@ -2534,12 +2534,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithAwsVolumeID sets provided value as "aws.volume.id" attribute for current resource.
 func WithAwsVolumeID(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.AwsVolumeID.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.AwsVolumeID.Enabled {
 			rm.Resource().Attributes().PutStr("aws.volume.id", val)
 		}
 	}
@@ -2547,8 +2547,8 @@ func WithAwsVolumeID(val string) ResourceMetricsOption {
 
 // WithContainerID sets provided value as "container.id" attribute for current resource.
 func WithContainerID(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ContainerID.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ContainerID.Enabled {
 			rm.Resource().Attributes().PutStr("container.id", val)
 		}
 	}
@@ -2556,8 +2556,8 @@ func WithContainerID(val string) ResourceMetricsOption {
 
 // WithFsType sets provided value as "fs.type" attribute for current resource.
 func WithFsType(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.FsType.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.FsType.Enabled {
 			rm.Resource().Attributes().PutStr("fs.type", val)
 		}
 	}
@@ -2565,8 +2565,8 @@ func WithFsType(val string) ResourceMetricsOption {
 
 // WithGcePdName sets provided value as "gce.pd.name" attribute for current resource.
 func WithGcePdName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.GcePdName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.GcePdName.Enabled {
 			rm.Resource().Attributes().PutStr("gce.pd.name", val)
 		}
 	}
@@ -2574,8 +2574,8 @@ func WithGcePdName(val string) ResourceMetricsOption {
 
 // WithGlusterfsEndpointsName sets provided value as "glusterfs.endpoints.name" attribute for current resource.
 func WithGlusterfsEndpointsName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.GlusterfsEndpointsName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.GlusterfsEndpointsName.Enabled {
 			rm.Resource().Attributes().PutStr("glusterfs.endpoints.name", val)
 		}
 	}
@@ -2583,8 +2583,8 @@ func WithGlusterfsEndpointsName(val string) ResourceMetricsOption {
 
 // WithGlusterfsPath sets provided value as "glusterfs.path" attribute for current resource.
 func WithGlusterfsPath(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.GlusterfsPath.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.GlusterfsPath.Enabled {
 			rm.Resource().Attributes().PutStr("glusterfs.path", val)
 		}
 	}
@@ -2592,8 +2592,8 @@ func WithGlusterfsPath(val string) ResourceMetricsOption {
 
 // WithK8sContainerName sets provided value as "k8s.container.name" attribute for current resource.
 func WithK8sContainerName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.K8sContainerName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.K8sContainerName.Enabled {
 			rm.Resource().Attributes().PutStr("k8s.container.name", val)
 		}
 	}
@@ -2601,8 +2601,8 @@ func WithK8sContainerName(val string) ResourceMetricsOption {
 
 // WithK8sNamespaceName sets provided value as "k8s.namespace.name" attribute for current resource.
 func WithK8sNamespaceName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.K8sNamespaceName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.K8sNamespaceName.Enabled {
 			rm.Resource().Attributes().PutStr("k8s.namespace.name", val)
 		}
 	}
@@ -2610,8 +2610,8 @@ func WithK8sNamespaceName(val string) ResourceMetricsOption {
 
 // WithK8sNodeName sets provided value as "k8s.node.name" attribute for current resource.
 func WithK8sNodeName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.K8sNodeName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.K8sNodeName.Enabled {
 			rm.Resource().Attributes().PutStr("k8s.node.name", val)
 		}
 	}
@@ -2619,8 +2619,8 @@ func WithK8sNodeName(val string) ResourceMetricsOption {
 
 // WithK8sPersistentvolumeclaimName sets provided value as "k8s.persistentvolumeclaim.name" attribute for current resource.
 func WithK8sPersistentvolumeclaimName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.K8sPersistentvolumeclaimName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.K8sPersistentvolumeclaimName.Enabled {
 			rm.Resource().Attributes().PutStr("k8s.persistentvolumeclaim.name", val)
 		}
 	}
@@ -2628,8 +2628,8 @@ func WithK8sPersistentvolumeclaimName(val string) ResourceMetricsOption {
 
 // WithK8sPodName sets provided value as "k8s.pod.name" attribute for current resource.
 func WithK8sPodName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.K8sPodName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.K8sPodName.Enabled {
 			rm.Resource().Attributes().PutStr("k8s.pod.name", val)
 		}
 	}
@@ -2637,8 +2637,8 @@ func WithK8sPodName(val string) ResourceMetricsOption {
 
 // WithK8sPodUID sets provided value as "k8s.pod.uid" attribute for current resource.
 func WithK8sPodUID(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.K8sPodUID.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.K8sPodUID.Enabled {
 			rm.Resource().Attributes().PutStr("k8s.pod.uid", val)
 		}
 	}
@@ -2646,8 +2646,8 @@ func WithK8sPodUID(val string) ResourceMetricsOption {
 
 // WithK8sVolumeName sets provided value as "k8s.volume.name" attribute for current resource.
 func WithK8sVolumeName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.K8sVolumeName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.K8sVolumeName.Enabled {
 			rm.Resource().Attributes().PutStr("k8s.volume.name", val)
 		}
 	}
@@ -2655,8 +2655,8 @@ func WithK8sVolumeName(val string) ResourceMetricsOption {
 
 // WithK8sVolumeType sets provided value as "k8s.volume.type" attribute for current resource.
 func WithK8sVolumeType(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.K8sVolumeType.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.K8sVolumeType.Enabled {
 			rm.Resource().Attributes().PutStr("k8s.volume.type", val)
 		}
 	}
@@ -2664,8 +2664,8 @@ func WithK8sVolumeType(val string) ResourceMetricsOption {
 
 // WithPartition sets provided value as "partition" attribute for current resource.
 func WithPartition(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.Partition.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.Partition.Enabled {
 			rm.Resource().Attributes().PutStr("partition", val)
 		}
 	}
@@ -2674,7 +2674,7 @@ func WithPartition(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -2747,7 +2747,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricK8sVolumeInodesUsed.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -2757,7 +2757,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics_test.go
@@ -239,106 +239,106 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("aws.volume.id")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.AwsVolumeID.Enabled, ok)
-			if mb.resourceAttributesSettings.AwsVolumeID.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.AwsVolumeID.Enabled, ok)
+			if mb.resourceAttributesConfig.AwsVolumeID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("container.id")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ContainerID.Enabled, ok)
-			if mb.resourceAttributesSettings.ContainerID.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ContainerID.Enabled, ok)
+			if mb.resourceAttributesConfig.ContainerID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("fs.type")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.FsType.Enabled, ok)
-			if mb.resourceAttributesSettings.FsType.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.FsType.Enabled, ok)
+			if mb.resourceAttributesConfig.FsType.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("gce.pd.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.GcePdName.Enabled, ok)
-			if mb.resourceAttributesSettings.GcePdName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.GcePdName.Enabled, ok)
+			if mb.resourceAttributesConfig.GcePdName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("glusterfs.endpoints.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.GlusterfsEndpointsName.Enabled, ok)
-			if mb.resourceAttributesSettings.GlusterfsEndpointsName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.GlusterfsEndpointsName.Enabled, ok)
+			if mb.resourceAttributesConfig.GlusterfsEndpointsName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("glusterfs.path")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.GlusterfsPath.Enabled, ok)
-			if mb.resourceAttributesSettings.GlusterfsPath.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.GlusterfsPath.Enabled, ok)
+			if mb.resourceAttributesConfig.GlusterfsPath.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("k8s.container.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.K8sContainerName.Enabled, ok)
-			if mb.resourceAttributesSettings.K8sContainerName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.K8sContainerName.Enabled, ok)
+			if mb.resourceAttributesConfig.K8sContainerName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("k8s.namespace.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.K8sNamespaceName.Enabled, ok)
-			if mb.resourceAttributesSettings.K8sNamespaceName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.K8sNamespaceName.Enabled, ok)
+			if mb.resourceAttributesConfig.K8sNamespaceName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("k8s.node.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.K8sNodeName.Enabled, ok)
-			if mb.resourceAttributesSettings.K8sNodeName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.K8sNodeName.Enabled, ok)
+			if mb.resourceAttributesConfig.K8sNodeName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("k8s.persistentvolumeclaim.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.K8sPersistentvolumeclaimName.Enabled, ok)
-			if mb.resourceAttributesSettings.K8sPersistentvolumeclaimName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.K8sPersistentvolumeclaimName.Enabled, ok)
+			if mb.resourceAttributesConfig.K8sPersistentvolumeclaimName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("k8s.pod.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.K8sPodName.Enabled, ok)
-			if mb.resourceAttributesSettings.K8sPodName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.K8sPodName.Enabled, ok)
+			if mb.resourceAttributesConfig.K8sPodName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("k8s.pod.uid")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.K8sPodUID.Enabled, ok)
-			if mb.resourceAttributesSettings.K8sPodUID.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.K8sPodUID.Enabled, ok)
+			if mb.resourceAttributesConfig.K8sPodUID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("k8s.volume.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.K8sVolumeName.Enabled, ok)
-			if mb.resourceAttributesSettings.K8sVolumeName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.K8sVolumeName.Enabled, ok)
+			if mb.resourceAttributesConfig.K8sVolumeName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("k8s.volume.type")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.K8sVolumeType.Enabled, ok)
-			if mb.resourceAttributesSettings.K8sVolumeType.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.K8sVolumeType.Enabled, ok)
+			if mb.resourceAttributesConfig.K8sVolumeType.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("partition")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.Partition.Enabled, ok)
-			if mb.resourceAttributesSettings.Partition.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.Partition.Enabled, ok)
+			if mb.resourceAttributesConfig.Partition.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,316 +31,316 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for mongoatlasreceiver metrics.
-type MetricsSettings struct {
-	MongodbatlasDbCounts                                  MetricSettings `mapstructure:"mongodbatlas.db.counts"`
-	MongodbatlasDbSize                                    MetricSettings `mapstructure:"mongodbatlas.db.size"`
-	MongodbatlasDiskPartitionIopsAverage                  MetricSettings `mapstructure:"mongodbatlas.disk.partition.iops.average"`
-	MongodbatlasDiskPartitionIopsMax                      MetricSettings `mapstructure:"mongodbatlas.disk.partition.iops.max"`
-	MongodbatlasDiskPartitionLatencyAverage               MetricSettings `mapstructure:"mongodbatlas.disk.partition.latency.average"`
-	MongodbatlasDiskPartitionLatencyMax                   MetricSettings `mapstructure:"mongodbatlas.disk.partition.latency.max"`
-	MongodbatlasDiskPartitionSpaceAverage                 MetricSettings `mapstructure:"mongodbatlas.disk.partition.space.average"`
-	MongodbatlasDiskPartitionSpaceMax                     MetricSettings `mapstructure:"mongodbatlas.disk.partition.space.max"`
-	MongodbatlasDiskPartitionUsageAverage                 MetricSettings `mapstructure:"mongodbatlas.disk.partition.usage.average"`
-	MongodbatlasDiskPartitionUsageMax                     MetricSettings `mapstructure:"mongodbatlas.disk.partition.usage.max"`
-	MongodbatlasDiskPartitionUtilizationAverage           MetricSettings `mapstructure:"mongodbatlas.disk.partition.utilization.average"`
-	MongodbatlasDiskPartitionUtilizationMax               MetricSettings `mapstructure:"mongodbatlas.disk.partition.utilization.max"`
-	MongodbatlasProcessAsserts                            MetricSettings `mapstructure:"mongodbatlas.process.asserts"`
-	MongodbatlasProcessBackgroundFlush                    MetricSettings `mapstructure:"mongodbatlas.process.background_flush"`
-	MongodbatlasProcessCacheIo                            MetricSettings `mapstructure:"mongodbatlas.process.cache.io"`
-	MongodbatlasProcessCacheSize                          MetricSettings `mapstructure:"mongodbatlas.process.cache.size"`
-	MongodbatlasProcessConnections                        MetricSettings `mapstructure:"mongodbatlas.process.connections"`
-	MongodbatlasProcessCPUChildrenNormalizedUsageAverage  MetricSettings `mapstructure:"mongodbatlas.process.cpu.children.normalized.usage.average"`
-	MongodbatlasProcessCPUChildrenNormalizedUsageMax      MetricSettings `mapstructure:"mongodbatlas.process.cpu.children.normalized.usage.max"`
-	MongodbatlasProcessCPUChildrenUsageAverage            MetricSettings `mapstructure:"mongodbatlas.process.cpu.children.usage.average"`
-	MongodbatlasProcessCPUChildrenUsageMax                MetricSettings `mapstructure:"mongodbatlas.process.cpu.children.usage.max"`
-	MongodbatlasProcessCPUNormalizedUsageAverage          MetricSettings `mapstructure:"mongodbatlas.process.cpu.normalized.usage.average"`
-	MongodbatlasProcessCPUNormalizedUsageMax              MetricSettings `mapstructure:"mongodbatlas.process.cpu.normalized.usage.max"`
-	MongodbatlasProcessCPUUsageAverage                    MetricSettings `mapstructure:"mongodbatlas.process.cpu.usage.average"`
-	MongodbatlasProcessCPUUsageMax                        MetricSettings `mapstructure:"mongodbatlas.process.cpu.usage.max"`
-	MongodbatlasProcessCursors                            MetricSettings `mapstructure:"mongodbatlas.process.cursors"`
-	MongodbatlasProcessDbDocumentRate                     MetricSettings `mapstructure:"mongodbatlas.process.db.document.rate"`
-	MongodbatlasProcessDbOperationsRate                   MetricSettings `mapstructure:"mongodbatlas.process.db.operations.rate"`
-	MongodbatlasProcessDbOperationsTime                   MetricSettings `mapstructure:"mongodbatlas.process.db.operations.time"`
-	MongodbatlasProcessDbQueryExecutorScanned             MetricSettings `mapstructure:"mongodbatlas.process.db.query_executor.scanned"`
-	MongodbatlasProcessDbQueryTargetingScannedPerReturned MetricSettings `mapstructure:"mongodbatlas.process.db.query_targeting.scanned_per_returned"`
-	MongodbatlasProcessDbStorage                          MetricSettings `mapstructure:"mongodbatlas.process.db.storage"`
-	MongodbatlasProcessGlobalLock                         MetricSettings `mapstructure:"mongodbatlas.process.global_lock"`
-	MongodbatlasProcessIndexBtreeMissRatio                MetricSettings `mapstructure:"mongodbatlas.process.index.btree_miss_ratio"`
-	MongodbatlasProcessIndexCounters                      MetricSettings `mapstructure:"mongodbatlas.process.index.counters"`
-	MongodbatlasProcessJournalingCommits                  MetricSettings `mapstructure:"mongodbatlas.process.journaling.commits"`
-	MongodbatlasProcessJournalingDataFiles                MetricSettings `mapstructure:"mongodbatlas.process.journaling.data_files"`
-	MongodbatlasProcessJournalingWritten                  MetricSettings `mapstructure:"mongodbatlas.process.journaling.written"`
-	MongodbatlasProcessMemoryUsage                        MetricSettings `mapstructure:"mongodbatlas.process.memory.usage"`
-	MongodbatlasProcessNetworkIo                          MetricSettings `mapstructure:"mongodbatlas.process.network.io"`
-	MongodbatlasProcessNetworkRequests                    MetricSettings `mapstructure:"mongodbatlas.process.network.requests"`
-	MongodbatlasProcessOplogRate                          MetricSettings `mapstructure:"mongodbatlas.process.oplog.rate"`
-	MongodbatlasProcessOplogTime                          MetricSettings `mapstructure:"mongodbatlas.process.oplog.time"`
-	MongodbatlasProcessPageFaults                         MetricSettings `mapstructure:"mongodbatlas.process.page_faults"`
-	MongodbatlasProcessRestarts                           MetricSettings `mapstructure:"mongodbatlas.process.restarts"`
-	MongodbatlasProcessTickets                            MetricSettings `mapstructure:"mongodbatlas.process.tickets"`
-	MongodbatlasSystemCPUNormalizedUsageAverage           MetricSettings `mapstructure:"mongodbatlas.system.cpu.normalized.usage.average"`
-	MongodbatlasSystemCPUNormalizedUsageMax               MetricSettings `mapstructure:"mongodbatlas.system.cpu.normalized.usage.max"`
-	MongodbatlasSystemCPUUsageAverage                     MetricSettings `mapstructure:"mongodbatlas.system.cpu.usage.average"`
-	MongodbatlasSystemCPUUsageMax                         MetricSettings `mapstructure:"mongodbatlas.system.cpu.usage.max"`
-	MongodbatlasSystemFtsCPUNormalizedUsage               MetricSettings `mapstructure:"mongodbatlas.system.fts.cpu.normalized.usage"`
-	MongodbatlasSystemFtsCPUUsage                         MetricSettings `mapstructure:"mongodbatlas.system.fts.cpu.usage"`
-	MongodbatlasSystemFtsDiskUsed                         MetricSettings `mapstructure:"mongodbatlas.system.fts.disk.used"`
-	MongodbatlasSystemFtsMemoryUsage                      MetricSettings `mapstructure:"mongodbatlas.system.fts.memory.usage"`
-	MongodbatlasSystemMemoryUsageAverage                  MetricSettings `mapstructure:"mongodbatlas.system.memory.usage.average"`
-	MongodbatlasSystemMemoryUsageMax                      MetricSettings `mapstructure:"mongodbatlas.system.memory.usage.max"`
-	MongodbatlasSystemNetworkIoAverage                    MetricSettings `mapstructure:"mongodbatlas.system.network.io.average"`
-	MongodbatlasSystemNetworkIoMax                        MetricSettings `mapstructure:"mongodbatlas.system.network.io.max"`
-	MongodbatlasSystemPagingIoAverage                     MetricSettings `mapstructure:"mongodbatlas.system.paging.io.average"`
-	MongodbatlasSystemPagingIoMax                         MetricSettings `mapstructure:"mongodbatlas.system.paging.io.max"`
-	MongodbatlasSystemPagingUsageAverage                  MetricSettings `mapstructure:"mongodbatlas.system.paging.usage.average"`
-	MongodbatlasSystemPagingUsageMax                      MetricSettings `mapstructure:"mongodbatlas.system.paging.usage.max"`
+// MetricsConfig provides config for mongoatlasreceiver metrics.
+type MetricsConfig struct {
+	MongodbatlasDbCounts                                  MetricConfig `mapstructure:"mongodbatlas.db.counts"`
+	MongodbatlasDbSize                                    MetricConfig `mapstructure:"mongodbatlas.db.size"`
+	MongodbatlasDiskPartitionIopsAverage                  MetricConfig `mapstructure:"mongodbatlas.disk.partition.iops.average"`
+	MongodbatlasDiskPartitionIopsMax                      MetricConfig `mapstructure:"mongodbatlas.disk.partition.iops.max"`
+	MongodbatlasDiskPartitionLatencyAverage               MetricConfig `mapstructure:"mongodbatlas.disk.partition.latency.average"`
+	MongodbatlasDiskPartitionLatencyMax                   MetricConfig `mapstructure:"mongodbatlas.disk.partition.latency.max"`
+	MongodbatlasDiskPartitionSpaceAverage                 MetricConfig `mapstructure:"mongodbatlas.disk.partition.space.average"`
+	MongodbatlasDiskPartitionSpaceMax                     MetricConfig `mapstructure:"mongodbatlas.disk.partition.space.max"`
+	MongodbatlasDiskPartitionUsageAverage                 MetricConfig `mapstructure:"mongodbatlas.disk.partition.usage.average"`
+	MongodbatlasDiskPartitionUsageMax                     MetricConfig `mapstructure:"mongodbatlas.disk.partition.usage.max"`
+	MongodbatlasDiskPartitionUtilizationAverage           MetricConfig `mapstructure:"mongodbatlas.disk.partition.utilization.average"`
+	MongodbatlasDiskPartitionUtilizationMax               MetricConfig `mapstructure:"mongodbatlas.disk.partition.utilization.max"`
+	MongodbatlasProcessAsserts                            MetricConfig `mapstructure:"mongodbatlas.process.asserts"`
+	MongodbatlasProcessBackgroundFlush                    MetricConfig `mapstructure:"mongodbatlas.process.background_flush"`
+	MongodbatlasProcessCacheIo                            MetricConfig `mapstructure:"mongodbatlas.process.cache.io"`
+	MongodbatlasProcessCacheSize                          MetricConfig `mapstructure:"mongodbatlas.process.cache.size"`
+	MongodbatlasProcessConnections                        MetricConfig `mapstructure:"mongodbatlas.process.connections"`
+	MongodbatlasProcessCPUChildrenNormalizedUsageAverage  MetricConfig `mapstructure:"mongodbatlas.process.cpu.children.normalized.usage.average"`
+	MongodbatlasProcessCPUChildrenNormalizedUsageMax      MetricConfig `mapstructure:"mongodbatlas.process.cpu.children.normalized.usage.max"`
+	MongodbatlasProcessCPUChildrenUsageAverage            MetricConfig `mapstructure:"mongodbatlas.process.cpu.children.usage.average"`
+	MongodbatlasProcessCPUChildrenUsageMax                MetricConfig `mapstructure:"mongodbatlas.process.cpu.children.usage.max"`
+	MongodbatlasProcessCPUNormalizedUsageAverage          MetricConfig `mapstructure:"mongodbatlas.process.cpu.normalized.usage.average"`
+	MongodbatlasProcessCPUNormalizedUsageMax              MetricConfig `mapstructure:"mongodbatlas.process.cpu.normalized.usage.max"`
+	MongodbatlasProcessCPUUsageAverage                    MetricConfig `mapstructure:"mongodbatlas.process.cpu.usage.average"`
+	MongodbatlasProcessCPUUsageMax                        MetricConfig `mapstructure:"mongodbatlas.process.cpu.usage.max"`
+	MongodbatlasProcessCursors                            MetricConfig `mapstructure:"mongodbatlas.process.cursors"`
+	MongodbatlasProcessDbDocumentRate                     MetricConfig `mapstructure:"mongodbatlas.process.db.document.rate"`
+	MongodbatlasProcessDbOperationsRate                   MetricConfig `mapstructure:"mongodbatlas.process.db.operations.rate"`
+	MongodbatlasProcessDbOperationsTime                   MetricConfig `mapstructure:"mongodbatlas.process.db.operations.time"`
+	MongodbatlasProcessDbQueryExecutorScanned             MetricConfig `mapstructure:"mongodbatlas.process.db.query_executor.scanned"`
+	MongodbatlasProcessDbQueryTargetingScannedPerReturned MetricConfig `mapstructure:"mongodbatlas.process.db.query_targeting.scanned_per_returned"`
+	MongodbatlasProcessDbStorage                          MetricConfig `mapstructure:"mongodbatlas.process.db.storage"`
+	MongodbatlasProcessGlobalLock                         MetricConfig `mapstructure:"mongodbatlas.process.global_lock"`
+	MongodbatlasProcessIndexBtreeMissRatio                MetricConfig `mapstructure:"mongodbatlas.process.index.btree_miss_ratio"`
+	MongodbatlasProcessIndexCounters                      MetricConfig `mapstructure:"mongodbatlas.process.index.counters"`
+	MongodbatlasProcessJournalingCommits                  MetricConfig `mapstructure:"mongodbatlas.process.journaling.commits"`
+	MongodbatlasProcessJournalingDataFiles                MetricConfig `mapstructure:"mongodbatlas.process.journaling.data_files"`
+	MongodbatlasProcessJournalingWritten                  MetricConfig `mapstructure:"mongodbatlas.process.journaling.written"`
+	MongodbatlasProcessMemoryUsage                        MetricConfig `mapstructure:"mongodbatlas.process.memory.usage"`
+	MongodbatlasProcessNetworkIo                          MetricConfig `mapstructure:"mongodbatlas.process.network.io"`
+	MongodbatlasProcessNetworkRequests                    MetricConfig `mapstructure:"mongodbatlas.process.network.requests"`
+	MongodbatlasProcessOplogRate                          MetricConfig `mapstructure:"mongodbatlas.process.oplog.rate"`
+	MongodbatlasProcessOplogTime                          MetricConfig `mapstructure:"mongodbatlas.process.oplog.time"`
+	MongodbatlasProcessPageFaults                         MetricConfig `mapstructure:"mongodbatlas.process.page_faults"`
+	MongodbatlasProcessRestarts                           MetricConfig `mapstructure:"mongodbatlas.process.restarts"`
+	MongodbatlasProcessTickets                            MetricConfig `mapstructure:"mongodbatlas.process.tickets"`
+	MongodbatlasSystemCPUNormalizedUsageAverage           MetricConfig `mapstructure:"mongodbatlas.system.cpu.normalized.usage.average"`
+	MongodbatlasSystemCPUNormalizedUsageMax               MetricConfig `mapstructure:"mongodbatlas.system.cpu.normalized.usage.max"`
+	MongodbatlasSystemCPUUsageAverage                     MetricConfig `mapstructure:"mongodbatlas.system.cpu.usage.average"`
+	MongodbatlasSystemCPUUsageMax                         MetricConfig `mapstructure:"mongodbatlas.system.cpu.usage.max"`
+	MongodbatlasSystemFtsCPUNormalizedUsage               MetricConfig `mapstructure:"mongodbatlas.system.fts.cpu.normalized.usage"`
+	MongodbatlasSystemFtsCPUUsage                         MetricConfig `mapstructure:"mongodbatlas.system.fts.cpu.usage"`
+	MongodbatlasSystemFtsDiskUsed                         MetricConfig `mapstructure:"mongodbatlas.system.fts.disk.used"`
+	MongodbatlasSystemFtsMemoryUsage                      MetricConfig `mapstructure:"mongodbatlas.system.fts.memory.usage"`
+	MongodbatlasSystemMemoryUsageAverage                  MetricConfig `mapstructure:"mongodbatlas.system.memory.usage.average"`
+	MongodbatlasSystemMemoryUsageMax                      MetricConfig `mapstructure:"mongodbatlas.system.memory.usage.max"`
+	MongodbatlasSystemNetworkIoAverage                    MetricConfig `mapstructure:"mongodbatlas.system.network.io.average"`
+	MongodbatlasSystemNetworkIoMax                        MetricConfig `mapstructure:"mongodbatlas.system.network.io.max"`
+	MongodbatlasSystemPagingIoAverage                     MetricConfig `mapstructure:"mongodbatlas.system.paging.io.average"`
+	MongodbatlasSystemPagingIoMax                         MetricConfig `mapstructure:"mongodbatlas.system.paging.io.max"`
+	MongodbatlasSystemPagingUsageAverage                  MetricConfig `mapstructure:"mongodbatlas.system.paging.usage.average"`
+	MongodbatlasSystemPagingUsageMax                      MetricConfig `mapstructure:"mongodbatlas.system.paging.usage.max"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		MongodbatlasDbCounts: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		MongodbatlasDbCounts: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDbSize: MetricSettings{
+		MongodbatlasDbSize: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionIopsAverage: MetricSettings{
+		MongodbatlasDiskPartitionIopsAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionIopsMax: MetricSettings{
+		MongodbatlasDiskPartitionIopsMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionLatencyAverage: MetricSettings{
+		MongodbatlasDiskPartitionLatencyAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionLatencyMax: MetricSettings{
+		MongodbatlasDiskPartitionLatencyMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionSpaceAverage: MetricSettings{
+		MongodbatlasDiskPartitionSpaceAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionSpaceMax: MetricSettings{
+		MongodbatlasDiskPartitionSpaceMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionUsageAverage: MetricSettings{
+		MongodbatlasDiskPartitionUsageAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionUsageMax: MetricSettings{
+		MongodbatlasDiskPartitionUsageMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionUtilizationAverage: MetricSettings{
+		MongodbatlasDiskPartitionUtilizationAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasDiskPartitionUtilizationMax: MetricSettings{
+		MongodbatlasDiskPartitionUtilizationMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessAsserts: MetricSettings{
+		MongodbatlasProcessAsserts: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessBackgroundFlush: MetricSettings{
+		MongodbatlasProcessBackgroundFlush: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCacheIo: MetricSettings{
+		MongodbatlasProcessCacheIo: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCacheSize: MetricSettings{
+		MongodbatlasProcessCacheSize: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessConnections: MetricSettings{
+		MongodbatlasProcessConnections: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCPUChildrenNormalizedUsageAverage: MetricSettings{
+		MongodbatlasProcessCPUChildrenNormalizedUsageAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCPUChildrenNormalizedUsageMax: MetricSettings{
+		MongodbatlasProcessCPUChildrenNormalizedUsageMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCPUChildrenUsageAverage: MetricSettings{
+		MongodbatlasProcessCPUChildrenUsageAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCPUChildrenUsageMax: MetricSettings{
+		MongodbatlasProcessCPUChildrenUsageMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCPUNormalizedUsageAverage: MetricSettings{
+		MongodbatlasProcessCPUNormalizedUsageAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCPUNormalizedUsageMax: MetricSettings{
+		MongodbatlasProcessCPUNormalizedUsageMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCPUUsageAverage: MetricSettings{
+		MongodbatlasProcessCPUUsageAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCPUUsageMax: MetricSettings{
+		MongodbatlasProcessCPUUsageMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessCursors: MetricSettings{
+		MongodbatlasProcessCursors: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessDbDocumentRate: MetricSettings{
+		MongodbatlasProcessDbDocumentRate: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessDbOperationsRate: MetricSettings{
+		MongodbatlasProcessDbOperationsRate: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessDbOperationsTime: MetricSettings{
+		MongodbatlasProcessDbOperationsTime: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessDbQueryExecutorScanned: MetricSettings{
+		MongodbatlasProcessDbQueryExecutorScanned: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessDbQueryTargetingScannedPerReturned: MetricSettings{
+		MongodbatlasProcessDbQueryTargetingScannedPerReturned: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessDbStorage: MetricSettings{
+		MongodbatlasProcessDbStorage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessGlobalLock: MetricSettings{
+		MongodbatlasProcessGlobalLock: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessIndexBtreeMissRatio: MetricSettings{
+		MongodbatlasProcessIndexBtreeMissRatio: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessIndexCounters: MetricSettings{
+		MongodbatlasProcessIndexCounters: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessJournalingCommits: MetricSettings{
+		MongodbatlasProcessJournalingCommits: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessJournalingDataFiles: MetricSettings{
+		MongodbatlasProcessJournalingDataFiles: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessJournalingWritten: MetricSettings{
+		MongodbatlasProcessJournalingWritten: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessMemoryUsage: MetricSettings{
+		MongodbatlasProcessMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessNetworkIo: MetricSettings{
+		MongodbatlasProcessNetworkIo: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessNetworkRequests: MetricSettings{
+		MongodbatlasProcessNetworkRequests: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessOplogRate: MetricSettings{
+		MongodbatlasProcessOplogRate: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessOplogTime: MetricSettings{
+		MongodbatlasProcessOplogTime: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessPageFaults: MetricSettings{
+		MongodbatlasProcessPageFaults: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessRestarts: MetricSettings{
+		MongodbatlasProcessRestarts: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasProcessTickets: MetricSettings{
+		MongodbatlasProcessTickets: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemCPUNormalizedUsageAverage: MetricSettings{
+		MongodbatlasSystemCPUNormalizedUsageAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemCPUNormalizedUsageMax: MetricSettings{
+		MongodbatlasSystemCPUNormalizedUsageMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemCPUUsageAverage: MetricSettings{
+		MongodbatlasSystemCPUUsageAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemCPUUsageMax: MetricSettings{
+		MongodbatlasSystemCPUUsageMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemFtsCPUNormalizedUsage: MetricSettings{
+		MongodbatlasSystemFtsCPUNormalizedUsage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemFtsCPUUsage: MetricSettings{
+		MongodbatlasSystemFtsCPUUsage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemFtsDiskUsed: MetricSettings{
+		MongodbatlasSystemFtsDiskUsed: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemFtsMemoryUsage: MetricSettings{
+		MongodbatlasSystemFtsMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemMemoryUsageAverage: MetricSettings{
+		MongodbatlasSystemMemoryUsageAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemMemoryUsageMax: MetricSettings{
+		MongodbatlasSystemMemoryUsageMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemNetworkIoAverage: MetricSettings{
+		MongodbatlasSystemNetworkIoAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemNetworkIoMax: MetricSettings{
+		MongodbatlasSystemNetworkIoMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemPagingIoAverage: MetricSettings{
+		MongodbatlasSystemPagingIoAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemPagingIoMax: MetricSettings{
+		MongodbatlasSystemPagingIoMax: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemPagingUsageAverage: MetricSettings{
+		MongodbatlasSystemPagingUsageAverage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbatlasSystemPagingUsageMax: MetricSettings{
+		MongodbatlasSystemPagingUsageMax: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for mongoatlasreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	MongodbAtlasClusterName     ResourceAttributeSettings `mapstructure:"mongodb_atlas.cluster.name"`
-	MongodbAtlasDbName          ResourceAttributeSettings `mapstructure:"mongodb_atlas.db.name"`
-	MongodbAtlasDiskPartition   ResourceAttributeSettings `mapstructure:"mongodb_atlas.disk.partition"`
-	MongodbAtlasHostName        ResourceAttributeSettings `mapstructure:"mongodb_atlas.host.name"`
-	MongodbAtlasOrgName         ResourceAttributeSettings `mapstructure:"mongodb_atlas.org_name"`
-	MongodbAtlasProcessID       ResourceAttributeSettings `mapstructure:"mongodb_atlas.process.id"`
-	MongodbAtlasProcessPort     ResourceAttributeSettings `mapstructure:"mongodb_atlas.process.port"`
-	MongodbAtlasProcessTypeName ResourceAttributeSettings `mapstructure:"mongodb_atlas.process.type_name"`
-	MongodbAtlasProjectID       ResourceAttributeSettings `mapstructure:"mongodb_atlas.project.id"`
-	MongodbAtlasProjectName     ResourceAttributeSettings `mapstructure:"mongodb_atlas.project.name"`
-	MongodbAtlasUserAlias       ResourceAttributeSettings `mapstructure:"mongodb_atlas.user.alias"`
+// ResourceAttributesConfig provides config for mongoatlasreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	MongodbAtlasClusterName     ResourceAttributeConfig `mapstructure:"mongodb_atlas.cluster.name"`
+	MongodbAtlasDbName          ResourceAttributeConfig `mapstructure:"mongodb_atlas.db.name"`
+	MongodbAtlasDiskPartition   ResourceAttributeConfig `mapstructure:"mongodb_atlas.disk.partition"`
+	MongodbAtlasHostName        ResourceAttributeConfig `mapstructure:"mongodb_atlas.host.name"`
+	MongodbAtlasOrgName         ResourceAttributeConfig `mapstructure:"mongodb_atlas.org_name"`
+	MongodbAtlasProcessID       ResourceAttributeConfig `mapstructure:"mongodb_atlas.process.id"`
+	MongodbAtlasProcessPort     ResourceAttributeConfig `mapstructure:"mongodb_atlas.process.port"`
+	MongodbAtlasProcessTypeName ResourceAttributeConfig `mapstructure:"mongodb_atlas.process.type_name"`
+	MongodbAtlasProjectID       ResourceAttributeConfig `mapstructure:"mongodb_atlas.project.id"`
+	MongodbAtlasProjectName     ResourceAttributeConfig `mapstructure:"mongodb_atlas.project.name"`
+	MongodbAtlasUserAlias       ResourceAttributeConfig `mapstructure:"mongodb_atlas.user.alias"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		MongodbAtlasClusterName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		MongodbAtlasClusterName: ResourceAttributeConfig{
 			Enabled: false,
 		},
-		MongodbAtlasDbName: ResourceAttributeSettings{
+		MongodbAtlasDbName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		MongodbAtlasDiskPartition: ResourceAttributeSettings{
+		MongodbAtlasDiskPartition: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		MongodbAtlasHostName: ResourceAttributeSettings{
+		MongodbAtlasHostName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		MongodbAtlasOrgName: ResourceAttributeSettings{
+		MongodbAtlasOrgName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		MongodbAtlasProcessID: ResourceAttributeSettings{
+		MongodbAtlasProcessID: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		MongodbAtlasProcessPort: ResourceAttributeSettings{
+		MongodbAtlasProcessPort: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		MongodbAtlasProcessTypeName: ResourceAttributeSettings{
+		MongodbAtlasProcessTypeName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		MongodbAtlasProjectID: ResourceAttributeSettings{
+		MongodbAtlasProjectID: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		MongodbAtlasProjectName: ResourceAttributeSettings{
+		MongodbAtlasProjectName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		MongodbAtlasUserAlias: ResourceAttributeSettings{
+		MongodbAtlasUserAlias: ResourceAttributeConfig{
 			Enabled: false,
 		},
 	}
@@ -1068,7 +1068,7 @@ var MapAttributeTicketType = map[string]AttributeTicketType{
 
 type metricMongodbatlasDbCounts struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1082,7 +1082,7 @@ func (m *metricMongodbatlasDbCounts) init() {
 }
 
 func (m *metricMongodbatlasDbCounts) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, objectTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1101,16 +1101,16 @@ func (m *metricMongodbatlasDbCounts) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDbCounts) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDbCounts(settings MetricSettings) metricMongodbatlasDbCounts {
-	m := metricMongodbatlasDbCounts{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDbCounts(cfg MetricConfig) metricMongodbatlasDbCounts {
+	m := metricMongodbatlasDbCounts{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1119,7 +1119,7 @@ func newMetricMongodbatlasDbCounts(settings MetricSettings) metricMongodbatlasDb
 
 type metricMongodbatlasDbSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1133,7 +1133,7 @@ func (m *metricMongodbatlasDbSize) init() {
 }
 
 func (m *metricMongodbatlasDbSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, objectTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1152,16 +1152,16 @@ func (m *metricMongodbatlasDbSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDbSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDbSize(settings MetricSettings) metricMongodbatlasDbSize {
-	m := metricMongodbatlasDbSize{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDbSize(cfg MetricConfig) metricMongodbatlasDbSize {
+	m := metricMongodbatlasDbSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1170,7 +1170,7 @@ func newMetricMongodbatlasDbSize(settings MetricSettings) metricMongodbatlasDbSi
 
 type metricMongodbatlasDiskPartitionIopsAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1184,7 +1184,7 @@ func (m *metricMongodbatlasDiskPartitionIopsAverage) init() {
 }
 
 func (m *metricMongodbatlasDiskPartitionIopsAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1203,16 +1203,16 @@ func (m *metricMongodbatlasDiskPartitionIopsAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionIopsAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionIopsAverage(settings MetricSettings) metricMongodbatlasDiskPartitionIopsAverage {
-	m := metricMongodbatlasDiskPartitionIopsAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDiskPartitionIopsAverage(cfg MetricConfig) metricMongodbatlasDiskPartitionIopsAverage {
+	m := metricMongodbatlasDiskPartitionIopsAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1221,7 +1221,7 @@ func newMetricMongodbatlasDiskPartitionIopsAverage(settings MetricSettings) metr
 
 type metricMongodbatlasDiskPartitionIopsMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1235,7 +1235,7 @@ func (m *metricMongodbatlasDiskPartitionIopsMax) init() {
 }
 
 func (m *metricMongodbatlasDiskPartitionIopsMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1254,16 +1254,16 @@ func (m *metricMongodbatlasDiskPartitionIopsMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionIopsMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionIopsMax(settings MetricSettings) metricMongodbatlasDiskPartitionIopsMax {
-	m := metricMongodbatlasDiskPartitionIopsMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDiskPartitionIopsMax(cfg MetricConfig) metricMongodbatlasDiskPartitionIopsMax {
+	m := metricMongodbatlasDiskPartitionIopsMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1272,7 +1272,7 @@ func newMetricMongodbatlasDiskPartitionIopsMax(settings MetricSettings) metricMo
 
 type metricMongodbatlasDiskPartitionLatencyAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1286,7 +1286,7 @@ func (m *metricMongodbatlasDiskPartitionLatencyAverage) init() {
 }
 
 func (m *metricMongodbatlasDiskPartitionLatencyAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1305,16 +1305,16 @@ func (m *metricMongodbatlasDiskPartitionLatencyAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionLatencyAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionLatencyAverage(settings MetricSettings) metricMongodbatlasDiskPartitionLatencyAverage {
-	m := metricMongodbatlasDiskPartitionLatencyAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDiskPartitionLatencyAverage(cfg MetricConfig) metricMongodbatlasDiskPartitionLatencyAverage {
+	m := metricMongodbatlasDiskPartitionLatencyAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1323,7 +1323,7 @@ func newMetricMongodbatlasDiskPartitionLatencyAverage(settings MetricSettings) m
 
 type metricMongodbatlasDiskPartitionLatencyMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1337,7 +1337,7 @@ func (m *metricMongodbatlasDiskPartitionLatencyMax) init() {
 }
 
 func (m *metricMongodbatlasDiskPartitionLatencyMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1356,16 +1356,16 @@ func (m *metricMongodbatlasDiskPartitionLatencyMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionLatencyMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionLatencyMax(settings MetricSettings) metricMongodbatlasDiskPartitionLatencyMax {
-	m := metricMongodbatlasDiskPartitionLatencyMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDiskPartitionLatencyMax(cfg MetricConfig) metricMongodbatlasDiskPartitionLatencyMax {
+	m := metricMongodbatlasDiskPartitionLatencyMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1374,7 +1374,7 @@ func newMetricMongodbatlasDiskPartitionLatencyMax(settings MetricSettings) metri
 
 type metricMongodbatlasDiskPartitionSpaceAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1388,7 +1388,7 @@ func (m *metricMongodbatlasDiskPartitionSpaceAverage) init() {
 }
 
 func (m *metricMongodbatlasDiskPartitionSpaceAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1407,16 +1407,16 @@ func (m *metricMongodbatlasDiskPartitionSpaceAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionSpaceAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionSpaceAverage(settings MetricSettings) metricMongodbatlasDiskPartitionSpaceAverage {
-	m := metricMongodbatlasDiskPartitionSpaceAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDiskPartitionSpaceAverage(cfg MetricConfig) metricMongodbatlasDiskPartitionSpaceAverage {
+	m := metricMongodbatlasDiskPartitionSpaceAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1425,7 +1425,7 @@ func newMetricMongodbatlasDiskPartitionSpaceAverage(settings MetricSettings) met
 
 type metricMongodbatlasDiskPartitionSpaceMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1439,7 +1439,7 @@ func (m *metricMongodbatlasDiskPartitionSpaceMax) init() {
 }
 
 func (m *metricMongodbatlasDiskPartitionSpaceMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1458,16 +1458,16 @@ func (m *metricMongodbatlasDiskPartitionSpaceMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionSpaceMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionSpaceMax(settings MetricSettings) metricMongodbatlasDiskPartitionSpaceMax {
-	m := metricMongodbatlasDiskPartitionSpaceMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDiskPartitionSpaceMax(cfg MetricConfig) metricMongodbatlasDiskPartitionSpaceMax {
+	m := metricMongodbatlasDiskPartitionSpaceMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1476,7 +1476,7 @@ func newMetricMongodbatlasDiskPartitionSpaceMax(settings MetricSettings) metricM
 
 type metricMongodbatlasDiskPartitionUsageAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1490,7 +1490,7 @@ func (m *metricMongodbatlasDiskPartitionUsageAverage) init() {
 }
 
 func (m *metricMongodbatlasDiskPartitionUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1509,16 +1509,16 @@ func (m *metricMongodbatlasDiskPartitionUsageAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionUsageAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionUsageAverage(settings MetricSettings) metricMongodbatlasDiskPartitionUsageAverage {
-	m := metricMongodbatlasDiskPartitionUsageAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDiskPartitionUsageAverage(cfg MetricConfig) metricMongodbatlasDiskPartitionUsageAverage {
+	m := metricMongodbatlasDiskPartitionUsageAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1527,7 +1527,7 @@ func newMetricMongodbatlasDiskPartitionUsageAverage(settings MetricSettings) met
 
 type metricMongodbatlasDiskPartitionUsageMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1541,7 +1541,7 @@ func (m *metricMongodbatlasDiskPartitionUsageMax) init() {
 }
 
 func (m *metricMongodbatlasDiskPartitionUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, diskStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1560,16 +1560,16 @@ func (m *metricMongodbatlasDiskPartitionUsageMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionUsageMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionUsageMax(settings MetricSettings) metricMongodbatlasDiskPartitionUsageMax {
-	m := metricMongodbatlasDiskPartitionUsageMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDiskPartitionUsageMax(cfg MetricConfig) metricMongodbatlasDiskPartitionUsageMax {
+	m := metricMongodbatlasDiskPartitionUsageMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1578,7 +1578,7 @@ func newMetricMongodbatlasDiskPartitionUsageMax(settings MetricSettings) metricM
 
 type metricMongodbatlasDiskPartitionUtilizationAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1591,7 +1591,7 @@ func (m *metricMongodbatlasDiskPartitionUtilizationAverage) init() {
 }
 
 func (m *metricMongodbatlasDiskPartitionUtilizationAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1609,16 +1609,16 @@ func (m *metricMongodbatlasDiskPartitionUtilizationAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionUtilizationAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionUtilizationAverage(settings MetricSettings) metricMongodbatlasDiskPartitionUtilizationAverage {
-	m := metricMongodbatlasDiskPartitionUtilizationAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDiskPartitionUtilizationAverage(cfg MetricConfig) metricMongodbatlasDiskPartitionUtilizationAverage {
+	m := metricMongodbatlasDiskPartitionUtilizationAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1627,7 +1627,7 @@ func newMetricMongodbatlasDiskPartitionUtilizationAverage(settings MetricSetting
 
 type metricMongodbatlasDiskPartitionUtilizationMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1640,7 +1640,7 @@ func (m *metricMongodbatlasDiskPartitionUtilizationMax) init() {
 }
 
 func (m *metricMongodbatlasDiskPartitionUtilizationMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1658,16 +1658,16 @@ func (m *metricMongodbatlasDiskPartitionUtilizationMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasDiskPartitionUtilizationMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasDiskPartitionUtilizationMax(settings MetricSettings) metricMongodbatlasDiskPartitionUtilizationMax {
-	m := metricMongodbatlasDiskPartitionUtilizationMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasDiskPartitionUtilizationMax(cfg MetricConfig) metricMongodbatlasDiskPartitionUtilizationMax {
+	m := metricMongodbatlasDiskPartitionUtilizationMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1676,7 +1676,7 @@ func newMetricMongodbatlasDiskPartitionUtilizationMax(settings MetricSettings) m
 
 type metricMongodbatlasProcessAsserts struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1690,7 +1690,7 @@ func (m *metricMongodbatlasProcessAsserts) init() {
 }
 
 func (m *metricMongodbatlasProcessAsserts) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, assertTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1709,16 +1709,16 @@ func (m *metricMongodbatlasProcessAsserts) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessAsserts) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessAsserts(settings MetricSettings) metricMongodbatlasProcessAsserts {
-	m := metricMongodbatlasProcessAsserts{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessAsserts(cfg MetricConfig) metricMongodbatlasProcessAsserts {
+	m := metricMongodbatlasProcessAsserts{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1727,7 +1727,7 @@ func newMetricMongodbatlasProcessAsserts(settings MetricSettings) metricMongodba
 
 type metricMongodbatlasProcessBackgroundFlush struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1740,7 +1740,7 @@ func (m *metricMongodbatlasProcessBackgroundFlush) init() {
 }
 
 func (m *metricMongodbatlasProcessBackgroundFlush) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1758,16 +1758,16 @@ func (m *metricMongodbatlasProcessBackgroundFlush) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessBackgroundFlush) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessBackgroundFlush(settings MetricSettings) metricMongodbatlasProcessBackgroundFlush {
-	m := metricMongodbatlasProcessBackgroundFlush{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessBackgroundFlush(cfg MetricConfig) metricMongodbatlasProcessBackgroundFlush {
+	m := metricMongodbatlasProcessBackgroundFlush{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1776,7 +1776,7 @@ func newMetricMongodbatlasProcessBackgroundFlush(settings MetricSettings) metric
 
 type metricMongodbatlasProcessCacheIo struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1790,7 +1790,7 @@ func (m *metricMongodbatlasProcessCacheIo) init() {
 }
 
 func (m *metricMongodbatlasProcessCacheIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cacheDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1809,16 +1809,16 @@ func (m *metricMongodbatlasProcessCacheIo) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCacheIo) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCacheIo(settings MetricSettings) metricMongodbatlasProcessCacheIo {
-	m := metricMongodbatlasProcessCacheIo{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessCacheIo(cfg MetricConfig) metricMongodbatlasProcessCacheIo {
+	m := metricMongodbatlasProcessCacheIo{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1827,7 +1827,7 @@ func newMetricMongodbatlasProcessCacheIo(settings MetricSettings) metricMongodba
 
 type metricMongodbatlasProcessCacheSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1843,7 +1843,7 @@ func (m *metricMongodbatlasProcessCacheSize) init() {
 }
 
 func (m *metricMongodbatlasProcessCacheSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cacheStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1862,16 +1862,16 @@ func (m *metricMongodbatlasProcessCacheSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCacheSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCacheSize(settings MetricSettings) metricMongodbatlasProcessCacheSize {
-	m := metricMongodbatlasProcessCacheSize{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessCacheSize(cfg MetricConfig) metricMongodbatlasProcessCacheSize {
+	m := metricMongodbatlasProcessCacheSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1880,7 +1880,7 @@ func newMetricMongodbatlasProcessCacheSize(settings MetricSettings) metricMongod
 
 type metricMongodbatlasProcessConnections struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1895,7 +1895,7 @@ func (m *metricMongodbatlasProcessConnections) init() {
 }
 
 func (m *metricMongodbatlasProcessConnections) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1913,16 +1913,16 @@ func (m *metricMongodbatlasProcessConnections) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessConnections) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessConnections(settings MetricSettings) metricMongodbatlasProcessConnections {
-	m := metricMongodbatlasProcessConnections{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessConnections(cfg MetricConfig) metricMongodbatlasProcessConnections {
+	m := metricMongodbatlasProcessConnections{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1931,7 +1931,7 @@ func newMetricMongodbatlasProcessConnections(settings MetricSettings) metricMong
 
 type metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1945,7 +1945,7 @@ func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage) init() {
 }
 
 func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1964,16 +1964,16 @@ func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage) updateCapac
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageAverage(settings MetricSettings) metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage {
-	m := metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageAverage(cfg MetricConfig) metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage {
+	m := metricMongodbatlasProcessCPUChildrenNormalizedUsageAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1982,7 +1982,7 @@ func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageAverage(settings Metr
 
 type metricMongodbatlasProcessCPUChildrenNormalizedUsageMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1996,7 +1996,7 @@ func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageMax) init() {
 }
 
 func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2015,16 +2015,16 @@ func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageMax) updateCapacity(
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUChildrenNormalizedUsageMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageMax(settings MetricSettings) metricMongodbatlasProcessCPUChildrenNormalizedUsageMax {
-	m := metricMongodbatlasProcessCPUChildrenNormalizedUsageMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageMax(cfg MetricConfig) metricMongodbatlasProcessCPUChildrenNormalizedUsageMax {
+	m := metricMongodbatlasProcessCPUChildrenNormalizedUsageMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2033,7 +2033,7 @@ func newMetricMongodbatlasProcessCPUChildrenNormalizedUsageMax(settings MetricSe
 
 type metricMongodbatlasProcessCPUChildrenUsageAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2047,7 +2047,7 @@ func (m *metricMongodbatlasProcessCPUChildrenUsageAverage) init() {
 }
 
 func (m *metricMongodbatlasProcessCPUChildrenUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2066,16 +2066,16 @@ func (m *metricMongodbatlasProcessCPUChildrenUsageAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUChildrenUsageAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUChildrenUsageAverage(settings MetricSettings) metricMongodbatlasProcessCPUChildrenUsageAverage {
-	m := metricMongodbatlasProcessCPUChildrenUsageAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessCPUChildrenUsageAverage(cfg MetricConfig) metricMongodbatlasProcessCPUChildrenUsageAverage {
+	m := metricMongodbatlasProcessCPUChildrenUsageAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2084,7 +2084,7 @@ func newMetricMongodbatlasProcessCPUChildrenUsageAverage(settings MetricSettings
 
 type metricMongodbatlasProcessCPUChildrenUsageMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2098,7 +2098,7 @@ func (m *metricMongodbatlasProcessCPUChildrenUsageMax) init() {
 }
 
 func (m *metricMongodbatlasProcessCPUChildrenUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2117,16 +2117,16 @@ func (m *metricMongodbatlasProcessCPUChildrenUsageMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUChildrenUsageMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUChildrenUsageMax(settings MetricSettings) metricMongodbatlasProcessCPUChildrenUsageMax {
-	m := metricMongodbatlasProcessCPUChildrenUsageMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessCPUChildrenUsageMax(cfg MetricConfig) metricMongodbatlasProcessCPUChildrenUsageMax {
+	m := metricMongodbatlasProcessCPUChildrenUsageMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2135,7 +2135,7 @@ func newMetricMongodbatlasProcessCPUChildrenUsageMax(settings MetricSettings) me
 
 type metricMongodbatlasProcessCPUNormalizedUsageAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2149,7 +2149,7 @@ func (m *metricMongodbatlasProcessCPUNormalizedUsageAverage) init() {
 }
 
 func (m *metricMongodbatlasProcessCPUNormalizedUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2168,16 +2168,16 @@ func (m *metricMongodbatlasProcessCPUNormalizedUsageAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUNormalizedUsageAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUNormalizedUsageAverage(settings MetricSettings) metricMongodbatlasProcessCPUNormalizedUsageAverage {
-	m := metricMongodbatlasProcessCPUNormalizedUsageAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessCPUNormalizedUsageAverage(cfg MetricConfig) metricMongodbatlasProcessCPUNormalizedUsageAverage {
+	m := metricMongodbatlasProcessCPUNormalizedUsageAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2186,7 +2186,7 @@ func newMetricMongodbatlasProcessCPUNormalizedUsageAverage(settings MetricSettin
 
 type metricMongodbatlasProcessCPUNormalizedUsageMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2200,7 +2200,7 @@ func (m *metricMongodbatlasProcessCPUNormalizedUsageMax) init() {
 }
 
 func (m *metricMongodbatlasProcessCPUNormalizedUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2219,16 +2219,16 @@ func (m *metricMongodbatlasProcessCPUNormalizedUsageMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUNormalizedUsageMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUNormalizedUsageMax(settings MetricSettings) metricMongodbatlasProcessCPUNormalizedUsageMax {
-	m := metricMongodbatlasProcessCPUNormalizedUsageMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessCPUNormalizedUsageMax(cfg MetricConfig) metricMongodbatlasProcessCPUNormalizedUsageMax {
+	m := metricMongodbatlasProcessCPUNormalizedUsageMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2237,7 +2237,7 @@ func newMetricMongodbatlasProcessCPUNormalizedUsageMax(settings MetricSettings) 
 
 type metricMongodbatlasProcessCPUUsageAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2251,7 +2251,7 @@ func (m *metricMongodbatlasProcessCPUUsageAverage) init() {
 }
 
 func (m *metricMongodbatlasProcessCPUUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2270,16 +2270,16 @@ func (m *metricMongodbatlasProcessCPUUsageAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUUsageAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUUsageAverage(settings MetricSettings) metricMongodbatlasProcessCPUUsageAverage {
-	m := metricMongodbatlasProcessCPUUsageAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessCPUUsageAverage(cfg MetricConfig) metricMongodbatlasProcessCPUUsageAverage {
+	m := metricMongodbatlasProcessCPUUsageAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2288,7 +2288,7 @@ func newMetricMongodbatlasProcessCPUUsageAverage(settings MetricSettings) metric
 
 type metricMongodbatlasProcessCPUUsageMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2302,7 +2302,7 @@ func (m *metricMongodbatlasProcessCPUUsageMax) init() {
 }
 
 func (m *metricMongodbatlasProcessCPUUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2321,16 +2321,16 @@ func (m *metricMongodbatlasProcessCPUUsageMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCPUUsageMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCPUUsageMax(settings MetricSettings) metricMongodbatlasProcessCPUUsageMax {
-	m := metricMongodbatlasProcessCPUUsageMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessCPUUsageMax(cfg MetricConfig) metricMongodbatlasProcessCPUUsageMax {
+	m := metricMongodbatlasProcessCPUUsageMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2339,7 +2339,7 @@ func newMetricMongodbatlasProcessCPUUsageMax(settings MetricSettings) metricMong
 
 type metricMongodbatlasProcessCursors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2353,7 +2353,7 @@ func (m *metricMongodbatlasProcessCursors) init() {
 }
 
 func (m *metricMongodbatlasProcessCursors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cursorStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2372,16 +2372,16 @@ func (m *metricMongodbatlasProcessCursors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessCursors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessCursors(settings MetricSettings) metricMongodbatlasProcessCursors {
-	m := metricMongodbatlasProcessCursors{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessCursors(cfg MetricConfig) metricMongodbatlasProcessCursors {
+	m := metricMongodbatlasProcessCursors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2390,7 +2390,7 @@ func newMetricMongodbatlasProcessCursors(settings MetricSettings) metricMongodba
 
 type metricMongodbatlasProcessDbDocumentRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2404,7 +2404,7 @@ func (m *metricMongodbatlasProcessDbDocumentRate) init() {
 }
 
 func (m *metricMongodbatlasProcessDbDocumentRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, documentStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2423,16 +2423,16 @@ func (m *metricMongodbatlasProcessDbDocumentRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbDocumentRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbDocumentRate(settings MetricSettings) metricMongodbatlasProcessDbDocumentRate {
-	m := metricMongodbatlasProcessDbDocumentRate{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessDbDocumentRate(cfg MetricConfig) metricMongodbatlasProcessDbDocumentRate {
+	m := metricMongodbatlasProcessDbDocumentRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2441,7 +2441,7 @@ func newMetricMongodbatlasProcessDbDocumentRate(settings MetricSettings) metricM
 
 type metricMongodbatlasProcessDbOperationsRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2455,7 +2455,7 @@ func (m *metricMongodbatlasProcessDbOperationsRate) init() {
 }
 
 func (m *metricMongodbatlasProcessDbOperationsRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, operationAttributeValue string, clusterRoleAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2475,16 +2475,16 @@ func (m *metricMongodbatlasProcessDbOperationsRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbOperationsRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbOperationsRate(settings MetricSettings) metricMongodbatlasProcessDbOperationsRate {
-	m := metricMongodbatlasProcessDbOperationsRate{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessDbOperationsRate(cfg MetricConfig) metricMongodbatlasProcessDbOperationsRate {
+	m := metricMongodbatlasProcessDbOperationsRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2493,7 +2493,7 @@ func newMetricMongodbatlasProcessDbOperationsRate(settings MetricSettings) metri
 
 type metricMongodbatlasProcessDbOperationsTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2509,7 +2509,7 @@ func (m *metricMongodbatlasProcessDbOperationsTime) init() {
 }
 
 func (m *metricMongodbatlasProcessDbOperationsTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, executionTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2528,16 +2528,16 @@ func (m *metricMongodbatlasProcessDbOperationsTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbOperationsTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbOperationsTime(settings MetricSettings) metricMongodbatlasProcessDbOperationsTime {
-	m := metricMongodbatlasProcessDbOperationsTime{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessDbOperationsTime(cfg MetricConfig) metricMongodbatlasProcessDbOperationsTime {
+	m := metricMongodbatlasProcessDbOperationsTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2546,7 +2546,7 @@ func newMetricMongodbatlasProcessDbOperationsTime(settings MetricSettings) metri
 
 type metricMongodbatlasProcessDbQueryExecutorScanned struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2560,7 +2560,7 @@ func (m *metricMongodbatlasProcessDbQueryExecutorScanned) init() {
 }
 
 func (m *metricMongodbatlasProcessDbQueryExecutorScanned) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, scannedTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2579,16 +2579,16 @@ func (m *metricMongodbatlasProcessDbQueryExecutorScanned) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbQueryExecutorScanned) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbQueryExecutorScanned(settings MetricSettings) metricMongodbatlasProcessDbQueryExecutorScanned {
-	m := metricMongodbatlasProcessDbQueryExecutorScanned{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessDbQueryExecutorScanned(cfg MetricConfig) metricMongodbatlasProcessDbQueryExecutorScanned {
+	m := metricMongodbatlasProcessDbQueryExecutorScanned{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2597,7 +2597,7 @@ func newMetricMongodbatlasProcessDbQueryExecutorScanned(settings MetricSettings)
 
 type metricMongodbatlasProcessDbQueryTargetingScannedPerReturned struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2611,7 +2611,7 @@ func (m *metricMongodbatlasProcessDbQueryTargetingScannedPerReturned) init() {
 }
 
 func (m *metricMongodbatlasProcessDbQueryTargetingScannedPerReturned) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, scannedTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2630,16 +2630,16 @@ func (m *metricMongodbatlasProcessDbQueryTargetingScannedPerReturned) updateCapa
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbQueryTargetingScannedPerReturned) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbQueryTargetingScannedPerReturned(settings MetricSettings) metricMongodbatlasProcessDbQueryTargetingScannedPerReturned {
-	m := metricMongodbatlasProcessDbQueryTargetingScannedPerReturned{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessDbQueryTargetingScannedPerReturned(cfg MetricConfig) metricMongodbatlasProcessDbQueryTargetingScannedPerReturned {
+	m := metricMongodbatlasProcessDbQueryTargetingScannedPerReturned{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2648,7 +2648,7 @@ func newMetricMongodbatlasProcessDbQueryTargetingScannedPerReturned(settings Met
 
 type metricMongodbatlasProcessDbStorage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2662,7 +2662,7 @@ func (m *metricMongodbatlasProcessDbStorage) init() {
 }
 
 func (m *metricMongodbatlasProcessDbStorage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, storageStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2681,16 +2681,16 @@ func (m *metricMongodbatlasProcessDbStorage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessDbStorage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessDbStorage(settings MetricSettings) metricMongodbatlasProcessDbStorage {
-	m := metricMongodbatlasProcessDbStorage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessDbStorage(cfg MetricConfig) metricMongodbatlasProcessDbStorage {
+	m := metricMongodbatlasProcessDbStorage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2699,7 +2699,7 @@ func newMetricMongodbatlasProcessDbStorage(settings MetricSettings) metricMongod
 
 type metricMongodbatlasProcessGlobalLock struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2713,7 +2713,7 @@ func (m *metricMongodbatlasProcessGlobalLock) init() {
 }
 
 func (m *metricMongodbatlasProcessGlobalLock) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, globalLockStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2732,16 +2732,16 @@ func (m *metricMongodbatlasProcessGlobalLock) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessGlobalLock) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessGlobalLock(settings MetricSettings) metricMongodbatlasProcessGlobalLock {
-	m := metricMongodbatlasProcessGlobalLock{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessGlobalLock(cfg MetricConfig) metricMongodbatlasProcessGlobalLock {
+	m := metricMongodbatlasProcessGlobalLock{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2750,7 +2750,7 @@ func newMetricMongodbatlasProcessGlobalLock(settings MetricSettings) metricMongo
 
 type metricMongodbatlasProcessIndexBtreeMissRatio struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2763,7 +2763,7 @@ func (m *metricMongodbatlasProcessIndexBtreeMissRatio) init() {
 }
 
 func (m *metricMongodbatlasProcessIndexBtreeMissRatio) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2781,16 +2781,16 @@ func (m *metricMongodbatlasProcessIndexBtreeMissRatio) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessIndexBtreeMissRatio) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessIndexBtreeMissRatio(settings MetricSettings) metricMongodbatlasProcessIndexBtreeMissRatio {
-	m := metricMongodbatlasProcessIndexBtreeMissRatio{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessIndexBtreeMissRatio(cfg MetricConfig) metricMongodbatlasProcessIndexBtreeMissRatio {
+	m := metricMongodbatlasProcessIndexBtreeMissRatio{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2799,7 +2799,7 @@ func newMetricMongodbatlasProcessIndexBtreeMissRatio(settings MetricSettings) me
 
 type metricMongodbatlasProcessIndexCounters struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2813,7 +2813,7 @@ func (m *metricMongodbatlasProcessIndexCounters) init() {
 }
 
 func (m *metricMongodbatlasProcessIndexCounters) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, btreeCounterTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2832,16 +2832,16 @@ func (m *metricMongodbatlasProcessIndexCounters) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessIndexCounters) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessIndexCounters(settings MetricSettings) metricMongodbatlasProcessIndexCounters {
-	m := metricMongodbatlasProcessIndexCounters{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessIndexCounters(cfg MetricConfig) metricMongodbatlasProcessIndexCounters {
+	m := metricMongodbatlasProcessIndexCounters{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2850,7 +2850,7 @@ func newMetricMongodbatlasProcessIndexCounters(settings MetricSettings) metricMo
 
 type metricMongodbatlasProcessJournalingCommits struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2863,7 +2863,7 @@ func (m *metricMongodbatlasProcessJournalingCommits) init() {
 }
 
 func (m *metricMongodbatlasProcessJournalingCommits) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2881,16 +2881,16 @@ func (m *metricMongodbatlasProcessJournalingCommits) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessJournalingCommits) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessJournalingCommits(settings MetricSettings) metricMongodbatlasProcessJournalingCommits {
-	m := metricMongodbatlasProcessJournalingCommits{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessJournalingCommits(cfg MetricConfig) metricMongodbatlasProcessJournalingCommits {
+	m := metricMongodbatlasProcessJournalingCommits{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2899,7 +2899,7 @@ func newMetricMongodbatlasProcessJournalingCommits(settings MetricSettings) metr
 
 type metricMongodbatlasProcessJournalingDataFiles struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2912,7 +2912,7 @@ func (m *metricMongodbatlasProcessJournalingDataFiles) init() {
 }
 
 func (m *metricMongodbatlasProcessJournalingDataFiles) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2930,16 +2930,16 @@ func (m *metricMongodbatlasProcessJournalingDataFiles) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessJournalingDataFiles) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessJournalingDataFiles(settings MetricSettings) metricMongodbatlasProcessJournalingDataFiles {
-	m := metricMongodbatlasProcessJournalingDataFiles{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessJournalingDataFiles(cfg MetricConfig) metricMongodbatlasProcessJournalingDataFiles {
+	m := metricMongodbatlasProcessJournalingDataFiles{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2948,7 +2948,7 @@ func newMetricMongodbatlasProcessJournalingDataFiles(settings MetricSettings) me
 
 type metricMongodbatlasProcessJournalingWritten struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2961,7 +2961,7 @@ func (m *metricMongodbatlasProcessJournalingWritten) init() {
 }
 
 func (m *metricMongodbatlasProcessJournalingWritten) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2979,16 +2979,16 @@ func (m *metricMongodbatlasProcessJournalingWritten) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessJournalingWritten) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessJournalingWritten(settings MetricSettings) metricMongodbatlasProcessJournalingWritten {
-	m := metricMongodbatlasProcessJournalingWritten{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessJournalingWritten(cfg MetricConfig) metricMongodbatlasProcessJournalingWritten {
+	m := metricMongodbatlasProcessJournalingWritten{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2997,7 +2997,7 @@ func newMetricMongodbatlasProcessJournalingWritten(settings MetricSettings) metr
 
 type metricMongodbatlasProcessMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3011,7 +3011,7 @@ func (m *metricMongodbatlasProcessMemoryUsage) init() {
 }
 
 func (m *metricMongodbatlasProcessMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3030,16 +3030,16 @@ func (m *metricMongodbatlasProcessMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessMemoryUsage(settings MetricSettings) metricMongodbatlasProcessMemoryUsage {
-	m := metricMongodbatlasProcessMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessMemoryUsage(cfg MetricConfig) metricMongodbatlasProcessMemoryUsage {
+	m := metricMongodbatlasProcessMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3048,7 +3048,7 @@ func newMetricMongodbatlasProcessMemoryUsage(settings MetricSettings) metricMong
 
 type metricMongodbatlasProcessNetworkIo struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3062,7 +3062,7 @@ func (m *metricMongodbatlasProcessNetworkIo) init() {
 }
 
 func (m *metricMongodbatlasProcessNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3081,16 +3081,16 @@ func (m *metricMongodbatlasProcessNetworkIo) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessNetworkIo) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessNetworkIo(settings MetricSettings) metricMongodbatlasProcessNetworkIo {
-	m := metricMongodbatlasProcessNetworkIo{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessNetworkIo(cfg MetricConfig) metricMongodbatlasProcessNetworkIo {
+	m := metricMongodbatlasProcessNetworkIo{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3099,7 +3099,7 @@ func newMetricMongodbatlasProcessNetworkIo(settings MetricSettings) metricMongod
 
 type metricMongodbatlasProcessNetworkRequests struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3114,7 +3114,7 @@ func (m *metricMongodbatlasProcessNetworkRequests) init() {
 }
 
 func (m *metricMongodbatlasProcessNetworkRequests) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3132,16 +3132,16 @@ func (m *metricMongodbatlasProcessNetworkRequests) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessNetworkRequests) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessNetworkRequests(settings MetricSettings) metricMongodbatlasProcessNetworkRequests {
-	m := metricMongodbatlasProcessNetworkRequests{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessNetworkRequests(cfg MetricConfig) metricMongodbatlasProcessNetworkRequests {
+	m := metricMongodbatlasProcessNetworkRequests{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3150,7 +3150,7 @@ func newMetricMongodbatlasProcessNetworkRequests(settings MetricSettings) metric
 
 type metricMongodbatlasProcessOplogRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3163,7 +3163,7 @@ func (m *metricMongodbatlasProcessOplogRate) init() {
 }
 
 func (m *metricMongodbatlasProcessOplogRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3181,16 +3181,16 @@ func (m *metricMongodbatlasProcessOplogRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessOplogRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessOplogRate(settings MetricSettings) metricMongodbatlasProcessOplogRate {
-	m := metricMongodbatlasProcessOplogRate{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessOplogRate(cfg MetricConfig) metricMongodbatlasProcessOplogRate {
+	m := metricMongodbatlasProcessOplogRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3199,7 +3199,7 @@ func newMetricMongodbatlasProcessOplogRate(settings MetricSettings) metricMongod
 
 type metricMongodbatlasProcessOplogTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3213,7 +3213,7 @@ func (m *metricMongodbatlasProcessOplogTime) init() {
 }
 
 func (m *metricMongodbatlasProcessOplogTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, oplogTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3232,16 +3232,16 @@ func (m *metricMongodbatlasProcessOplogTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessOplogTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessOplogTime(settings MetricSettings) metricMongodbatlasProcessOplogTime {
-	m := metricMongodbatlasProcessOplogTime{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessOplogTime(cfg MetricConfig) metricMongodbatlasProcessOplogTime {
+	m := metricMongodbatlasProcessOplogTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3250,7 +3250,7 @@ func newMetricMongodbatlasProcessOplogTime(settings MetricSettings) metricMongod
 
 type metricMongodbatlasProcessPageFaults struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3264,7 +3264,7 @@ func (m *metricMongodbatlasProcessPageFaults) init() {
 }
 
 func (m *metricMongodbatlasProcessPageFaults) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryIssueTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3283,16 +3283,16 @@ func (m *metricMongodbatlasProcessPageFaults) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessPageFaults) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessPageFaults(settings MetricSettings) metricMongodbatlasProcessPageFaults {
-	m := metricMongodbatlasProcessPageFaults{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessPageFaults(cfg MetricConfig) metricMongodbatlasProcessPageFaults {
+	m := metricMongodbatlasProcessPageFaults{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3301,7 +3301,7 @@ func newMetricMongodbatlasProcessPageFaults(settings MetricSettings) metricMongo
 
 type metricMongodbatlasProcessRestarts struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3314,7 +3314,7 @@ func (m *metricMongodbatlasProcessRestarts) init() {
 }
 
 func (m *metricMongodbatlasProcessRestarts) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3332,16 +3332,16 @@ func (m *metricMongodbatlasProcessRestarts) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessRestarts) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessRestarts(settings MetricSettings) metricMongodbatlasProcessRestarts {
-	m := metricMongodbatlasProcessRestarts{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessRestarts(cfg MetricConfig) metricMongodbatlasProcessRestarts {
+	m := metricMongodbatlasProcessRestarts{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3350,7 +3350,7 @@ func newMetricMongodbatlasProcessRestarts(settings MetricSettings) metricMongodb
 
 type metricMongodbatlasProcessTickets struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3364,7 +3364,7 @@ func (m *metricMongodbatlasProcessTickets) init() {
 }
 
 func (m *metricMongodbatlasProcessTickets) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, ticketTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3383,16 +3383,16 @@ func (m *metricMongodbatlasProcessTickets) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasProcessTickets) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasProcessTickets(settings MetricSettings) metricMongodbatlasProcessTickets {
-	m := metricMongodbatlasProcessTickets{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasProcessTickets(cfg MetricConfig) metricMongodbatlasProcessTickets {
+	m := metricMongodbatlasProcessTickets{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3401,7 +3401,7 @@ func newMetricMongodbatlasProcessTickets(settings MetricSettings) metricMongodba
 
 type metricMongodbatlasSystemCPUNormalizedUsageAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3415,7 +3415,7 @@ func (m *metricMongodbatlasSystemCPUNormalizedUsageAverage) init() {
 }
 
 func (m *metricMongodbatlasSystemCPUNormalizedUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3434,16 +3434,16 @@ func (m *metricMongodbatlasSystemCPUNormalizedUsageAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemCPUNormalizedUsageAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemCPUNormalizedUsageAverage(settings MetricSettings) metricMongodbatlasSystemCPUNormalizedUsageAverage {
-	m := metricMongodbatlasSystemCPUNormalizedUsageAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemCPUNormalizedUsageAverage(cfg MetricConfig) metricMongodbatlasSystemCPUNormalizedUsageAverage {
+	m := metricMongodbatlasSystemCPUNormalizedUsageAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3452,7 +3452,7 @@ func newMetricMongodbatlasSystemCPUNormalizedUsageAverage(settings MetricSetting
 
 type metricMongodbatlasSystemCPUNormalizedUsageMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3466,7 +3466,7 @@ func (m *metricMongodbatlasSystemCPUNormalizedUsageMax) init() {
 }
 
 func (m *metricMongodbatlasSystemCPUNormalizedUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3485,16 +3485,16 @@ func (m *metricMongodbatlasSystemCPUNormalizedUsageMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemCPUNormalizedUsageMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemCPUNormalizedUsageMax(settings MetricSettings) metricMongodbatlasSystemCPUNormalizedUsageMax {
-	m := metricMongodbatlasSystemCPUNormalizedUsageMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemCPUNormalizedUsageMax(cfg MetricConfig) metricMongodbatlasSystemCPUNormalizedUsageMax {
+	m := metricMongodbatlasSystemCPUNormalizedUsageMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3503,7 +3503,7 @@ func newMetricMongodbatlasSystemCPUNormalizedUsageMax(settings MetricSettings) m
 
 type metricMongodbatlasSystemCPUUsageAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3517,7 +3517,7 @@ func (m *metricMongodbatlasSystemCPUUsageAverage) init() {
 }
 
 func (m *metricMongodbatlasSystemCPUUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3536,16 +3536,16 @@ func (m *metricMongodbatlasSystemCPUUsageAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemCPUUsageAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemCPUUsageAverage(settings MetricSettings) metricMongodbatlasSystemCPUUsageAverage {
-	m := metricMongodbatlasSystemCPUUsageAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemCPUUsageAverage(cfg MetricConfig) metricMongodbatlasSystemCPUUsageAverage {
+	m := metricMongodbatlasSystemCPUUsageAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3554,7 +3554,7 @@ func newMetricMongodbatlasSystemCPUUsageAverage(settings MetricSettings) metricM
 
 type metricMongodbatlasSystemCPUUsageMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3568,7 +3568,7 @@ func (m *metricMongodbatlasSystemCPUUsageMax) init() {
 }
 
 func (m *metricMongodbatlasSystemCPUUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3587,16 +3587,16 @@ func (m *metricMongodbatlasSystemCPUUsageMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemCPUUsageMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemCPUUsageMax(settings MetricSettings) metricMongodbatlasSystemCPUUsageMax {
-	m := metricMongodbatlasSystemCPUUsageMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemCPUUsageMax(cfg MetricConfig) metricMongodbatlasSystemCPUUsageMax {
+	m := metricMongodbatlasSystemCPUUsageMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3605,7 +3605,7 @@ func newMetricMongodbatlasSystemCPUUsageMax(settings MetricSettings) metricMongo
 
 type metricMongodbatlasSystemFtsCPUNormalizedUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3619,7 +3619,7 @@ func (m *metricMongodbatlasSystemFtsCPUNormalizedUsage) init() {
 }
 
 func (m *metricMongodbatlasSystemFtsCPUNormalizedUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3638,16 +3638,16 @@ func (m *metricMongodbatlasSystemFtsCPUNormalizedUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemFtsCPUNormalizedUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemFtsCPUNormalizedUsage(settings MetricSettings) metricMongodbatlasSystemFtsCPUNormalizedUsage {
-	m := metricMongodbatlasSystemFtsCPUNormalizedUsage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemFtsCPUNormalizedUsage(cfg MetricConfig) metricMongodbatlasSystemFtsCPUNormalizedUsage {
+	m := metricMongodbatlasSystemFtsCPUNormalizedUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3656,7 +3656,7 @@ func newMetricMongodbatlasSystemFtsCPUNormalizedUsage(settings MetricSettings) m
 
 type metricMongodbatlasSystemFtsCPUUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3670,7 +3670,7 @@ func (m *metricMongodbatlasSystemFtsCPUUsage) init() {
 }
 
 func (m *metricMongodbatlasSystemFtsCPUUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, cpuStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3689,16 +3689,16 @@ func (m *metricMongodbatlasSystemFtsCPUUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemFtsCPUUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemFtsCPUUsage(settings MetricSettings) metricMongodbatlasSystemFtsCPUUsage {
-	m := metricMongodbatlasSystemFtsCPUUsage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemFtsCPUUsage(cfg MetricConfig) metricMongodbatlasSystemFtsCPUUsage {
+	m := metricMongodbatlasSystemFtsCPUUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3707,7 +3707,7 @@ func newMetricMongodbatlasSystemFtsCPUUsage(settings MetricSettings) metricMongo
 
 type metricMongodbatlasSystemFtsDiskUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3720,7 +3720,7 @@ func (m *metricMongodbatlasSystemFtsDiskUsed) init() {
 }
 
 func (m *metricMongodbatlasSystemFtsDiskUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3738,16 +3738,16 @@ func (m *metricMongodbatlasSystemFtsDiskUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemFtsDiskUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemFtsDiskUsed(settings MetricSettings) metricMongodbatlasSystemFtsDiskUsed {
-	m := metricMongodbatlasSystemFtsDiskUsed{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemFtsDiskUsed(cfg MetricConfig) metricMongodbatlasSystemFtsDiskUsed {
+	m := metricMongodbatlasSystemFtsDiskUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3756,7 +3756,7 @@ func newMetricMongodbatlasSystemFtsDiskUsed(settings MetricSettings) metricMongo
 
 type metricMongodbatlasSystemFtsMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3772,7 +3772,7 @@ func (m *metricMongodbatlasSystemFtsMemoryUsage) init() {
 }
 
 func (m *metricMongodbatlasSystemFtsMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3791,16 +3791,16 @@ func (m *metricMongodbatlasSystemFtsMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemFtsMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemFtsMemoryUsage(settings MetricSettings) metricMongodbatlasSystemFtsMemoryUsage {
-	m := metricMongodbatlasSystemFtsMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemFtsMemoryUsage(cfg MetricConfig) metricMongodbatlasSystemFtsMemoryUsage {
+	m := metricMongodbatlasSystemFtsMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3809,7 +3809,7 @@ func newMetricMongodbatlasSystemFtsMemoryUsage(settings MetricSettings) metricMo
 
 type metricMongodbatlasSystemMemoryUsageAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3823,7 +3823,7 @@ func (m *metricMongodbatlasSystemMemoryUsageAverage) init() {
 }
 
 func (m *metricMongodbatlasSystemMemoryUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3842,16 +3842,16 @@ func (m *metricMongodbatlasSystemMemoryUsageAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemMemoryUsageAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemMemoryUsageAverage(settings MetricSettings) metricMongodbatlasSystemMemoryUsageAverage {
-	m := metricMongodbatlasSystemMemoryUsageAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemMemoryUsageAverage(cfg MetricConfig) metricMongodbatlasSystemMemoryUsageAverage {
+	m := metricMongodbatlasSystemMemoryUsageAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3860,7 +3860,7 @@ func newMetricMongodbatlasSystemMemoryUsageAverage(settings MetricSettings) metr
 
 type metricMongodbatlasSystemMemoryUsageMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3874,7 +3874,7 @@ func (m *metricMongodbatlasSystemMemoryUsageMax) init() {
 }
 
 func (m *metricMongodbatlasSystemMemoryUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3893,16 +3893,16 @@ func (m *metricMongodbatlasSystemMemoryUsageMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemMemoryUsageMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemMemoryUsageMax(settings MetricSettings) metricMongodbatlasSystemMemoryUsageMax {
-	m := metricMongodbatlasSystemMemoryUsageMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemMemoryUsageMax(cfg MetricConfig) metricMongodbatlasSystemMemoryUsageMax {
+	m := metricMongodbatlasSystemMemoryUsageMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3911,7 +3911,7 @@ func newMetricMongodbatlasSystemMemoryUsageMax(settings MetricSettings) metricMo
 
 type metricMongodbatlasSystemNetworkIoAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3925,7 +3925,7 @@ func (m *metricMongodbatlasSystemNetworkIoAverage) init() {
 }
 
 func (m *metricMongodbatlasSystemNetworkIoAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3944,16 +3944,16 @@ func (m *metricMongodbatlasSystemNetworkIoAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemNetworkIoAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemNetworkIoAverage(settings MetricSettings) metricMongodbatlasSystemNetworkIoAverage {
-	m := metricMongodbatlasSystemNetworkIoAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemNetworkIoAverage(cfg MetricConfig) metricMongodbatlasSystemNetworkIoAverage {
+	m := metricMongodbatlasSystemNetworkIoAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3962,7 +3962,7 @@ func newMetricMongodbatlasSystemNetworkIoAverage(settings MetricSettings) metric
 
 type metricMongodbatlasSystemNetworkIoMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3976,7 +3976,7 @@ func (m *metricMongodbatlasSystemNetworkIoMax) init() {
 }
 
 func (m *metricMongodbatlasSystemNetworkIoMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -3995,16 +3995,16 @@ func (m *metricMongodbatlasSystemNetworkIoMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemNetworkIoMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemNetworkIoMax(settings MetricSettings) metricMongodbatlasSystemNetworkIoMax {
-	m := metricMongodbatlasSystemNetworkIoMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemNetworkIoMax(cfg MetricConfig) metricMongodbatlasSystemNetworkIoMax {
+	m := metricMongodbatlasSystemNetworkIoMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4013,7 +4013,7 @@ func newMetricMongodbatlasSystemNetworkIoMax(settings MetricSettings) metricMong
 
 type metricMongodbatlasSystemPagingIoAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4027,7 +4027,7 @@ func (m *metricMongodbatlasSystemPagingIoAverage) init() {
 }
 
 func (m *metricMongodbatlasSystemPagingIoAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -4046,16 +4046,16 @@ func (m *metricMongodbatlasSystemPagingIoAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemPagingIoAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemPagingIoAverage(settings MetricSettings) metricMongodbatlasSystemPagingIoAverage {
-	m := metricMongodbatlasSystemPagingIoAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemPagingIoAverage(cfg MetricConfig) metricMongodbatlasSystemPagingIoAverage {
+	m := metricMongodbatlasSystemPagingIoAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4064,7 +4064,7 @@ func newMetricMongodbatlasSystemPagingIoAverage(settings MetricSettings) metricM
 
 type metricMongodbatlasSystemPagingIoMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4078,7 +4078,7 @@ func (m *metricMongodbatlasSystemPagingIoMax) init() {
 }
 
 func (m *metricMongodbatlasSystemPagingIoMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -4097,16 +4097,16 @@ func (m *metricMongodbatlasSystemPagingIoMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemPagingIoMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemPagingIoMax(settings MetricSettings) metricMongodbatlasSystemPagingIoMax {
-	m := metricMongodbatlasSystemPagingIoMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemPagingIoMax(cfg MetricConfig) metricMongodbatlasSystemPagingIoMax {
+	m := metricMongodbatlasSystemPagingIoMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4115,7 +4115,7 @@ func newMetricMongodbatlasSystemPagingIoMax(settings MetricSettings) metricMongo
 
 type metricMongodbatlasSystemPagingUsageAverage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4129,7 +4129,7 @@ func (m *metricMongodbatlasSystemPagingUsageAverage) init() {
 }
 
 func (m *metricMongodbatlasSystemPagingUsageAverage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -4148,16 +4148,16 @@ func (m *metricMongodbatlasSystemPagingUsageAverage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemPagingUsageAverage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemPagingUsageAverage(settings MetricSettings) metricMongodbatlasSystemPagingUsageAverage {
-	m := metricMongodbatlasSystemPagingUsageAverage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemPagingUsageAverage(cfg MetricConfig) metricMongodbatlasSystemPagingUsageAverage {
+	m := metricMongodbatlasSystemPagingUsageAverage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4166,7 +4166,7 @@ func newMetricMongodbatlasSystemPagingUsageAverage(settings MetricSettings) metr
 
 type metricMongodbatlasSystemPagingUsageMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -4180,7 +4180,7 @@ func (m *metricMongodbatlasSystemPagingUsageMax) init() {
 }
 
 func (m *metricMongodbatlasSystemPagingUsageMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, memoryStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -4199,16 +4199,16 @@ func (m *metricMongodbatlasSystemPagingUsageMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbatlasSystemPagingUsageMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbatlasSystemPagingUsageMax(settings MetricSettings) metricMongodbatlasSystemPagingUsageMax {
-	m := metricMongodbatlasSystemPagingUsageMax{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbatlasSystemPagingUsageMax(cfg MetricConfig) metricMongodbatlasSystemPagingUsageMax {
+	m := metricMongodbatlasSystemPagingUsageMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -4217,19 +4217,19 @@ func newMetricMongodbatlasSystemPagingUsageMax(settings MetricSettings) metricMo
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                                   pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                                             int                 // maximum observed number of metrics per resource.
 	resourceCapacity                                            int                 // maximum observed number of resource attributes.
 	metricsBuffer                                               pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                                                   component.BuildInfo // contains version information
-	resourceAttributesSettings                                  ResourceAttributesSettings
+	resourceAttributesConfig                                    ResourceAttributesConfig
 	metricMongodbatlasDbCounts                                  metricMongodbatlasDbCounts
 	metricMongodbatlasDbSize                                    metricMongodbatlasDbSize
 	metricMongodbatlasDiskPartitionIopsAverage                  metricMongodbatlasDiskPartitionIopsAverage
@@ -4306,8 +4306,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -4316,7 +4316,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                  pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:              pmetric.NewMetrics(),
 		buildInfo:                  settings.BuildInfo,
-		resourceAttributesSettings: mbc.ResourceAttributes,
+		resourceAttributesConfig:   mbc.ResourceAttributes,
 		metricMongodbatlasDbCounts: newMetricMongodbatlasDbCounts(mbc.Metrics.MongodbatlasDbCounts),
 		metricMongodbatlasDbSize:   newMetricMongodbatlasDbSize(mbc.Metrics.MongodbatlasDbSize),
 		metricMongodbatlasDiskPartitionIopsAverage:                  newMetricMongodbatlasDiskPartitionIopsAverage(mbc.Metrics.MongodbatlasDiskPartitionIopsAverage),
@@ -4397,12 +4397,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithMongodbAtlasClusterName sets provided value as "mongodb_atlas.cluster.name" attribute for current resource.
 func WithMongodbAtlasClusterName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MongodbAtlasClusterName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MongodbAtlasClusterName.Enabled {
 			rm.Resource().Attributes().PutStr("mongodb_atlas.cluster.name", val)
 		}
 	}
@@ -4410,8 +4410,8 @@ func WithMongodbAtlasClusterName(val string) ResourceMetricsOption {
 
 // WithMongodbAtlasDbName sets provided value as "mongodb_atlas.db.name" attribute for current resource.
 func WithMongodbAtlasDbName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MongodbAtlasDbName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MongodbAtlasDbName.Enabled {
 			rm.Resource().Attributes().PutStr("mongodb_atlas.db.name", val)
 		}
 	}
@@ -4419,8 +4419,8 @@ func WithMongodbAtlasDbName(val string) ResourceMetricsOption {
 
 // WithMongodbAtlasDiskPartition sets provided value as "mongodb_atlas.disk.partition" attribute for current resource.
 func WithMongodbAtlasDiskPartition(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MongodbAtlasDiskPartition.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MongodbAtlasDiskPartition.Enabled {
 			rm.Resource().Attributes().PutStr("mongodb_atlas.disk.partition", val)
 		}
 	}
@@ -4428,8 +4428,8 @@ func WithMongodbAtlasDiskPartition(val string) ResourceMetricsOption {
 
 // WithMongodbAtlasHostName sets provided value as "mongodb_atlas.host.name" attribute for current resource.
 func WithMongodbAtlasHostName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MongodbAtlasHostName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MongodbAtlasHostName.Enabled {
 			rm.Resource().Attributes().PutStr("mongodb_atlas.host.name", val)
 		}
 	}
@@ -4437,8 +4437,8 @@ func WithMongodbAtlasHostName(val string) ResourceMetricsOption {
 
 // WithMongodbAtlasOrgName sets provided value as "mongodb_atlas.org_name" attribute for current resource.
 func WithMongodbAtlasOrgName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MongodbAtlasOrgName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MongodbAtlasOrgName.Enabled {
 			rm.Resource().Attributes().PutStr("mongodb_atlas.org_name", val)
 		}
 	}
@@ -4446,8 +4446,8 @@ func WithMongodbAtlasOrgName(val string) ResourceMetricsOption {
 
 // WithMongodbAtlasProcessID sets provided value as "mongodb_atlas.process.id" attribute for current resource.
 func WithMongodbAtlasProcessID(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MongodbAtlasProcessID.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MongodbAtlasProcessID.Enabled {
 			rm.Resource().Attributes().PutStr("mongodb_atlas.process.id", val)
 		}
 	}
@@ -4455,8 +4455,8 @@ func WithMongodbAtlasProcessID(val string) ResourceMetricsOption {
 
 // WithMongodbAtlasProcessPort sets provided value as "mongodb_atlas.process.port" attribute for current resource.
 func WithMongodbAtlasProcessPort(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MongodbAtlasProcessPort.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MongodbAtlasProcessPort.Enabled {
 			rm.Resource().Attributes().PutStr("mongodb_atlas.process.port", val)
 		}
 	}
@@ -4464,8 +4464,8 @@ func WithMongodbAtlasProcessPort(val string) ResourceMetricsOption {
 
 // WithMongodbAtlasProcessTypeName sets provided value as "mongodb_atlas.process.type_name" attribute for current resource.
 func WithMongodbAtlasProcessTypeName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MongodbAtlasProcessTypeName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MongodbAtlasProcessTypeName.Enabled {
 			rm.Resource().Attributes().PutStr("mongodb_atlas.process.type_name", val)
 		}
 	}
@@ -4473,8 +4473,8 @@ func WithMongodbAtlasProcessTypeName(val string) ResourceMetricsOption {
 
 // WithMongodbAtlasProjectID sets provided value as "mongodb_atlas.project.id" attribute for current resource.
 func WithMongodbAtlasProjectID(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MongodbAtlasProjectID.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MongodbAtlasProjectID.Enabled {
 			rm.Resource().Attributes().PutStr("mongodb_atlas.project.id", val)
 		}
 	}
@@ -4482,8 +4482,8 @@ func WithMongodbAtlasProjectID(val string) ResourceMetricsOption {
 
 // WithMongodbAtlasProjectName sets provided value as "mongodb_atlas.project.name" attribute for current resource.
 func WithMongodbAtlasProjectName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MongodbAtlasProjectName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MongodbAtlasProjectName.Enabled {
 			rm.Resource().Attributes().PutStr("mongodb_atlas.project.name", val)
 		}
 	}
@@ -4491,8 +4491,8 @@ func WithMongodbAtlasProjectName(val string) ResourceMetricsOption {
 
 // WithMongodbAtlasUserAlias sets provided value as "mongodb_atlas.user.alias" attribute for current resource.
 func WithMongodbAtlasUserAlias(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MongodbAtlasUserAlias.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MongodbAtlasUserAlias.Enabled {
 			rm.Resource().Attributes().PutStr("mongodb_atlas.user.alias", val)
 		}
 	}
@@ -4501,7 +4501,7 @@ func WithMongodbAtlasUserAlias(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -4594,7 +4594,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricMongodbatlasSystemPagingUsageMax.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -4604,7 +4604,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics_test.go
@@ -319,78 +319,78 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("mongodb_atlas.cluster.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MongodbAtlasClusterName.Enabled, ok)
-			if mb.resourceAttributesSettings.MongodbAtlasClusterName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MongodbAtlasClusterName.Enabled, ok)
+			if mb.resourceAttributesConfig.MongodbAtlasClusterName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("mongodb_atlas.db.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MongodbAtlasDbName.Enabled, ok)
-			if mb.resourceAttributesSettings.MongodbAtlasDbName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MongodbAtlasDbName.Enabled, ok)
+			if mb.resourceAttributesConfig.MongodbAtlasDbName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("mongodb_atlas.disk.partition")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MongodbAtlasDiskPartition.Enabled, ok)
-			if mb.resourceAttributesSettings.MongodbAtlasDiskPartition.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MongodbAtlasDiskPartition.Enabled, ok)
+			if mb.resourceAttributesConfig.MongodbAtlasDiskPartition.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("mongodb_atlas.host.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MongodbAtlasHostName.Enabled, ok)
-			if mb.resourceAttributesSettings.MongodbAtlasHostName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MongodbAtlasHostName.Enabled, ok)
+			if mb.resourceAttributesConfig.MongodbAtlasHostName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("mongodb_atlas.org_name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MongodbAtlasOrgName.Enabled, ok)
-			if mb.resourceAttributesSettings.MongodbAtlasOrgName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MongodbAtlasOrgName.Enabled, ok)
+			if mb.resourceAttributesConfig.MongodbAtlasOrgName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("mongodb_atlas.process.id")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MongodbAtlasProcessID.Enabled, ok)
-			if mb.resourceAttributesSettings.MongodbAtlasProcessID.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MongodbAtlasProcessID.Enabled, ok)
+			if mb.resourceAttributesConfig.MongodbAtlasProcessID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("mongodb_atlas.process.port")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MongodbAtlasProcessPort.Enabled, ok)
-			if mb.resourceAttributesSettings.MongodbAtlasProcessPort.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MongodbAtlasProcessPort.Enabled, ok)
+			if mb.resourceAttributesConfig.MongodbAtlasProcessPort.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("mongodb_atlas.process.type_name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MongodbAtlasProcessTypeName.Enabled, ok)
-			if mb.resourceAttributesSettings.MongodbAtlasProcessTypeName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MongodbAtlasProcessTypeName.Enabled, ok)
+			if mb.resourceAttributesConfig.MongodbAtlasProcessTypeName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("mongodb_atlas.project.id")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MongodbAtlasProjectID.Enabled, ok)
-			if mb.resourceAttributesSettings.MongodbAtlasProjectID.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MongodbAtlasProjectID.Enabled, ok)
+			if mb.resourceAttributesConfig.MongodbAtlasProjectID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("mongodb_atlas.project.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MongodbAtlasProjectName.Enabled, ok)
-			if mb.resourceAttributesSettings.MongodbAtlasProjectName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MongodbAtlasProjectName.Enabled, ok)
+			if mb.resourceAttributesConfig.MongodbAtlasProjectName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("mongodb_atlas.user.alias")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MongodbAtlasUserAlias.Enabled, ok)
-			if mb.resourceAttributesSettings.MongodbAtlasUserAlias.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MongodbAtlasUserAlias.Enabled, ok)
+			if mb.resourceAttributesConfig.MongodbAtlasUserAlias.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,148 +31,148 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for mongodbreceiver metrics.
-type MetricsSettings struct {
-	MongodbCacheOperations        MetricSettings `mapstructure:"mongodb.cache.operations"`
-	MongodbCollectionCount        MetricSettings `mapstructure:"mongodb.collection.count"`
-	MongodbConnectionCount        MetricSettings `mapstructure:"mongodb.connection.count"`
-	MongodbCursorCount            MetricSettings `mapstructure:"mongodb.cursor.count"`
-	MongodbCursorTimeoutCount     MetricSettings `mapstructure:"mongodb.cursor.timeout.count"`
-	MongodbDataSize               MetricSettings `mapstructure:"mongodb.data.size"`
-	MongodbDatabaseCount          MetricSettings `mapstructure:"mongodb.database.count"`
-	MongodbDocumentOperationCount MetricSettings `mapstructure:"mongodb.document.operation.count"`
-	MongodbExtentCount            MetricSettings `mapstructure:"mongodb.extent.count"`
-	MongodbGlobalLockTime         MetricSettings `mapstructure:"mongodb.global_lock.time"`
-	MongodbHealth                 MetricSettings `mapstructure:"mongodb.health"`
-	MongodbIndexAccessCount       MetricSettings `mapstructure:"mongodb.index.access.count"`
-	MongodbIndexCount             MetricSettings `mapstructure:"mongodb.index.count"`
-	MongodbIndexSize              MetricSettings `mapstructure:"mongodb.index.size"`
-	MongodbLockAcquireCount       MetricSettings `mapstructure:"mongodb.lock.acquire.count"`
-	MongodbLockAcquireTime        MetricSettings `mapstructure:"mongodb.lock.acquire.time"`
-	MongodbLockAcquireWaitCount   MetricSettings `mapstructure:"mongodb.lock.acquire.wait_count"`
-	MongodbLockDeadlockCount      MetricSettings `mapstructure:"mongodb.lock.deadlock.count"`
-	MongodbMemoryUsage            MetricSettings `mapstructure:"mongodb.memory.usage"`
-	MongodbNetworkIoReceive       MetricSettings `mapstructure:"mongodb.network.io.receive"`
-	MongodbNetworkIoTransmit      MetricSettings `mapstructure:"mongodb.network.io.transmit"`
-	MongodbNetworkRequestCount    MetricSettings `mapstructure:"mongodb.network.request.count"`
-	MongodbObjectCount            MetricSettings `mapstructure:"mongodb.object.count"`
-	MongodbOperationCount         MetricSettings `mapstructure:"mongodb.operation.count"`
-	MongodbOperationLatencyTime   MetricSettings `mapstructure:"mongodb.operation.latency.time"`
-	MongodbOperationReplCount     MetricSettings `mapstructure:"mongodb.operation.repl.count"`
-	MongodbOperationTime          MetricSettings `mapstructure:"mongodb.operation.time"`
-	MongodbSessionCount           MetricSettings `mapstructure:"mongodb.session.count"`
-	MongodbStorageSize            MetricSettings `mapstructure:"mongodb.storage.size"`
-	MongodbUptime                 MetricSettings `mapstructure:"mongodb.uptime"`
+// MetricsConfig provides config for mongodbreceiver metrics.
+type MetricsConfig struct {
+	MongodbCacheOperations        MetricConfig `mapstructure:"mongodb.cache.operations"`
+	MongodbCollectionCount        MetricConfig `mapstructure:"mongodb.collection.count"`
+	MongodbConnectionCount        MetricConfig `mapstructure:"mongodb.connection.count"`
+	MongodbCursorCount            MetricConfig `mapstructure:"mongodb.cursor.count"`
+	MongodbCursorTimeoutCount     MetricConfig `mapstructure:"mongodb.cursor.timeout.count"`
+	MongodbDataSize               MetricConfig `mapstructure:"mongodb.data.size"`
+	MongodbDatabaseCount          MetricConfig `mapstructure:"mongodb.database.count"`
+	MongodbDocumentOperationCount MetricConfig `mapstructure:"mongodb.document.operation.count"`
+	MongodbExtentCount            MetricConfig `mapstructure:"mongodb.extent.count"`
+	MongodbGlobalLockTime         MetricConfig `mapstructure:"mongodb.global_lock.time"`
+	MongodbHealth                 MetricConfig `mapstructure:"mongodb.health"`
+	MongodbIndexAccessCount       MetricConfig `mapstructure:"mongodb.index.access.count"`
+	MongodbIndexCount             MetricConfig `mapstructure:"mongodb.index.count"`
+	MongodbIndexSize              MetricConfig `mapstructure:"mongodb.index.size"`
+	MongodbLockAcquireCount       MetricConfig `mapstructure:"mongodb.lock.acquire.count"`
+	MongodbLockAcquireTime        MetricConfig `mapstructure:"mongodb.lock.acquire.time"`
+	MongodbLockAcquireWaitCount   MetricConfig `mapstructure:"mongodb.lock.acquire.wait_count"`
+	MongodbLockDeadlockCount      MetricConfig `mapstructure:"mongodb.lock.deadlock.count"`
+	MongodbMemoryUsage            MetricConfig `mapstructure:"mongodb.memory.usage"`
+	MongodbNetworkIoReceive       MetricConfig `mapstructure:"mongodb.network.io.receive"`
+	MongodbNetworkIoTransmit      MetricConfig `mapstructure:"mongodb.network.io.transmit"`
+	MongodbNetworkRequestCount    MetricConfig `mapstructure:"mongodb.network.request.count"`
+	MongodbObjectCount            MetricConfig `mapstructure:"mongodb.object.count"`
+	MongodbOperationCount         MetricConfig `mapstructure:"mongodb.operation.count"`
+	MongodbOperationLatencyTime   MetricConfig `mapstructure:"mongodb.operation.latency.time"`
+	MongodbOperationReplCount     MetricConfig `mapstructure:"mongodb.operation.repl.count"`
+	MongodbOperationTime          MetricConfig `mapstructure:"mongodb.operation.time"`
+	MongodbSessionCount           MetricConfig `mapstructure:"mongodb.session.count"`
+	MongodbStorageSize            MetricConfig `mapstructure:"mongodb.storage.size"`
+	MongodbUptime                 MetricConfig `mapstructure:"mongodb.uptime"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		MongodbCacheOperations: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		MongodbCacheOperations: MetricConfig{
 			Enabled: true,
 		},
-		MongodbCollectionCount: MetricSettings{
+		MongodbCollectionCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbConnectionCount: MetricSettings{
+		MongodbConnectionCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbCursorCount: MetricSettings{
+		MongodbCursorCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbCursorTimeoutCount: MetricSettings{
+		MongodbCursorTimeoutCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbDataSize: MetricSettings{
+		MongodbDataSize: MetricConfig{
 			Enabled: true,
 		},
-		MongodbDatabaseCount: MetricSettings{
+		MongodbDatabaseCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbDocumentOperationCount: MetricSettings{
+		MongodbDocumentOperationCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbExtentCount: MetricSettings{
+		MongodbExtentCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbGlobalLockTime: MetricSettings{
+		MongodbGlobalLockTime: MetricConfig{
 			Enabled: true,
 		},
-		MongodbHealth: MetricSettings{
+		MongodbHealth: MetricConfig{
 			Enabled: false,
 		},
-		MongodbIndexAccessCount: MetricSettings{
+		MongodbIndexAccessCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbIndexCount: MetricSettings{
+		MongodbIndexCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbIndexSize: MetricSettings{
+		MongodbIndexSize: MetricConfig{
 			Enabled: true,
 		},
-		MongodbLockAcquireCount: MetricSettings{
+		MongodbLockAcquireCount: MetricConfig{
 			Enabled: false,
 		},
-		MongodbLockAcquireTime: MetricSettings{
+		MongodbLockAcquireTime: MetricConfig{
 			Enabled: false,
 		},
-		MongodbLockAcquireWaitCount: MetricSettings{
+		MongodbLockAcquireWaitCount: MetricConfig{
 			Enabled: false,
 		},
-		MongodbLockDeadlockCount: MetricSettings{
+		MongodbLockDeadlockCount: MetricConfig{
 			Enabled: false,
 		},
-		MongodbMemoryUsage: MetricSettings{
+		MongodbMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		MongodbNetworkIoReceive: MetricSettings{
+		MongodbNetworkIoReceive: MetricConfig{
 			Enabled: true,
 		},
-		MongodbNetworkIoTransmit: MetricSettings{
+		MongodbNetworkIoTransmit: MetricConfig{
 			Enabled: true,
 		},
-		MongodbNetworkRequestCount: MetricSettings{
+		MongodbNetworkRequestCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbObjectCount: MetricSettings{
+		MongodbObjectCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbOperationCount: MetricSettings{
+		MongodbOperationCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbOperationLatencyTime: MetricSettings{
+		MongodbOperationLatencyTime: MetricConfig{
 			Enabled: false,
 		},
-		MongodbOperationReplCount: MetricSettings{
+		MongodbOperationReplCount: MetricConfig{
 			Enabled: false,
 		},
-		MongodbOperationTime: MetricSettings{
+		MongodbOperationTime: MetricConfig{
 			Enabled: true,
 		},
-		MongodbSessionCount: MetricSettings{
+		MongodbSessionCount: MetricConfig{
 			Enabled: true,
 		},
-		MongodbStorageSize: MetricSettings{
+		MongodbStorageSize: MetricConfig{
 			Enabled: true,
 		},
-		MongodbUptime: MetricSettings{
+		MongodbUptime: MetricConfig{
 			Enabled: false,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for mongodbreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	Database ResourceAttributeSettings `mapstructure:"database"`
+// ResourceAttributesConfig provides config for mongodbreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	Database ResourceAttributeConfig `mapstructure:"database"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		Database: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		Database: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -418,7 +418,7 @@ var MapAttributeType = map[string]AttributeType{
 
 type metricMongodbCacheOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -434,7 +434,7 @@ func (m *metricMongodbCacheOperations) init() {
 }
 
 func (m *metricMongodbCacheOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, typeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -453,16 +453,16 @@ func (m *metricMongodbCacheOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbCacheOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbCacheOperations(settings MetricSettings) metricMongodbCacheOperations {
-	m := metricMongodbCacheOperations{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbCacheOperations(cfg MetricConfig) metricMongodbCacheOperations {
+	m := metricMongodbCacheOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -471,7 +471,7 @@ func newMetricMongodbCacheOperations(settings MetricSettings) metricMongodbCache
 
 type metricMongodbCollectionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -487,7 +487,7 @@ func (m *metricMongodbCollectionCount) init() {
 }
 
 func (m *metricMongodbCollectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -506,16 +506,16 @@ func (m *metricMongodbCollectionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbCollectionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbCollectionCount(settings MetricSettings) metricMongodbCollectionCount {
-	m := metricMongodbCollectionCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbCollectionCount(cfg MetricConfig) metricMongodbCollectionCount {
+	m := metricMongodbCollectionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -524,7 +524,7 @@ func newMetricMongodbCollectionCount(settings MetricSettings) metricMongodbColle
 
 type metricMongodbConnectionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -540,7 +540,7 @@ func (m *metricMongodbConnectionCount) init() {
 }
 
 func (m *metricMongodbConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, connectionTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -560,16 +560,16 @@ func (m *metricMongodbConnectionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbConnectionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbConnectionCount(settings MetricSettings) metricMongodbConnectionCount {
-	m := metricMongodbConnectionCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbConnectionCount(cfg MetricConfig) metricMongodbConnectionCount {
+	m := metricMongodbConnectionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -578,7 +578,7 @@ func newMetricMongodbConnectionCount(settings MetricSettings) metricMongodbConne
 
 type metricMongodbCursorCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -593,7 +593,7 @@ func (m *metricMongodbCursorCount) init() {
 }
 
 func (m *metricMongodbCursorCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -611,16 +611,16 @@ func (m *metricMongodbCursorCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbCursorCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbCursorCount(settings MetricSettings) metricMongodbCursorCount {
-	m := metricMongodbCursorCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbCursorCount(cfg MetricConfig) metricMongodbCursorCount {
+	m := metricMongodbCursorCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -629,7 +629,7 @@ func newMetricMongodbCursorCount(settings MetricSettings) metricMongodbCursorCou
 
 type metricMongodbCursorTimeoutCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -644,7 +644,7 @@ func (m *metricMongodbCursorTimeoutCount) init() {
 }
 
 func (m *metricMongodbCursorTimeoutCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -662,16 +662,16 @@ func (m *metricMongodbCursorTimeoutCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbCursorTimeoutCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbCursorTimeoutCount(settings MetricSettings) metricMongodbCursorTimeoutCount {
-	m := metricMongodbCursorTimeoutCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbCursorTimeoutCount(cfg MetricConfig) metricMongodbCursorTimeoutCount {
+	m := metricMongodbCursorTimeoutCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -680,7 +680,7 @@ func newMetricMongodbCursorTimeoutCount(settings MetricSettings) metricMongodbCu
 
 type metricMongodbDataSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -696,7 +696,7 @@ func (m *metricMongodbDataSize) init() {
 }
 
 func (m *metricMongodbDataSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -715,16 +715,16 @@ func (m *metricMongodbDataSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbDataSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbDataSize(settings MetricSettings) metricMongodbDataSize {
-	m := metricMongodbDataSize{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbDataSize(cfg MetricConfig) metricMongodbDataSize {
+	m := metricMongodbDataSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -733,7 +733,7 @@ func newMetricMongodbDataSize(settings MetricSettings) metricMongodbDataSize {
 
 type metricMongodbDatabaseCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -748,7 +748,7 @@ func (m *metricMongodbDatabaseCount) init() {
 }
 
 func (m *metricMongodbDatabaseCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -766,16 +766,16 @@ func (m *metricMongodbDatabaseCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbDatabaseCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbDatabaseCount(settings MetricSettings) metricMongodbDatabaseCount {
-	m := metricMongodbDatabaseCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbDatabaseCount(cfg MetricConfig) metricMongodbDatabaseCount {
+	m := metricMongodbDatabaseCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -784,7 +784,7 @@ func newMetricMongodbDatabaseCount(settings MetricSettings) metricMongodbDatabas
 
 type metricMongodbDocumentOperationCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -800,7 +800,7 @@ func (m *metricMongodbDocumentOperationCount) init() {
 }
 
 func (m *metricMongodbDocumentOperationCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -820,16 +820,16 @@ func (m *metricMongodbDocumentOperationCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbDocumentOperationCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbDocumentOperationCount(settings MetricSettings) metricMongodbDocumentOperationCount {
-	m := metricMongodbDocumentOperationCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbDocumentOperationCount(cfg MetricConfig) metricMongodbDocumentOperationCount {
+	m := metricMongodbDocumentOperationCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -838,7 +838,7 @@ func newMetricMongodbDocumentOperationCount(settings MetricSettings) metricMongo
 
 type metricMongodbExtentCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -854,7 +854,7 @@ func (m *metricMongodbExtentCount) init() {
 }
 
 func (m *metricMongodbExtentCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -873,16 +873,16 @@ func (m *metricMongodbExtentCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbExtentCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbExtentCount(settings MetricSettings) metricMongodbExtentCount {
-	m := metricMongodbExtentCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbExtentCount(cfg MetricConfig) metricMongodbExtentCount {
+	m := metricMongodbExtentCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -891,7 +891,7 @@ func newMetricMongodbExtentCount(settings MetricSettings) metricMongodbExtentCou
 
 type metricMongodbGlobalLockTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -906,7 +906,7 @@ func (m *metricMongodbGlobalLockTime) init() {
 }
 
 func (m *metricMongodbGlobalLockTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -924,16 +924,16 @@ func (m *metricMongodbGlobalLockTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbGlobalLockTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbGlobalLockTime(settings MetricSettings) metricMongodbGlobalLockTime {
-	m := metricMongodbGlobalLockTime{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbGlobalLockTime(cfg MetricConfig) metricMongodbGlobalLockTime {
+	m := metricMongodbGlobalLockTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -942,7 +942,7 @@ func newMetricMongodbGlobalLockTime(settings MetricSettings) metricMongodbGlobal
 
 type metricMongodbHealth struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -955,7 +955,7 @@ func (m *metricMongodbHealth) init() {
 }
 
 func (m *metricMongodbHealth) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -973,16 +973,16 @@ func (m *metricMongodbHealth) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbHealth) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbHealth(settings MetricSettings) metricMongodbHealth {
-	m := metricMongodbHealth{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbHealth(cfg MetricConfig) metricMongodbHealth {
+	m := metricMongodbHealth{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -991,7 +991,7 @@ func newMetricMongodbHealth(settings MetricSettings) metricMongodbHealth {
 
 type metricMongodbIndexAccessCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1007,7 +1007,7 @@ func (m *metricMongodbIndexAccessCount) init() {
 }
 
 func (m *metricMongodbIndexAccessCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, collectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1027,16 +1027,16 @@ func (m *metricMongodbIndexAccessCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbIndexAccessCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbIndexAccessCount(settings MetricSettings) metricMongodbIndexAccessCount {
-	m := metricMongodbIndexAccessCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbIndexAccessCount(cfg MetricConfig) metricMongodbIndexAccessCount {
+	m := metricMongodbIndexAccessCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1045,7 +1045,7 @@ func newMetricMongodbIndexAccessCount(settings MetricSettings) metricMongodbInde
 
 type metricMongodbIndexCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1061,7 +1061,7 @@ func (m *metricMongodbIndexCount) init() {
 }
 
 func (m *metricMongodbIndexCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1080,16 +1080,16 @@ func (m *metricMongodbIndexCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbIndexCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbIndexCount(settings MetricSettings) metricMongodbIndexCount {
-	m := metricMongodbIndexCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbIndexCount(cfg MetricConfig) metricMongodbIndexCount {
+	m := metricMongodbIndexCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1098,7 +1098,7 @@ func newMetricMongodbIndexCount(settings MetricSettings) metricMongodbIndexCount
 
 type metricMongodbIndexSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1114,7 +1114,7 @@ func (m *metricMongodbIndexSize) init() {
 }
 
 func (m *metricMongodbIndexSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1133,16 +1133,16 @@ func (m *metricMongodbIndexSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbIndexSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbIndexSize(settings MetricSettings) metricMongodbIndexSize {
-	m := metricMongodbIndexSize{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbIndexSize(cfg MetricConfig) metricMongodbIndexSize {
+	m := metricMongodbIndexSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1151,7 +1151,7 @@ func newMetricMongodbIndexSize(settings MetricSettings) metricMongodbIndexSize {
 
 type metricMongodbLockAcquireCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1167,7 +1167,7 @@ func (m *metricMongodbLockAcquireCount) init() {
 }
 
 func (m *metricMongodbLockAcquireCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, lockTypeAttributeValue string, lockModeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1188,16 +1188,16 @@ func (m *metricMongodbLockAcquireCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbLockAcquireCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbLockAcquireCount(settings MetricSettings) metricMongodbLockAcquireCount {
-	m := metricMongodbLockAcquireCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbLockAcquireCount(cfg MetricConfig) metricMongodbLockAcquireCount {
+	m := metricMongodbLockAcquireCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1206,7 +1206,7 @@ func newMetricMongodbLockAcquireCount(settings MetricSettings) metricMongodbLock
 
 type metricMongodbLockAcquireTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1222,7 +1222,7 @@ func (m *metricMongodbLockAcquireTime) init() {
 }
 
 func (m *metricMongodbLockAcquireTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, lockTypeAttributeValue string, lockModeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1243,16 +1243,16 @@ func (m *metricMongodbLockAcquireTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbLockAcquireTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbLockAcquireTime(settings MetricSettings) metricMongodbLockAcquireTime {
-	m := metricMongodbLockAcquireTime{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbLockAcquireTime(cfg MetricConfig) metricMongodbLockAcquireTime {
+	m := metricMongodbLockAcquireTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1261,7 +1261,7 @@ func newMetricMongodbLockAcquireTime(settings MetricSettings) metricMongodbLockA
 
 type metricMongodbLockAcquireWaitCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1277,7 +1277,7 @@ func (m *metricMongodbLockAcquireWaitCount) init() {
 }
 
 func (m *metricMongodbLockAcquireWaitCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, lockTypeAttributeValue string, lockModeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1298,16 +1298,16 @@ func (m *metricMongodbLockAcquireWaitCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbLockAcquireWaitCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbLockAcquireWaitCount(settings MetricSettings) metricMongodbLockAcquireWaitCount {
-	m := metricMongodbLockAcquireWaitCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbLockAcquireWaitCount(cfg MetricConfig) metricMongodbLockAcquireWaitCount {
+	m := metricMongodbLockAcquireWaitCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1316,7 +1316,7 @@ func newMetricMongodbLockAcquireWaitCount(settings MetricSettings) metricMongodb
 
 type metricMongodbLockDeadlockCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1332,7 +1332,7 @@ func (m *metricMongodbLockDeadlockCount) init() {
 }
 
 func (m *metricMongodbLockDeadlockCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, lockTypeAttributeValue string, lockModeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1353,16 +1353,16 @@ func (m *metricMongodbLockDeadlockCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbLockDeadlockCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbLockDeadlockCount(settings MetricSettings) metricMongodbLockDeadlockCount {
-	m := metricMongodbLockDeadlockCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbLockDeadlockCount(cfg MetricConfig) metricMongodbLockDeadlockCount {
+	m := metricMongodbLockDeadlockCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1371,7 +1371,7 @@ func newMetricMongodbLockDeadlockCount(settings MetricSettings) metricMongodbLoc
 
 type metricMongodbMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1387,7 +1387,7 @@ func (m *metricMongodbMemoryUsage) init() {
 }
 
 func (m *metricMongodbMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, memoryTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1407,16 +1407,16 @@ func (m *metricMongodbMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbMemoryUsage(settings MetricSettings) metricMongodbMemoryUsage {
-	m := metricMongodbMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbMemoryUsage(cfg MetricConfig) metricMongodbMemoryUsage {
+	m := metricMongodbMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1425,7 +1425,7 @@ func newMetricMongodbMemoryUsage(settings MetricSettings) metricMongodbMemoryUsa
 
 type metricMongodbNetworkIoReceive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1440,7 +1440,7 @@ func (m *metricMongodbNetworkIoReceive) init() {
 }
 
 func (m *metricMongodbNetworkIoReceive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1458,16 +1458,16 @@ func (m *metricMongodbNetworkIoReceive) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbNetworkIoReceive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbNetworkIoReceive(settings MetricSettings) metricMongodbNetworkIoReceive {
-	m := metricMongodbNetworkIoReceive{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbNetworkIoReceive(cfg MetricConfig) metricMongodbNetworkIoReceive {
+	m := metricMongodbNetworkIoReceive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1476,7 +1476,7 @@ func newMetricMongodbNetworkIoReceive(settings MetricSettings) metricMongodbNetw
 
 type metricMongodbNetworkIoTransmit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1491,7 +1491,7 @@ func (m *metricMongodbNetworkIoTransmit) init() {
 }
 
 func (m *metricMongodbNetworkIoTransmit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1509,16 +1509,16 @@ func (m *metricMongodbNetworkIoTransmit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbNetworkIoTransmit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbNetworkIoTransmit(settings MetricSettings) metricMongodbNetworkIoTransmit {
-	m := metricMongodbNetworkIoTransmit{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbNetworkIoTransmit(cfg MetricConfig) metricMongodbNetworkIoTransmit {
+	m := metricMongodbNetworkIoTransmit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1527,7 +1527,7 @@ func newMetricMongodbNetworkIoTransmit(settings MetricSettings) metricMongodbNet
 
 type metricMongodbNetworkRequestCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1542,7 +1542,7 @@ func (m *metricMongodbNetworkRequestCount) init() {
 }
 
 func (m *metricMongodbNetworkRequestCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1560,16 +1560,16 @@ func (m *metricMongodbNetworkRequestCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbNetworkRequestCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbNetworkRequestCount(settings MetricSettings) metricMongodbNetworkRequestCount {
-	m := metricMongodbNetworkRequestCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbNetworkRequestCount(cfg MetricConfig) metricMongodbNetworkRequestCount {
+	m := metricMongodbNetworkRequestCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1578,7 +1578,7 @@ func newMetricMongodbNetworkRequestCount(settings MetricSettings) metricMongodbN
 
 type metricMongodbObjectCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1594,7 +1594,7 @@ func (m *metricMongodbObjectCount) init() {
 }
 
 func (m *metricMongodbObjectCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1613,16 +1613,16 @@ func (m *metricMongodbObjectCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbObjectCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbObjectCount(settings MetricSettings) metricMongodbObjectCount {
-	m := metricMongodbObjectCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbObjectCount(cfg MetricConfig) metricMongodbObjectCount {
+	m := metricMongodbObjectCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1631,7 +1631,7 @@ func newMetricMongodbObjectCount(settings MetricSettings) metricMongodbObjectCou
 
 type metricMongodbOperationCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1647,7 +1647,7 @@ func (m *metricMongodbOperationCount) init() {
 }
 
 func (m *metricMongodbOperationCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1666,16 +1666,16 @@ func (m *metricMongodbOperationCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbOperationCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbOperationCount(settings MetricSettings) metricMongodbOperationCount {
-	m := metricMongodbOperationCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbOperationCount(cfg MetricConfig) metricMongodbOperationCount {
+	m := metricMongodbOperationCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1684,7 +1684,7 @@ func newMetricMongodbOperationCount(settings MetricSettings) metricMongodbOperat
 
 type metricMongodbOperationLatencyTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1698,7 +1698,7 @@ func (m *metricMongodbOperationLatencyTime) init() {
 }
 
 func (m *metricMongodbOperationLatencyTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationLatencyAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1717,16 +1717,16 @@ func (m *metricMongodbOperationLatencyTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbOperationLatencyTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbOperationLatencyTime(settings MetricSettings) metricMongodbOperationLatencyTime {
-	m := metricMongodbOperationLatencyTime{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbOperationLatencyTime(cfg MetricConfig) metricMongodbOperationLatencyTime {
+	m := metricMongodbOperationLatencyTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1735,7 +1735,7 @@ func newMetricMongodbOperationLatencyTime(settings MetricSettings) metricMongodb
 
 type metricMongodbOperationReplCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1751,7 +1751,7 @@ func (m *metricMongodbOperationReplCount) init() {
 }
 
 func (m *metricMongodbOperationReplCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1770,16 +1770,16 @@ func (m *metricMongodbOperationReplCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbOperationReplCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbOperationReplCount(settings MetricSettings) metricMongodbOperationReplCount {
-	m := metricMongodbOperationReplCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbOperationReplCount(cfg MetricConfig) metricMongodbOperationReplCount {
+	m := metricMongodbOperationReplCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1788,7 +1788,7 @@ func newMetricMongodbOperationReplCount(settings MetricSettings) metricMongodbOp
 
 type metricMongodbOperationTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1804,7 +1804,7 @@ func (m *metricMongodbOperationTime) init() {
 }
 
 func (m *metricMongodbOperationTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1823,16 +1823,16 @@ func (m *metricMongodbOperationTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbOperationTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbOperationTime(settings MetricSettings) metricMongodbOperationTime {
-	m := metricMongodbOperationTime{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbOperationTime(cfg MetricConfig) metricMongodbOperationTime {
+	m := metricMongodbOperationTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1841,7 +1841,7 @@ func newMetricMongodbOperationTime(settings MetricSettings) metricMongodbOperati
 
 type metricMongodbSessionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1856,7 +1856,7 @@ func (m *metricMongodbSessionCount) init() {
 }
 
 func (m *metricMongodbSessionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1874,16 +1874,16 @@ func (m *metricMongodbSessionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbSessionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbSessionCount(settings MetricSettings) metricMongodbSessionCount {
-	m := metricMongodbSessionCount{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbSessionCount(cfg MetricConfig) metricMongodbSessionCount {
+	m := metricMongodbSessionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1892,7 +1892,7 @@ func newMetricMongodbSessionCount(settings MetricSettings) metricMongodbSessionC
 
 type metricMongodbStorageSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1908,7 +1908,7 @@ func (m *metricMongodbStorageSize) init() {
 }
 
 func (m *metricMongodbStorageSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1927,16 +1927,16 @@ func (m *metricMongodbStorageSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbStorageSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbStorageSize(settings MetricSettings) metricMongodbStorageSize {
-	m := metricMongodbStorageSize{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbStorageSize(cfg MetricConfig) metricMongodbStorageSize {
+	m := metricMongodbStorageSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1945,7 +1945,7 @@ func newMetricMongodbStorageSize(settings MetricSettings) metricMongodbStorageSi
 
 type metricMongodbUptime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1960,7 +1960,7 @@ func (m *metricMongodbUptime) init() {
 }
 
 func (m *metricMongodbUptime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1978,16 +1978,16 @@ func (m *metricMongodbUptime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMongodbUptime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMongodbUptime(settings MetricSettings) metricMongodbUptime {
-	m := metricMongodbUptime{settings: settings}
-	if settings.Enabled {
+func newMetricMongodbUptime(cfg MetricConfig) metricMongodbUptime {
+	m := metricMongodbUptime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1996,19 +1996,19 @@ func newMetricMongodbUptime(settings MetricSettings) metricMongodbUptime {
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                           pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                     int                 // maximum observed number of metrics per resource.
 	resourceCapacity                    int                 // maximum observed number of resource attributes.
 	metricsBuffer                       pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                           component.BuildInfo // contains version information
-	resourceAttributesSettings          ResourceAttributesSettings
+	resourceAttributesConfig            ResourceAttributesConfig
 	metricMongodbCacheOperations        metricMongodbCacheOperations
 	metricMongodbCollectionCount        metricMongodbCollectionCount
 	metricMongodbConnectionCount        metricMongodbConnectionCount
@@ -2053,8 +2053,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -2063,7 +2063,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                           pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                       pmetric.NewMetrics(),
 		buildInfo:                           settings.BuildInfo,
-		resourceAttributesSettings:          mbc.ResourceAttributes,
+		resourceAttributesConfig:            mbc.ResourceAttributes,
 		metricMongodbCacheOperations:        newMetricMongodbCacheOperations(mbc.Metrics.MongodbCacheOperations),
 		metricMongodbCollectionCount:        newMetricMongodbCollectionCount(mbc.Metrics.MongodbCollectionCount),
 		metricMongodbConnectionCount:        newMetricMongodbConnectionCount(mbc.Metrics.MongodbConnectionCount),
@@ -2112,12 +2112,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithDatabase sets provided value as "database" attribute for current resource.
 func WithDatabase(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.Database.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.Database.Enabled {
 			rm.Resource().Attributes().PutStr("database", val)
 		}
 	}
@@ -2126,7 +2126,7 @@ func WithDatabase(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -2187,7 +2187,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricMongodbUptime.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -2197,7 +2197,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
@@ -183,8 +183,8 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("database")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.Database.Enabled, ok)
-			if mb.resourceAttributesSettings.Database.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.Database.Enabled, ok)
+			if mb.resourceAttributesConfig.Database.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -14,14 +14,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -33,200 +33,200 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for mysqlreceiver metrics.
-type MetricsSettings struct {
-	MysqlBufferPoolDataPages     MetricSettings `mapstructure:"mysql.buffer_pool.data_pages"`
-	MysqlBufferPoolLimit         MetricSettings `mapstructure:"mysql.buffer_pool.limit"`
-	MysqlBufferPoolOperations    MetricSettings `mapstructure:"mysql.buffer_pool.operations"`
-	MysqlBufferPoolPageFlushes   MetricSettings `mapstructure:"mysql.buffer_pool.page_flushes"`
-	MysqlBufferPoolPages         MetricSettings `mapstructure:"mysql.buffer_pool.pages"`
-	MysqlBufferPoolUsage         MetricSettings `mapstructure:"mysql.buffer_pool.usage"`
-	MysqlClientNetworkIo         MetricSettings `mapstructure:"mysql.client.network.io"`
-	MysqlCommands                MetricSettings `mapstructure:"mysql.commands"`
-	MysqlConnectionCount         MetricSettings `mapstructure:"mysql.connection.count"`
-	MysqlConnectionErrors        MetricSettings `mapstructure:"mysql.connection.errors"`
-	MysqlDoubleWrites            MetricSettings `mapstructure:"mysql.double_writes"`
-	MysqlHandlers                MetricSettings `mapstructure:"mysql.handlers"`
-	MysqlIndexIoWaitCount        MetricSettings `mapstructure:"mysql.index.io.wait.count"`
-	MysqlIndexIoWaitTime         MetricSettings `mapstructure:"mysql.index.io.wait.time"`
-	MysqlJoins                   MetricSettings `mapstructure:"mysql.joins"`
-	MysqlLockedConnects          MetricSettings `mapstructure:"mysql.locked_connects"`
-	MysqlLocks                   MetricSettings `mapstructure:"mysql.locks"`
-	MysqlLogOperations           MetricSettings `mapstructure:"mysql.log_operations"`
-	MysqlMysqlxConnections       MetricSettings `mapstructure:"mysql.mysqlx_connections"`
-	MysqlMysqlxWorkerThreads     MetricSettings `mapstructure:"mysql.mysqlx_worker_threads"`
-	MysqlOpenedResources         MetricSettings `mapstructure:"mysql.opened_resources"`
-	MysqlOperations              MetricSettings `mapstructure:"mysql.operations"`
-	MysqlPageOperations          MetricSettings `mapstructure:"mysql.page_operations"`
-	MysqlPreparedStatements      MetricSettings `mapstructure:"mysql.prepared_statements"`
-	MysqlQueryClientCount        MetricSettings `mapstructure:"mysql.query.client.count"`
-	MysqlQueryCount              MetricSettings `mapstructure:"mysql.query.count"`
-	MysqlQuerySlowCount          MetricSettings `mapstructure:"mysql.query.slow.count"`
-	MysqlReplicaSQLDelay         MetricSettings `mapstructure:"mysql.replica.sql_delay"`
-	MysqlReplicaTimeBehindSource MetricSettings `mapstructure:"mysql.replica.time_behind_source"`
-	MysqlRowLocks                MetricSettings `mapstructure:"mysql.row_locks"`
-	MysqlRowOperations           MetricSettings `mapstructure:"mysql.row_operations"`
-	MysqlSorts                   MetricSettings `mapstructure:"mysql.sorts"`
-	MysqlStatementEventCount     MetricSettings `mapstructure:"mysql.statement_event.count"`
-	MysqlStatementEventWaitTime  MetricSettings `mapstructure:"mysql.statement_event.wait.time"`
-	MysqlTableIoWaitCount        MetricSettings `mapstructure:"mysql.table.io.wait.count"`
-	MysqlTableIoWaitTime         MetricSettings `mapstructure:"mysql.table.io.wait.time"`
-	MysqlTableLockWaitReadCount  MetricSettings `mapstructure:"mysql.table.lock_wait.read.count"`
-	MysqlTableLockWaitReadTime   MetricSettings `mapstructure:"mysql.table.lock_wait.read.time"`
-	MysqlTableLockWaitWriteCount MetricSettings `mapstructure:"mysql.table.lock_wait.write.count"`
-	MysqlTableLockWaitWriteTime  MetricSettings `mapstructure:"mysql.table.lock_wait.write.time"`
-	MysqlTableOpenCache          MetricSettings `mapstructure:"mysql.table_open_cache"`
-	MysqlThreads                 MetricSettings `mapstructure:"mysql.threads"`
-	MysqlTmpResources            MetricSettings `mapstructure:"mysql.tmp_resources"`
+// MetricsConfig provides config for mysqlreceiver metrics.
+type MetricsConfig struct {
+	MysqlBufferPoolDataPages     MetricConfig `mapstructure:"mysql.buffer_pool.data_pages"`
+	MysqlBufferPoolLimit         MetricConfig `mapstructure:"mysql.buffer_pool.limit"`
+	MysqlBufferPoolOperations    MetricConfig `mapstructure:"mysql.buffer_pool.operations"`
+	MysqlBufferPoolPageFlushes   MetricConfig `mapstructure:"mysql.buffer_pool.page_flushes"`
+	MysqlBufferPoolPages         MetricConfig `mapstructure:"mysql.buffer_pool.pages"`
+	MysqlBufferPoolUsage         MetricConfig `mapstructure:"mysql.buffer_pool.usage"`
+	MysqlClientNetworkIo         MetricConfig `mapstructure:"mysql.client.network.io"`
+	MysqlCommands                MetricConfig `mapstructure:"mysql.commands"`
+	MysqlConnectionCount         MetricConfig `mapstructure:"mysql.connection.count"`
+	MysqlConnectionErrors        MetricConfig `mapstructure:"mysql.connection.errors"`
+	MysqlDoubleWrites            MetricConfig `mapstructure:"mysql.double_writes"`
+	MysqlHandlers                MetricConfig `mapstructure:"mysql.handlers"`
+	MysqlIndexIoWaitCount        MetricConfig `mapstructure:"mysql.index.io.wait.count"`
+	MysqlIndexIoWaitTime         MetricConfig `mapstructure:"mysql.index.io.wait.time"`
+	MysqlJoins                   MetricConfig `mapstructure:"mysql.joins"`
+	MysqlLockedConnects          MetricConfig `mapstructure:"mysql.locked_connects"`
+	MysqlLocks                   MetricConfig `mapstructure:"mysql.locks"`
+	MysqlLogOperations           MetricConfig `mapstructure:"mysql.log_operations"`
+	MysqlMysqlxConnections       MetricConfig `mapstructure:"mysql.mysqlx_connections"`
+	MysqlMysqlxWorkerThreads     MetricConfig `mapstructure:"mysql.mysqlx_worker_threads"`
+	MysqlOpenedResources         MetricConfig `mapstructure:"mysql.opened_resources"`
+	MysqlOperations              MetricConfig `mapstructure:"mysql.operations"`
+	MysqlPageOperations          MetricConfig `mapstructure:"mysql.page_operations"`
+	MysqlPreparedStatements      MetricConfig `mapstructure:"mysql.prepared_statements"`
+	MysqlQueryClientCount        MetricConfig `mapstructure:"mysql.query.client.count"`
+	MysqlQueryCount              MetricConfig `mapstructure:"mysql.query.count"`
+	MysqlQuerySlowCount          MetricConfig `mapstructure:"mysql.query.slow.count"`
+	MysqlReplicaSQLDelay         MetricConfig `mapstructure:"mysql.replica.sql_delay"`
+	MysqlReplicaTimeBehindSource MetricConfig `mapstructure:"mysql.replica.time_behind_source"`
+	MysqlRowLocks                MetricConfig `mapstructure:"mysql.row_locks"`
+	MysqlRowOperations           MetricConfig `mapstructure:"mysql.row_operations"`
+	MysqlSorts                   MetricConfig `mapstructure:"mysql.sorts"`
+	MysqlStatementEventCount     MetricConfig `mapstructure:"mysql.statement_event.count"`
+	MysqlStatementEventWaitTime  MetricConfig `mapstructure:"mysql.statement_event.wait.time"`
+	MysqlTableIoWaitCount        MetricConfig `mapstructure:"mysql.table.io.wait.count"`
+	MysqlTableIoWaitTime         MetricConfig `mapstructure:"mysql.table.io.wait.time"`
+	MysqlTableLockWaitReadCount  MetricConfig `mapstructure:"mysql.table.lock_wait.read.count"`
+	MysqlTableLockWaitReadTime   MetricConfig `mapstructure:"mysql.table.lock_wait.read.time"`
+	MysqlTableLockWaitWriteCount MetricConfig `mapstructure:"mysql.table.lock_wait.write.count"`
+	MysqlTableLockWaitWriteTime  MetricConfig `mapstructure:"mysql.table.lock_wait.write.time"`
+	MysqlTableOpenCache          MetricConfig `mapstructure:"mysql.table_open_cache"`
+	MysqlThreads                 MetricConfig `mapstructure:"mysql.threads"`
+	MysqlTmpResources            MetricConfig `mapstructure:"mysql.tmp_resources"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		MysqlBufferPoolDataPages: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		MysqlBufferPoolDataPages: MetricConfig{
 			Enabled: true,
 		},
-		MysqlBufferPoolLimit: MetricSettings{
+		MysqlBufferPoolLimit: MetricConfig{
 			Enabled: true,
 		},
-		MysqlBufferPoolOperations: MetricSettings{
+		MysqlBufferPoolOperations: MetricConfig{
 			Enabled: true,
 		},
-		MysqlBufferPoolPageFlushes: MetricSettings{
+		MysqlBufferPoolPageFlushes: MetricConfig{
 			Enabled: true,
 		},
-		MysqlBufferPoolPages: MetricSettings{
+		MysqlBufferPoolPages: MetricConfig{
 			Enabled: true,
 		},
-		MysqlBufferPoolUsage: MetricSettings{
+		MysqlBufferPoolUsage: MetricConfig{
 			Enabled: true,
 		},
-		MysqlClientNetworkIo: MetricSettings{
+		MysqlClientNetworkIo: MetricConfig{
 			Enabled: false,
 		},
-		MysqlCommands: MetricSettings{
+		MysqlCommands: MetricConfig{
 			Enabled: false,
 		},
-		MysqlConnectionCount: MetricSettings{
+		MysqlConnectionCount: MetricConfig{
 			Enabled: false,
 		},
-		MysqlConnectionErrors: MetricSettings{
+		MysqlConnectionErrors: MetricConfig{
 			Enabled: false,
 		},
-		MysqlDoubleWrites: MetricSettings{
+		MysqlDoubleWrites: MetricConfig{
 			Enabled: true,
 		},
-		MysqlHandlers: MetricSettings{
+		MysqlHandlers: MetricConfig{
 			Enabled: true,
 		},
-		MysqlIndexIoWaitCount: MetricSettings{
+		MysqlIndexIoWaitCount: MetricConfig{
 			Enabled: true,
 		},
-		MysqlIndexIoWaitTime: MetricSettings{
+		MysqlIndexIoWaitTime: MetricConfig{
 			Enabled: true,
 		},
-		MysqlJoins: MetricSettings{
+		MysqlJoins: MetricConfig{
 			Enabled: false,
 		},
-		MysqlLockedConnects: MetricSettings{
+		MysqlLockedConnects: MetricConfig{
 			Enabled: true,
 		},
-		MysqlLocks: MetricSettings{
+		MysqlLocks: MetricConfig{
 			Enabled: true,
 		},
-		MysqlLogOperations: MetricSettings{
+		MysqlLogOperations: MetricConfig{
 			Enabled: true,
 		},
-		MysqlMysqlxConnections: MetricSettings{
+		MysqlMysqlxConnections: MetricConfig{
 			Enabled: true,
 		},
-		MysqlMysqlxWorkerThreads: MetricSettings{
+		MysqlMysqlxWorkerThreads: MetricConfig{
 			Enabled: false,
 		},
-		MysqlOpenedResources: MetricSettings{
+		MysqlOpenedResources: MetricConfig{
 			Enabled: true,
 		},
-		MysqlOperations: MetricSettings{
+		MysqlOperations: MetricConfig{
 			Enabled: true,
 		},
-		MysqlPageOperations: MetricSettings{
+		MysqlPageOperations: MetricConfig{
 			Enabled: true,
 		},
-		MysqlPreparedStatements: MetricSettings{
+		MysqlPreparedStatements: MetricConfig{
 			Enabled: true,
 		},
-		MysqlQueryClientCount: MetricSettings{
+		MysqlQueryClientCount: MetricConfig{
 			Enabled: false,
 		},
-		MysqlQueryCount: MetricSettings{
+		MysqlQueryCount: MetricConfig{
 			Enabled: false,
 		},
-		MysqlQuerySlowCount: MetricSettings{
+		MysqlQuerySlowCount: MetricConfig{
 			Enabled: false,
 		},
-		MysqlReplicaSQLDelay: MetricSettings{
+		MysqlReplicaSQLDelay: MetricConfig{
 			Enabled: false,
 		},
-		MysqlReplicaTimeBehindSource: MetricSettings{
+		MysqlReplicaTimeBehindSource: MetricConfig{
 			Enabled: false,
 		},
-		MysqlRowLocks: MetricSettings{
+		MysqlRowLocks: MetricConfig{
 			Enabled: true,
 		},
-		MysqlRowOperations: MetricSettings{
+		MysqlRowOperations: MetricConfig{
 			Enabled: true,
 		},
-		MysqlSorts: MetricSettings{
+		MysqlSorts: MetricConfig{
 			Enabled: true,
 		},
-		MysqlStatementEventCount: MetricSettings{
+		MysqlStatementEventCount: MetricConfig{
 			Enabled: false,
 		},
-		MysqlStatementEventWaitTime: MetricSettings{
+		MysqlStatementEventWaitTime: MetricConfig{
 			Enabled: false,
 		},
-		MysqlTableIoWaitCount: MetricSettings{
+		MysqlTableIoWaitCount: MetricConfig{
 			Enabled: true,
 		},
-		MysqlTableIoWaitTime: MetricSettings{
+		MysqlTableIoWaitTime: MetricConfig{
 			Enabled: true,
 		},
-		MysqlTableLockWaitReadCount: MetricSettings{
+		MysqlTableLockWaitReadCount: MetricConfig{
 			Enabled: false,
 		},
-		MysqlTableLockWaitReadTime: MetricSettings{
+		MysqlTableLockWaitReadTime: MetricConfig{
 			Enabled: false,
 		},
-		MysqlTableLockWaitWriteCount: MetricSettings{
+		MysqlTableLockWaitWriteCount: MetricConfig{
 			Enabled: false,
 		},
-		MysqlTableLockWaitWriteTime: MetricSettings{
+		MysqlTableLockWaitWriteTime: MetricConfig{
 			Enabled: false,
 		},
-		MysqlTableOpenCache: MetricSettings{
+		MysqlTableOpenCache: MetricConfig{
 			Enabled: false,
 		},
-		MysqlThreads: MetricSettings{
+		MysqlThreads: MetricConfig{
 			Enabled: true,
 		},
-		MysqlTmpResources: MetricSettings{
+		MysqlTmpResources: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for mysqlreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	MysqlInstanceEndpoint ResourceAttributeSettings `mapstructure:"mysql.instance.endpoint"`
+// ResourceAttributesConfig provides config for mysqlreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	MysqlInstanceEndpoint ResourceAttributeConfig `mapstructure:"mysql.instance.endpoint"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		MysqlInstanceEndpoint: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		MysqlInstanceEndpoint: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -1192,7 +1192,7 @@ var MapAttributeWriteLockType = map[string]AttributeWriteLockType{
 
 type metricMysqlBufferPoolDataPages struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1208,7 +1208,7 @@ func (m *metricMysqlBufferPoolDataPages) init() {
 }
 
 func (m *metricMysqlBufferPoolDataPages) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, bufferPoolDataAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1227,16 +1227,16 @@ func (m *metricMysqlBufferPoolDataPages) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlBufferPoolDataPages) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlBufferPoolDataPages(settings MetricSettings) metricMysqlBufferPoolDataPages {
-	m := metricMysqlBufferPoolDataPages{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlBufferPoolDataPages(cfg MetricConfig) metricMysqlBufferPoolDataPages {
+	m := metricMysqlBufferPoolDataPages{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1245,7 +1245,7 @@ func newMetricMysqlBufferPoolDataPages(settings MetricSettings) metricMysqlBuffe
 
 type metricMysqlBufferPoolLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1260,7 +1260,7 @@ func (m *metricMysqlBufferPoolLimit) init() {
 }
 
 func (m *metricMysqlBufferPoolLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1278,16 +1278,16 @@ func (m *metricMysqlBufferPoolLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlBufferPoolLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlBufferPoolLimit(settings MetricSettings) metricMysqlBufferPoolLimit {
-	m := metricMysqlBufferPoolLimit{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlBufferPoolLimit(cfg MetricConfig) metricMysqlBufferPoolLimit {
+	m := metricMysqlBufferPoolLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1296,7 +1296,7 @@ func newMetricMysqlBufferPoolLimit(settings MetricSettings) metricMysqlBufferPoo
 
 type metricMysqlBufferPoolOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1312,7 +1312,7 @@ func (m *metricMysqlBufferPoolOperations) init() {
 }
 
 func (m *metricMysqlBufferPoolOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, bufferPoolOperationsAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1331,16 +1331,16 @@ func (m *metricMysqlBufferPoolOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlBufferPoolOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlBufferPoolOperations(settings MetricSettings) metricMysqlBufferPoolOperations {
-	m := metricMysqlBufferPoolOperations{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlBufferPoolOperations(cfg MetricConfig) metricMysqlBufferPoolOperations {
+	m := metricMysqlBufferPoolOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1349,7 +1349,7 @@ func newMetricMysqlBufferPoolOperations(settings MetricSettings) metricMysqlBuff
 
 type metricMysqlBufferPoolPageFlushes struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1364,7 +1364,7 @@ func (m *metricMysqlBufferPoolPageFlushes) init() {
 }
 
 func (m *metricMysqlBufferPoolPageFlushes) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1382,16 +1382,16 @@ func (m *metricMysqlBufferPoolPageFlushes) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlBufferPoolPageFlushes) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlBufferPoolPageFlushes(settings MetricSettings) metricMysqlBufferPoolPageFlushes {
-	m := metricMysqlBufferPoolPageFlushes{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlBufferPoolPageFlushes(cfg MetricConfig) metricMysqlBufferPoolPageFlushes {
+	m := metricMysqlBufferPoolPageFlushes{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1400,7 +1400,7 @@ func newMetricMysqlBufferPoolPageFlushes(settings MetricSettings) metricMysqlBuf
 
 type metricMysqlBufferPoolPages struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1416,7 +1416,7 @@ func (m *metricMysqlBufferPoolPages) init() {
 }
 
 func (m *metricMysqlBufferPoolPages) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, bufferPoolPagesAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1435,16 +1435,16 @@ func (m *metricMysqlBufferPoolPages) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlBufferPoolPages) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlBufferPoolPages(settings MetricSettings) metricMysqlBufferPoolPages {
-	m := metricMysqlBufferPoolPages{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlBufferPoolPages(cfg MetricConfig) metricMysqlBufferPoolPages {
+	m := metricMysqlBufferPoolPages{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1453,7 +1453,7 @@ func newMetricMysqlBufferPoolPages(settings MetricSettings) metricMysqlBufferPoo
 
 type metricMysqlBufferPoolUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1469,7 +1469,7 @@ func (m *metricMysqlBufferPoolUsage) init() {
 }
 
 func (m *metricMysqlBufferPoolUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, bufferPoolDataAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1488,16 +1488,16 @@ func (m *metricMysqlBufferPoolUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlBufferPoolUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlBufferPoolUsage(settings MetricSettings) metricMysqlBufferPoolUsage {
-	m := metricMysqlBufferPoolUsage{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlBufferPoolUsage(cfg MetricConfig) metricMysqlBufferPoolUsage {
+	m := metricMysqlBufferPoolUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1506,7 +1506,7 @@ func newMetricMysqlBufferPoolUsage(settings MetricSettings) metricMysqlBufferPoo
 
 type metricMysqlClientNetworkIo struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1522,7 +1522,7 @@ func (m *metricMysqlClientNetworkIo) init() {
 }
 
 func (m *metricMysqlClientNetworkIo) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1541,16 +1541,16 @@ func (m *metricMysqlClientNetworkIo) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlClientNetworkIo) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlClientNetworkIo(settings MetricSettings) metricMysqlClientNetworkIo {
-	m := metricMysqlClientNetworkIo{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlClientNetworkIo(cfg MetricConfig) metricMysqlClientNetworkIo {
+	m := metricMysqlClientNetworkIo{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1559,7 +1559,7 @@ func newMetricMysqlClientNetworkIo(settings MetricSettings) metricMysqlClientNet
 
 type metricMysqlCommands struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1575,7 +1575,7 @@ func (m *metricMysqlCommands) init() {
 }
 
 func (m *metricMysqlCommands) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, commandAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1594,16 +1594,16 @@ func (m *metricMysqlCommands) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlCommands) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlCommands(settings MetricSettings) metricMysqlCommands {
-	m := metricMysqlCommands{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlCommands(cfg MetricConfig) metricMysqlCommands {
+	m := metricMysqlCommands{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1612,7 +1612,7 @@ func newMetricMysqlCommands(settings MetricSettings) metricMysqlCommands {
 
 type metricMysqlConnectionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1627,7 +1627,7 @@ func (m *metricMysqlConnectionCount) init() {
 }
 
 func (m *metricMysqlConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1645,16 +1645,16 @@ func (m *metricMysqlConnectionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlConnectionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlConnectionCount(settings MetricSettings) metricMysqlConnectionCount {
-	m := metricMysqlConnectionCount{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlConnectionCount(cfg MetricConfig) metricMysqlConnectionCount {
+	m := metricMysqlConnectionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1663,7 +1663,7 @@ func newMetricMysqlConnectionCount(settings MetricSettings) metricMysqlConnectio
 
 type metricMysqlConnectionErrors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1679,7 +1679,7 @@ func (m *metricMysqlConnectionErrors) init() {
 }
 
 func (m *metricMysqlConnectionErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, connectionErrorAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1698,16 +1698,16 @@ func (m *metricMysqlConnectionErrors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlConnectionErrors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlConnectionErrors(settings MetricSettings) metricMysqlConnectionErrors {
-	m := metricMysqlConnectionErrors{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlConnectionErrors(cfg MetricConfig) metricMysqlConnectionErrors {
+	m := metricMysqlConnectionErrors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1716,7 +1716,7 @@ func newMetricMysqlConnectionErrors(settings MetricSettings) metricMysqlConnecti
 
 type metricMysqlDoubleWrites struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1732,7 +1732,7 @@ func (m *metricMysqlDoubleWrites) init() {
 }
 
 func (m *metricMysqlDoubleWrites) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, doubleWritesAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1751,16 +1751,16 @@ func (m *metricMysqlDoubleWrites) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlDoubleWrites) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlDoubleWrites(settings MetricSettings) metricMysqlDoubleWrites {
-	m := metricMysqlDoubleWrites{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlDoubleWrites(cfg MetricConfig) metricMysqlDoubleWrites {
+	m := metricMysqlDoubleWrites{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1769,7 +1769,7 @@ func newMetricMysqlDoubleWrites(settings MetricSettings) metricMysqlDoubleWrites
 
 type metricMysqlHandlers struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1785,7 +1785,7 @@ func (m *metricMysqlHandlers) init() {
 }
 
 func (m *metricMysqlHandlers) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, handlerAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1804,16 +1804,16 @@ func (m *metricMysqlHandlers) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlHandlers) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlHandlers(settings MetricSettings) metricMysqlHandlers {
-	m := metricMysqlHandlers{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlHandlers(cfg MetricConfig) metricMysqlHandlers {
+	m := metricMysqlHandlers{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1822,7 +1822,7 @@ func newMetricMysqlHandlers(settings MetricSettings) metricMysqlHandlers {
 
 type metricMysqlIndexIoWaitCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1838,7 +1838,7 @@ func (m *metricMysqlIndexIoWaitCount) init() {
 }
 
 func (m *metricMysqlIndexIoWaitCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ioWaitsOperationsAttributeValue string, tableNameAttributeValue string, schemaAttributeValue string, indexNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1860,16 +1860,16 @@ func (m *metricMysqlIndexIoWaitCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlIndexIoWaitCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlIndexIoWaitCount(settings MetricSettings) metricMysqlIndexIoWaitCount {
-	m := metricMysqlIndexIoWaitCount{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlIndexIoWaitCount(cfg MetricConfig) metricMysqlIndexIoWaitCount {
+	m := metricMysqlIndexIoWaitCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1878,7 +1878,7 @@ func newMetricMysqlIndexIoWaitCount(settings MetricSettings) metricMysqlIndexIoW
 
 type metricMysqlIndexIoWaitTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1894,7 +1894,7 @@ func (m *metricMysqlIndexIoWaitTime) init() {
 }
 
 func (m *metricMysqlIndexIoWaitTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ioWaitsOperationsAttributeValue string, tableNameAttributeValue string, schemaAttributeValue string, indexNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1916,16 +1916,16 @@ func (m *metricMysqlIndexIoWaitTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlIndexIoWaitTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlIndexIoWaitTime(settings MetricSettings) metricMysqlIndexIoWaitTime {
-	m := metricMysqlIndexIoWaitTime{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlIndexIoWaitTime(cfg MetricConfig) metricMysqlIndexIoWaitTime {
+	m := metricMysqlIndexIoWaitTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1934,7 +1934,7 @@ func newMetricMysqlIndexIoWaitTime(settings MetricSettings) metricMysqlIndexIoWa
 
 type metricMysqlJoins struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1950,7 +1950,7 @@ func (m *metricMysqlJoins) init() {
 }
 
 func (m *metricMysqlJoins) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, joinKindAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1969,16 +1969,16 @@ func (m *metricMysqlJoins) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlJoins) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlJoins(settings MetricSettings) metricMysqlJoins {
-	m := metricMysqlJoins{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlJoins(cfg MetricConfig) metricMysqlJoins {
+	m := metricMysqlJoins{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1987,7 +1987,7 @@ func newMetricMysqlJoins(settings MetricSettings) metricMysqlJoins {
 
 type metricMysqlLockedConnects struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2002,7 +2002,7 @@ func (m *metricMysqlLockedConnects) init() {
 }
 
 func (m *metricMysqlLockedConnects) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2020,16 +2020,16 @@ func (m *metricMysqlLockedConnects) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlLockedConnects) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlLockedConnects(settings MetricSettings) metricMysqlLockedConnects {
-	m := metricMysqlLockedConnects{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlLockedConnects(cfg MetricConfig) metricMysqlLockedConnects {
+	m := metricMysqlLockedConnects{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2038,7 +2038,7 @@ func newMetricMysqlLockedConnects(settings MetricSettings) metricMysqlLockedConn
 
 type metricMysqlLocks struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2054,7 +2054,7 @@ func (m *metricMysqlLocks) init() {
 }
 
 func (m *metricMysqlLocks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, locksAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2073,16 +2073,16 @@ func (m *metricMysqlLocks) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlLocks) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlLocks(settings MetricSettings) metricMysqlLocks {
-	m := metricMysqlLocks{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlLocks(cfg MetricConfig) metricMysqlLocks {
+	m := metricMysqlLocks{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2091,7 +2091,7 @@ func newMetricMysqlLocks(settings MetricSettings) metricMysqlLocks {
 
 type metricMysqlLogOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2107,7 +2107,7 @@ func (m *metricMysqlLogOperations) init() {
 }
 
 func (m *metricMysqlLogOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, logOperationsAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2126,16 +2126,16 @@ func (m *metricMysqlLogOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlLogOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlLogOperations(settings MetricSettings) metricMysqlLogOperations {
-	m := metricMysqlLogOperations{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlLogOperations(cfg MetricConfig) metricMysqlLogOperations {
+	m := metricMysqlLogOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2144,7 +2144,7 @@ func newMetricMysqlLogOperations(settings MetricSettings) metricMysqlLogOperatio
 
 type metricMysqlMysqlxConnections struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2160,7 +2160,7 @@ func (m *metricMysqlMysqlxConnections) init() {
 }
 
 func (m *metricMysqlMysqlxConnections) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, connectionStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2179,16 +2179,16 @@ func (m *metricMysqlMysqlxConnections) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlMysqlxConnections) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlMysqlxConnections(settings MetricSettings) metricMysqlMysqlxConnections {
-	m := metricMysqlMysqlxConnections{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlMysqlxConnections(cfg MetricConfig) metricMysqlMysqlxConnections {
+	m := metricMysqlMysqlxConnections{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2197,7 +2197,7 @@ func newMetricMysqlMysqlxConnections(settings MetricSettings) metricMysqlMysqlxC
 
 type metricMysqlMysqlxWorkerThreads struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2213,7 +2213,7 @@ func (m *metricMysqlMysqlxWorkerThreads) init() {
 }
 
 func (m *metricMysqlMysqlxWorkerThreads) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, mysqlxThreadsAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2232,16 +2232,16 @@ func (m *metricMysqlMysqlxWorkerThreads) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlMysqlxWorkerThreads) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlMysqlxWorkerThreads(settings MetricSettings) metricMysqlMysqlxWorkerThreads {
-	m := metricMysqlMysqlxWorkerThreads{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlMysqlxWorkerThreads(cfg MetricConfig) metricMysqlMysqlxWorkerThreads {
+	m := metricMysqlMysqlxWorkerThreads{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2250,7 +2250,7 @@ func newMetricMysqlMysqlxWorkerThreads(settings MetricSettings) metricMysqlMysql
 
 type metricMysqlOpenedResources struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2266,7 +2266,7 @@ func (m *metricMysqlOpenedResources) init() {
 }
 
 func (m *metricMysqlOpenedResources) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, openedResourcesAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2285,16 +2285,16 @@ func (m *metricMysqlOpenedResources) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlOpenedResources) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlOpenedResources(settings MetricSettings) metricMysqlOpenedResources {
-	m := metricMysqlOpenedResources{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlOpenedResources(cfg MetricConfig) metricMysqlOpenedResources {
+	m := metricMysqlOpenedResources{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2303,7 +2303,7 @@ func newMetricMysqlOpenedResources(settings MetricSettings) metricMysqlOpenedRes
 
 type metricMysqlOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2319,7 +2319,7 @@ func (m *metricMysqlOperations) init() {
 }
 
 func (m *metricMysqlOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationsAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2338,16 +2338,16 @@ func (m *metricMysqlOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlOperations(settings MetricSettings) metricMysqlOperations {
-	m := metricMysqlOperations{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlOperations(cfg MetricConfig) metricMysqlOperations {
+	m := metricMysqlOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2356,7 +2356,7 @@ func newMetricMysqlOperations(settings MetricSettings) metricMysqlOperations {
 
 type metricMysqlPageOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2372,7 +2372,7 @@ func (m *metricMysqlPageOperations) init() {
 }
 
 func (m *metricMysqlPageOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, pageOperationsAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2391,16 +2391,16 @@ func (m *metricMysqlPageOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlPageOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlPageOperations(settings MetricSettings) metricMysqlPageOperations {
-	m := metricMysqlPageOperations{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlPageOperations(cfg MetricConfig) metricMysqlPageOperations {
+	m := metricMysqlPageOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2409,7 +2409,7 @@ func newMetricMysqlPageOperations(settings MetricSettings) metricMysqlPageOperat
 
 type metricMysqlPreparedStatements struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2425,7 +2425,7 @@ func (m *metricMysqlPreparedStatements) init() {
 }
 
 func (m *metricMysqlPreparedStatements) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, preparedStatementsCommandAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2444,16 +2444,16 @@ func (m *metricMysqlPreparedStatements) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlPreparedStatements) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlPreparedStatements(settings MetricSettings) metricMysqlPreparedStatements {
-	m := metricMysqlPreparedStatements{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlPreparedStatements(cfg MetricConfig) metricMysqlPreparedStatements {
+	m := metricMysqlPreparedStatements{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2462,7 +2462,7 @@ func newMetricMysqlPreparedStatements(settings MetricSettings) metricMysqlPrepar
 
 type metricMysqlQueryClientCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2477,7 +2477,7 @@ func (m *metricMysqlQueryClientCount) init() {
 }
 
 func (m *metricMysqlQueryClientCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2495,16 +2495,16 @@ func (m *metricMysqlQueryClientCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlQueryClientCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlQueryClientCount(settings MetricSettings) metricMysqlQueryClientCount {
-	m := metricMysqlQueryClientCount{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlQueryClientCount(cfg MetricConfig) metricMysqlQueryClientCount {
+	m := metricMysqlQueryClientCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2513,7 +2513,7 @@ func newMetricMysqlQueryClientCount(settings MetricSettings) metricMysqlQueryCli
 
 type metricMysqlQueryCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2528,7 +2528,7 @@ func (m *metricMysqlQueryCount) init() {
 }
 
 func (m *metricMysqlQueryCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2546,16 +2546,16 @@ func (m *metricMysqlQueryCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlQueryCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlQueryCount(settings MetricSettings) metricMysqlQueryCount {
-	m := metricMysqlQueryCount{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlQueryCount(cfg MetricConfig) metricMysqlQueryCount {
+	m := metricMysqlQueryCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2564,7 +2564,7 @@ func newMetricMysqlQueryCount(settings MetricSettings) metricMysqlQueryCount {
 
 type metricMysqlQuerySlowCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2579,7 +2579,7 @@ func (m *metricMysqlQuerySlowCount) init() {
 }
 
 func (m *metricMysqlQuerySlowCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2597,16 +2597,16 @@ func (m *metricMysqlQuerySlowCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlQuerySlowCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlQuerySlowCount(settings MetricSettings) metricMysqlQuerySlowCount {
-	m := metricMysqlQuerySlowCount{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlQuerySlowCount(cfg MetricConfig) metricMysqlQuerySlowCount {
+	m := metricMysqlQuerySlowCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2615,7 +2615,7 @@ func newMetricMysqlQuerySlowCount(settings MetricSettings) metricMysqlQuerySlowC
 
 type metricMysqlReplicaSQLDelay struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2630,7 +2630,7 @@ func (m *metricMysqlReplicaSQLDelay) init() {
 }
 
 func (m *metricMysqlReplicaSQLDelay) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2648,16 +2648,16 @@ func (m *metricMysqlReplicaSQLDelay) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlReplicaSQLDelay) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlReplicaSQLDelay(settings MetricSettings) metricMysqlReplicaSQLDelay {
-	m := metricMysqlReplicaSQLDelay{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlReplicaSQLDelay(cfg MetricConfig) metricMysqlReplicaSQLDelay {
+	m := metricMysqlReplicaSQLDelay{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2666,7 +2666,7 @@ func newMetricMysqlReplicaSQLDelay(settings MetricSettings) metricMysqlReplicaSQ
 
 type metricMysqlReplicaTimeBehindSource struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2681,7 +2681,7 @@ func (m *metricMysqlReplicaTimeBehindSource) init() {
 }
 
 func (m *metricMysqlReplicaTimeBehindSource) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2699,16 +2699,16 @@ func (m *metricMysqlReplicaTimeBehindSource) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlReplicaTimeBehindSource) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlReplicaTimeBehindSource(settings MetricSettings) metricMysqlReplicaTimeBehindSource {
-	m := metricMysqlReplicaTimeBehindSource{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlReplicaTimeBehindSource(cfg MetricConfig) metricMysqlReplicaTimeBehindSource {
+	m := metricMysqlReplicaTimeBehindSource{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2717,7 +2717,7 @@ func newMetricMysqlReplicaTimeBehindSource(settings MetricSettings) metricMysqlR
 
 type metricMysqlRowLocks struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2733,7 +2733,7 @@ func (m *metricMysqlRowLocks) init() {
 }
 
 func (m *metricMysqlRowLocks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, rowLocksAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2752,16 +2752,16 @@ func (m *metricMysqlRowLocks) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlRowLocks) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlRowLocks(settings MetricSettings) metricMysqlRowLocks {
-	m := metricMysqlRowLocks{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlRowLocks(cfg MetricConfig) metricMysqlRowLocks {
+	m := metricMysqlRowLocks{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2770,7 +2770,7 @@ func newMetricMysqlRowLocks(settings MetricSettings) metricMysqlRowLocks {
 
 type metricMysqlRowOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2786,7 +2786,7 @@ func (m *metricMysqlRowOperations) init() {
 }
 
 func (m *metricMysqlRowOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, rowOperationsAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2805,16 +2805,16 @@ func (m *metricMysqlRowOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlRowOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlRowOperations(settings MetricSettings) metricMysqlRowOperations {
-	m := metricMysqlRowOperations{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlRowOperations(cfg MetricConfig) metricMysqlRowOperations {
+	m := metricMysqlRowOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2823,7 +2823,7 @@ func newMetricMysqlRowOperations(settings MetricSettings) metricMysqlRowOperatio
 
 type metricMysqlSorts struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2839,7 +2839,7 @@ func (m *metricMysqlSorts) init() {
 }
 
 func (m *metricMysqlSorts) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, sortsAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2858,16 +2858,16 @@ func (m *metricMysqlSorts) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlSorts) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlSorts(settings MetricSettings) metricMysqlSorts {
-	m := metricMysqlSorts{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlSorts(cfg MetricConfig) metricMysqlSorts {
+	m := metricMysqlSorts{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2876,7 +2876,7 @@ func newMetricMysqlSorts(settings MetricSettings) metricMysqlSorts {
 
 type metricMysqlStatementEventCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2892,7 +2892,7 @@ func (m *metricMysqlStatementEventCount) init() {
 }
 
 func (m *metricMysqlStatementEventCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaAttributeValue string, digestAttributeValue string, digestTextAttributeValue string, eventStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2914,16 +2914,16 @@ func (m *metricMysqlStatementEventCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlStatementEventCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlStatementEventCount(settings MetricSettings) metricMysqlStatementEventCount {
-	m := metricMysqlStatementEventCount{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlStatementEventCount(cfg MetricConfig) metricMysqlStatementEventCount {
+	m := metricMysqlStatementEventCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2932,7 +2932,7 @@ func newMetricMysqlStatementEventCount(settings MetricSettings) metricMysqlState
 
 type metricMysqlStatementEventWaitTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2948,7 +2948,7 @@ func (m *metricMysqlStatementEventWaitTime) init() {
 }
 
 func (m *metricMysqlStatementEventWaitTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaAttributeValue string, digestAttributeValue string, digestTextAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2969,16 +2969,16 @@ func (m *metricMysqlStatementEventWaitTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlStatementEventWaitTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlStatementEventWaitTime(settings MetricSettings) metricMysqlStatementEventWaitTime {
-	m := metricMysqlStatementEventWaitTime{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlStatementEventWaitTime(cfg MetricConfig) metricMysqlStatementEventWaitTime {
+	m := metricMysqlStatementEventWaitTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2987,7 +2987,7 @@ func newMetricMysqlStatementEventWaitTime(settings MetricSettings) metricMysqlSt
 
 type metricMysqlTableIoWaitCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3003,7 +3003,7 @@ func (m *metricMysqlTableIoWaitCount) init() {
 }
 
 func (m *metricMysqlTableIoWaitCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ioWaitsOperationsAttributeValue string, tableNameAttributeValue string, schemaAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3024,16 +3024,16 @@ func (m *metricMysqlTableIoWaitCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlTableIoWaitCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlTableIoWaitCount(settings MetricSettings) metricMysqlTableIoWaitCount {
-	m := metricMysqlTableIoWaitCount{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlTableIoWaitCount(cfg MetricConfig) metricMysqlTableIoWaitCount {
+	m := metricMysqlTableIoWaitCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3042,7 +3042,7 @@ func newMetricMysqlTableIoWaitCount(settings MetricSettings) metricMysqlTableIoW
 
 type metricMysqlTableIoWaitTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3058,7 +3058,7 @@ func (m *metricMysqlTableIoWaitTime) init() {
 }
 
 func (m *metricMysqlTableIoWaitTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, ioWaitsOperationsAttributeValue string, tableNameAttributeValue string, schemaAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3079,16 +3079,16 @@ func (m *metricMysqlTableIoWaitTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlTableIoWaitTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlTableIoWaitTime(settings MetricSettings) metricMysqlTableIoWaitTime {
-	m := metricMysqlTableIoWaitTime{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlTableIoWaitTime(cfg MetricConfig) metricMysqlTableIoWaitTime {
+	m := metricMysqlTableIoWaitTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3097,7 +3097,7 @@ func newMetricMysqlTableIoWaitTime(settings MetricSettings) metricMysqlTableIoWa
 
 type metricMysqlTableLockWaitReadCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3113,7 +3113,7 @@ func (m *metricMysqlTableLockWaitReadCount) init() {
 }
 
 func (m *metricMysqlTableLockWaitReadCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaAttributeValue string, tableNameAttributeValue string, readLockTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3134,16 +3134,16 @@ func (m *metricMysqlTableLockWaitReadCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlTableLockWaitReadCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlTableLockWaitReadCount(settings MetricSettings) metricMysqlTableLockWaitReadCount {
-	m := metricMysqlTableLockWaitReadCount{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlTableLockWaitReadCount(cfg MetricConfig) metricMysqlTableLockWaitReadCount {
+	m := metricMysqlTableLockWaitReadCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3152,7 +3152,7 @@ func newMetricMysqlTableLockWaitReadCount(settings MetricSettings) metricMysqlTa
 
 type metricMysqlTableLockWaitReadTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3168,7 +3168,7 @@ func (m *metricMysqlTableLockWaitReadTime) init() {
 }
 
 func (m *metricMysqlTableLockWaitReadTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaAttributeValue string, tableNameAttributeValue string, readLockTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3189,16 +3189,16 @@ func (m *metricMysqlTableLockWaitReadTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlTableLockWaitReadTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlTableLockWaitReadTime(settings MetricSettings) metricMysqlTableLockWaitReadTime {
-	m := metricMysqlTableLockWaitReadTime{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlTableLockWaitReadTime(cfg MetricConfig) metricMysqlTableLockWaitReadTime {
+	m := metricMysqlTableLockWaitReadTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3207,7 +3207,7 @@ func newMetricMysqlTableLockWaitReadTime(settings MetricSettings) metricMysqlTab
 
 type metricMysqlTableLockWaitWriteCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3223,7 +3223,7 @@ func (m *metricMysqlTableLockWaitWriteCount) init() {
 }
 
 func (m *metricMysqlTableLockWaitWriteCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaAttributeValue string, tableNameAttributeValue string, writeLockTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3244,16 +3244,16 @@ func (m *metricMysqlTableLockWaitWriteCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlTableLockWaitWriteCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlTableLockWaitWriteCount(settings MetricSettings) metricMysqlTableLockWaitWriteCount {
-	m := metricMysqlTableLockWaitWriteCount{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlTableLockWaitWriteCount(cfg MetricConfig) metricMysqlTableLockWaitWriteCount {
+	m := metricMysqlTableLockWaitWriteCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3262,7 +3262,7 @@ func newMetricMysqlTableLockWaitWriteCount(settings MetricSettings) metricMysqlT
 
 type metricMysqlTableLockWaitWriteTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3278,7 +3278,7 @@ func (m *metricMysqlTableLockWaitWriteTime) init() {
 }
 
 func (m *metricMysqlTableLockWaitWriteTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaAttributeValue string, tableNameAttributeValue string, writeLockTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3299,16 +3299,16 @@ func (m *metricMysqlTableLockWaitWriteTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlTableLockWaitWriteTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlTableLockWaitWriteTime(settings MetricSettings) metricMysqlTableLockWaitWriteTime {
-	m := metricMysqlTableLockWaitWriteTime{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlTableLockWaitWriteTime(cfg MetricConfig) metricMysqlTableLockWaitWriteTime {
+	m := metricMysqlTableLockWaitWriteTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3317,7 +3317,7 @@ func newMetricMysqlTableLockWaitWriteTime(settings MetricSettings) metricMysqlTa
 
 type metricMysqlTableOpenCache struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3333,7 +3333,7 @@ func (m *metricMysqlTableOpenCache) init() {
 }
 
 func (m *metricMysqlTableOpenCache) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cacheStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3352,16 +3352,16 @@ func (m *metricMysqlTableOpenCache) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlTableOpenCache) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlTableOpenCache(settings MetricSettings) metricMysqlTableOpenCache {
-	m := metricMysqlTableOpenCache{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlTableOpenCache(cfg MetricConfig) metricMysqlTableOpenCache {
+	m := metricMysqlTableOpenCache{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3370,7 +3370,7 @@ func newMetricMysqlTableOpenCache(settings MetricSettings) metricMysqlTableOpenC
 
 type metricMysqlThreads struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3386,7 +3386,7 @@ func (m *metricMysqlThreads) init() {
 }
 
 func (m *metricMysqlThreads) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, threadsAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3405,16 +3405,16 @@ func (m *metricMysqlThreads) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlThreads) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlThreads(settings MetricSettings) metricMysqlThreads {
-	m := metricMysqlThreads{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlThreads(cfg MetricConfig) metricMysqlThreads {
+	m := metricMysqlThreads{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3423,7 +3423,7 @@ func newMetricMysqlThreads(settings MetricSettings) metricMysqlThreads {
 
 type metricMysqlTmpResources struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3439,7 +3439,7 @@ func (m *metricMysqlTmpResources) init() {
 }
 
 func (m *metricMysqlTmpResources) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, tmpResourceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3458,16 +3458,16 @@ func (m *metricMysqlTmpResources) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricMysqlTmpResources) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricMysqlTmpResources(settings MetricSettings) metricMysqlTmpResources {
-	m := metricMysqlTmpResources{settings: settings}
-	if settings.Enabled {
+func newMetricMysqlTmpResources(cfg MetricConfig) metricMysqlTmpResources {
+	m := metricMysqlTmpResources{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3476,19 +3476,19 @@ func newMetricMysqlTmpResources(settings MetricSettings) metricMysqlTmpResources
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                          pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                    int                 // maximum observed number of metrics per resource.
 	resourceCapacity                   int                 // maximum observed number of resource attributes.
 	metricsBuffer                      pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                          component.BuildInfo // contains version information
-	resourceAttributesSettings         ResourceAttributesSettings
+	resourceAttributesConfig           ResourceAttributesConfig
 	metricMysqlBufferPoolDataPages     metricMysqlBufferPoolDataPages
 	metricMysqlBufferPoolLimit         metricMysqlBufferPoolLimit
 	metricMysqlBufferPoolOperations    metricMysqlBufferPoolOperations
@@ -3546,8 +3546,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -3556,7 +3556,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                          pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                      pmetric.NewMetrics(),
 		buildInfo:                          settings.BuildInfo,
-		resourceAttributesSettings:         mbc.ResourceAttributes,
+		resourceAttributesConfig:           mbc.ResourceAttributes,
 		metricMysqlBufferPoolDataPages:     newMetricMysqlBufferPoolDataPages(mbc.Metrics.MysqlBufferPoolDataPages),
 		metricMysqlBufferPoolLimit:         newMetricMysqlBufferPoolLimit(mbc.Metrics.MysqlBufferPoolLimit),
 		metricMysqlBufferPoolOperations:    newMetricMysqlBufferPoolOperations(mbc.Metrics.MysqlBufferPoolOperations),
@@ -3618,12 +3618,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithMysqlInstanceEndpoint sets provided value as "mysql.instance.endpoint" attribute for current resource.
 func WithMysqlInstanceEndpoint(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.MysqlInstanceEndpoint.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.MysqlInstanceEndpoint.Enabled {
 			rm.Resource().Attributes().PutStr("mysql.instance.endpoint", val)
 		}
 	}
@@ -3632,7 +3632,7 @@ func WithMysqlInstanceEndpoint(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -3706,7 +3706,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricMysqlTmpResources.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -3716,7 +3716,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -225,8 +225,8 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("mysql.instance.endpoint")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.MysqlInstanceEndpoint.Enabled, ok)
-			if mb.resourceAttributesSettings.MysqlInstanceEndpoint.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.MysqlInstanceEndpoint.Enabled, ok)
+			if mb.resourceAttributesConfig.MysqlInstanceEndpoint.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/nsxtreceiver/config.go
+++ b/receiver/nsxtreceiver/config.go
@@ -31,9 +31,9 @@ type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 	confighttp.HTTPClientSettings           `mapstructure:",squash"`
 	metadata.MetricsBuilderConfig           `mapstructure:",squash"`
-	ResourceAttributes                      metadata.ResourceAttributesSettings `mapstructure:",squash"`
-	Username                                string                              `mapstructure:"username"`
-	Password                                string                              `mapstructure:"password"`
+	ResourceAttributes                      metadata.ResourceAttributesConfig `mapstructure:",squash"`
+	Username                                string                            `mapstructure:"username"`
+	Password                                string                            `mapstructure:"password"`
 }
 
 // Validate returns if the NSX configuration is valid

--- a/receiver/nsxtreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/nsxtreceiver/internal/metadata/generated_metrics_test.go
@@ -99,29 +99,29 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("device.id")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.DeviceID.Enabled, ok)
-			if mb.resourceAttributesSettings.DeviceID.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.DeviceID.Enabled, ok)
+			if mb.resourceAttributesConfig.DeviceID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("nsxt.node.id")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.NsxtNodeID.Enabled, ok)
-			if mb.resourceAttributesSettings.NsxtNodeID.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.NsxtNodeID.Enabled, ok)
+			if mb.resourceAttributesConfig.NsxtNodeID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("nsxt.node.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.NsxtNodeName.Enabled, ok)
-			if mb.resourceAttributesSettings.NsxtNodeName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.NsxtNodeName.Enabled, ok)
+			if mb.resourceAttributesConfig.NsxtNodeName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("nsxt.node.type")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.NsxtNodeType.Enabled, ok)
-			if mb.resourceAttributesSettings.NsxtNodeType.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.NsxtNodeType.Enabled, ok)
+			if mb.resourceAttributesConfig.NsxtNodeType.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics.go
@@ -14,14 +14,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -33,128 +33,128 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for oracledbreceiver metrics.
-type MetricsSettings struct {
-	OracledbCPUTime               MetricSettings `mapstructure:"oracledb.cpu_time"`
-	OracledbDmlLocksLimit         MetricSettings `mapstructure:"oracledb.dml_locks.limit"`
-	OracledbDmlLocksUsage         MetricSettings `mapstructure:"oracledb.dml_locks.usage"`
-	OracledbEnqueueDeadlocks      MetricSettings `mapstructure:"oracledb.enqueue_deadlocks"`
-	OracledbEnqueueLocksLimit     MetricSettings `mapstructure:"oracledb.enqueue_locks.limit"`
-	OracledbEnqueueLocksUsage     MetricSettings `mapstructure:"oracledb.enqueue_locks.usage"`
-	OracledbEnqueueResourcesLimit MetricSettings `mapstructure:"oracledb.enqueue_resources.limit"`
-	OracledbEnqueueResourcesUsage MetricSettings `mapstructure:"oracledb.enqueue_resources.usage"`
-	OracledbExchangeDeadlocks     MetricSettings `mapstructure:"oracledb.exchange_deadlocks"`
-	OracledbExecutions            MetricSettings `mapstructure:"oracledb.executions"`
-	OracledbHardParses            MetricSettings `mapstructure:"oracledb.hard_parses"`
-	OracledbLogicalReads          MetricSettings `mapstructure:"oracledb.logical_reads"`
-	OracledbParseCalls            MetricSettings `mapstructure:"oracledb.parse_calls"`
-	OracledbPgaMemory             MetricSettings `mapstructure:"oracledb.pga_memory"`
-	OracledbPhysicalReads         MetricSettings `mapstructure:"oracledb.physical_reads"`
-	OracledbProcessesLimit        MetricSettings `mapstructure:"oracledb.processes.limit"`
-	OracledbProcessesUsage        MetricSettings `mapstructure:"oracledb.processes.usage"`
-	OracledbSessionsLimit         MetricSettings `mapstructure:"oracledb.sessions.limit"`
-	OracledbSessionsUsage         MetricSettings `mapstructure:"oracledb.sessions.usage"`
-	OracledbTablespaceSizeLimit   MetricSettings `mapstructure:"oracledb.tablespace_size.limit"`
-	OracledbTablespaceSizeUsage   MetricSettings `mapstructure:"oracledb.tablespace_size.usage"`
-	OracledbTransactionsLimit     MetricSettings `mapstructure:"oracledb.transactions.limit"`
-	OracledbTransactionsUsage     MetricSettings `mapstructure:"oracledb.transactions.usage"`
-	OracledbUserCommits           MetricSettings `mapstructure:"oracledb.user_commits"`
-	OracledbUserRollbacks         MetricSettings `mapstructure:"oracledb.user_rollbacks"`
+// MetricsConfig provides config for oracledbreceiver metrics.
+type MetricsConfig struct {
+	OracledbCPUTime               MetricConfig `mapstructure:"oracledb.cpu_time"`
+	OracledbDmlLocksLimit         MetricConfig `mapstructure:"oracledb.dml_locks.limit"`
+	OracledbDmlLocksUsage         MetricConfig `mapstructure:"oracledb.dml_locks.usage"`
+	OracledbEnqueueDeadlocks      MetricConfig `mapstructure:"oracledb.enqueue_deadlocks"`
+	OracledbEnqueueLocksLimit     MetricConfig `mapstructure:"oracledb.enqueue_locks.limit"`
+	OracledbEnqueueLocksUsage     MetricConfig `mapstructure:"oracledb.enqueue_locks.usage"`
+	OracledbEnqueueResourcesLimit MetricConfig `mapstructure:"oracledb.enqueue_resources.limit"`
+	OracledbEnqueueResourcesUsage MetricConfig `mapstructure:"oracledb.enqueue_resources.usage"`
+	OracledbExchangeDeadlocks     MetricConfig `mapstructure:"oracledb.exchange_deadlocks"`
+	OracledbExecutions            MetricConfig `mapstructure:"oracledb.executions"`
+	OracledbHardParses            MetricConfig `mapstructure:"oracledb.hard_parses"`
+	OracledbLogicalReads          MetricConfig `mapstructure:"oracledb.logical_reads"`
+	OracledbParseCalls            MetricConfig `mapstructure:"oracledb.parse_calls"`
+	OracledbPgaMemory             MetricConfig `mapstructure:"oracledb.pga_memory"`
+	OracledbPhysicalReads         MetricConfig `mapstructure:"oracledb.physical_reads"`
+	OracledbProcessesLimit        MetricConfig `mapstructure:"oracledb.processes.limit"`
+	OracledbProcessesUsage        MetricConfig `mapstructure:"oracledb.processes.usage"`
+	OracledbSessionsLimit         MetricConfig `mapstructure:"oracledb.sessions.limit"`
+	OracledbSessionsUsage         MetricConfig `mapstructure:"oracledb.sessions.usage"`
+	OracledbTablespaceSizeLimit   MetricConfig `mapstructure:"oracledb.tablespace_size.limit"`
+	OracledbTablespaceSizeUsage   MetricConfig `mapstructure:"oracledb.tablespace_size.usage"`
+	OracledbTransactionsLimit     MetricConfig `mapstructure:"oracledb.transactions.limit"`
+	OracledbTransactionsUsage     MetricConfig `mapstructure:"oracledb.transactions.usage"`
+	OracledbUserCommits           MetricConfig `mapstructure:"oracledb.user_commits"`
+	OracledbUserRollbacks         MetricConfig `mapstructure:"oracledb.user_rollbacks"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		OracledbCPUTime: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		OracledbCPUTime: MetricConfig{
 			Enabled: true,
 		},
-		OracledbDmlLocksLimit: MetricSettings{
+		OracledbDmlLocksLimit: MetricConfig{
 			Enabled: true,
 		},
-		OracledbDmlLocksUsage: MetricSettings{
+		OracledbDmlLocksUsage: MetricConfig{
 			Enabled: true,
 		},
-		OracledbEnqueueDeadlocks: MetricSettings{
+		OracledbEnqueueDeadlocks: MetricConfig{
 			Enabled: true,
 		},
-		OracledbEnqueueLocksLimit: MetricSettings{
+		OracledbEnqueueLocksLimit: MetricConfig{
 			Enabled: true,
 		},
-		OracledbEnqueueLocksUsage: MetricSettings{
+		OracledbEnqueueLocksUsage: MetricConfig{
 			Enabled: true,
 		},
-		OracledbEnqueueResourcesLimit: MetricSettings{
+		OracledbEnqueueResourcesLimit: MetricConfig{
 			Enabled: true,
 		},
-		OracledbEnqueueResourcesUsage: MetricSettings{
+		OracledbEnqueueResourcesUsage: MetricConfig{
 			Enabled: true,
 		},
-		OracledbExchangeDeadlocks: MetricSettings{
+		OracledbExchangeDeadlocks: MetricConfig{
 			Enabled: true,
 		},
-		OracledbExecutions: MetricSettings{
+		OracledbExecutions: MetricConfig{
 			Enabled: true,
 		},
-		OracledbHardParses: MetricSettings{
+		OracledbHardParses: MetricConfig{
 			Enabled: true,
 		},
-		OracledbLogicalReads: MetricSettings{
+		OracledbLogicalReads: MetricConfig{
 			Enabled: true,
 		},
-		OracledbParseCalls: MetricSettings{
+		OracledbParseCalls: MetricConfig{
 			Enabled: true,
 		},
-		OracledbPgaMemory: MetricSettings{
+		OracledbPgaMemory: MetricConfig{
 			Enabled: true,
 		},
-		OracledbPhysicalReads: MetricSettings{
+		OracledbPhysicalReads: MetricConfig{
 			Enabled: true,
 		},
-		OracledbProcessesLimit: MetricSettings{
+		OracledbProcessesLimit: MetricConfig{
 			Enabled: true,
 		},
-		OracledbProcessesUsage: MetricSettings{
+		OracledbProcessesUsage: MetricConfig{
 			Enabled: true,
 		},
-		OracledbSessionsLimit: MetricSettings{
+		OracledbSessionsLimit: MetricConfig{
 			Enabled: true,
 		},
-		OracledbSessionsUsage: MetricSettings{
+		OracledbSessionsUsage: MetricConfig{
 			Enabled: true,
 		},
-		OracledbTablespaceSizeLimit: MetricSettings{
+		OracledbTablespaceSizeLimit: MetricConfig{
 			Enabled: true,
 		},
-		OracledbTablespaceSizeUsage: MetricSettings{
+		OracledbTablespaceSizeUsage: MetricConfig{
 			Enabled: true,
 		},
-		OracledbTransactionsLimit: MetricSettings{
+		OracledbTransactionsLimit: MetricConfig{
 			Enabled: true,
 		},
-		OracledbTransactionsUsage: MetricSettings{
+		OracledbTransactionsUsage: MetricConfig{
 			Enabled: true,
 		},
-		OracledbUserCommits: MetricSettings{
+		OracledbUserCommits: MetricConfig{
 			Enabled: true,
 		},
-		OracledbUserRollbacks: MetricSettings{
+		OracledbUserRollbacks: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for oracledbreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	OracledbInstanceName ResourceAttributeSettings `mapstructure:"oracledb.instance.name"`
+// ResourceAttributesConfig provides config for oracledbreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	OracledbInstanceName ResourceAttributeConfig `mapstructure:"oracledb.instance.name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		OracledbInstanceName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		OracledbInstanceName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -162,7 +162,7 @@ func DefaultResourceAttributesSettings() ResourceAttributesSettings {
 
 type metricOracledbCPUTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -177,7 +177,7 @@ func (m *metricOracledbCPUTime) init() {
 }
 
 func (m *metricOracledbCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -195,16 +195,16 @@ func (m *metricOracledbCPUTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbCPUTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbCPUTime(settings MetricSettings) metricOracledbCPUTime {
-	m := metricOracledbCPUTime{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbCPUTime(cfg MetricConfig) metricOracledbCPUTime {
+	m := metricOracledbCPUTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -213,7 +213,7 @@ func newMetricOracledbCPUTime(settings MetricSettings) metricOracledbCPUTime {
 
 type metricOracledbDmlLocksLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -226,7 +226,7 @@ func (m *metricOracledbDmlLocksLimit) init() {
 }
 
 func (m *metricOracledbDmlLocksLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -244,16 +244,16 @@ func (m *metricOracledbDmlLocksLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbDmlLocksLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbDmlLocksLimit(settings MetricSettings) metricOracledbDmlLocksLimit {
-	m := metricOracledbDmlLocksLimit{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbDmlLocksLimit(cfg MetricConfig) metricOracledbDmlLocksLimit {
+	m := metricOracledbDmlLocksLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -262,7 +262,7 @@ func newMetricOracledbDmlLocksLimit(settings MetricSettings) metricOracledbDmlLo
 
 type metricOracledbDmlLocksUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -275,7 +275,7 @@ func (m *metricOracledbDmlLocksUsage) init() {
 }
 
 func (m *metricOracledbDmlLocksUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -293,16 +293,16 @@ func (m *metricOracledbDmlLocksUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbDmlLocksUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbDmlLocksUsage(settings MetricSettings) metricOracledbDmlLocksUsage {
-	m := metricOracledbDmlLocksUsage{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbDmlLocksUsage(cfg MetricConfig) metricOracledbDmlLocksUsage {
+	m := metricOracledbDmlLocksUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -311,7 +311,7 @@ func newMetricOracledbDmlLocksUsage(settings MetricSettings) metricOracledbDmlLo
 
 type metricOracledbEnqueueDeadlocks struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -326,7 +326,7 @@ func (m *metricOracledbEnqueueDeadlocks) init() {
 }
 
 func (m *metricOracledbEnqueueDeadlocks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -344,16 +344,16 @@ func (m *metricOracledbEnqueueDeadlocks) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbEnqueueDeadlocks) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbEnqueueDeadlocks(settings MetricSettings) metricOracledbEnqueueDeadlocks {
-	m := metricOracledbEnqueueDeadlocks{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbEnqueueDeadlocks(cfg MetricConfig) metricOracledbEnqueueDeadlocks {
+	m := metricOracledbEnqueueDeadlocks{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -362,7 +362,7 @@ func newMetricOracledbEnqueueDeadlocks(settings MetricSettings) metricOracledbEn
 
 type metricOracledbEnqueueLocksLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -375,7 +375,7 @@ func (m *metricOracledbEnqueueLocksLimit) init() {
 }
 
 func (m *metricOracledbEnqueueLocksLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -393,16 +393,16 @@ func (m *metricOracledbEnqueueLocksLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbEnqueueLocksLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbEnqueueLocksLimit(settings MetricSettings) metricOracledbEnqueueLocksLimit {
-	m := metricOracledbEnqueueLocksLimit{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbEnqueueLocksLimit(cfg MetricConfig) metricOracledbEnqueueLocksLimit {
+	m := metricOracledbEnqueueLocksLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -411,7 +411,7 @@ func newMetricOracledbEnqueueLocksLimit(settings MetricSettings) metricOracledbE
 
 type metricOracledbEnqueueLocksUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -424,7 +424,7 @@ func (m *metricOracledbEnqueueLocksUsage) init() {
 }
 
 func (m *metricOracledbEnqueueLocksUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -442,16 +442,16 @@ func (m *metricOracledbEnqueueLocksUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbEnqueueLocksUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbEnqueueLocksUsage(settings MetricSettings) metricOracledbEnqueueLocksUsage {
-	m := metricOracledbEnqueueLocksUsage{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbEnqueueLocksUsage(cfg MetricConfig) metricOracledbEnqueueLocksUsage {
+	m := metricOracledbEnqueueLocksUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -460,7 +460,7 @@ func newMetricOracledbEnqueueLocksUsage(settings MetricSettings) metricOracledbE
 
 type metricOracledbEnqueueResourcesLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -473,7 +473,7 @@ func (m *metricOracledbEnqueueResourcesLimit) init() {
 }
 
 func (m *metricOracledbEnqueueResourcesLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -491,16 +491,16 @@ func (m *metricOracledbEnqueueResourcesLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbEnqueueResourcesLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbEnqueueResourcesLimit(settings MetricSettings) metricOracledbEnqueueResourcesLimit {
-	m := metricOracledbEnqueueResourcesLimit{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbEnqueueResourcesLimit(cfg MetricConfig) metricOracledbEnqueueResourcesLimit {
+	m := metricOracledbEnqueueResourcesLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -509,7 +509,7 @@ func newMetricOracledbEnqueueResourcesLimit(settings MetricSettings) metricOracl
 
 type metricOracledbEnqueueResourcesUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -522,7 +522,7 @@ func (m *metricOracledbEnqueueResourcesUsage) init() {
 }
 
 func (m *metricOracledbEnqueueResourcesUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -540,16 +540,16 @@ func (m *metricOracledbEnqueueResourcesUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbEnqueueResourcesUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbEnqueueResourcesUsage(settings MetricSettings) metricOracledbEnqueueResourcesUsage {
-	m := metricOracledbEnqueueResourcesUsage{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbEnqueueResourcesUsage(cfg MetricConfig) metricOracledbEnqueueResourcesUsage {
+	m := metricOracledbEnqueueResourcesUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -558,7 +558,7 @@ func newMetricOracledbEnqueueResourcesUsage(settings MetricSettings) metricOracl
 
 type metricOracledbExchangeDeadlocks struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -573,7 +573,7 @@ func (m *metricOracledbExchangeDeadlocks) init() {
 }
 
 func (m *metricOracledbExchangeDeadlocks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -591,16 +591,16 @@ func (m *metricOracledbExchangeDeadlocks) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbExchangeDeadlocks) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbExchangeDeadlocks(settings MetricSettings) metricOracledbExchangeDeadlocks {
-	m := metricOracledbExchangeDeadlocks{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbExchangeDeadlocks(cfg MetricConfig) metricOracledbExchangeDeadlocks {
+	m := metricOracledbExchangeDeadlocks{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -609,7 +609,7 @@ func newMetricOracledbExchangeDeadlocks(settings MetricSettings) metricOracledbE
 
 type metricOracledbExecutions struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -624,7 +624,7 @@ func (m *metricOracledbExecutions) init() {
 }
 
 func (m *metricOracledbExecutions) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -642,16 +642,16 @@ func (m *metricOracledbExecutions) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbExecutions) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbExecutions(settings MetricSettings) metricOracledbExecutions {
-	m := metricOracledbExecutions{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbExecutions(cfg MetricConfig) metricOracledbExecutions {
+	m := metricOracledbExecutions{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -660,7 +660,7 @@ func newMetricOracledbExecutions(settings MetricSettings) metricOracledbExecutio
 
 type metricOracledbHardParses struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -675,7 +675,7 @@ func (m *metricOracledbHardParses) init() {
 }
 
 func (m *metricOracledbHardParses) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -693,16 +693,16 @@ func (m *metricOracledbHardParses) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbHardParses) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbHardParses(settings MetricSettings) metricOracledbHardParses {
-	m := metricOracledbHardParses{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbHardParses(cfg MetricConfig) metricOracledbHardParses {
+	m := metricOracledbHardParses{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -711,7 +711,7 @@ func newMetricOracledbHardParses(settings MetricSettings) metricOracledbHardPars
 
 type metricOracledbLogicalReads struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -726,7 +726,7 @@ func (m *metricOracledbLogicalReads) init() {
 }
 
 func (m *metricOracledbLogicalReads) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -744,16 +744,16 @@ func (m *metricOracledbLogicalReads) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbLogicalReads) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbLogicalReads(settings MetricSettings) metricOracledbLogicalReads {
-	m := metricOracledbLogicalReads{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbLogicalReads(cfg MetricConfig) metricOracledbLogicalReads {
+	m := metricOracledbLogicalReads{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -762,7 +762,7 @@ func newMetricOracledbLogicalReads(settings MetricSettings) metricOracledbLogica
 
 type metricOracledbParseCalls struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -777,7 +777,7 @@ func (m *metricOracledbParseCalls) init() {
 }
 
 func (m *metricOracledbParseCalls) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -795,16 +795,16 @@ func (m *metricOracledbParseCalls) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbParseCalls) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbParseCalls(settings MetricSettings) metricOracledbParseCalls {
-	m := metricOracledbParseCalls{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbParseCalls(cfg MetricConfig) metricOracledbParseCalls {
+	m := metricOracledbParseCalls{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -813,7 +813,7 @@ func newMetricOracledbParseCalls(settings MetricSettings) metricOracledbParseCal
 
 type metricOracledbPgaMemory struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -828,7 +828,7 @@ func (m *metricOracledbPgaMemory) init() {
 }
 
 func (m *metricOracledbPgaMemory) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -846,16 +846,16 @@ func (m *metricOracledbPgaMemory) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbPgaMemory) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbPgaMemory(settings MetricSettings) metricOracledbPgaMemory {
-	m := metricOracledbPgaMemory{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbPgaMemory(cfg MetricConfig) metricOracledbPgaMemory {
+	m := metricOracledbPgaMemory{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -864,7 +864,7 @@ func newMetricOracledbPgaMemory(settings MetricSettings) metricOracledbPgaMemory
 
 type metricOracledbPhysicalReads struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -879,7 +879,7 @@ func (m *metricOracledbPhysicalReads) init() {
 }
 
 func (m *metricOracledbPhysicalReads) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -897,16 +897,16 @@ func (m *metricOracledbPhysicalReads) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbPhysicalReads) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbPhysicalReads(settings MetricSettings) metricOracledbPhysicalReads {
-	m := metricOracledbPhysicalReads{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbPhysicalReads(cfg MetricConfig) metricOracledbPhysicalReads {
+	m := metricOracledbPhysicalReads{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -915,7 +915,7 @@ func newMetricOracledbPhysicalReads(settings MetricSettings) metricOracledbPhysi
 
 type metricOracledbProcessesLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -928,7 +928,7 @@ func (m *metricOracledbProcessesLimit) init() {
 }
 
 func (m *metricOracledbProcessesLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -946,16 +946,16 @@ func (m *metricOracledbProcessesLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbProcessesLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbProcessesLimit(settings MetricSettings) metricOracledbProcessesLimit {
-	m := metricOracledbProcessesLimit{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbProcessesLimit(cfg MetricConfig) metricOracledbProcessesLimit {
+	m := metricOracledbProcessesLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -964,7 +964,7 @@ func newMetricOracledbProcessesLimit(settings MetricSettings) metricOracledbProc
 
 type metricOracledbProcessesUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -977,7 +977,7 @@ func (m *metricOracledbProcessesUsage) init() {
 }
 
 func (m *metricOracledbProcessesUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -995,16 +995,16 @@ func (m *metricOracledbProcessesUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbProcessesUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbProcessesUsage(settings MetricSettings) metricOracledbProcessesUsage {
-	m := metricOracledbProcessesUsage{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbProcessesUsage(cfg MetricConfig) metricOracledbProcessesUsage {
+	m := metricOracledbProcessesUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1013,7 +1013,7 @@ func newMetricOracledbProcessesUsage(settings MetricSettings) metricOracledbProc
 
 type metricOracledbSessionsLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1026,7 +1026,7 @@ func (m *metricOracledbSessionsLimit) init() {
 }
 
 func (m *metricOracledbSessionsLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1044,16 +1044,16 @@ func (m *metricOracledbSessionsLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbSessionsLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbSessionsLimit(settings MetricSettings) metricOracledbSessionsLimit {
-	m := metricOracledbSessionsLimit{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbSessionsLimit(cfg MetricConfig) metricOracledbSessionsLimit {
+	m := metricOracledbSessionsLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1062,7 +1062,7 @@ func newMetricOracledbSessionsLimit(settings MetricSettings) metricOracledbSessi
 
 type metricOracledbSessionsUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1076,7 +1076,7 @@ func (m *metricOracledbSessionsUsage) init() {
 }
 
 func (m *metricOracledbSessionsUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, sessionTypeAttributeValue string, sessionStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1096,16 +1096,16 @@ func (m *metricOracledbSessionsUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbSessionsUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbSessionsUsage(settings MetricSettings) metricOracledbSessionsUsage {
-	m := metricOracledbSessionsUsage{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbSessionsUsage(cfg MetricConfig) metricOracledbSessionsUsage {
+	m := metricOracledbSessionsUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1114,7 +1114,7 @@ func newMetricOracledbSessionsUsage(settings MetricSettings) metricOracledbSessi
 
 type metricOracledbTablespaceSizeLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1128,7 +1128,7 @@ func (m *metricOracledbTablespaceSizeLimit) init() {
 }
 
 func (m *metricOracledbTablespaceSizeLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, tablespaceNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1147,16 +1147,16 @@ func (m *metricOracledbTablespaceSizeLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbTablespaceSizeLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbTablespaceSizeLimit(settings MetricSettings) metricOracledbTablespaceSizeLimit {
-	m := metricOracledbTablespaceSizeLimit{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbTablespaceSizeLimit(cfg MetricConfig) metricOracledbTablespaceSizeLimit {
+	m := metricOracledbTablespaceSizeLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1165,7 +1165,7 @@ func newMetricOracledbTablespaceSizeLimit(settings MetricSettings) metricOracled
 
 type metricOracledbTablespaceSizeUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1179,7 +1179,7 @@ func (m *metricOracledbTablespaceSizeUsage) init() {
 }
 
 func (m *metricOracledbTablespaceSizeUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, tablespaceNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1198,16 +1198,16 @@ func (m *metricOracledbTablespaceSizeUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbTablespaceSizeUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbTablespaceSizeUsage(settings MetricSettings) metricOracledbTablespaceSizeUsage {
-	m := metricOracledbTablespaceSizeUsage{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbTablespaceSizeUsage(cfg MetricConfig) metricOracledbTablespaceSizeUsage {
+	m := metricOracledbTablespaceSizeUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1216,7 +1216,7 @@ func newMetricOracledbTablespaceSizeUsage(settings MetricSettings) metricOracled
 
 type metricOracledbTransactionsLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1229,7 +1229,7 @@ func (m *metricOracledbTransactionsLimit) init() {
 }
 
 func (m *metricOracledbTransactionsLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1247,16 +1247,16 @@ func (m *metricOracledbTransactionsLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbTransactionsLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbTransactionsLimit(settings MetricSettings) metricOracledbTransactionsLimit {
-	m := metricOracledbTransactionsLimit{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbTransactionsLimit(cfg MetricConfig) metricOracledbTransactionsLimit {
+	m := metricOracledbTransactionsLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1265,7 +1265,7 @@ func newMetricOracledbTransactionsLimit(settings MetricSettings) metricOracledbT
 
 type metricOracledbTransactionsUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1278,7 +1278,7 @@ func (m *metricOracledbTransactionsUsage) init() {
 }
 
 func (m *metricOracledbTransactionsUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1296,16 +1296,16 @@ func (m *metricOracledbTransactionsUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbTransactionsUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbTransactionsUsage(settings MetricSettings) metricOracledbTransactionsUsage {
-	m := metricOracledbTransactionsUsage{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbTransactionsUsage(cfg MetricConfig) metricOracledbTransactionsUsage {
+	m := metricOracledbTransactionsUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1314,7 +1314,7 @@ func newMetricOracledbTransactionsUsage(settings MetricSettings) metricOracledbT
 
 type metricOracledbUserCommits struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1329,7 +1329,7 @@ func (m *metricOracledbUserCommits) init() {
 }
 
 func (m *metricOracledbUserCommits) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1347,16 +1347,16 @@ func (m *metricOracledbUserCommits) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbUserCommits) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbUserCommits(settings MetricSettings) metricOracledbUserCommits {
-	m := metricOracledbUserCommits{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbUserCommits(cfg MetricConfig) metricOracledbUserCommits {
+	m := metricOracledbUserCommits{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1365,7 +1365,7 @@ func newMetricOracledbUserCommits(settings MetricSettings) metricOracledbUserCom
 
 type metricOracledbUserRollbacks struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1380,7 +1380,7 @@ func (m *metricOracledbUserRollbacks) init() {
 }
 
 func (m *metricOracledbUserRollbacks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1398,16 +1398,16 @@ func (m *metricOracledbUserRollbacks) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricOracledbUserRollbacks) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricOracledbUserRollbacks(settings MetricSettings) metricOracledbUserRollbacks {
-	m := metricOracledbUserRollbacks{settings: settings}
-	if settings.Enabled {
+func newMetricOracledbUserRollbacks(cfg MetricConfig) metricOracledbUserRollbacks {
+	m := metricOracledbUserRollbacks{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1416,19 +1416,19 @@ func newMetricOracledbUserRollbacks(settings MetricSettings) metricOracledbUserR
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                           pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                     int                 // maximum observed number of metrics per resource.
 	resourceCapacity                    int                 // maximum observed number of resource attributes.
 	metricsBuffer                       pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                           component.BuildInfo // contains version information
-	resourceAttributesSettings          ResourceAttributesSettings
+	resourceAttributesConfig            ResourceAttributesConfig
 	metricOracledbCPUTime               metricOracledbCPUTime
 	metricOracledbDmlLocksLimit         metricOracledbDmlLocksLimit
 	metricOracledbDmlLocksUsage         metricOracledbDmlLocksUsage
@@ -1468,8 +1468,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -1478,7 +1478,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                           pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                       pmetric.NewMetrics(),
 		buildInfo:                           settings.BuildInfo,
-		resourceAttributesSettings:          mbc.ResourceAttributes,
+		resourceAttributesConfig:            mbc.ResourceAttributes,
 		metricOracledbCPUTime:               newMetricOracledbCPUTime(mbc.Metrics.OracledbCPUTime),
 		metricOracledbDmlLocksLimit:         newMetricOracledbDmlLocksLimit(mbc.Metrics.OracledbDmlLocksLimit),
 		metricOracledbDmlLocksUsage:         newMetricOracledbDmlLocksUsage(mbc.Metrics.OracledbDmlLocksUsage),
@@ -1522,12 +1522,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithOracledbInstanceName sets provided value as "oracledb.instance.name" attribute for current resource.
 func WithOracledbInstanceName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.OracledbInstanceName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.OracledbInstanceName.Enabled {
 			rm.Resource().Attributes().PutStr("oracledb.instance.name", val)
 		}
 	}
@@ -1536,7 +1536,7 @@ func WithOracledbInstanceName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -1592,7 +1592,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricOracledbUserRollbacks.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -1602,7 +1602,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/oracledbreceiver/internal/metadata/generated_metrics_test.go
@@ -171,8 +171,8 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("oracledb.instance.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.OracledbInstanceName.Enabled, ok)
-			if mb.resourceAttributesSettings.OracledbInstanceName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.OracledbInstanceName.Enabled, ok)
+			if mb.resourceAttributesConfig.OracledbInstanceName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/postgresqlreceiver/internal/metadata/custom.go
+++ b/receiver/postgresqlreceiver/internal/metadata/custom.go
@@ -22,7 +22,7 @@ func (mb *MetricsBuilder) RecordPostgresqlDbSizeDataPointWithoutDatabase(ts pcom
 }
 
 func (m *metricPostgresqlDbSize) recordDatapointWithoutDatabase(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -37,7 +37,7 @@ func (mb *MetricsBuilder) RecordPostgresqlBackendsDataPointWithoutDatabase(ts pc
 }
 
 func (m *metricPostgresqlBackends) recordDatapointWithoutDatabase(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -52,7 +52,7 @@ func (mb *MetricsBuilder) RecordPostgresqlBlocksReadDataPointWithoutDatabaseAndT
 }
 
 func (m *metricPostgresqlBlocksRead) recordDatapointWithoutDatabaseAndTable(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, sourceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -68,7 +68,7 @@ func (mb *MetricsBuilder) RecordPostgresqlCommitsDataPointWithoutDatabase(ts pco
 }
 
 func (m *metricPostgresqlCommits) recordDatapointWithoutDatabase(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -83,7 +83,7 @@ func (mb *MetricsBuilder) RecordPostgresqlRollbacksDataPointWithoutDatabase(ts p
 }
 
 func (m *metricPostgresqlRollbacks) recordDatapointWithoutDatabase(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -98,7 +98,7 @@ func (mb *MetricsBuilder) RecordPostgresqlRowsDataPointWithoutDatabaseAndTable(t
 }
 
 func (m *metricPostgresqlRows) recordDatapointWithoutDatabaseAndTable(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -114,7 +114,7 @@ func (mb *MetricsBuilder) RecordPostgresqlOperationsDataPointWithoutDatabaseAndT
 }
 
 func (m *metricPostgresqlOperations) recordDatapointWithoutDatabaseAndTable(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,124 +31,124 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for postgresqlreceiver metrics.
-type MetricsSettings struct {
-	PostgresqlBackends                 MetricSettings `mapstructure:"postgresql.backends"`
-	PostgresqlBgwriterBuffersAllocated MetricSettings `mapstructure:"postgresql.bgwriter.buffers.allocated"`
-	PostgresqlBgwriterBuffersWrites    MetricSettings `mapstructure:"postgresql.bgwriter.buffers.writes"`
-	PostgresqlBgwriterCheckpointCount  MetricSettings `mapstructure:"postgresql.bgwriter.checkpoint.count"`
-	PostgresqlBgwriterDuration         MetricSettings `mapstructure:"postgresql.bgwriter.duration"`
-	PostgresqlBgwriterMaxwritten       MetricSettings `mapstructure:"postgresql.bgwriter.maxwritten"`
-	PostgresqlBlocksRead               MetricSettings `mapstructure:"postgresql.blocks_read"`
-	PostgresqlCommits                  MetricSettings `mapstructure:"postgresql.commits"`
-	PostgresqlConnectionMax            MetricSettings `mapstructure:"postgresql.connection.max"`
-	PostgresqlDatabaseCount            MetricSettings `mapstructure:"postgresql.database.count"`
-	PostgresqlDbSize                   MetricSettings `mapstructure:"postgresql.db_size"`
-	PostgresqlIndexScans               MetricSettings `mapstructure:"postgresql.index.scans"`
-	PostgresqlIndexSize                MetricSettings `mapstructure:"postgresql.index.size"`
-	PostgresqlOperations               MetricSettings `mapstructure:"postgresql.operations"`
-	PostgresqlReplicationDataDelay     MetricSettings `mapstructure:"postgresql.replication.data_delay"`
-	PostgresqlRollbacks                MetricSettings `mapstructure:"postgresql.rollbacks"`
-	PostgresqlRows                     MetricSettings `mapstructure:"postgresql.rows"`
-	PostgresqlTableCount               MetricSettings `mapstructure:"postgresql.table.count"`
-	PostgresqlTableSize                MetricSettings `mapstructure:"postgresql.table.size"`
-	PostgresqlTableVacuumCount         MetricSettings `mapstructure:"postgresql.table.vacuum.count"`
-	PostgresqlWalAge                   MetricSettings `mapstructure:"postgresql.wal.age"`
-	PostgresqlWalLag                   MetricSettings `mapstructure:"postgresql.wal.lag"`
+// MetricsConfig provides config for postgresqlreceiver metrics.
+type MetricsConfig struct {
+	PostgresqlBackends                 MetricConfig `mapstructure:"postgresql.backends"`
+	PostgresqlBgwriterBuffersAllocated MetricConfig `mapstructure:"postgresql.bgwriter.buffers.allocated"`
+	PostgresqlBgwriterBuffersWrites    MetricConfig `mapstructure:"postgresql.bgwriter.buffers.writes"`
+	PostgresqlBgwriterCheckpointCount  MetricConfig `mapstructure:"postgresql.bgwriter.checkpoint.count"`
+	PostgresqlBgwriterDuration         MetricConfig `mapstructure:"postgresql.bgwriter.duration"`
+	PostgresqlBgwriterMaxwritten       MetricConfig `mapstructure:"postgresql.bgwriter.maxwritten"`
+	PostgresqlBlocksRead               MetricConfig `mapstructure:"postgresql.blocks_read"`
+	PostgresqlCommits                  MetricConfig `mapstructure:"postgresql.commits"`
+	PostgresqlConnectionMax            MetricConfig `mapstructure:"postgresql.connection.max"`
+	PostgresqlDatabaseCount            MetricConfig `mapstructure:"postgresql.database.count"`
+	PostgresqlDbSize                   MetricConfig `mapstructure:"postgresql.db_size"`
+	PostgresqlIndexScans               MetricConfig `mapstructure:"postgresql.index.scans"`
+	PostgresqlIndexSize                MetricConfig `mapstructure:"postgresql.index.size"`
+	PostgresqlOperations               MetricConfig `mapstructure:"postgresql.operations"`
+	PostgresqlReplicationDataDelay     MetricConfig `mapstructure:"postgresql.replication.data_delay"`
+	PostgresqlRollbacks                MetricConfig `mapstructure:"postgresql.rollbacks"`
+	PostgresqlRows                     MetricConfig `mapstructure:"postgresql.rows"`
+	PostgresqlTableCount               MetricConfig `mapstructure:"postgresql.table.count"`
+	PostgresqlTableSize                MetricConfig `mapstructure:"postgresql.table.size"`
+	PostgresqlTableVacuumCount         MetricConfig `mapstructure:"postgresql.table.vacuum.count"`
+	PostgresqlWalAge                   MetricConfig `mapstructure:"postgresql.wal.age"`
+	PostgresqlWalLag                   MetricConfig `mapstructure:"postgresql.wal.lag"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		PostgresqlBackends: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		PostgresqlBackends: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlBgwriterBuffersAllocated: MetricSettings{
+		PostgresqlBgwriterBuffersAllocated: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlBgwriterBuffersWrites: MetricSettings{
+		PostgresqlBgwriterBuffersWrites: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlBgwriterCheckpointCount: MetricSettings{
+		PostgresqlBgwriterCheckpointCount: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlBgwriterDuration: MetricSettings{
+		PostgresqlBgwriterDuration: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlBgwriterMaxwritten: MetricSettings{
+		PostgresqlBgwriterMaxwritten: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlBlocksRead: MetricSettings{
+		PostgresqlBlocksRead: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlCommits: MetricSettings{
+		PostgresqlCommits: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlConnectionMax: MetricSettings{
+		PostgresqlConnectionMax: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlDatabaseCount: MetricSettings{
+		PostgresqlDatabaseCount: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlDbSize: MetricSettings{
+		PostgresqlDbSize: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlIndexScans: MetricSettings{
+		PostgresqlIndexScans: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlIndexSize: MetricSettings{
+		PostgresqlIndexSize: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlOperations: MetricSettings{
+		PostgresqlOperations: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlReplicationDataDelay: MetricSettings{
+		PostgresqlReplicationDataDelay: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlRollbacks: MetricSettings{
+		PostgresqlRollbacks: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlRows: MetricSettings{
+		PostgresqlRows: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlTableCount: MetricSettings{
+		PostgresqlTableCount: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlTableSize: MetricSettings{
+		PostgresqlTableSize: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlTableVacuumCount: MetricSettings{
+		PostgresqlTableVacuumCount: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlWalAge: MetricSettings{
+		PostgresqlWalAge: MetricConfig{
 			Enabled: true,
 		},
-		PostgresqlWalLag: MetricSettings{
+		PostgresqlWalLag: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for postgresqlreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	PostgresqlDatabaseName ResourceAttributeSettings `mapstructure:"postgresql.database.name"`
-	PostgresqlIndexName    ResourceAttributeSettings `mapstructure:"postgresql.index.name"`
-	PostgresqlTableName    ResourceAttributeSettings `mapstructure:"postgresql.table.name"`
+// ResourceAttributesConfig provides config for postgresqlreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	PostgresqlDatabaseName ResourceAttributeConfig `mapstructure:"postgresql.database.name"`
+	PostgresqlIndexName    ResourceAttributeConfig `mapstructure:"postgresql.index.name"`
+	PostgresqlTableName    ResourceAttributeConfig `mapstructure:"postgresql.table.name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		PostgresqlDatabaseName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		PostgresqlDatabaseName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		PostgresqlIndexName: ResourceAttributeSettings{
+		PostgresqlIndexName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		PostgresqlTableName: ResourceAttributeSettings{
+		PostgresqlTableName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -382,7 +382,7 @@ var MapAttributeWalOperationLag = map[string]AttributeWalOperationLag{
 
 type metricPostgresqlBackends struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -398,7 +398,7 @@ func (m *metricPostgresqlBackends) init() {
 }
 
 func (m *metricPostgresqlBackends) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -417,16 +417,16 @@ func (m *metricPostgresqlBackends) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlBackends) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlBackends(settings MetricSettings) metricPostgresqlBackends {
-	m := metricPostgresqlBackends{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlBackends(cfg MetricConfig) metricPostgresqlBackends {
+	m := metricPostgresqlBackends{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -435,7 +435,7 @@ func newMetricPostgresqlBackends(settings MetricSettings) metricPostgresqlBacken
 
 type metricPostgresqlBgwriterBuffersAllocated struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -450,7 +450,7 @@ func (m *metricPostgresqlBgwriterBuffersAllocated) init() {
 }
 
 func (m *metricPostgresqlBgwriterBuffersAllocated) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -468,16 +468,16 @@ func (m *metricPostgresqlBgwriterBuffersAllocated) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlBgwriterBuffersAllocated) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlBgwriterBuffersAllocated(settings MetricSettings) metricPostgresqlBgwriterBuffersAllocated {
-	m := metricPostgresqlBgwriterBuffersAllocated{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlBgwriterBuffersAllocated(cfg MetricConfig) metricPostgresqlBgwriterBuffersAllocated {
+	m := metricPostgresqlBgwriterBuffersAllocated{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -486,7 +486,7 @@ func newMetricPostgresqlBgwriterBuffersAllocated(settings MetricSettings) metric
 
 type metricPostgresqlBgwriterBuffersWrites struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -502,7 +502,7 @@ func (m *metricPostgresqlBgwriterBuffersWrites) init() {
 }
 
 func (m *metricPostgresqlBgwriterBuffersWrites) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, bgBufferSourceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -521,16 +521,16 @@ func (m *metricPostgresqlBgwriterBuffersWrites) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlBgwriterBuffersWrites) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlBgwriterBuffersWrites(settings MetricSettings) metricPostgresqlBgwriterBuffersWrites {
-	m := metricPostgresqlBgwriterBuffersWrites{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlBgwriterBuffersWrites(cfg MetricConfig) metricPostgresqlBgwriterBuffersWrites {
+	m := metricPostgresqlBgwriterBuffersWrites{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -539,7 +539,7 @@ func newMetricPostgresqlBgwriterBuffersWrites(settings MetricSettings) metricPos
 
 type metricPostgresqlBgwriterCheckpointCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -555,7 +555,7 @@ func (m *metricPostgresqlBgwriterCheckpointCount) init() {
 }
 
 func (m *metricPostgresqlBgwriterCheckpointCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, bgCheckpointTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -574,16 +574,16 @@ func (m *metricPostgresqlBgwriterCheckpointCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlBgwriterCheckpointCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlBgwriterCheckpointCount(settings MetricSettings) metricPostgresqlBgwriterCheckpointCount {
-	m := metricPostgresqlBgwriterCheckpointCount{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlBgwriterCheckpointCount(cfg MetricConfig) metricPostgresqlBgwriterCheckpointCount {
+	m := metricPostgresqlBgwriterCheckpointCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -592,7 +592,7 @@ func newMetricPostgresqlBgwriterCheckpointCount(settings MetricSettings) metricP
 
 type metricPostgresqlBgwriterDuration struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -608,7 +608,7 @@ func (m *metricPostgresqlBgwriterDuration) init() {
 }
 
 func (m *metricPostgresqlBgwriterDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, bgDurationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -627,16 +627,16 @@ func (m *metricPostgresqlBgwriterDuration) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlBgwriterDuration) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlBgwriterDuration(settings MetricSettings) metricPostgresqlBgwriterDuration {
-	m := metricPostgresqlBgwriterDuration{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlBgwriterDuration(cfg MetricConfig) metricPostgresqlBgwriterDuration {
+	m := metricPostgresqlBgwriterDuration{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -645,7 +645,7 @@ func newMetricPostgresqlBgwriterDuration(settings MetricSettings) metricPostgres
 
 type metricPostgresqlBgwriterMaxwritten struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -660,7 +660,7 @@ func (m *metricPostgresqlBgwriterMaxwritten) init() {
 }
 
 func (m *metricPostgresqlBgwriterMaxwritten) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -678,16 +678,16 @@ func (m *metricPostgresqlBgwriterMaxwritten) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlBgwriterMaxwritten) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlBgwriterMaxwritten(settings MetricSettings) metricPostgresqlBgwriterMaxwritten {
-	m := metricPostgresqlBgwriterMaxwritten{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlBgwriterMaxwritten(cfg MetricConfig) metricPostgresqlBgwriterMaxwritten {
+	m := metricPostgresqlBgwriterMaxwritten{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -696,7 +696,7 @@ func newMetricPostgresqlBgwriterMaxwritten(settings MetricSettings) metricPostgr
 
 type metricPostgresqlBlocksRead struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -712,7 +712,7 @@ func (m *metricPostgresqlBlocksRead) init() {
 }
 
 func (m *metricPostgresqlBlocksRead) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, tableAttributeValue string, sourceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -733,16 +733,16 @@ func (m *metricPostgresqlBlocksRead) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlBlocksRead) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlBlocksRead(settings MetricSettings) metricPostgresqlBlocksRead {
-	m := metricPostgresqlBlocksRead{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlBlocksRead(cfg MetricConfig) metricPostgresqlBlocksRead {
+	m := metricPostgresqlBlocksRead{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -751,7 +751,7 @@ func newMetricPostgresqlBlocksRead(settings MetricSettings) metricPostgresqlBloc
 
 type metricPostgresqlCommits struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -767,7 +767,7 @@ func (m *metricPostgresqlCommits) init() {
 }
 
 func (m *metricPostgresqlCommits) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -786,16 +786,16 @@ func (m *metricPostgresqlCommits) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlCommits) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlCommits(settings MetricSettings) metricPostgresqlCommits {
-	m := metricPostgresqlCommits{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlCommits(cfg MetricConfig) metricPostgresqlCommits {
+	m := metricPostgresqlCommits{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -804,7 +804,7 @@ func newMetricPostgresqlCommits(settings MetricSettings) metricPostgresqlCommits
 
 type metricPostgresqlConnectionMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -817,7 +817,7 @@ func (m *metricPostgresqlConnectionMax) init() {
 }
 
 func (m *metricPostgresqlConnectionMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -835,16 +835,16 @@ func (m *metricPostgresqlConnectionMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlConnectionMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlConnectionMax(settings MetricSettings) metricPostgresqlConnectionMax {
-	m := metricPostgresqlConnectionMax{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlConnectionMax(cfg MetricConfig) metricPostgresqlConnectionMax {
+	m := metricPostgresqlConnectionMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -853,7 +853,7 @@ func newMetricPostgresqlConnectionMax(settings MetricSettings) metricPostgresqlC
 
 type metricPostgresqlDatabaseCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -868,7 +868,7 @@ func (m *metricPostgresqlDatabaseCount) init() {
 }
 
 func (m *metricPostgresqlDatabaseCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -886,16 +886,16 @@ func (m *metricPostgresqlDatabaseCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlDatabaseCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlDatabaseCount(settings MetricSettings) metricPostgresqlDatabaseCount {
-	m := metricPostgresqlDatabaseCount{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlDatabaseCount(cfg MetricConfig) metricPostgresqlDatabaseCount {
+	m := metricPostgresqlDatabaseCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -904,7 +904,7 @@ func newMetricPostgresqlDatabaseCount(settings MetricSettings) metricPostgresqlD
 
 type metricPostgresqlDbSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -920,7 +920,7 @@ func (m *metricPostgresqlDbSize) init() {
 }
 
 func (m *metricPostgresqlDbSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -939,16 +939,16 @@ func (m *metricPostgresqlDbSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlDbSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlDbSize(settings MetricSettings) metricPostgresqlDbSize {
-	m := metricPostgresqlDbSize{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlDbSize(cfg MetricConfig) metricPostgresqlDbSize {
+	m := metricPostgresqlDbSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -957,7 +957,7 @@ func newMetricPostgresqlDbSize(settings MetricSettings) metricPostgresqlDbSize {
 
 type metricPostgresqlIndexScans struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -972,7 +972,7 @@ func (m *metricPostgresqlIndexScans) init() {
 }
 
 func (m *metricPostgresqlIndexScans) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -990,16 +990,16 @@ func (m *metricPostgresqlIndexScans) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlIndexScans) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlIndexScans(settings MetricSettings) metricPostgresqlIndexScans {
-	m := metricPostgresqlIndexScans{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlIndexScans(cfg MetricConfig) metricPostgresqlIndexScans {
+	m := metricPostgresqlIndexScans{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1008,7 +1008,7 @@ func newMetricPostgresqlIndexScans(settings MetricSettings) metricPostgresqlInde
 
 type metricPostgresqlIndexSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1021,7 +1021,7 @@ func (m *metricPostgresqlIndexSize) init() {
 }
 
 func (m *metricPostgresqlIndexSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1039,16 +1039,16 @@ func (m *metricPostgresqlIndexSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlIndexSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlIndexSize(settings MetricSettings) metricPostgresqlIndexSize {
-	m := metricPostgresqlIndexSize{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlIndexSize(cfg MetricConfig) metricPostgresqlIndexSize {
+	m := metricPostgresqlIndexSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1057,7 +1057,7 @@ func newMetricPostgresqlIndexSize(settings MetricSettings) metricPostgresqlIndex
 
 type metricPostgresqlOperations struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1073,7 +1073,7 @@ func (m *metricPostgresqlOperations) init() {
 }
 
 func (m *metricPostgresqlOperations) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, tableAttributeValue string, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1094,16 +1094,16 @@ func (m *metricPostgresqlOperations) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlOperations) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlOperations(settings MetricSettings) metricPostgresqlOperations {
-	m := metricPostgresqlOperations{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlOperations(cfg MetricConfig) metricPostgresqlOperations {
+	m := metricPostgresqlOperations{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1112,7 +1112,7 @@ func newMetricPostgresqlOperations(settings MetricSettings) metricPostgresqlOper
 
 type metricPostgresqlReplicationDataDelay struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1126,7 +1126,7 @@ func (m *metricPostgresqlReplicationDataDelay) init() {
 }
 
 func (m *metricPostgresqlReplicationDataDelay) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, replicationClientAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1145,16 +1145,16 @@ func (m *metricPostgresqlReplicationDataDelay) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlReplicationDataDelay) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlReplicationDataDelay(settings MetricSettings) metricPostgresqlReplicationDataDelay {
-	m := metricPostgresqlReplicationDataDelay{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlReplicationDataDelay(cfg MetricConfig) metricPostgresqlReplicationDataDelay {
+	m := metricPostgresqlReplicationDataDelay{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1163,7 +1163,7 @@ func newMetricPostgresqlReplicationDataDelay(settings MetricSettings) metricPost
 
 type metricPostgresqlRollbacks struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1179,7 +1179,7 @@ func (m *metricPostgresqlRollbacks) init() {
 }
 
 func (m *metricPostgresqlRollbacks) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1198,16 +1198,16 @@ func (m *metricPostgresqlRollbacks) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlRollbacks) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlRollbacks(settings MetricSettings) metricPostgresqlRollbacks {
-	m := metricPostgresqlRollbacks{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlRollbacks(cfg MetricConfig) metricPostgresqlRollbacks {
+	m := metricPostgresqlRollbacks{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1216,7 +1216,7 @@ func newMetricPostgresqlRollbacks(settings MetricSettings) metricPostgresqlRollb
 
 type metricPostgresqlRows struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1232,7 +1232,7 @@ func (m *metricPostgresqlRows) init() {
 }
 
 func (m *metricPostgresqlRows) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, databaseAttributeValue string, tableAttributeValue string, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1253,16 +1253,16 @@ func (m *metricPostgresqlRows) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlRows) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlRows(settings MetricSettings) metricPostgresqlRows {
-	m := metricPostgresqlRows{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlRows(cfg MetricConfig) metricPostgresqlRows {
+	m := metricPostgresqlRows{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1271,7 +1271,7 @@ func newMetricPostgresqlRows(settings MetricSettings) metricPostgresqlRows {
 
 type metricPostgresqlTableCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1286,7 +1286,7 @@ func (m *metricPostgresqlTableCount) init() {
 }
 
 func (m *metricPostgresqlTableCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1304,16 +1304,16 @@ func (m *metricPostgresqlTableCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlTableCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlTableCount(settings MetricSettings) metricPostgresqlTableCount {
-	m := metricPostgresqlTableCount{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlTableCount(cfg MetricConfig) metricPostgresqlTableCount {
+	m := metricPostgresqlTableCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1322,7 +1322,7 @@ func newMetricPostgresqlTableCount(settings MetricSettings) metricPostgresqlTabl
 
 type metricPostgresqlTableSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1337,7 +1337,7 @@ func (m *metricPostgresqlTableSize) init() {
 }
 
 func (m *metricPostgresqlTableSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1355,16 +1355,16 @@ func (m *metricPostgresqlTableSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlTableSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlTableSize(settings MetricSettings) metricPostgresqlTableSize {
-	m := metricPostgresqlTableSize{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlTableSize(cfg MetricConfig) metricPostgresqlTableSize {
+	m := metricPostgresqlTableSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1373,7 +1373,7 @@ func newMetricPostgresqlTableSize(settings MetricSettings) metricPostgresqlTable
 
 type metricPostgresqlTableVacuumCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1388,7 +1388,7 @@ func (m *metricPostgresqlTableVacuumCount) init() {
 }
 
 func (m *metricPostgresqlTableVacuumCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1406,16 +1406,16 @@ func (m *metricPostgresqlTableVacuumCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlTableVacuumCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlTableVacuumCount(settings MetricSettings) metricPostgresqlTableVacuumCount {
-	m := metricPostgresqlTableVacuumCount{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlTableVacuumCount(cfg MetricConfig) metricPostgresqlTableVacuumCount {
+	m := metricPostgresqlTableVacuumCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1424,7 +1424,7 @@ func newMetricPostgresqlTableVacuumCount(settings MetricSettings) metricPostgres
 
 type metricPostgresqlWalAge struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1437,7 +1437,7 @@ func (m *metricPostgresqlWalAge) init() {
 }
 
 func (m *metricPostgresqlWalAge) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1455,16 +1455,16 @@ func (m *metricPostgresqlWalAge) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlWalAge) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlWalAge(settings MetricSettings) metricPostgresqlWalAge {
-	m := metricPostgresqlWalAge{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlWalAge(cfg MetricConfig) metricPostgresqlWalAge {
+	m := metricPostgresqlWalAge{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1473,7 +1473,7 @@ func newMetricPostgresqlWalAge(settings MetricSettings) metricPostgresqlWalAge {
 
 type metricPostgresqlWalLag struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1487,7 +1487,7 @@ func (m *metricPostgresqlWalLag) init() {
 }
 
 func (m *metricPostgresqlWalLag) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, walOperationLagAttributeValue string, replicationClientAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1507,16 +1507,16 @@ func (m *metricPostgresqlWalLag) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricPostgresqlWalLag) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricPostgresqlWalLag(settings MetricSettings) metricPostgresqlWalLag {
-	m := metricPostgresqlWalLag{settings: settings}
-	if settings.Enabled {
+func newMetricPostgresqlWalLag(cfg MetricConfig) metricPostgresqlWalLag {
+	m := metricPostgresqlWalLag{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1525,19 +1525,19 @@ func newMetricPostgresqlWalLag(settings MetricSettings) metricPostgresqlWalLag {
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                          int                 // maximum observed number of metrics per resource.
 	resourceCapacity                         int                 // maximum observed number of resource attributes.
 	metricsBuffer                            pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                                component.BuildInfo // contains version information
-	resourceAttributesSettings               ResourceAttributesSettings
+	resourceAttributesConfig                 ResourceAttributesConfig
 	metricPostgresqlBackends                 metricPostgresqlBackends
 	metricPostgresqlBgwriterBuffersAllocated metricPostgresqlBgwriterBuffersAllocated
 	metricPostgresqlBgwriterBuffersWrites    metricPostgresqlBgwriterBuffersWrites
@@ -1574,8 +1574,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -1584,7 +1584,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                                pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                            pmetric.NewMetrics(),
 		buildInfo:                                settings.BuildInfo,
-		resourceAttributesSettings:               mbc.ResourceAttributes,
+		resourceAttributesConfig:                 mbc.ResourceAttributes,
 		metricPostgresqlBackends:                 newMetricPostgresqlBackends(mbc.Metrics.PostgresqlBackends),
 		metricPostgresqlBgwriterBuffersAllocated: newMetricPostgresqlBgwriterBuffersAllocated(mbc.Metrics.PostgresqlBgwriterBuffersAllocated),
 		metricPostgresqlBgwriterBuffersWrites:    newMetricPostgresqlBgwriterBuffersWrites(mbc.Metrics.PostgresqlBgwriterBuffersWrites),
@@ -1625,12 +1625,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithPostgresqlDatabaseName sets provided value as "postgresql.database.name" attribute for current resource.
 func WithPostgresqlDatabaseName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.PostgresqlDatabaseName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.PostgresqlDatabaseName.Enabled {
 			rm.Resource().Attributes().PutStr("postgresql.database.name", val)
 		}
 	}
@@ -1638,8 +1638,8 @@ func WithPostgresqlDatabaseName(val string) ResourceMetricsOption {
 
 // WithPostgresqlIndexName sets provided value as "postgresql.index.name" attribute for current resource.
 func WithPostgresqlIndexName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.PostgresqlIndexName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.PostgresqlIndexName.Enabled {
 			rm.Resource().Attributes().PutStr("postgresql.index.name", val)
 		}
 	}
@@ -1647,8 +1647,8 @@ func WithPostgresqlIndexName(val string) ResourceMetricsOption {
 
 // WithPostgresqlTableName sets provided value as "postgresql.table.name" attribute for current resource.
 func WithPostgresqlTableName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.PostgresqlTableName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.PostgresqlTableName.Enabled {
 			rm.Resource().Attributes().PutStr("postgresql.table.name", val)
 		}
 	}
@@ -1657,7 +1657,7 @@ func WithPostgresqlTableName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -1710,7 +1710,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricPostgresqlWalLag.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -1720,7 +1720,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
@@ -159,22 +159,22 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("postgresql.database.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.PostgresqlDatabaseName.Enabled, ok)
-			if mb.resourceAttributesSettings.PostgresqlDatabaseName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.PostgresqlDatabaseName.Enabled, ok)
+			if mb.resourceAttributesConfig.PostgresqlDatabaseName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("postgresql.index.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.PostgresqlIndexName.Enabled, ok)
-			if mb.resourceAttributesSettings.PostgresqlIndexName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.PostgresqlIndexName.Enabled, ok)
+			if mb.resourceAttributesConfig.PostgresqlIndexName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("postgresql.table.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.PostgresqlTableName.Enabled, ok)
-			if mb.resourceAttributesSettings.PostgresqlTableName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.PostgresqlTableName.Enabled, ok)
+			if mb.resourceAttributesConfig.PostgresqlTableName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/rabbitmqreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/rabbitmqreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,60 +31,60 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for rabbitmqreceiver metrics.
-type MetricsSettings struct {
-	RabbitmqConsumerCount       MetricSettings `mapstructure:"rabbitmq.consumer.count"`
-	RabbitmqMessageAcknowledged MetricSettings `mapstructure:"rabbitmq.message.acknowledged"`
-	RabbitmqMessageCurrent      MetricSettings `mapstructure:"rabbitmq.message.current"`
-	RabbitmqMessageDelivered    MetricSettings `mapstructure:"rabbitmq.message.delivered"`
-	RabbitmqMessageDropped      MetricSettings `mapstructure:"rabbitmq.message.dropped"`
-	RabbitmqMessagePublished    MetricSettings `mapstructure:"rabbitmq.message.published"`
+// MetricsConfig provides config for rabbitmqreceiver metrics.
+type MetricsConfig struct {
+	RabbitmqConsumerCount       MetricConfig `mapstructure:"rabbitmq.consumer.count"`
+	RabbitmqMessageAcknowledged MetricConfig `mapstructure:"rabbitmq.message.acknowledged"`
+	RabbitmqMessageCurrent      MetricConfig `mapstructure:"rabbitmq.message.current"`
+	RabbitmqMessageDelivered    MetricConfig `mapstructure:"rabbitmq.message.delivered"`
+	RabbitmqMessageDropped      MetricConfig `mapstructure:"rabbitmq.message.dropped"`
+	RabbitmqMessagePublished    MetricConfig `mapstructure:"rabbitmq.message.published"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		RabbitmqConsumerCount: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		RabbitmqConsumerCount: MetricConfig{
 			Enabled: true,
 		},
-		RabbitmqMessageAcknowledged: MetricSettings{
+		RabbitmqMessageAcknowledged: MetricConfig{
 			Enabled: true,
 		},
-		RabbitmqMessageCurrent: MetricSettings{
+		RabbitmqMessageCurrent: MetricConfig{
 			Enabled: true,
 		},
-		RabbitmqMessageDelivered: MetricSettings{
+		RabbitmqMessageDelivered: MetricConfig{
 			Enabled: true,
 		},
-		RabbitmqMessageDropped: MetricSettings{
+		RabbitmqMessageDropped: MetricConfig{
 			Enabled: true,
 		},
-		RabbitmqMessagePublished: MetricSettings{
+		RabbitmqMessagePublished: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for rabbitmqreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	RabbitmqNodeName  ResourceAttributeSettings `mapstructure:"rabbitmq.node.name"`
-	RabbitmqQueueName ResourceAttributeSettings `mapstructure:"rabbitmq.queue.name"`
-	RabbitmqVhostName ResourceAttributeSettings `mapstructure:"rabbitmq.vhost.name"`
+// ResourceAttributesConfig provides config for rabbitmqreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	RabbitmqNodeName  ResourceAttributeConfig `mapstructure:"rabbitmq.node.name"`
+	RabbitmqQueueName ResourceAttributeConfig `mapstructure:"rabbitmq.queue.name"`
+	RabbitmqVhostName ResourceAttributeConfig `mapstructure:"rabbitmq.vhost.name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		RabbitmqNodeName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		RabbitmqNodeName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		RabbitmqQueueName: ResourceAttributeSettings{
+		RabbitmqQueueName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		RabbitmqVhostName: ResourceAttributeSettings{
+		RabbitmqVhostName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -118,7 +118,7 @@ var MapAttributeMessageState = map[string]AttributeMessageState{
 
 type metricRabbitmqConsumerCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -133,7 +133,7 @@ func (m *metricRabbitmqConsumerCount) init() {
 }
 
 func (m *metricRabbitmqConsumerCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -151,16 +151,16 @@ func (m *metricRabbitmqConsumerCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRabbitmqConsumerCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRabbitmqConsumerCount(settings MetricSettings) metricRabbitmqConsumerCount {
-	m := metricRabbitmqConsumerCount{settings: settings}
-	if settings.Enabled {
+func newMetricRabbitmqConsumerCount(cfg MetricConfig) metricRabbitmqConsumerCount {
+	m := metricRabbitmqConsumerCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -169,7 +169,7 @@ func newMetricRabbitmqConsumerCount(settings MetricSettings) metricRabbitmqConsu
 
 type metricRabbitmqMessageAcknowledged struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -184,7 +184,7 @@ func (m *metricRabbitmqMessageAcknowledged) init() {
 }
 
 func (m *metricRabbitmqMessageAcknowledged) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -202,16 +202,16 @@ func (m *metricRabbitmqMessageAcknowledged) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRabbitmqMessageAcknowledged) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRabbitmqMessageAcknowledged(settings MetricSettings) metricRabbitmqMessageAcknowledged {
-	m := metricRabbitmqMessageAcknowledged{settings: settings}
-	if settings.Enabled {
+func newMetricRabbitmqMessageAcknowledged(cfg MetricConfig) metricRabbitmqMessageAcknowledged {
+	m := metricRabbitmqMessageAcknowledged{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -220,7 +220,7 @@ func newMetricRabbitmqMessageAcknowledged(settings MetricSettings) metricRabbitm
 
 type metricRabbitmqMessageCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -236,7 +236,7 @@ func (m *metricRabbitmqMessageCurrent) init() {
 }
 
 func (m *metricRabbitmqMessageCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, messageStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -255,16 +255,16 @@ func (m *metricRabbitmqMessageCurrent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRabbitmqMessageCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRabbitmqMessageCurrent(settings MetricSettings) metricRabbitmqMessageCurrent {
-	m := metricRabbitmqMessageCurrent{settings: settings}
-	if settings.Enabled {
+func newMetricRabbitmqMessageCurrent(cfg MetricConfig) metricRabbitmqMessageCurrent {
+	m := metricRabbitmqMessageCurrent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -273,7 +273,7 @@ func newMetricRabbitmqMessageCurrent(settings MetricSettings) metricRabbitmqMess
 
 type metricRabbitmqMessageDelivered struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -288,7 +288,7 @@ func (m *metricRabbitmqMessageDelivered) init() {
 }
 
 func (m *metricRabbitmqMessageDelivered) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -306,16 +306,16 @@ func (m *metricRabbitmqMessageDelivered) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRabbitmqMessageDelivered) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRabbitmqMessageDelivered(settings MetricSettings) metricRabbitmqMessageDelivered {
-	m := metricRabbitmqMessageDelivered{settings: settings}
-	if settings.Enabled {
+func newMetricRabbitmqMessageDelivered(cfg MetricConfig) metricRabbitmqMessageDelivered {
+	m := metricRabbitmqMessageDelivered{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -324,7 +324,7 @@ func newMetricRabbitmqMessageDelivered(settings MetricSettings) metricRabbitmqMe
 
 type metricRabbitmqMessageDropped struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -339,7 +339,7 @@ func (m *metricRabbitmqMessageDropped) init() {
 }
 
 func (m *metricRabbitmqMessageDropped) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -357,16 +357,16 @@ func (m *metricRabbitmqMessageDropped) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRabbitmqMessageDropped) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRabbitmqMessageDropped(settings MetricSettings) metricRabbitmqMessageDropped {
-	m := metricRabbitmqMessageDropped{settings: settings}
-	if settings.Enabled {
+func newMetricRabbitmqMessageDropped(cfg MetricConfig) metricRabbitmqMessageDropped {
+	m := metricRabbitmqMessageDropped{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -375,7 +375,7 @@ func newMetricRabbitmqMessageDropped(settings MetricSettings) metricRabbitmqMess
 
 type metricRabbitmqMessagePublished struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -390,7 +390,7 @@ func (m *metricRabbitmqMessagePublished) init() {
 }
 
 func (m *metricRabbitmqMessagePublished) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -408,16 +408,16 @@ func (m *metricRabbitmqMessagePublished) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRabbitmqMessagePublished) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRabbitmqMessagePublished(settings MetricSettings) metricRabbitmqMessagePublished {
-	m := metricRabbitmqMessagePublished{settings: settings}
-	if settings.Enabled {
+func newMetricRabbitmqMessagePublished(cfg MetricConfig) metricRabbitmqMessagePublished {
+	m := metricRabbitmqMessagePublished{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -426,19 +426,19 @@ func newMetricRabbitmqMessagePublished(settings MetricSettings) metricRabbitmqMe
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                         pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                   int                 // maximum observed number of metrics per resource.
 	resourceCapacity                  int                 // maximum observed number of resource attributes.
 	metricsBuffer                     pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                         component.BuildInfo // contains version information
-	resourceAttributesSettings        ResourceAttributesSettings
+	resourceAttributesConfig          ResourceAttributesConfig
 	metricRabbitmqConsumerCount       metricRabbitmqConsumerCount
 	metricRabbitmqMessageAcknowledged metricRabbitmqMessageAcknowledged
 	metricRabbitmqMessageCurrent      metricRabbitmqMessageCurrent
@@ -459,8 +459,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -469,7 +469,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                         pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                     pmetric.NewMetrics(),
 		buildInfo:                         settings.BuildInfo,
-		resourceAttributesSettings:        mbc.ResourceAttributes,
+		resourceAttributesConfig:          mbc.ResourceAttributes,
 		metricRabbitmqConsumerCount:       newMetricRabbitmqConsumerCount(mbc.Metrics.RabbitmqConsumerCount),
 		metricRabbitmqMessageAcknowledged: newMetricRabbitmqMessageAcknowledged(mbc.Metrics.RabbitmqMessageAcknowledged),
 		metricRabbitmqMessageCurrent:      newMetricRabbitmqMessageCurrent(mbc.Metrics.RabbitmqMessageCurrent),
@@ -494,12 +494,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithRabbitmqNodeName sets provided value as "rabbitmq.node.name" attribute for current resource.
 func WithRabbitmqNodeName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.RabbitmqNodeName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.RabbitmqNodeName.Enabled {
 			rm.Resource().Attributes().PutStr("rabbitmq.node.name", val)
 		}
 	}
@@ -507,8 +507,8 @@ func WithRabbitmqNodeName(val string) ResourceMetricsOption {
 
 // WithRabbitmqQueueName sets provided value as "rabbitmq.queue.name" attribute for current resource.
 func WithRabbitmqQueueName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.RabbitmqQueueName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.RabbitmqQueueName.Enabled {
 			rm.Resource().Attributes().PutStr("rabbitmq.queue.name", val)
 		}
 	}
@@ -516,8 +516,8 @@ func WithRabbitmqQueueName(val string) ResourceMetricsOption {
 
 // WithRabbitmqVhostName sets provided value as "rabbitmq.vhost.name" attribute for current resource.
 func WithRabbitmqVhostName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.RabbitmqVhostName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.RabbitmqVhostName.Enabled {
 			rm.Resource().Attributes().PutStr("rabbitmq.vhost.name", val)
 		}
 	}
@@ -526,7 +526,7 @@ func WithRabbitmqVhostName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -563,7 +563,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricRabbitmqMessagePublished.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -573,7 +573,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/rabbitmqreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/rabbitmqreceiver/internal/metadata/generated_metrics_test.go
@@ -95,22 +95,22 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("rabbitmq.node.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.RabbitmqNodeName.Enabled, ok)
-			if mb.resourceAttributesSettings.RabbitmqNodeName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.RabbitmqNodeName.Enabled, ok)
+			if mb.resourceAttributesConfig.RabbitmqNodeName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("rabbitmq.queue.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.RabbitmqQueueName.Enabled, ok)
-			if mb.resourceAttributesSettings.RabbitmqQueueName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.RabbitmqQueueName.Enabled, ok)
+			if mb.resourceAttributesConfig.RabbitmqQueueName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("rabbitmq.vhost.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.RabbitmqVhostName.Enabled, ok)
-			if mb.resourceAttributesSettings.RabbitmqVhostName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.RabbitmqVhostName.Enabled, ok)
+			if mb.resourceAttributesConfig.RabbitmqVhostName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/redisreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/redisreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,160 +31,160 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for redisreceiver metrics.
-type MetricsSettings struct {
-	RedisClientsBlocked                    MetricSettings `mapstructure:"redis.clients.blocked"`
-	RedisClientsConnected                  MetricSettings `mapstructure:"redis.clients.connected"`
-	RedisClientsMaxInputBuffer             MetricSettings `mapstructure:"redis.clients.max_input_buffer"`
-	RedisClientsMaxOutputBuffer            MetricSettings `mapstructure:"redis.clients.max_output_buffer"`
-	RedisCmdCalls                          MetricSettings `mapstructure:"redis.cmd.calls"`
-	RedisCmdUsec                           MetricSettings `mapstructure:"redis.cmd.usec"`
-	RedisCommands                          MetricSettings `mapstructure:"redis.commands"`
-	RedisCommandsProcessed                 MetricSettings `mapstructure:"redis.commands.processed"`
-	RedisConnectionsReceived               MetricSettings `mapstructure:"redis.connections.received"`
-	RedisConnectionsRejected               MetricSettings `mapstructure:"redis.connections.rejected"`
-	RedisCPUTime                           MetricSettings `mapstructure:"redis.cpu.time"`
-	RedisDbAvgTTL                          MetricSettings `mapstructure:"redis.db.avg_ttl"`
-	RedisDbExpires                         MetricSettings `mapstructure:"redis.db.expires"`
-	RedisDbKeys                            MetricSettings `mapstructure:"redis.db.keys"`
-	RedisKeysEvicted                       MetricSettings `mapstructure:"redis.keys.evicted"`
-	RedisKeysExpired                       MetricSettings `mapstructure:"redis.keys.expired"`
-	RedisKeyspaceHits                      MetricSettings `mapstructure:"redis.keyspace.hits"`
-	RedisKeyspaceMisses                    MetricSettings `mapstructure:"redis.keyspace.misses"`
-	RedisLatestFork                        MetricSettings `mapstructure:"redis.latest_fork"`
-	RedisMaxmemory                         MetricSettings `mapstructure:"redis.maxmemory"`
-	RedisMemoryFragmentationRatio          MetricSettings `mapstructure:"redis.memory.fragmentation_ratio"`
-	RedisMemoryLua                         MetricSettings `mapstructure:"redis.memory.lua"`
-	RedisMemoryPeak                        MetricSettings `mapstructure:"redis.memory.peak"`
-	RedisMemoryRss                         MetricSettings `mapstructure:"redis.memory.rss"`
-	RedisMemoryUsed                        MetricSettings `mapstructure:"redis.memory.used"`
-	RedisNetInput                          MetricSettings `mapstructure:"redis.net.input"`
-	RedisNetOutput                         MetricSettings `mapstructure:"redis.net.output"`
-	RedisRdbChangesSinceLastSave           MetricSettings `mapstructure:"redis.rdb.changes_since_last_save"`
-	RedisReplicationBacklogFirstByteOffset MetricSettings `mapstructure:"redis.replication.backlog_first_byte_offset"`
-	RedisReplicationOffset                 MetricSettings `mapstructure:"redis.replication.offset"`
-	RedisRole                              MetricSettings `mapstructure:"redis.role"`
-	RedisSlavesConnected                   MetricSettings `mapstructure:"redis.slaves.connected"`
-	RedisUptime                            MetricSettings `mapstructure:"redis.uptime"`
+// MetricsConfig provides config for redisreceiver metrics.
+type MetricsConfig struct {
+	RedisClientsBlocked                    MetricConfig `mapstructure:"redis.clients.blocked"`
+	RedisClientsConnected                  MetricConfig `mapstructure:"redis.clients.connected"`
+	RedisClientsMaxInputBuffer             MetricConfig `mapstructure:"redis.clients.max_input_buffer"`
+	RedisClientsMaxOutputBuffer            MetricConfig `mapstructure:"redis.clients.max_output_buffer"`
+	RedisCmdCalls                          MetricConfig `mapstructure:"redis.cmd.calls"`
+	RedisCmdUsec                           MetricConfig `mapstructure:"redis.cmd.usec"`
+	RedisCommands                          MetricConfig `mapstructure:"redis.commands"`
+	RedisCommandsProcessed                 MetricConfig `mapstructure:"redis.commands.processed"`
+	RedisConnectionsReceived               MetricConfig `mapstructure:"redis.connections.received"`
+	RedisConnectionsRejected               MetricConfig `mapstructure:"redis.connections.rejected"`
+	RedisCPUTime                           MetricConfig `mapstructure:"redis.cpu.time"`
+	RedisDbAvgTTL                          MetricConfig `mapstructure:"redis.db.avg_ttl"`
+	RedisDbExpires                         MetricConfig `mapstructure:"redis.db.expires"`
+	RedisDbKeys                            MetricConfig `mapstructure:"redis.db.keys"`
+	RedisKeysEvicted                       MetricConfig `mapstructure:"redis.keys.evicted"`
+	RedisKeysExpired                       MetricConfig `mapstructure:"redis.keys.expired"`
+	RedisKeyspaceHits                      MetricConfig `mapstructure:"redis.keyspace.hits"`
+	RedisKeyspaceMisses                    MetricConfig `mapstructure:"redis.keyspace.misses"`
+	RedisLatestFork                        MetricConfig `mapstructure:"redis.latest_fork"`
+	RedisMaxmemory                         MetricConfig `mapstructure:"redis.maxmemory"`
+	RedisMemoryFragmentationRatio          MetricConfig `mapstructure:"redis.memory.fragmentation_ratio"`
+	RedisMemoryLua                         MetricConfig `mapstructure:"redis.memory.lua"`
+	RedisMemoryPeak                        MetricConfig `mapstructure:"redis.memory.peak"`
+	RedisMemoryRss                         MetricConfig `mapstructure:"redis.memory.rss"`
+	RedisMemoryUsed                        MetricConfig `mapstructure:"redis.memory.used"`
+	RedisNetInput                          MetricConfig `mapstructure:"redis.net.input"`
+	RedisNetOutput                         MetricConfig `mapstructure:"redis.net.output"`
+	RedisRdbChangesSinceLastSave           MetricConfig `mapstructure:"redis.rdb.changes_since_last_save"`
+	RedisReplicationBacklogFirstByteOffset MetricConfig `mapstructure:"redis.replication.backlog_first_byte_offset"`
+	RedisReplicationOffset                 MetricConfig `mapstructure:"redis.replication.offset"`
+	RedisRole                              MetricConfig `mapstructure:"redis.role"`
+	RedisSlavesConnected                   MetricConfig `mapstructure:"redis.slaves.connected"`
+	RedisUptime                            MetricConfig `mapstructure:"redis.uptime"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		RedisClientsBlocked: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		RedisClientsBlocked: MetricConfig{
 			Enabled: true,
 		},
-		RedisClientsConnected: MetricSettings{
+		RedisClientsConnected: MetricConfig{
 			Enabled: true,
 		},
-		RedisClientsMaxInputBuffer: MetricSettings{
+		RedisClientsMaxInputBuffer: MetricConfig{
 			Enabled: true,
 		},
-		RedisClientsMaxOutputBuffer: MetricSettings{
+		RedisClientsMaxOutputBuffer: MetricConfig{
 			Enabled: true,
 		},
-		RedisCmdCalls: MetricSettings{
+		RedisCmdCalls: MetricConfig{
 			Enabled: false,
 		},
-		RedisCmdUsec: MetricSettings{
+		RedisCmdUsec: MetricConfig{
 			Enabled: false,
 		},
-		RedisCommands: MetricSettings{
+		RedisCommands: MetricConfig{
 			Enabled: true,
 		},
-		RedisCommandsProcessed: MetricSettings{
+		RedisCommandsProcessed: MetricConfig{
 			Enabled: true,
 		},
-		RedisConnectionsReceived: MetricSettings{
+		RedisConnectionsReceived: MetricConfig{
 			Enabled: true,
 		},
-		RedisConnectionsRejected: MetricSettings{
+		RedisConnectionsRejected: MetricConfig{
 			Enabled: true,
 		},
-		RedisCPUTime: MetricSettings{
+		RedisCPUTime: MetricConfig{
 			Enabled: true,
 		},
-		RedisDbAvgTTL: MetricSettings{
+		RedisDbAvgTTL: MetricConfig{
 			Enabled: true,
 		},
-		RedisDbExpires: MetricSettings{
+		RedisDbExpires: MetricConfig{
 			Enabled: true,
 		},
-		RedisDbKeys: MetricSettings{
+		RedisDbKeys: MetricConfig{
 			Enabled: true,
 		},
-		RedisKeysEvicted: MetricSettings{
+		RedisKeysEvicted: MetricConfig{
 			Enabled: true,
 		},
-		RedisKeysExpired: MetricSettings{
+		RedisKeysExpired: MetricConfig{
 			Enabled: true,
 		},
-		RedisKeyspaceHits: MetricSettings{
+		RedisKeyspaceHits: MetricConfig{
 			Enabled: true,
 		},
-		RedisKeyspaceMisses: MetricSettings{
+		RedisKeyspaceMisses: MetricConfig{
 			Enabled: true,
 		},
-		RedisLatestFork: MetricSettings{
+		RedisLatestFork: MetricConfig{
 			Enabled: true,
 		},
-		RedisMaxmemory: MetricSettings{
+		RedisMaxmemory: MetricConfig{
 			Enabled: false,
 		},
-		RedisMemoryFragmentationRatio: MetricSettings{
+		RedisMemoryFragmentationRatio: MetricConfig{
 			Enabled: true,
 		},
-		RedisMemoryLua: MetricSettings{
+		RedisMemoryLua: MetricConfig{
 			Enabled: true,
 		},
-		RedisMemoryPeak: MetricSettings{
+		RedisMemoryPeak: MetricConfig{
 			Enabled: true,
 		},
-		RedisMemoryRss: MetricSettings{
+		RedisMemoryRss: MetricConfig{
 			Enabled: true,
 		},
-		RedisMemoryUsed: MetricSettings{
+		RedisMemoryUsed: MetricConfig{
 			Enabled: true,
 		},
-		RedisNetInput: MetricSettings{
+		RedisNetInput: MetricConfig{
 			Enabled: true,
 		},
-		RedisNetOutput: MetricSettings{
+		RedisNetOutput: MetricConfig{
 			Enabled: true,
 		},
-		RedisRdbChangesSinceLastSave: MetricSettings{
+		RedisRdbChangesSinceLastSave: MetricConfig{
 			Enabled: true,
 		},
-		RedisReplicationBacklogFirstByteOffset: MetricSettings{
+		RedisReplicationBacklogFirstByteOffset: MetricConfig{
 			Enabled: true,
 		},
-		RedisReplicationOffset: MetricSettings{
+		RedisReplicationOffset: MetricConfig{
 			Enabled: true,
 		},
-		RedisRole: MetricSettings{
+		RedisRole: MetricConfig{
 			Enabled: false,
 		},
-		RedisSlavesConnected: MetricSettings{
+		RedisSlavesConnected: MetricConfig{
 			Enabled: true,
 		},
-		RedisUptime: MetricSettings{
+		RedisUptime: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for redisreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	RedisVersion ResourceAttributeSettings `mapstructure:"redis.version"`
+// ResourceAttributesConfig provides config for redisreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	RedisVersion ResourceAttributeConfig `mapstructure:"redis.version"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		RedisVersion: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		RedisVersion: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -260,7 +260,7 @@ var MapAttributeState = map[string]AttributeState{
 
 type metricRedisClientsBlocked struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -275,7 +275,7 @@ func (m *metricRedisClientsBlocked) init() {
 }
 
 func (m *metricRedisClientsBlocked) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -293,16 +293,16 @@ func (m *metricRedisClientsBlocked) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisClientsBlocked) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisClientsBlocked(settings MetricSettings) metricRedisClientsBlocked {
-	m := metricRedisClientsBlocked{settings: settings}
-	if settings.Enabled {
+func newMetricRedisClientsBlocked(cfg MetricConfig) metricRedisClientsBlocked {
+	m := metricRedisClientsBlocked{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -311,7 +311,7 @@ func newMetricRedisClientsBlocked(settings MetricSettings) metricRedisClientsBlo
 
 type metricRedisClientsConnected struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -326,7 +326,7 @@ func (m *metricRedisClientsConnected) init() {
 }
 
 func (m *metricRedisClientsConnected) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -344,16 +344,16 @@ func (m *metricRedisClientsConnected) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisClientsConnected) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisClientsConnected(settings MetricSettings) metricRedisClientsConnected {
-	m := metricRedisClientsConnected{settings: settings}
-	if settings.Enabled {
+func newMetricRedisClientsConnected(cfg MetricConfig) metricRedisClientsConnected {
+	m := metricRedisClientsConnected{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -362,7 +362,7 @@ func newMetricRedisClientsConnected(settings MetricSettings) metricRedisClientsC
 
 type metricRedisClientsMaxInputBuffer struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -375,7 +375,7 @@ func (m *metricRedisClientsMaxInputBuffer) init() {
 }
 
 func (m *metricRedisClientsMaxInputBuffer) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -393,16 +393,16 @@ func (m *metricRedisClientsMaxInputBuffer) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisClientsMaxInputBuffer) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisClientsMaxInputBuffer(settings MetricSettings) metricRedisClientsMaxInputBuffer {
-	m := metricRedisClientsMaxInputBuffer{settings: settings}
-	if settings.Enabled {
+func newMetricRedisClientsMaxInputBuffer(cfg MetricConfig) metricRedisClientsMaxInputBuffer {
+	m := metricRedisClientsMaxInputBuffer{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -411,7 +411,7 @@ func newMetricRedisClientsMaxInputBuffer(settings MetricSettings) metricRedisCli
 
 type metricRedisClientsMaxOutputBuffer struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -424,7 +424,7 @@ func (m *metricRedisClientsMaxOutputBuffer) init() {
 }
 
 func (m *metricRedisClientsMaxOutputBuffer) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -442,16 +442,16 @@ func (m *metricRedisClientsMaxOutputBuffer) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisClientsMaxOutputBuffer) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisClientsMaxOutputBuffer(settings MetricSettings) metricRedisClientsMaxOutputBuffer {
-	m := metricRedisClientsMaxOutputBuffer{settings: settings}
-	if settings.Enabled {
+func newMetricRedisClientsMaxOutputBuffer(cfg MetricConfig) metricRedisClientsMaxOutputBuffer {
+	m := metricRedisClientsMaxOutputBuffer{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -460,7 +460,7 @@ func newMetricRedisClientsMaxOutputBuffer(settings MetricSettings) metricRedisCl
 
 type metricRedisCmdCalls struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -476,7 +476,7 @@ func (m *metricRedisCmdCalls) init() {
 }
 
 func (m *metricRedisCmdCalls) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cmdAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -495,16 +495,16 @@ func (m *metricRedisCmdCalls) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisCmdCalls) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisCmdCalls(settings MetricSettings) metricRedisCmdCalls {
-	m := metricRedisCmdCalls{settings: settings}
-	if settings.Enabled {
+func newMetricRedisCmdCalls(cfg MetricConfig) metricRedisCmdCalls {
+	m := metricRedisCmdCalls{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -513,7 +513,7 @@ func newMetricRedisCmdCalls(settings MetricSettings) metricRedisCmdCalls {
 
 type metricRedisCmdUsec struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -529,7 +529,7 @@ func (m *metricRedisCmdUsec) init() {
 }
 
 func (m *metricRedisCmdUsec) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cmdAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -548,16 +548,16 @@ func (m *metricRedisCmdUsec) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisCmdUsec) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisCmdUsec(settings MetricSettings) metricRedisCmdUsec {
-	m := metricRedisCmdUsec{settings: settings}
-	if settings.Enabled {
+func newMetricRedisCmdUsec(cfg MetricConfig) metricRedisCmdUsec {
+	m := metricRedisCmdUsec{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -566,7 +566,7 @@ func newMetricRedisCmdUsec(settings MetricSettings) metricRedisCmdUsec {
 
 type metricRedisCommands struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -579,7 +579,7 @@ func (m *metricRedisCommands) init() {
 }
 
 func (m *metricRedisCommands) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -597,16 +597,16 @@ func (m *metricRedisCommands) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisCommands) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisCommands(settings MetricSettings) metricRedisCommands {
-	m := metricRedisCommands{settings: settings}
-	if settings.Enabled {
+func newMetricRedisCommands(cfg MetricConfig) metricRedisCommands {
+	m := metricRedisCommands{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -615,7 +615,7 @@ func newMetricRedisCommands(settings MetricSettings) metricRedisCommands {
 
 type metricRedisCommandsProcessed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -630,7 +630,7 @@ func (m *metricRedisCommandsProcessed) init() {
 }
 
 func (m *metricRedisCommandsProcessed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -648,16 +648,16 @@ func (m *metricRedisCommandsProcessed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisCommandsProcessed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisCommandsProcessed(settings MetricSettings) metricRedisCommandsProcessed {
-	m := metricRedisCommandsProcessed{settings: settings}
-	if settings.Enabled {
+func newMetricRedisCommandsProcessed(cfg MetricConfig) metricRedisCommandsProcessed {
+	m := metricRedisCommandsProcessed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -666,7 +666,7 @@ func newMetricRedisCommandsProcessed(settings MetricSettings) metricRedisCommand
 
 type metricRedisConnectionsReceived struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -681,7 +681,7 @@ func (m *metricRedisConnectionsReceived) init() {
 }
 
 func (m *metricRedisConnectionsReceived) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -699,16 +699,16 @@ func (m *metricRedisConnectionsReceived) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisConnectionsReceived) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisConnectionsReceived(settings MetricSettings) metricRedisConnectionsReceived {
-	m := metricRedisConnectionsReceived{settings: settings}
-	if settings.Enabled {
+func newMetricRedisConnectionsReceived(cfg MetricConfig) metricRedisConnectionsReceived {
+	m := metricRedisConnectionsReceived{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -717,7 +717,7 @@ func newMetricRedisConnectionsReceived(settings MetricSettings) metricRedisConne
 
 type metricRedisConnectionsRejected struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -732,7 +732,7 @@ func (m *metricRedisConnectionsRejected) init() {
 }
 
 func (m *metricRedisConnectionsRejected) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -750,16 +750,16 @@ func (m *metricRedisConnectionsRejected) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisConnectionsRejected) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisConnectionsRejected(settings MetricSettings) metricRedisConnectionsRejected {
-	m := metricRedisConnectionsRejected{settings: settings}
-	if settings.Enabled {
+func newMetricRedisConnectionsRejected(cfg MetricConfig) metricRedisConnectionsRejected {
+	m := metricRedisConnectionsRejected{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -768,7 +768,7 @@ func newMetricRedisConnectionsRejected(settings MetricSettings) metricRedisConne
 
 type metricRedisCPUTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -784,7 +784,7 @@ func (m *metricRedisCPUTime) init() {
 }
 
 func (m *metricRedisCPUTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -803,16 +803,16 @@ func (m *metricRedisCPUTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisCPUTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisCPUTime(settings MetricSettings) metricRedisCPUTime {
-	m := metricRedisCPUTime{settings: settings}
-	if settings.Enabled {
+func newMetricRedisCPUTime(cfg MetricConfig) metricRedisCPUTime {
+	m := metricRedisCPUTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -821,7 +821,7 @@ func newMetricRedisCPUTime(settings MetricSettings) metricRedisCPUTime {
 
 type metricRedisDbAvgTTL struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -835,7 +835,7 @@ func (m *metricRedisDbAvgTTL) init() {
 }
 
 func (m *metricRedisDbAvgTTL) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -854,16 +854,16 @@ func (m *metricRedisDbAvgTTL) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisDbAvgTTL) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisDbAvgTTL(settings MetricSettings) metricRedisDbAvgTTL {
-	m := metricRedisDbAvgTTL{settings: settings}
-	if settings.Enabled {
+func newMetricRedisDbAvgTTL(cfg MetricConfig) metricRedisDbAvgTTL {
+	m := metricRedisDbAvgTTL{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -872,7 +872,7 @@ func newMetricRedisDbAvgTTL(settings MetricSettings) metricRedisDbAvgTTL {
 
 type metricRedisDbExpires struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -886,7 +886,7 @@ func (m *metricRedisDbExpires) init() {
 }
 
 func (m *metricRedisDbExpires) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -905,16 +905,16 @@ func (m *metricRedisDbExpires) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisDbExpires) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisDbExpires(settings MetricSettings) metricRedisDbExpires {
-	m := metricRedisDbExpires{settings: settings}
-	if settings.Enabled {
+func newMetricRedisDbExpires(cfg MetricConfig) metricRedisDbExpires {
+	m := metricRedisDbExpires{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -923,7 +923,7 @@ func newMetricRedisDbExpires(settings MetricSettings) metricRedisDbExpires {
 
 type metricRedisDbKeys struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -937,7 +937,7 @@ func (m *metricRedisDbKeys) init() {
 }
 
 func (m *metricRedisDbKeys) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, dbAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -956,16 +956,16 @@ func (m *metricRedisDbKeys) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisDbKeys) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisDbKeys(settings MetricSettings) metricRedisDbKeys {
-	m := metricRedisDbKeys{settings: settings}
-	if settings.Enabled {
+func newMetricRedisDbKeys(cfg MetricConfig) metricRedisDbKeys {
+	m := metricRedisDbKeys{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -974,7 +974,7 @@ func newMetricRedisDbKeys(settings MetricSettings) metricRedisDbKeys {
 
 type metricRedisKeysEvicted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -989,7 +989,7 @@ func (m *metricRedisKeysEvicted) init() {
 }
 
 func (m *metricRedisKeysEvicted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1007,16 +1007,16 @@ func (m *metricRedisKeysEvicted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisKeysEvicted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisKeysEvicted(settings MetricSettings) metricRedisKeysEvicted {
-	m := metricRedisKeysEvicted{settings: settings}
-	if settings.Enabled {
+func newMetricRedisKeysEvicted(cfg MetricConfig) metricRedisKeysEvicted {
+	m := metricRedisKeysEvicted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1025,7 +1025,7 @@ func newMetricRedisKeysEvicted(settings MetricSettings) metricRedisKeysEvicted {
 
 type metricRedisKeysExpired struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1040,7 +1040,7 @@ func (m *metricRedisKeysExpired) init() {
 }
 
 func (m *metricRedisKeysExpired) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1058,16 +1058,16 @@ func (m *metricRedisKeysExpired) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisKeysExpired) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisKeysExpired(settings MetricSettings) metricRedisKeysExpired {
-	m := metricRedisKeysExpired{settings: settings}
-	if settings.Enabled {
+func newMetricRedisKeysExpired(cfg MetricConfig) metricRedisKeysExpired {
+	m := metricRedisKeysExpired{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1076,7 +1076,7 @@ func newMetricRedisKeysExpired(settings MetricSettings) metricRedisKeysExpired {
 
 type metricRedisKeyspaceHits struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1091,7 +1091,7 @@ func (m *metricRedisKeyspaceHits) init() {
 }
 
 func (m *metricRedisKeyspaceHits) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1109,16 +1109,16 @@ func (m *metricRedisKeyspaceHits) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisKeyspaceHits) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisKeyspaceHits(settings MetricSettings) metricRedisKeyspaceHits {
-	m := metricRedisKeyspaceHits{settings: settings}
-	if settings.Enabled {
+func newMetricRedisKeyspaceHits(cfg MetricConfig) metricRedisKeyspaceHits {
+	m := metricRedisKeyspaceHits{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1127,7 +1127,7 @@ func newMetricRedisKeyspaceHits(settings MetricSettings) metricRedisKeyspaceHits
 
 type metricRedisKeyspaceMisses struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1142,7 +1142,7 @@ func (m *metricRedisKeyspaceMisses) init() {
 }
 
 func (m *metricRedisKeyspaceMisses) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1160,16 +1160,16 @@ func (m *metricRedisKeyspaceMisses) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisKeyspaceMisses) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisKeyspaceMisses(settings MetricSettings) metricRedisKeyspaceMisses {
-	m := metricRedisKeyspaceMisses{settings: settings}
-	if settings.Enabled {
+func newMetricRedisKeyspaceMisses(cfg MetricConfig) metricRedisKeyspaceMisses {
+	m := metricRedisKeyspaceMisses{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1178,7 +1178,7 @@ func newMetricRedisKeyspaceMisses(settings MetricSettings) metricRedisKeyspaceMi
 
 type metricRedisLatestFork struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1191,7 +1191,7 @@ func (m *metricRedisLatestFork) init() {
 }
 
 func (m *metricRedisLatestFork) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1209,16 +1209,16 @@ func (m *metricRedisLatestFork) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisLatestFork) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisLatestFork(settings MetricSettings) metricRedisLatestFork {
-	m := metricRedisLatestFork{settings: settings}
-	if settings.Enabled {
+func newMetricRedisLatestFork(cfg MetricConfig) metricRedisLatestFork {
+	m := metricRedisLatestFork{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1227,7 +1227,7 @@ func newMetricRedisLatestFork(settings MetricSettings) metricRedisLatestFork {
 
 type metricRedisMaxmemory struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1240,7 +1240,7 @@ func (m *metricRedisMaxmemory) init() {
 }
 
 func (m *metricRedisMaxmemory) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1258,16 +1258,16 @@ func (m *metricRedisMaxmemory) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisMaxmemory) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisMaxmemory(settings MetricSettings) metricRedisMaxmemory {
-	m := metricRedisMaxmemory{settings: settings}
-	if settings.Enabled {
+func newMetricRedisMaxmemory(cfg MetricConfig) metricRedisMaxmemory {
+	m := metricRedisMaxmemory{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1276,7 +1276,7 @@ func newMetricRedisMaxmemory(settings MetricSettings) metricRedisMaxmemory {
 
 type metricRedisMemoryFragmentationRatio struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1289,7 +1289,7 @@ func (m *metricRedisMemoryFragmentationRatio) init() {
 }
 
 func (m *metricRedisMemoryFragmentationRatio) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1307,16 +1307,16 @@ func (m *metricRedisMemoryFragmentationRatio) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisMemoryFragmentationRatio) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisMemoryFragmentationRatio(settings MetricSettings) metricRedisMemoryFragmentationRatio {
-	m := metricRedisMemoryFragmentationRatio{settings: settings}
-	if settings.Enabled {
+func newMetricRedisMemoryFragmentationRatio(cfg MetricConfig) metricRedisMemoryFragmentationRatio {
+	m := metricRedisMemoryFragmentationRatio{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1325,7 +1325,7 @@ func newMetricRedisMemoryFragmentationRatio(settings MetricSettings) metricRedis
 
 type metricRedisMemoryLua struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1338,7 +1338,7 @@ func (m *metricRedisMemoryLua) init() {
 }
 
 func (m *metricRedisMemoryLua) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1356,16 +1356,16 @@ func (m *metricRedisMemoryLua) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisMemoryLua) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisMemoryLua(settings MetricSettings) metricRedisMemoryLua {
-	m := metricRedisMemoryLua{settings: settings}
-	if settings.Enabled {
+func newMetricRedisMemoryLua(cfg MetricConfig) metricRedisMemoryLua {
+	m := metricRedisMemoryLua{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1374,7 +1374,7 @@ func newMetricRedisMemoryLua(settings MetricSettings) metricRedisMemoryLua {
 
 type metricRedisMemoryPeak struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1387,7 +1387,7 @@ func (m *metricRedisMemoryPeak) init() {
 }
 
 func (m *metricRedisMemoryPeak) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1405,16 +1405,16 @@ func (m *metricRedisMemoryPeak) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisMemoryPeak) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisMemoryPeak(settings MetricSettings) metricRedisMemoryPeak {
-	m := metricRedisMemoryPeak{settings: settings}
-	if settings.Enabled {
+func newMetricRedisMemoryPeak(cfg MetricConfig) metricRedisMemoryPeak {
+	m := metricRedisMemoryPeak{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1423,7 +1423,7 @@ func newMetricRedisMemoryPeak(settings MetricSettings) metricRedisMemoryPeak {
 
 type metricRedisMemoryRss struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1436,7 +1436,7 @@ func (m *metricRedisMemoryRss) init() {
 }
 
 func (m *metricRedisMemoryRss) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1454,16 +1454,16 @@ func (m *metricRedisMemoryRss) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisMemoryRss) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisMemoryRss(settings MetricSettings) metricRedisMemoryRss {
-	m := metricRedisMemoryRss{settings: settings}
-	if settings.Enabled {
+func newMetricRedisMemoryRss(cfg MetricConfig) metricRedisMemoryRss {
+	m := metricRedisMemoryRss{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1472,7 +1472,7 @@ func newMetricRedisMemoryRss(settings MetricSettings) metricRedisMemoryRss {
 
 type metricRedisMemoryUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1485,7 +1485,7 @@ func (m *metricRedisMemoryUsed) init() {
 }
 
 func (m *metricRedisMemoryUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1503,16 +1503,16 @@ func (m *metricRedisMemoryUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisMemoryUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisMemoryUsed(settings MetricSettings) metricRedisMemoryUsed {
-	m := metricRedisMemoryUsed{settings: settings}
-	if settings.Enabled {
+func newMetricRedisMemoryUsed(cfg MetricConfig) metricRedisMemoryUsed {
+	m := metricRedisMemoryUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1521,7 +1521,7 @@ func newMetricRedisMemoryUsed(settings MetricSettings) metricRedisMemoryUsed {
 
 type metricRedisNetInput struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1536,7 +1536,7 @@ func (m *metricRedisNetInput) init() {
 }
 
 func (m *metricRedisNetInput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1554,16 +1554,16 @@ func (m *metricRedisNetInput) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisNetInput) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisNetInput(settings MetricSettings) metricRedisNetInput {
-	m := metricRedisNetInput{settings: settings}
-	if settings.Enabled {
+func newMetricRedisNetInput(cfg MetricConfig) metricRedisNetInput {
+	m := metricRedisNetInput{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1572,7 +1572,7 @@ func newMetricRedisNetInput(settings MetricSettings) metricRedisNetInput {
 
 type metricRedisNetOutput struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1587,7 +1587,7 @@ func (m *metricRedisNetOutput) init() {
 }
 
 func (m *metricRedisNetOutput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1605,16 +1605,16 @@ func (m *metricRedisNetOutput) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisNetOutput) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisNetOutput(settings MetricSettings) metricRedisNetOutput {
-	m := metricRedisNetOutput{settings: settings}
-	if settings.Enabled {
+func newMetricRedisNetOutput(cfg MetricConfig) metricRedisNetOutput {
+	m := metricRedisNetOutput{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1623,7 +1623,7 @@ func newMetricRedisNetOutput(settings MetricSettings) metricRedisNetOutput {
 
 type metricRedisRdbChangesSinceLastSave struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1638,7 +1638,7 @@ func (m *metricRedisRdbChangesSinceLastSave) init() {
 }
 
 func (m *metricRedisRdbChangesSinceLastSave) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1656,16 +1656,16 @@ func (m *metricRedisRdbChangesSinceLastSave) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisRdbChangesSinceLastSave) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisRdbChangesSinceLastSave(settings MetricSettings) metricRedisRdbChangesSinceLastSave {
-	m := metricRedisRdbChangesSinceLastSave{settings: settings}
-	if settings.Enabled {
+func newMetricRedisRdbChangesSinceLastSave(cfg MetricConfig) metricRedisRdbChangesSinceLastSave {
+	m := metricRedisRdbChangesSinceLastSave{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1674,7 +1674,7 @@ func newMetricRedisRdbChangesSinceLastSave(settings MetricSettings) metricRedisR
 
 type metricRedisReplicationBacklogFirstByteOffset struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1687,7 +1687,7 @@ func (m *metricRedisReplicationBacklogFirstByteOffset) init() {
 }
 
 func (m *metricRedisReplicationBacklogFirstByteOffset) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1705,16 +1705,16 @@ func (m *metricRedisReplicationBacklogFirstByteOffset) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisReplicationBacklogFirstByteOffset) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisReplicationBacklogFirstByteOffset(settings MetricSettings) metricRedisReplicationBacklogFirstByteOffset {
-	m := metricRedisReplicationBacklogFirstByteOffset{settings: settings}
-	if settings.Enabled {
+func newMetricRedisReplicationBacklogFirstByteOffset(cfg MetricConfig) metricRedisReplicationBacklogFirstByteOffset {
+	m := metricRedisReplicationBacklogFirstByteOffset{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1723,7 +1723,7 @@ func newMetricRedisReplicationBacklogFirstByteOffset(settings MetricSettings) me
 
 type metricRedisReplicationOffset struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1736,7 +1736,7 @@ func (m *metricRedisReplicationOffset) init() {
 }
 
 func (m *metricRedisReplicationOffset) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1754,16 +1754,16 @@ func (m *metricRedisReplicationOffset) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisReplicationOffset) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisReplicationOffset(settings MetricSettings) metricRedisReplicationOffset {
-	m := metricRedisReplicationOffset{settings: settings}
-	if settings.Enabled {
+func newMetricRedisReplicationOffset(cfg MetricConfig) metricRedisReplicationOffset {
+	m := metricRedisReplicationOffset{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1772,7 +1772,7 @@ func newMetricRedisReplicationOffset(settings MetricSettings) metricRedisReplica
 
 type metricRedisRole struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1788,7 +1788,7 @@ func (m *metricRedisRole) init() {
 }
 
 func (m *metricRedisRole) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, roleAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1807,16 +1807,16 @@ func (m *metricRedisRole) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisRole) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisRole(settings MetricSettings) metricRedisRole {
-	m := metricRedisRole{settings: settings}
-	if settings.Enabled {
+func newMetricRedisRole(cfg MetricConfig) metricRedisRole {
+	m := metricRedisRole{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1825,7 +1825,7 @@ func newMetricRedisRole(settings MetricSettings) metricRedisRole {
 
 type metricRedisSlavesConnected struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1840,7 +1840,7 @@ func (m *metricRedisSlavesConnected) init() {
 }
 
 func (m *metricRedisSlavesConnected) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1858,16 +1858,16 @@ func (m *metricRedisSlavesConnected) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisSlavesConnected) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisSlavesConnected(settings MetricSettings) metricRedisSlavesConnected {
-	m := metricRedisSlavesConnected{settings: settings}
-	if settings.Enabled {
+func newMetricRedisSlavesConnected(cfg MetricConfig) metricRedisSlavesConnected {
+	m := metricRedisSlavesConnected{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1876,7 +1876,7 @@ func newMetricRedisSlavesConnected(settings MetricSettings) metricRedisSlavesCon
 
 type metricRedisUptime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1891,7 +1891,7 @@ func (m *metricRedisUptime) init() {
 }
 
 func (m *metricRedisUptime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1909,16 +1909,16 @@ func (m *metricRedisUptime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRedisUptime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRedisUptime(settings MetricSettings) metricRedisUptime {
-	m := metricRedisUptime{settings: settings}
-	if settings.Enabled {
+func newMetricRedisUptime(cfg MetricConfig) metricRedisUptime {
+	m := metricRedisUptime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1927,19 +1927,19 @@ func newMetricRedisUptime(settings MetricSettings) metricRedisUptime {
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                    pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                              int                 // maximum observed number of metrics per resource.
 	resourceCapacity                             int                 // maximum observed number of resource attributes.
 	metricsBuffer                                pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                                    component.BuildInfo // contains version information
-	resourceAttributesSettings                   ResourceAttributesSettings
+	resourceAttributesConfig                     ResourceAttributesConfig
 	metricRedisClientsBlocked                    metricRedisClientsBlocked
 	metricRedisClientsConnected                  metricRedisClientsConnected
 	metricRedisClientsMaxInputBuffer             metricRedisClientsMaxInputBuffer
@@ -1987,8 +1987,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -1997,7 +1997,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                                    pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                                pmetric.NewMetrics(),
 		buildInfo:                                    settings.BuildInfo,
-		resourceAttributesSettings:                   mbc.ResourceAttributes,
+		resourceAttributesConfig:                     mbc.ResourceAttributes,
 		metricRedisClientsBlocked:                    newMetricRedisClientsBlocked(mbc.Metrics.RedisClientsBlocked),
 		metricRedisClientsConnected:                  newMetricRedisClientsConnected(mbc.Metrics.RedisClientsConnected),
 		metricRedisClientsMaxInputBuffer:             newMetricRedisClientsMaxInputBuffer(mbc.Metrics.RedisClientsMaxInputBuffer),
@@ -2049,12 +2049,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithRedisVersion sets provided value as "redis.version" attribute for current resource.
 func WithRedisVersion(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.RedisVersion.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.RedisVersion.Enabled {
 			rm.Resource().Attributes().PutStr("redis.version", val)
 		}
 	}
@@ -2063,7 +2063,7 @@ func WithRedisVersion(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -2127,7 +2127,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricRedisUptime.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -2137,7 +2137,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/redisreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/redisreceiver/internal/metadata/generated_metrics_test.go
@@ -199,8 +199,8 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("redis.version")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.RedisVersion.Enabled, ok)
-			if mb.resourceAttributesSettings.RedisVersion.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.RedisVersion.Enabled, ok)
+			if mb.resourceAttributesConfig.RedisVersion.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/riakreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/riakreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,52 +31,52 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for riakreceiver metrics.
-type MetricsSettings struct {
-	RiakMemoryLimit              MetricSettings `mapstructure:"riak.memory.limit"`
-	RiakNodeOperationCount       MetricSettings `mapstructure:"riak.node.operation.count"`
-	RiakNodeOperationTimeMean    MetricSettings `mapstructure:"riak.node.operation.time.mean"`
-	RiakNodeReadRepairCount      MetricSettings `mapstructure:"riak.node.read_repair.count"`
-	RiakVnodeIndexOperationCount MetricSettings `mapstructure:"riak.vnode.index.operation.count"`
-	RiakVnodeOperationCount      MetricSettings `mapstructure:"riak.vnode.operation.count"`
+// MetricsConfig provides config for riakreceiver metrics.
+type MetricsConfig struct {
+	RiakMemoryLimit              MetricConfig `mapstructure:"riak.memory.limit"`
+	RiakNodeOperationCount       MetricConfig `mapstructure:"riak.node.operation.count"`
+	RiakNodeOperationTimeMean    MetricConfig `mapstructure:"riak.node.operation.time.mean"`
+	RiakNodeReadRepairCount      MetricConfig `mapstructure:"riak.node.read_repair.count"`
+	RiakVnodeIndexOperationCount MetricConfig `mapstructure:"riak.vnode.index.operation.count"`
+	RiakVnodeOperationCount      MetricConfig `mapstructure:"riak.vnode.operation.count"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		RiakMemoryLimit: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		RiakMemoryLimit: MetricConfig{
 			Enabled: true,
 		},
-		RiakNodeOperationCount: MetricSettings{
+		RiakNodeOperationCount: MetricConfig{
 			Enabled: true,
 		},
-		RiakNodeOperationTimeMean: MetricSettings{
+		RiakNodeOperationTimeMean: MetricConfig{
 			Enabled: true,
 		},
-		RiakNodeReadRepairCount: MetricSettings{
+		RiakNodeReadRepairCount: MetricConfig{
 			Enabled: true,
 		},
-		RiakVnodeIndexOperationCount: MetricSettings{
+		RiakVnodeIndexOperationCount: MetricConfig{
 			Enabled: true,
 		},
-		RiakVnodeOperationCount: MetricSettings{
+		RiakVnodeOperationCount: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for riakreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	RiakNodeName ResourceAttributeSettings `mapstructure:"riak.node.name"`
+// ResourceAttributesConfig provides config for riakreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	RiakNodeName ResourceAttributeConfig `mapstructure:"riak.node.name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		RiakNodeName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		RiakNodeName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -140,7 +140,7 @@ var MapAttributeRequest = map[string]AttributeRequest{
 
 type metricRiakMemoryLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -155,7 +155,7 @@ func (m *metricRiakMemoryLimit) init() {
 }
 
 func (m *metricRiakMemoryLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -173,16 +173,16 @@ func (m *metricRiakMemoryLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRiakMemoryLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRiakMemoryLimit(settings MetricSettings) metricRiakMemoryLimit {
-	m := metricRiakMemoryLimit{settings: settings}
-	if settings.Enabled {
+func newMetricRiakMemoryLimit(cfg MetricConfig) metricRiakMemoryLimit {
+	m := metricRiakMemoryLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -191,7 +191,7 @@ func newMetricRiakMemoryLimit(settings MetricSettings) metricRiakMemoryLimit {
 
 type metricRiakNodeOperationCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -207,7 +207,7 @@ func (m *metricRiakNodeOperationCount) init() {
 }
 
 func (m *metricRiakNodeOperationCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, requestAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -226,16 +226,16 @@ func (m *metricRiakNodeOperationCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRiakNodeOperationCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRiakNodeOperationCount(settings MetricSettings) metricRiakNodeOperationCount {
-	m := metricRiakNodeOperationCount{settings: settings}
-	if settings.Enabled {
+func newMetricRiakNodeOperationCount(cfg MetricConfig) metricRiakNodeOperationCount {
+	m := metricRiakNodeOperationCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -244,7 +244,7 @@ func newMetricRiakNodeOperationCount(settings MetricSettings) metricRiakNodeOper
 
 type metricRiakNodeOperationTimeMean struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -258,7 +258,7 @@ func (m *metricRiakNodeOperationTimeMean) init() {
 }
 
 func (m *metricRiakNodeOperationTimeMean) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, requestAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -277,16 +277,16 @@ func (m *metricRiakNodeOperationTimeMean) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRiakNodeOperationTimeMean) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRiakNodeOperationTimeMean(settings MetricSettings) metricRiakNodeOperationTimeMean {
-	m := metricRiakNodeOperationTimeMean{settings: settings}
-	if settings.Enabled {
+func newMetricRiakNodeOperationTimeMean(cfg MetricConfig) metricRiakNodeOperationTimeMean {
+	m := metricRiakNodeOperationTimeMean{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -295,7 +295,7 @@ func newMetricRiakNodeOperationTimeMean(settings MetricSettings) metricRiakNodeO
 
 type metricRiakNodeReadRepairCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -310,7 +310,7 @@ func (m *metricRiakNodeReadRepairCount) init() {
 }
 
 func (m *metricRiakNodeReadRepairCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -328,16 +328,16 @@ func (m *metricRiakNodeReadRepairCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRiakNodeReadRepairCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRiakNodeReadRepairCount(settings MetricSettings) metricRiakNodeReadRepairCount {
-	m := metricRiakNodeReadRepairCount{settings: settings}
-	if settings.Enabled {
+func newMetricRiakNodeReadRepairCount(cfg MetricConfig) metricRiakNodeReadRepairCount {
+	m := metricRiakNodeReadRepairCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -346,7 +346,7 @@ func newMetricRiakNodeReadRepairCount(settings MetricSettings) metricRiakNodeRea
 
 type metricRiakVnodeIndexOperationCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -362,7 +362,7 @@ func (m *metricRiakVnodeIndexOperationCount) init() {
 }
 
 func (m *metricRiakVnodeIndexOperationCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, operationAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -381,16 +381,16 @@ func (m *metricRiakVnodeIndexOperationCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRiakVnodeIndexOperationCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRiakVnodeIndexOperationCount(settings MetricSettings) metricRiakVnodeIndexOperationCount {
-	m := metricRiakVnodeIndexOperationCount{settings: settings}
-	if settings.Enabled {
+func newMetricRiakVnodeIndexOperationCount(cfg MetricConfig) metricRiakVnodeIndexOperationCount {
+	m := metricRiakVnodeIndexOperationCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -399,7 +399,7 @@ func newMetricRiakVnodeIndexOperationCount(settings MetricSettings) metricRiakVn
 
 type metricRiakVnodeOperationCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -415,7 +415,7 @@ func (m *metricRiakVnodeOperationCount) init() {
 }
 
 func (m *metricRiakVnodeOperationCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, requestAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -434,16 +434,16 @@ func (m *metricRiakVnodeOperationCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricRiakVnodeOperationCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricRiakVnodeOperationCount(settings MetricSettings) metricRiakVnodeOperationCount {
-	m := metricRiakVnodeOperationCount{settings: settings}
-	if settings.Enabled {
+func newMetricRiakVnodeOperationCount(cfg MetricConfig) metricRiakVnodeOperationCount {
+	m := metricRiakVnodeOperationCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -452,19 +452,19 @@ func newMetricRiakVnodeOperationCount(settings MetricSettings) metricRiakVnodeOp
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                          pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                    int                 // maximum observed number of metrics per resource.
 	resourceCapacity                   int                 // maximum observed number of resource attributes.
 	metricsBuffer                      pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                          component.BuildInfo // contains version information
-	resourceAttributesSettings         ResourceAttributesSettings
+	resourceAttributesConfig           ResourceAttributesConfig
 	metricRiakMemoryLimit              metricRiakMemoryLimit
 	metricRiakNodeOperationCount       metricRiakNodeOperationCount
 	metricRiakNodeOperationTimeMean    metricRiakNodeOperationTimeMean
@@ -485,8 +485,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -495,7 +495,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                          pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                      pmetric.NewMetrics(),
 		buildInfo:                          settings.BuildInfo,
-		resourceAttributesSettings:         mbc.ResourceAttributes,
+		resourceAttributesConfig:           mbc.ResourceAttributes,
 		metricRiakMemoryLimit:              newMetricRiakMemoryLimit(mbc.Metrics.RiakMemoryLimit),
 		metricRiakNodeOperationCount:       newMetricRiakNodeOperationCount(mbc.Metrics.RiakNodeOperationCount),
 		metricRiakNodeOperationTimeMean:    newMetricRiakNodeOperationTimeMean(mbc.Metrics.RiakNodeOperationTimeMean),
@@ -520,12 +520,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithRiakNodeName sets provided value as "riak.node.name" attribute for current resource.
 func WithRiakNodeName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.RiakNodeName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.RiakNodeName.Enabled {
 			rm.Resource().Attributes().PutStr("riak.node.name", val)
 		}
 	}
@@ -534,7 +534,7 @@ func WithRiakNodeName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -571,7 +571,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricRiakVnodeOperationCount.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -581,7 +581,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/riakreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/riakreceiver/internal/metadata/generated_metrics_test.go
@@ -95,8 +95,8 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("riak.node.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.RiakNodeName.Enabled, ok)
-			if mb.resourceAttributesSettings.RiakNodeName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.RiakNodeName.Enabled, ok)
+			if mb.resourceAttributesConfig.RiakNodeName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/riakreceiver/scraper_test.go
+++ b/receiver/riakreceiver/scraper_test.go
@@ -145,23 +145,23 @@ func TestScaperScrape(t *testing.T) {
 			},
 			setupCfg: func() *Config {
 				cfg := createDefaultConfig().(*Config)
-				cfg.MetricsBuilderConfig.Metrics = metadata.MetricsSettings{
-					RiakMemoryLimit: metadata.MetricSettings{
+				cfg.MetricsBuilderConfig.Metrics = metadata.MetricsConfig{
+					RiakMemoryLimit: metadata.MetricConfig{
 						Enabled: false,
 					},
-					RiakNodeOperationCount: metadata.MetricSettings{
+					RiakNodeOperationCount: metadata.MetricConfig{
 						Enabled: false,
 					},
-					RiakNodeOperationTimeMean: metadata.MetricSettings{
+					RiakNodeOperationTimeMean: metadata.MetricConfig{
 						Enabled: true,
 					},
-					RiakNodeReadRepairCount: metadata.MetricSettings{
+					RiakNodeReadRepairCount: metadata.MetricConfig{
 						Enabled: true,
 					},
-					RiakVnodeIndexOperationCount: metadata.MetricSettings{
+					RiakVnodeIndexOperationCount: metadata.MetricConfig{
 						Enabled: true,
 					},
-					RiakVnodeOperationCount: metadata.MetricSettings{
+					RiakVnodeOperationCount: metadata.MetricConfig{
 						Enabled: true,
 					},
 				}

--- a/receiver/saphanareceiver/config_test.go
+++ b/receiver/saphanareceiver/config_test.go
@@ -101,7 +101,7 @@ func TestLoadConfig(t *testing.T) {
 	expected.Password = "password"
 	expected.CollectionInterval = 2 * time.Minute
 
-	if diff := cmp.Diff(expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricSettings{})); diff != "" {
+	if diff := cmp.Diff(expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricConfig{})); diff != "" {
 		t.Errorf("Config mismatch (-expected +actual):\n%s", diff)
 	}
 

--- a/receiver/saphanareceiver/internal/metadata/generated_metrics.go
+++ b/receiver/saphanareceiver/internal/metadata/generated_metrics.go
@@ -14,14 +14,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -33,212 +33,212 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for saphanareceiver metrics.
-type MetricsSettings struct {
-	SaphanaAlertCount                       MetricSettings `mapstructure:"saphana.alert.count"`
-	SaphanaBackupLatest                     MetricSettings `mapstructure:"saphana.backup.latest"`
-	SaphanaColumnMemoryUsed                 MetricSettings `mapstructure:"saphana.column.memory.used"`
-	SaphanaComponentMemoryUsed              MetricSettings `mapstructure:"saphana.component.memory.used"`
-	SaphanaConnectionCount                  MetricSettings `mapstructure:"saphana.connection.count"`
-	SaphanaCPUUsed                          MetricSettings `mapstructure:"saphana.cpu.used"`
-	SaphanaDiskSizeCurrent                  MetricSettings `mapstructure:"saphana.disk.size.current"`
-	SaphanaHostMemoryCurrent                MetricSettings `mapstructure:"saphana.host.memory.current"`
-	SaphanaHostSwapCurrent                  MetricSettings `mapstructure:"saphana.host.swap.current"`
-	SaphanaInstanceCodeSize                 MetricSettings `mapstructure:"saphana.instance.code_size"`
-	SaphanaInstanceMemoryCurrent            MetricSettings `mapstructure:"saphana.instance.memory.current"`
-	SaphanaInstanceMemorySharedAllocated    MetricSettings `mapstructure:"saphana.instance.memory.shared.allocated"`
-	SaphanaInstanceMemoryUsedPeak           MetricSettings `mapstructure:"saphana.instance.memory.used.peak"`
-	SaphanaLicenseExpirationTime            MetricSettings `mapstructure:"saphana.license.expiration.time"`
-	SaphanaLicenseLimit                     MetricSettings `mapstructure:"saphana.license.limit"`
-	SaphanaLicensePeak                      MetricSettings `mapstructure:"saphana.license.peak"`
-	SaphanaNetworkRequestAverageTime        MetricSettings `mapstructure:"saphana.network.request.average_time"`
-	SaphanaNetworkRequestCount              MetricSettings `mapstructure:"saphana.network.request.count"`
-	SaphanaNetworkRequestFinishedCount      MetricSettings `mapstructure:"saphana.network.request.finished.count"`
-	SaphanaReplicationAverageTime           MetricSettings `mapstructure:"saphana.replication.average_time"`
-	SaphanaReplicationBacklogSize           MetricSettings `mapstructure:"saphana.replication.backlog.size"`
-	SaphanaReplicationBacklogTime           MetricSettings `mapstructure:"saphana.replication.backlog.time"`
-	SaphanaRowStoreMemoryUsed               MetricSettings `mapstructure:"saphana.row_store.memory.used"`
-	SaphanaSchemaMemoryUsedCurrent          MetricSettings `mapstructure:"saphana.schema.memory.used.current"`
-	SaphanaSchemaMemoryUsedMax              MetricSettings `mapstructure:"saphana.schema.memory.used.max"`
-	SaphanaSchemaOperationCount             MetricSettings `mapstructure:"saphana.schema.operation.count"`
-	SaphanaSchemaRecordCompressedCount      MetricSettings `mapstructure:"saphana.schema.record.compressed.count"`
-	SaphanaSchemaRecordCount                MetricSettings `mapstructure:"saphana.schema.record.count"`
-	SaphanaServiceCodeSize                  MetricSettings `mapstructure:"saphana.service.code_size"`
-	SaphanaServiceCount                     MetricSettings `mapstructure:"saphana.service.count"`
-	SaphanaServiceMemoryCompactorsAllocated MetricSettings `mapstructure:"saphana.service.memory.compactors.allocated"`
-	SaphanaServiceMemoryCompactorsFreeable  MetricSettings `mapstructure:"saphana.service.memory.compactors.freeable"`
-	SaphanaServiceMemoryEffectiveLimit      MetricSettings `mapstructure:"saphana.service.memory.effective_limit"`
-	SaphanaServiceMemoryHeapCurrent         MetricSettings `mapstructure:"saphana.service.memory.heap.current"`
-	SaphanaServiceMemoryLimit               MetricSettings `mapstructure:"saphana.service.memory.limit"`
-	SaphanaServiceMemorySharedCurrent       MetricSettings `mapstructure:"saphana.service.memory.shared.current"`
-	SaphanaServiceMemoryUsed                MetricSettings `mapstructure:"saphana.service.memory.used"`
-	SaphanaServiceStackSize                 MetricSettings `mapstructure:"saphana.service.stack_size"`
-	SaphanaServiceThreadCount               MetricSettings `mapstructure:"saphana.service.thread.count"`
-	SaphanaTransactionBlocked               MetricSettings `mapstructure:"saphana.transaction.blocked"`
-	SaphanaTransactionCount                 MetricSettings `mapstructure:"saphana.transaction.count"`
-	SaphanaUptime                           MetricSettings `mapstructure:"saphana.uptime"`
-	SaphanaVolumeOperationCount             MetricSettings `mapstructure:"saphana.volume.operation.count"`
-	SaphanaVolumeOperationSize              MetricSettings `mapstructure:"saphana.volume.operation.size"`
-	SaphanaVolumeOperationTime              MetricSettings `mapstructure:"saphana.volume.operation.time"`
+// MetricsConfig provides config for saphanareceiver metrics.
+type MetricsConfig struct {
+	SaphanaAlertCount                       MetricConfig `mapstructure:"saphana.alert.count"`
+	SaphanaBackupLatest                     MetricConfig `mapstructure:"saphana.backup.latest"`
+	SaphanaColumnMemoryUsed                 MetricConfig `mapstructure:"saphana.column.memory.used"`
+	SaphanaComponentMemoryUsed              MetricConfig `mapstructure:"saphana.component.memory.used"`
+	SaphanaConnectionCount                  MetricConfig `mapstructure:"saphana.connection.count"`
+	SaphanaCPUUsed                          MetricConfig `mapstructure:"saphana.cpu.used"`
+	SaphanaDiskSizeCurrent                  MetricConfig `mapstructure:"saphana.disk.size.current"`
+	SaphanaHostMemoryCurrent                MetricConfig `mapstructure:"saphana.host.memory.current"`
+	SaphanaHostSwapCurrent                  MetricConfig `mapstructure:"saphana.host.swap.current"`
+	SaphanaInstanceCodeSize                 MetricConfig `mapstructure:"saphana.instance.code_size"`
+	SaphanaInstanceMemoryCurrent            MetricConfig `mapstructure:"saphana.instance.memory.current"`
+	SaphanaInstanceMemorySharedAllocated    MetricConfig `mapstructure:"saphana.instance.memory.shared.allocated"`
+	SaphanaInstanceMemoryUsedPeak           MetricConfig `mapstructure:"saphana.instance.memory.used.peak"`
+	SaphanaLicenseExpirationTime            MetricConfig `mapstructure:"saphana.license.expiration.time"`
+	SaphanaLicenseLimit                     MetricConfig `mapstructure:"saphana.license.limit"`
+	SaphanaLicensePeak                      MetricConfig `mapstructure:"saphana.license.peak"`
+	SaphanaNetworkRequestAverageTime        MetricConfig `mapstructure:"saphana.network.request.average_time"`
+	SaphanaNetworkRequestCount              MetricConfig `mapstructure:"saphana.network.request.count"`
+	SaphanaNetworkRequestFinishedCount      MetricConfig `mapstructure:"saphana.network.request.finished.count"`
+	SaphanaReplicationAverageTime           MetricConfig `mapstructure:"saphana.replication.average_time"`
+	SaphanaReplicationBacklogSize           MetricConfig `mapstructure:"saphana.replication.backlog.size"`
+	SaphanaReplicationBacklogTime           MetricConfig `mapstructure:"saphana.replication.backlog.time"`
+	SaphanaRowStoreMemoryUsed               MetricConfig `mapstructure:"saphana.row_store.memory.used"`
+	SaphanaSchemaMemoryUsedCurrent          MetricConfig `mapstructure:"saphana.schema.memory.used.current"`
+	SaphanaSchemaMemoryUsedMax              MetricConfig `mapstructure:"saphana.schema.memory.used.max"`
+	SaphanaSchemaOperationCount             MetricConfig `mapstructure:"saphana.schema.operation.count"`
+	SaphanaSchemaRecordCompressedCount      MetricConfig `mapstructure:"saphana.schema.record.compressed.count"`
+	SaphanaSchemaRecordCount                MetricConfig `mapstructure:"saphana.schema.record.count"`
+	SaphanaServiceCodeSize                  MetricConfig `mapstructure:"saphana.service.code_size"`
+	SaphanaServiceCount                     MetricConfig `mapstructure:"saphana.service.count"`
+	SaphanaServiceMemoryCompactorsAllocated MetricConfig `mapstructure:"saphana.service.memory.compactors.allocated"`
+	SaphanaServiceMemoryCompactorsFreeable  MetricConfig `mapstructure:"saphana.service.memory.compactors.freeable"`
+	SaphanaServiceMemoryEffectiveLimit      MetricConfig `mapstructure:"saphana.service.memory.effective_limit"`
+	SaphanaServiceMemoryHeapCurrent         MetricConfig `mapstructure:"saphana.service.memory.heap.current"`
+	SaphanaServiceMemoryLimit               MetricConfig `mapstructure:"saphana.service.memory.limit"`
+	SaphanaServiceMemorySharedCurrent       MetricConfig `mapstructure:"saphana.service.memory.shared.current"`
+	SaphanaServiceMemoryUsed                MetricConfig `mapstructure:"saphana.service.memory.used"`
+	SaphanaServiceStackSize                 MetricConfig `mapstructure:"saphana.service.stack_size"`
+	SaphanaServiceThreadCount               MetricConfig `mapstructure:"saphana.service.thread.count"`
+	SaphanaTransactionBlocked               MetricConfig `mapstructure:"saphana.transaction.blocked"`
+	SaphanaTransactionCount                 MetricConfig `mapstructure:"saphana.transaction.count"`
+	SaphanaUptime                           MetricConfig `mapstructure:"saphana.uptime"`
+	SaphanaVolumeOperationCount             MetricConfig `mapstructure:"saphana.volume.operation.count"`
+	SaphanaVolumeOperationSize              MetricConfig `mapstructure:"saphana.volume.operation.size"`
+	SaphanaVolumeOperationTime              MetricConfig `mapstructure:"saphana.volume.operation.time"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		SaphanaAlertCount: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		SaphanaAlertCount: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaBackupLatest: MetricSettings{
+		SaphanaBackupLatest: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaColumnMemoryUsed: MetricSettings{
+		SaphanaColumnMemoryUsed: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaComponentMemoryUsed: MetricSettings{
+		SaphanaComponentMemoryUsed: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaConnectionCount: MetricSettings{
+		SaphanaConnectionCount: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaCPUUsed: MetricSettings{
+		SaphanaCPUUsed: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaDiskSizeCurrent: MetricSettings{
+		SaphanaDiskSizeCurrent: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaHostMemoryCurrent: MetricSettings{
+		SaphanaHostMemoryCurrent: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaHostSwapCurrent: MetricSettings{
+		SaphanaHostSwapCurrent: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaInstanceCodeSize: MetricSettings{
+		SaphanaInstanceCodeSize: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaInstanceMemoryCurrent: MetricSettings{
+		SaphanaInstanceMemoryCurrent: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaInstanceMemorySharedAllocated: MetricSettings{
+		SaphanaInstanceMemorySharedAllocated: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaInstanceMemoryUsedPeak: MetricSettings{
+		SaphanaInstanceMemoryUsedPeak: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaLicenseExpirationTime: MetricSettings{
+		SaphanaLicenseExpirationTime: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaLicenseLimit: MetricSettings{
+		SaphanaLicenseLimit: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaLicensePeak: MetricSettings{
+		SaphanaLicensePeak: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaNetworkRequestAverageTime: MetricSettings{
+		SaphanaNetworkRequestAverageTime: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaNetworkRequestCount: MetricSettings{
+		SaphanaNetworkRequestCount: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaNetworkRequestFinishedCount: MetricSettings{
+		SaphanaNetworkRequestFinishedCount: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaReplicationAverageTime: MetricSettings{
+		SaphanaReplicationAverageTime: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaReplicationBacklogSize: MetricSettings{
+		SaphanaReplicationBacklogSize: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaReplicationBacklogTime: MetricSettings{
+		SaphanaReplicationBacklogTime: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaRowStoreMemoryUsed: MetricSettings{
+		SaphanaRowStoreMemoryUsed: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaSchemaMemoryUsedCurrent: MetricSettings{
+		SaphanaSchemaMemoryUsedCurrent: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaSchemaMemoryUsedMax: MetricSettings{
+		SaphanaSchemaMemoryUsedMax: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaSchemaOperationCount: MetricSettings{
+		SaphanaSchemaOperationCount: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaSchemaRecordCompressedCount: MetricSettings{
+		SaphanaSchemaRecordCompressedCount: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaSchemaRecordCount: MetricSettings{
+		SaphanaSchemaRecordCount: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaServiceCodeSize: MetricSettings{
+		SaphanaServiceCodeSize: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaServiceCount: MetricSettings{
+		SaphanaServiceCount: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaServiceMemoryCompactorsAllocated: MetricSettings{
+		SaphanaServiceMemoryCompactorsAllocated: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaServiceMemoryCompactorsFreeable: MetricSettings{
+		SaphanaServiceMemoryCompactorsFreeable: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaServiceMemoryEffectiveLimit: MetricSettings{
+		SaphanaServiceMemoryEffectiveLimit: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaServiceMemoryHeapCurrent: MetricSettings{
+		SaphanaServiceMemoryHeapCurrent: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaServiceMemoryLimit: MetricSettings{
+		SaphanaServiceMemoryLimit: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaServiceMemorySharedCurrent: MetricSettings{
+		SaphanaServiceMemorySharedCurrent: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaServiceMemoryUsed: MetricSettings{
+		SaphanaServiceMemoryUsed: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaServiceStackSize: MetricSettings{
+		SaphanaServiceStackSize: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaServiceThreadCount: MetricSettings{
+		SaphanaServiceThreadCount: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaTransactionBlocked: MetricSettings{
+		SaphanaTransactionBlocked: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaTransactionCount: MetricSettings{
+		SaphanaTransactionCount: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaUptime: MetricSettings{
+		SaphanaUptime: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaVolumeOperationCount: MetricSettings{
+		SaphanaVolumeOperationCount: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaVolumeOperationSize: MetricSettings{
+		SaphanaVolumeOperationSize: MetricConfig{
 			Enabled: true,
 		},
-		SaphanaVolumeOperationTime: MetricSettings{
+		SaphanaVolumeOperationTime: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for saphanareceiver resource attributes.
-type ResourceAttributesSettings struct {
-	DbSystem    ResourceAttributeSettings `mapstructure:"db.system"`
-	SaphanaHost ResourceAttributeSettings `mapstructure:"saphana.host"`
+// ResourceAttributesConfig provides config for saphanareceiver resource attributes.
+type ResourceAttributesConfig struct {
+	DbSystem    ResourceAttributeConfig `mapstructure:"db.system"`
+	SaphanaHost ResourceAttributeConfig `mapstructure:"saphana.host"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		DbSystem: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		DbSystem: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		SaphanaHost: ResourceAttributeSettings{
+		SaphanaHost: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -758,7 +758,7 @@ var MapAttributeVolumeOperationType = map[string]AttributeVolumeOperationType{
 
 type metricSaphanaAlertCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -774,7 +774,7 @@ func (m *metricSaphanaAlertCount) init() {
 }
 
 func (m *metricSaphanaAlertCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, alertRatingAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -793,16 +793,16 @@ func (m *metricSaphanaAlertCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaAlertCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaAlertCount(settings MetricSettings) metricSaphanaAlertCount {
-	m := metricSaphanaAlertCount{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaAlertCount(cfg MetricConfig) metricSaphanaAlertCount {
+	m := metricSaphanaAlertCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -811,7 +811,7 @@ func newMetricSaphanaAlertCount(settings MetricSettings) metricSaphanaAlertCount
 
 type metricSaphanaBackupLatest struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -824,7 +824,7 @@ func (m *metricSaphanaBackupLatest) init() {
 }
 
 func (m *metricSaphanaBackupLatest) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -842,16 +842,16 @@ func (m *metricSaphanaBackupLatest) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaBackupLatest) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaBackupLatest(settings MetricSettings) metricSaphanaBackupLatest {
-	m := metricSaphanaBackupLatest{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaBackupLatest(cfg MetricConfig) metricSaphanaBackupLatest {
+	m := metricSaphanaBackupLatest{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -860,7 +860,7 @@ func newMetricSaphanaBackupLatest(settings MetricSettings) metricSaphanaBackupLa
 
 type metricSaphanaColumnMemoryUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -876,7 +876,7 @@ func (m *metricSaphanaColumnMemoryUsed) init() {
 }
 
 func (m *metricSaphanaColumnMemoryUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, columnMemoryTypeAttributeValue string, columnMemorySubtypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -896,16 +896,16 @@ func (m *metricSaphanaColumnMemoryUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaColumnMemoryUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaColumnMemoryUsed(settings MetricSettings) metricSaphanaColumnMemoryUsed {
-	m := metricSaphanaColumnMemoryUsed{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaColumnMemoryUsed(cfg MetricConfig) metricSaphanaColumnMemoryUsed {
+	m := metricSaphanaColumnMemoryUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -914,7 +914,7 @@ func newMetricSaphanaColumnMemoryUsed(settings MetricSettings) metricSaphanaColu
 
 type metricSaphanaComponentMemoryUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -930,7 +930,7 @@ func (m *metricSaphanaComponentMemoryUsed) init() {
 }
 
 func (m *metricSaphanaComponentMemoryUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, componentAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -949,16 +949,16 @@ func (m *metricSaphanaComponentMemoryUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaComponentMemoryUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaComponentMemoryUsed(settings MetricSettings) metricSaphanaComponentMemoryUsed {
-	m := metricSaphanaComponentMemoryUsed{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaComponentMemoryUsed(cfg MetricConfig) metricSaphanaComponentMemoryUsed {
+	m := metricSaphanaComponentMemoryUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -967,7 +967,7 @@ func newMetricSaphanaComponentMemoryUsed(settings MetricSettings) metricSaphanaC
 
 type metricSaphanaConnectionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -983,7 +983,7 @@ func (m *metricSaphanaConnectionCount) init() {
 }
 
 func (m *metricSaphanaConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, connectionStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1002,16 +1002,16 @@ func (m *metricSaphanaConnectionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaConnectionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaConnectionCount(settings MetricSettings) metricSaphanaConnectionCount {
-	m := metricSaphanaConnectionCount{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaConnectionCount(cfg MetricConfig) metricSaphanaConnectionCount {
+	m := metricSaphanaConnectionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1020,7 +1020,7 @@ func newMetricSaphanaConnectionCount(settings MetricSettings) metricSaphanaConne
 
 type metricSaphanaCPUUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1036,7 +1036,7 @@ func (m *metricSaphanaCPUUsed) init() {
 }
 
 func (m *metricSaphanaCPUUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, cpuTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1055,16 +1055,16 @@ func (m *metricSaphanaCPUUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaCPUUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaCPUUsed(settings MetricSettings) metricSaphanaCPUUsed {
-	m := metricSaphanaCPUUsed{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaCPUUsed(cfg MetricConfig) metricSaphanaCPUUsed {
+	m := metricSaphanaCPUUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1073,7 +1073,7 @@ func newMetricSaphanaCPUUsed(settings MetricSettings) metricSaphanaCPUUsed {
 
 type metricSaphanaDiskSizeCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1089,7 +1089,7 @@ func (m *metricSaphanaDiskSizeCurrent) init() {
 }
 
 func (m *metricSaphanaDiskSizeCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, pathAttributeValue string, diskUsageTypeAttributeValue string, diskStateUsedFreeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1110,16 +1110,16 @@ func (m *metricSaphanaDiskSizeCurrent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaDiskSizeCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaDiskSizeCurrent(settings MetricSettings) metricSaphanaDiskSizeCurrent {
-	m := metricSaphanaDiskSizeCurrent{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaDiskSizeCurrent(cfg MetricConfig) metricSaphanaDiskSizeCurrent {
+	m := metricSaphanaDiskSizeCurrent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1128,7 +1128,7 @@ func newMetricSaphanaDiskSizeCurrent(settings MetricSettings) metricSaphanaDiskS
 
 type metricSaphanaHostMemoryCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1144,7 +1144,7 @@ func (m *metricSaphanaHostMemoryCurrent) init() {
 }
 
 func (m *metricSaphanaHostMemoryCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, memoryStateUsedFreeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1163,16 +1163,16 @@ func (m *metricSaphanaHostMemoryCurrent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaHostMemoryCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaHostMemoryCurrent(settings MetricSettings) metricSaphanaHostMemoryCurrent {
-	m := metricSaphanaHostMemoryCurrent{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaHostMemoryCurrent(cfg MetricConfig) metricSaphanaHostMemoryCurrent {
+	m := metricSaphanaHostMemoryCurrent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1181,7 +1181,7 @@ func newMetricSaphanaHostMemoryCurrent(settings MetricSettings) metricSaphanaHos
 
 type metricSaphanaHostSwapCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1197,7 +1197,7 @@ func (m *metricSaphanaHostSwapCurrent) init() {
 }
 
 func (m *metricSaphanaHostSwapCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, hostSwapStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1216,16 +1216,16 @@ func (m *metricSaphanaHostSwapCurrent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaHostSwapCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaHostSwapCurrent(settings MetricSettings) metricSaphanaHostSwapCurrent {
-	m := metricSaphanaHostSwapCurrent{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaHostSwapCurrent(cfg MetricConfig) metricSaphanaHostSwapCurrent {
+	m := metricSaphanaHostSwapCurrent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1234,7 +1234,7 @@ func newMetricSaphanaHostSwapCurrent(settings MetricSettings) metricSaphanaHostS
 
 type metricSaphanaInstanceCodeSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1249,7 +1249,7 @@ func (m *metricSaphanaInstanceCodeSize) init() {
 }
 
 func (m *metricSaphanaInstanceCodeSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1267,16 +1267,16 @@ func (m *metricSaphanaInstanceCodeSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaInstanceCodeSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaInstanceCodeSize(settings MetricSettings) metricSaphanaInstanceCodeSize {
-	m := metricSaphanaInstanceCodeSize{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaInstanceCodeSize(cfg MetricConfig) metricSaphanaInstanceCodeSize {
+	m := metricSaphanaInstanceCodeSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1285,7 +1285,7 @@ func newMetricSaphanaInstanceCodeSize(settings MetricSettings) metricSaphanaInst
 
 type metricSaphanaInstanceMemoryCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1301,7 +1301,7 @@ func (m *metricSaphanaInstanceMemoryCurrent) init() {
 }
 
 func (m *metricSaphanaInstanceMemoryCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, memoryStateUsedFreeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1320,16 +1320,16 @@ func (m *metricSaphanaInstanceMemoryCurrent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaInstanceMemoryCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaInstanceMemoryCurrent(settings MetricSettings) metricSaphanaInstanceMemoryCurrent {
-	m := metricSaphanaInstanceMemoryCurrent{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaInstanceMemoryCurrent(cfg MetricConfig) metricSaphanaInstanceMemoryCurrent {
+	m := metricSaphanaInstanceMemoryCurrent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1338,7 +1338,7 @@ func newMetricSaphanaInstanceMemoryCurrent(settings MetricSettings) metricSaphan
 
 type metricSaphanaInstanceMemorySharedAllocated struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1353,7 +1353,7 @@ func (m *metricSaphanaInstanceMemorySharedAllocated) init() {
 }
 
 func (m *metricSaphanaInstanceMemorySharedAllocated) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1371,16 +1371,16 @@ func (m *metricSaphanaInstanceMemorySharedAllocated) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaInstanceMemorySharedAllocated) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaInstanceMemorySharedAllocated(settings MetricSettings) metricSaphanaInstanceMemorySharedAllocated {
-	m := metricSaphanaInstanceMemorySharedAllocated{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaInstanceMemorySharedAllocated(cfg MetricConfig) metricSaphanaInstanceMemorySharedAllocated {
+	m := metricSaphanaInstanceMemorySharedAllocated{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1389,7 +1389,7 @@ func newMetricSaphanaInstanceMemorySharedAllocated(settings MetricSettings) metr
 
 type metricSaphanaInstanceMemoryUsedPeak struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1404,7 +1404,7 @@ func (m *metricSaphanaInstanceMemoryUsedPeak) init() {
 }
 
 func (m *metricSaphanaInstanceMemoryUsedPeak) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1422,16 +1422,16 @@ func (m *metricSaphanaInstanceMemoryUsedPeak) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaInstanceMemoryUsedPeak) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaInstanceMemoryUsedPeak(settings MetricSettings) metricSaphanaInstanceMemoryUsedPeak {
-	m := metricSaphanaInstanceMemoryUsedPeak{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaInstanceMemoryUsedPeak(cfg MetricConfig) metricSaphanaInstanceMemoryUsedPeak {
+	m := metricSaphanaInstanceMemoryUsedPeak{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1440,7 +1440,7 @@ func newMetricSaphanaInstanceMemoryUsedPeak(settings MetricSettings) metricSapha
 
 type metricSaphanaLicenseExpirationTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1454,7 +1454,7 @@ func (m *metricSaphanaLicenseExpirationTime) init() {
 }
 
 func (m *metricSaphanaLicenseExpirationTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, systemAttributeValue string, productAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1474,16 +1474,16 @@ func (m *metricSaphanaLicenseExpirationTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaLicenseExpirationTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaLicenseExpirationTime(settings MetricSettings) metricSaphanaLicenseExpirationTime {
-	m := metricSaphanaLicenseExpirationTime{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaLicenseExpirationTime(cfg MetricConfig) metricSaphanaLicenseExpirationTime {
+	m := metricSaphanaLicenseExpirationTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1492,7 +1492,7 @@ func newMetricSaphanaLicenseExpirationTime(settings MetricSettings) metricSaphan
 
 type metricSaphanaLicenseLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1508,7 +1508,7 @@ func (m *metricSaphanaLicenseLimit) init() {
 }
 
 func (m *metricSaphanaLicenseLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, systemAttributeValue string, productAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1528,16 +1528,16 @@ func (m *metricSaphanaLicenseLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaLicenseLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaLicenseLimit(settings MetricSettings) metricSaphanaLicenseLimit {
-	m := metricSaphanaLicenseLimit{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaLicenseLimit(cfg MetricConfig) metricSaphanaLicenseLimit {
+	m := metricSaphanaLicenseLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1546,7 +1546,7 @@ func newMetricSaphanaLicenseLimit(settings MetricSettings) metricSaphanaLicenseL
 
 type metricSaphanaLicensePeak struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1562,7 +1562,7 @@ func (m *metricSaphanaLicensePeak) init() {
 }
 
 func (m *metricSaphanaLicensePeak) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, systemAttributeValue string, productAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1582,16 +1582,16 @@ func (m *metricSaphanaLicensePeak) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaLicensePeak) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaLicensePeak(settings MetricSettings) metricSaphanaLicensePeak {
-	m := metricSaphanaLicensePeak{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaLicensePeak(cfg MetricConfig) metricSaphanaLicensePeak {
+	m := metricSaphanaLicensePeak{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1600,7 +1600,7 @@ func newMetricSaphanaLicensePeak(settings MetricSettings) metricSaphanaLicensePe
 
 type metricSaphanaNetworkRequestAverageTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1613,7 +1613,7 @@ func (m *metricSaphanaNetworkRequestAverageTime) init() {
 }
 
 func (m *metricSaphanaNetworkRequestAverageTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1631,16 +1631,16 @@ func (m *metricSaphanaNetworkRequestAverageTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaNetworkRequestAverageTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaNetworkRequestAverageTime(settings MetricSettings) metricSaphanaNetworkRequestAverageTime {
-	m := metricSaphanaNetworkRequestAverageTime{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaNetworkRequestAverageTime(cfg MetricConfig) metricSaphanaNetworkRequestAverageTime {
+	m := metricSaphanaNetworkRequestAverageTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1649,7 +1649,7 @@ func newMetricSaphanaNetworkRequestAverageTime(settings MetricSettings) metricSa
 
 type metricSaphanaNetworkRequestCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1665,7 +1665,7 @@ func (m *metricSaphanaNetworkRequestCount) init() {
 }
 
 func (m *metricSaphanaNetworkRequestCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, activePendingRequestStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1684,16 +1684,16 @@ func (m *metricSaphanaNetworkRequestCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaNetworkRequestCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaNetworkRequestCount(settings MetricSettings) metricSaphanaNetworkRequestCount {
-	m := metricSaphanaNetworkRequestCount{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaNetworkRequestCount(cfg MetricConfig) metricSaphanaNetworkRequestCount {
+	m := metricSaphanaNetworkRequestCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1702,7 +1702,7 @@ func newMetricSaphanaNetworkRequestCount(settings MetricSettings) metricSaphanaN
 
 type metricSaphanaNetworkRequestFinishedCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1718,7 +1718,7 @@ func (m *metricSaphanaNetworkRequestFinishedCount) init() {
 }
 
 func (m *metricSaphanaNetworkRequestFinishedCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, internalExternalRequestTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1737,16 +1737,16 @@ func (m *metricSaphanaNetworkRequestFinishedCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaNetworkRequestFinishedCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaNetworkRequestFinishedCount(settings MetricSettings) metricSaphanaNetworkRequestFinishedCount {
-	m := metricSaphanaNetworkRequestFinishedCount{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaNetworkRequestFinishedCount(cfg MetricConfig) metricSaphanaNetworkRequestFinishedCount {
+	m := metricSaphanaNetworkRequestFinishedCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1755,7 +1755,7 @@ func newMetricSaphanaNetworkRequestFinishedCount(settings MetricSettings) metric
 
 type metricSaphanaReplicationAverageTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1769,7 +1769,7 @@ func (m *metricSaphanaReplicationAverageTime) init() {
 }
 
 func (m *metricSaphanaReplicationAverageTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, primaryHostAttributeValue string, secondaryHostAttributeValue string, portAttributeValue string, replicationModeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1791,16 +1791,16 @@ func (m *metricSaphanaReplicationAverageTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaReplicationAverageTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaReplicationAverageTime(settings MetricSettings) metricSaphanaReplicationAverageTime {
-	m := metricSaphanaReplicationAverageTime{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaReplicationAverageTime(cfg MetricConfig) metricSaphanaReplicationAverageTime {
+	m := metricSaphanaReplicationAverageTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1809,7 +1809,7 @@ func newMetricSaphanaReplicationAverageTime(settings MetricSettings) metricSapha
 
 type metricSaphanaReplicationBacklogSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1825,7 +1825,7 @@ func (m *metricSaphanaReplicationBacklogSize) init() {
 }
 
 func (m *metricSaphanaReplicationBacklogSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, primaryHostAttributeValue string, secondaryHostAttributeValue string, portAttributeValue string, replicationModeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1847,16 +1847,16 @@ func (m *metricSaphanaReplicationBacklogSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaReplicationBacklogSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaReplicationBacklogSize(settings MetricSettings) metricSaphanaReplicationBacklogSize {
-	m := metricSaphanaReplicationBacklogSize{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaReplicationBacklogSize(cfg MetricConfig) metricSaphanaReplicationBacklogSize {
+	m := metricSaphanaReplicationBacklogSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1865,7 +1865,7 @@ func newMetricSaphanaReplicationBacklogSize(settings MetricSettings) metricSapha
 
 type metricSaphanaReplicationBacklogTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1881,7 +1881,7 @@ func (m *metricSaphanaReplicationBacklogTime) init() {
 }
 
 func (m *metricSaphanaReplicationBacklogTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, primaryHostAttributeValue string, secondaryHostAttributeValue string, portAttributeValue string, replicationModeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1903,16 +1903,16 @@ func (m *metricSaphanaReplicationBacklogTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaReplicationBacklogTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaReplicationBacklogTime(settings MetricSettings) metricSaphanaReplicationBacklogTime {
-	m := metricSaphanaReplicationBacklogTime{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaReplicationBacklogTime(cfg MetricConfig) metricSaphanaReplicationBacklogTime {
+	m := metricSaphanaReplicationBacklogTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1921,7 +1921,7 @@ func newMetricSaphanaReplicationBacklogTime(settings MetricSettings) metricSapha
 
 type metricSaphanaRowStoreMemoryUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1937,7 +1937,7 @@ func (m *metricSaphanaRowStoreMemoryUsed) init() {
 }
 
 func (m *metricSaphanaRowStoreMemoryUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, rowMemoryTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1956,16 +1956,16 @@ func (m *metricSaphanaRowStoreMemoryUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaRowStoreMemoryUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaRowStoreMemoryUsed(settings MetricSettings) metricSaphanaRowStoreMemoryUsed {
-	m := metricSaphanaRowStoreMemoryUsed{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaRowStoreMemoryUsed(cfg MetricConfig) metricSaphanaRowStoreMemoryUsed {
+	m := metricSaphanaRowStoreMemoryUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1974,7 +1974,7 @@ func newMetricSaphanaRowStoreMemoryUsed(settings MetricSettings) metricSaphanaRo
 
 type metricSaphanaSchemaMemoryUsedCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1990,7 +1990,7 @@ func (m *metricSaphanaSchemaMemoryUsedCurrent) init() {
 }
 
 func (m *metricSaphanaSchemaMemoryUsedCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaAttributeValue string, schemaMemoryTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2010,16 +2010,16 @@ func (m *metricSaphanaSchemaMemoryUsedCurrent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaSchemaMemoryUsedCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaSchemaMemoryUsedCurrent(settings MetricSettings) metricSaphanaSchemaMemoryUsedCurrent {
-	m := metricSaphanaSchemaMemoryUsedCurrent{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaSchemaMemoryUsedCurrent(cfg MetricConfig) metricSaphanaSchemaMemoryUsedCurrent {
+	m := metricSaphanaSchemaMemoryUsedCurrent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2028,7 +2028,7 @@ func newMetricSaphanaSchemaMemoryUsedCurrent(settings MetricSettings) metricSaph
 
 type metricSaphanaSchemaMemoryUsedMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2044,7 +2044,7 @@ func (m *metricSaphanaSchemaMemoryUsedMax) init() {
 }
 
 func (m *metricSaphanaSchemaMemoryUsedMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2063,16 +2063,16 @@ func (m *metricSaphanaSchemaMemoryUsedMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaSchemaMemoryUsedMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaSchemaMemoryUsedMax(settings MetricSettings) metricSaphanaSchemaMemoryUsedMax {
-	m := metricSaphanaSchemaMemoryUsedMax{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaSchemaMemoryUsedMax(cfg MetricConfig) metricSaphanaSchemaMemoryUsedMax {
+	m := metricSaphanaSchemaMemoryUsedMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2081,7 +2081,7 @@ func newMetricSaphanaSchemaMemoryUsedMax(settings MetricSettings) metricSaphanaS
 
 type metricSaphanaSchemaOperationCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2097,7 +2097,7 @@ func (m *metricSaphanaSchemaOperationCount) init() {
 }
 
 func (m *metricSaphanaSchemaOperationCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaAttributeValue string, schemaOperationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2117,16 +2117,16 @@ func (m *metricSaphanaSchemaOperationCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaSchemaOperationCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaSchemaOperationCount(settings MetricSettings) metricSaphanaSchemaOperationCount {
-	m := metricSaphanaSchemaOperationCount{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaSchemaOperationCount(cfg MetricConfig) metricSaphanaSchemaOperationCount {
+	m := metricSaphanaSchemaOperationCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2135,7 +2135,7 @@ func newMetricSaphanaSchemaOperationCount(settings MetricSettings) metricSaphana
 
 type metricSaphanaSchemaRecordCompressedCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2151,7 +2151,7 @@ func (m *metricSaphanaSchemaRecordCompressedCount) init() {
 }
 
 func (m *metricSaphanaSchemaRecordCompressedCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2170,16 +2170,16 @@ func (m *metricSaphanaSchemaRecordCompressedCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaSchemaRecordCompressedCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaSchemaRecordCompressedCount(settings MetricSettings) metricSaphanaSchemaRecordCompressedCount {
-	m := metricSaphanaSchemaRecordCompressedCount{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaSchemaRecordCompressedCount(cfg MetricConfig) metricSaphanaSchemaRecordCompressedCount {
+	m := metricSaphanaSchemaRecordCompressedCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2188,7 +2188,7 @@ func newMetricSaphanaSchemaRecordCompressedCount(settings MetricSettings) metric
 
 type metricSaphanaSchemaRecordCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2204,7 +2204,7 @@ func (m *metricSaphanaSchemaRecordCount) init() {
 }
 
 func (m *metricSaphanaSchemaRecordCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaAttributeValue string, schemaRecordTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2224,16 +2224,16 @@ func (m *metricSaphanaSchemaRecordCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaSchemaRecordCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaSchemaRecordCount(settings MetricSettings) metricSaphanaSchemaRecordCount {
-	m := metricSaphanaSchemaRecordCount{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaSchemaRecordCount(cfg MetricConfig) metricSaphanaSchemaRecordCount {
+	m := metricSaphanaSchemaRecordCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2242,7 +2242,7 @@ func newMetricSaphanaSchemaRecordCount(settings MetricSettings) metricSaphanaSch
 
 type metricSaphanaServiceCodeSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2258,7 +2258,7 @@ func (m *metricSaphanaServiceCodeSize) init() {
 }
 
 func (m *metricSaphanaServiceCodeSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serviceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2277,16 +2277,16 @@ func (m *metricSaphanaServiceCodeSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaServiceCodeSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaServiceCodeSize(settings MetricSettings) metricSaphanaServiceCodeSize {
-	m := metricSaphanaServiceCodeSize{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaServiceCodeSize(cfg MetricConfig) metricSaphanaServiceCodeSize {
+	m := metricSaphanaServiceCodeSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2295,7 +2295,7 @@ func newMetricSaphanaServiceCodeSize(settings MetricSettings) metricSaphanaServi
 
 type metricSaphanaServiceCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2311,7 +2311,7 @@ func (m *metricSaphanaServiceCount) init() {
 }
 
 func (m *metricSaphanaServiceCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serviceStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2330,16 +2330,16 @@ func (m *metricSaphanaServiceCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaServiceCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaServiceCount(settings MetricSettings) metricSaphanaServiceCount {
-	m := metricSaphanaServiceCount{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaServiceCount(cfg MetricConfig) metricSaphanaServiceCount {
+	m := metricSaphanaServiceCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2348,7 +2348,7 @@ func newMetricSaphanaServiceCount(settings MetricSettings) metricSaphanaServiceC
 
 type metricSaphanaServiceMemoryCompactorsAllocated struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2364,7 +2364,7 @@ func (m *metricSaphanaServiceMemoryCompactorsAllocated) init() {
 }
 
 func (m *metricSaphanaServiceMemoryCompactorsAllocated) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serviceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2383,16 +2383,16 @@ func (m *metricSaphanaServiceMemoryCompactorsAllocated) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaServiceMemoryCompactorsAllocated) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaServiceMemoryCompactorsAllocated(settings MetricSettings) metricSaphanaServiceMemoryCompactorsAllocated {
-	m := metricSaphanaServiceMemoryCompactorsAllocated{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaServiceMemoryCompactorsAllocated(cfg MetricConfig) metricSaphanaServiceMemoryCompactorsAllocated {
+	m := metricSaphanaServiceMemoryCompactorsAllocated{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2401,7 +2401,7 @@ func newMetricSaphanaServiceMemoryCompactorsAllocated(settings MetricSettings) m
 
 type metricSaphanaServiceMemoryCompactorsFreeable struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2417,7 +2417,7 @@ func (m *metricSaphanaServiceMemoryCompactorsFreeable) init() {
 }
 
 func (m *metricSaphanaServiceMemoryCompactorsFreeable) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serviceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2436,16 +2436,16 @@ func (m *metricSaphanaServiceMemoryCompactorsFreeable) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaServiceMemoryCompactorsFreeable) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaServiceMemoryCompactorsFreeable(settings MetricSettings) metricSaphanaServiceMemoryCompactorsFreeable {
-	m := metricSaphanaServiceMemoryCompactorsFreeable{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaServiceMemoryCompactorsFreeable(cfg MetricConfig) metricSaphanaServiceMemoryCompactorsFreeable {
+	m := metricSaphanaServiceMemoryCompactorsFreeable{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2454,7 +2454,7 @@ func newMetricSaphanaServiceMemoryCompactorsFreeable(settings MetricSettings) me
 
 type metricSaphanaServiceMemoryEffectiveLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2470,7 +2470,7 @@ func (m *metricSaphanaServiceMemoryEffectiveLimit) init() {
 }
 
 func (m *metricSaphanaServiceMemoryEffectiveLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serviceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2489,16 +2489,16 @@ func (m *metricSaphanaServiceMemoryEffectiveLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaServiceMemoryEffectiveLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaServiceMemoryEffectiveLimit(settings MetricSettings) metricSaphanaServiceMemoryEffectiveLimit {
-	m := metricSaphanaServiceMemoryEffectiveLimit{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaServiceMemoryEffectiveLimit(cfg MetricConfig) metricSaphanaServiceMemoryEffectiveLimit {
+	m := metricSaphanaServiceMemoryEffectiveLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2507,7 +2507,7 @@ func newMetricSaphanaServiceMemoryEffectiveLimit(settings MetricSettings) metric
 
 type metricSaphanaServiceMemoryHeapCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2523,7 +2523,7 @@ func (m *metricSaphanaServiceMemoryHeapCurrent) init() {
 }
 
 func (m *metricSaphanaServiceMemoryHeapCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serviceAttributeValue string, memoryStateUsedFreeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2543,16 +2543,16 @@ func (m *metricSaphanaServiceMemoryHeapCurrent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaServiceMemoryHeapCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaServiceMemoryHeapCurrent(settings MetricSettings) metricSaphanaServiceMemoryHeapCurrent {
-	m := metricSaphanaServiceMemoryHeapCurrent{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaServiceMemoryHeapCurrent(cfg MetricConfig) metricSaphanaServiceMemoryHeapCurrent {
+	m := metricSaphanaServiceMemoryHeapCurrent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2561,7 +2561,7 @@ func newMetricSaphanaServiceMemoryHeapCurrent(settings MetricSettings) metricSap
 
 type metricSaphanaServiceMemoryLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2577,7 +2577,7 @@ func (m *metricSaphanaServiceMemoryLimit) init() {
 }
 
 func (m *metricSaphanaServiceMemoryLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serviceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2596,16 +2596,16 @@ func (m *metricSaphanaServiceMemoryLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaServiceMemoryLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaServiceMemoryLimit(settings MetricSettings) metricSaphanaServiceMemoryLimit {
-	m := metricSaphanaServiceMemoryLimit{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaServiceMemoryLimit(cfg MetricConfig) metricSaphanaServiceMemoryLimit {
+	m := metricSaphanaServiceMemoryLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2614,7 +2614,7 @@ func newMetricSaphanaServiceMemoryLimit(settings MetricSettings) metricSaphanaSe
 
 type metricSaphanaServiceMemorySharedCurrent struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2630,7 +2630,7 @@ func (m *metricSaphanaServiceMemorySharedCurrent) init() {
 }
 
 func (m *metricSaphanaServiceMemorySharedCurrent) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serviceAttributeValue string, memoryStateUsedFreeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2650,16 +2650,16 @@ func (m *metricSaphanaServiceMemorySharedCurrent) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaServiceMemorySharedCurrent) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaServiceMemorySharedCurrent(settings MetricSettings) metricSaphanaServiceMemorySharedCurrent {
-	m := metricSaphanaServiceMemorySharedCurrent{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaServiceMemorySharedCurrent(cfg MetricConfig) metricSaphanaServiceMemorySharedCurrent {
+	m := metricSaphanaServiceMemorySharedCurrent{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2668,7 +2668,7 @@ func newMetricSaphanaServiceMemorySharedCurrent(settings MetricSettings) metricS
 
 type metricSaphanaServiceMemoryUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2684,7 +2684,7 @@ func (m *metricSaphanaServiceMemoryUsed) init() {
 }
 
 func (m *metricSaphanaServiceMemoryUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serviceAttributeValue string, serviceMemoryUsedTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2704,16 +2704,16 @@ func (m *metricSaphanaServiceMemoryUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaServiceMemoryUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaServiceMemoryUsed(settings MetricSettings) metricSaphanaServiceMemoryUsed {
-	m := metricSaphanaServiceMemoryUsed{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaServiceMemoryUsed(cfg MetricConfig) metricSaphanaServiceMemoryUsed {
+	m := metricSaphanaServiceMemoryUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2722,7 +2722,7 @@ func newMetricSaphanaServiceMemoryUsed(settings MetricSettings) metricSaphanaSer
 
 type metricSaphanaServiceStackSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2738,7 +2738,7 @@ func (m *metricSaphanaServiceStackSize) init() {
 }
 
 func (m *metricSaphanaServiceStackSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, serviceAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2757,16 +2757,16 @@ func (m *metricSaphanaServiceStackSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaServiceStackSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaServiceStackSize(settings MetricSettings) metricSaphanaServiceStackSize {
-	m := metricSaphanaServiceStackSize{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaServiceStackSize(cfg MetricConfig) metricSaphanaServiceStackSize {
+	m := metricSaphanaServiceStackSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2775,7 +2775,7 @@ func newMetricSaphanaServiceStackSize(settings MetricSettings) metricSaphanaServ
 
 type metricSaphanaServiceThreadCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2791,7 +2791,7 @@ func (m *metricSaphanaServiceThreadCount) init() {
 }
 
 func (m *metricSaphanaServiceThreadCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, threadStatusAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2810,16 +2810,16 @@ func (m *metricSaphanaServiceThreadCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaServiceThreadCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaServiceThreadCount(settings MetricSettings) metricSaphanaServiceThreadCount {
-	m := metricSaphanaServiceThreadCount{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaServiceThreadCount(cfg MetricConfig) metricSaphanaServiceThreadCount {
+	m := metricSaphanaServiceThreadCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2828,7 +2828,7 @@ func newMetricSaphanaServiceThreadCount(settings MetricSettings) metricSaphanaSe
 
 type metricSaphanaTransactionBlocked struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2843,7 +2843,7 @@ func (m *metricSaphanaTransactionBlocked) init() {
 }
 
 func (m *metricSaphanaTransactionBlocked) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2861,16 +2861,16 @@ func (m *metricSaphanaTransactionBlocked) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaTransactionBlocked) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaTransactionBlocked(settings MetricSettings) metricSaphanaTransactionBlocked {
-	m := metricSaphanaTransactionBlocked{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaTransactionBlocked(cfg MetricConfig) metricSaphanaTransactionBlocked {
+	m := metricSaphanaTransactionBlocked{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2879,7 +2879,7 @@ func newMetricSaphanaTransactionBlocked(settings MetricSettings) metricSaphanaTr
 
 type metricSaphanaTransactionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2895,7 +2895,7 @@ func (m *metricSaphanaTransactionCount) init() {
 }
 
 func (m *metricSaphanaTransactionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, transactionTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2914,16 +2914,16 @@ func (m *metricSaphanaTransactionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaTransactionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaTransactionCount(settings MetricSettings) metricSaphanaTransactionCount {
-	m := metricSaphanaTransactionCount{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaTransactionCount(cfg MetricConfig) metricSaphanaTransactionCount {
+	m := metricSaphanaTransactionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2932,7 +2932,7 @@ func newMetricSaphanaTransactionCount(settings MetricSettings) metricSaphanaTran
 
 type metricSaphanaUptime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2948,7 +2948,7 @@ func (m *metricSaphanaUptime) init() {
 }
 
 func (m *metricSaphanaUptime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, systemAttributeValue string, databaseAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2968,16 +2968,16 @@ func (m *metricSaphanaUptime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaUptime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaUptime(settings MetricSettings) metricSaphanaUptime {
-	m := metricSaphanaUptime{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaUptime(cfg MetricConfig) metricSaphanaUptime {
+	m := metricSaphanaUptime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2986,7 +2986,7 @@ func newMetricSaphanaUptime(settings MetricSettings) metricSaphanaUptime {
 
 type metricSaphanaVolumeOperationCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3002,7 +3002,7 @@ func (m *metricSaphanaVolumeOperationCount) init() {
 }
 
 func (m *metricSaphanaVolumeOperationCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, pathAttributeValue string, diskUsageTypeAttributeValue string, volumeOperationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3023,16 +3023,16 @@ func (m *metricSaphanaVolumeOperationCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaVolumeOperationCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaVolumeOperationCount(settings MetricSettings) metricSaphanaVolumeOperationCount {
-	m := metricSaphanaVolumeOperationCount{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaVolumeOperationCount(cfg MetricConfig) metricSaphanaVolumeOperationCount {
+	m := metricSaphanaVolumeOperationCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3041,7 +3041,7 @@ func newMetricSaphanaVolumeOperationCount(settings MetricSettings) metricSaphana
 
 type metricSaphanaVolumeOperationSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3057,7 +3057,7 @@ func (m *metricSaphanaVolumeOperationSize) init() {
 }
 
 func (m *metricSaphanaVolumeOperationSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, pathAttributeValue string, diskUsageTypeAttributeValue string, volumeOperationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3078,16 +3078,16 @@ func (m *metricSaphanaVolumeOperationSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaVolumeOperationSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaVolumeOperationSize(settings MetricSettings) metricSaphanaVolumeOperationSize {
-	m := metricSaphanaVolumeOperationSize{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaVolumeOperationSize(cfg MetricConfig) metricSaphanaVolumeOperationSize {
+	m := metricSaphanaVolumeOperationSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3096,7 +3096,7 @@ func newMetricSaphanaVolumeOperationSize(settings MetricSettings) metricSaphanaV
 
 type metricSaphanaVolumeOperationTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -3112,7 +3112,7 @@ func (m *metricSaphanaVolumeOperationTime) init() {
 }
 
 func (m *metricSaphanaVolumeOperationTime) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, pathAttributeValue string, diskUsageTypeAttributeValue string, volumeOperationTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -3133,16 +3133,16 @@ func (m *metricSaphanaVolumeOperationTime) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSaphanaVolumeOperationTime) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSaphanaVolumeOperationTime(settings MetricSettings) metricSaphanaVolumeOperationTime {
-	m := metricSaphanaVolumeOperationTime{settings: settings}
-	if settings.Enabled {
+func newMetricSaphanaVolumeOperationTime(cfg MetricConfig) metricSaphanaVolumeOperationTime {
+	m := metricSaphanaVolumeOperationTime{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -3151,19 +3151,19 @@ func newMetricSaphanaVolumeOperationTime(settings MetricSettings) metricSaphanaV
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                     pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                               int                 // maximum observed number of metrics per resource.
 	resourceCapacity                              int                 // maximum observed number of resource attributes.
 	metricsBuffer                                 pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                                     component.BuildInfo // contains version information
-	resourceAttributesSettings                    ResourceAttributesSettings
+	resourceAttributesConfig                      ResourceAttributesConfig
 	metricSaphanaAlertCount                       metricSaphanaAlertCount
 	metricSaphanaBackupLatest                     metricSaphanaBackupLatest
 	metricSaphanaColumnMemoryUsed                 metricSaphanaColumnMemoryUsed
@@ -3223,8 +3223,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -3233,7 +3233,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                                     pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                                 pmetric.NewMetrics(),
 		buildInfo:                                     settings.BuildInfo,
-		resourceAttributesSettings:                    mbc.ResourceAttributes,
+		resourceAttributesConfig:                      mbc.ResourceAttributes,
 		metricSaphanaAlertCount:                       newMetricSaphanaAlertCount(mbc.Metrics.SaphanaAlertCount),
 		metricSaphanaBackupLatest:                     newMetricSaphanaBackupLatest(mbc.Metrics.SaphanaBackupLatest),
 		metricSaphanaColumnMemoryUsed:                 newMetricSaphanaColumnMemoryUsed(mbc.Metrics.SaphanaColumnMemoryUsed),
@@ -3297,12 +3297,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithDbSystem sets provided value as "db.system" attribute for current resource.
 func WithDbSystem(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.DbSystem.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.DbSystem.Enabled {
 			rm.Resource().Attributes().PutStr("db.system", val)
 		}
 	}
@@ -3310,8 +3310,8 @@ func WithDbSystem(val string) ResourceMetricsOption {
 
 // WithSaphanaHost sets provided value as "saphana.host" attribute for current resource.
 func WithSaphanaHost(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.SaphanaHost.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.SaphanaHost.Enabled {
 			rm.Resource().Attributes().PutStr("saphana.host", val)
 		}
 	}
@@ -3320,7 +3320,7 @@ func WithSaphanaHost(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -3396,7 +3396,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricSaphanaVolumeOperationTime.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -3406,7 +3406,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/saphanareceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/saphanareceiver/internal/metadata/generated_metrics_test.go
@@ -251,15 +251,15 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("db.system")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.DbSystem.Enabled, ok)
-			if mb.resourceAttributesSettings.DbSystem.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.DbSystem.Enabled, ok)
+			if mb.resourceAttributesConfig.DbSystem.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("saphana.host")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.SaphanaHost.Enabled, ok)
-			if mb.resourceAttributesSettings.SaphanaHost.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.SaphanaHost.Enabled, ok)
+			if mb.resourceAttributesConfig.SaphanaHost.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/snowflakereceiver/config_test.go
+++ b/receiver/snowflakereceiver/config_test.go
@@ -143,7 +143,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, component.UnmarshalConfig(cmNoStr, cfg))
 	assert.NoError(t, component.ValidateConfig(cfg))
 
-	diff := cmp.Diff(expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricSettings{}))
+	diff := cmp.Diff(expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricConfig{}))
 	if diff != "" {
 		t.Errorf("config mismatch (-expected / +actual)\n%s", diff)
 	}

--- a/receiver/snowflakereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/snowflakereceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,168 +31,168 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for snowflakereceiver metrics.
-type MetricsSettings struct {
-	SnowflakeBillingCloudServiceTotal              MetricSettings `mapstructure:"snowflake.billing.cloud_service.total"`
-	SnowflakeBillingTotalCreditTotal               MetricSettings `mapstructure:"snowflake.billing.total_credit.total"`
-	SnowflakeBillingVirtualWarehouseTotal          MetricSettings `mapstructure:"snowflake.billing.virtual_warehouse.total"`
-	SnowflakeBillingWarehouseCloudServiceTotal     MetricSettings `mapstructure:"snowflake.billing.warehouse.cloud_service.total"`
-	SnowflakeBillingWarehouseTotalCreditTotal      MetricSettings `mapstructure:"snowflake.billing.warehouse.total_credit.total"`
-	SnowflakeBillingWarehouseVirtualWarehouseTotal MetricSettings `mapstructure:"snowflake.billing.warehouse.virtual_warehouse.total"`
-	SnowflakeDatabaseBytesScannedAvg               MetricSettings `mapstructure:"snowflake.database.bytes_scanned.avg"`
-	SnowflakeDatabaseQueryCount                    MetricSettings `mapstructure:"snowflake.database.query.count"`
-	SnowflakeLoginsTotal                           MetricSettings `mapstructure:"snowflake.logins.total"`
-	SnowflakePipeCreditsUsedTotal                  MetricSettings `mapstructure:"snowflake.pipe.credits_used.total"`
-	SnowflakeQueryBlocked                          MetricSettings `mapstructure:"snowflake.query.blocked"`
-	SnowflakeQueryBytesDeletedAvg                  MetricSettings `mapstructure:"snowflake.query.bytes_deleted.avg"`
-	SnowflakeQueryBytesSpilledLocalAvg             MetricSettings `mapstructure:"snowflake.query.bytes_spilled.local.avg"`
-	SnowflakeQueryBytesSpilledRemoteAvg            MetricSettings `mapstructure:"snowflake.query.bytes_spilled.remote.avg"`
-	SnowflakeQueryBytesWrittenAvg                  MetricSettings `mapstructure:"snowflake.query.bytes_written.avg"`
-	SnowflakeQueryCompilationTimeAvg               MetricSettings `mapstructure:"snowflake.query.compilation_time.avg"`
-	SnowflakeQueryDataScannedCacheAvg              MetricSettings `mapstructure:"snowflake.query.data_scanned_cache.avg"`
-	SnowflakeQueryExecuted                         MetricSettings `mapstructure:"snowflake.query.executed"`
-	SnowflakeQueryExecutionTimeAvg                 MetricSettings `mapstructure:"snowflake.query.execution_time.avg"`
-	SnowflakeQueryPartitionsScannedAvg             MetricSettings `mapstructure:"snowflake.query.partitions_scanned.avg"`
-	SnowflakeQueryQueuedOverload                   MetricSettings `mapstructure:"snowflake.query.queued_overload"`
-	SnowflakeQueryQueuedProvision                  MetricSettings `mapstructure:"snowflake.query.queued_provision"`
-	SnowflakeQueuedOverloadTimeAvg                 MetricSettings `mapstructure:"snowflake.queued_overload_time.avg"`
-	SnowflakeQueuedProvisioningTimeAvg             MetricSettings `mapstructure:"snowflake.queued_provisioning_time.avg"`
-	SnowflakeQueuedRepairTimeAvg                   MetricSettings `mapstructure:"snowflake.queued_repair_time.avg"`
-	SnowflakeRowsDeletedAvg                        MetricSettings `mapstructure:"snowflake.rows_deleted.avg"`
-	SnowflakeRowsInsertedAvg                       MetricSettings `mapstructure:"snowflake.rows_inserted.avg"`
-	SnowflakeRowsProducedAvg                       MetricSettings `mapstructure:"snowflake.rows_produced.avg"`
-	SnowflakeRowsUnloadedAvg                       MetricSettings `mapstructure:"snowflake.rows_unloaded.avg"`
-	SnowflakeRowsUpdatedAvg                        MetricSettings `mapstructure:"snowflake.rows_updated.avg"`
-	SnowflakeSessionIDCount                        MetricSettings `mapstructure:"snowflake.session_id.count"`
-	SnowflakeStorageFailsafeBytesTotal             MetricSettings `mapstructure:"snowflake.storage.failsafe_bytes.total"`
-	SnowflakeStorageStageBytesTotal                MetricSettings `mapstructure:"snowflake.storage.stage_bytes.total"`
-	SnowflakeStorageStorageBytesTotal              MetricSettings `mapstructure:"snowflake.storage.storage_bytes.total"`
-	SnowflakeTotalElapsedTimeAvg                   MetricSettings `mapstructure:"snowflake.total_elapsed_time.avg"`
+// MetricsConfig provides config for snowflakereceiver metrics.
+type MetricsConfig struct {
+	SnowflakeBillingCloudServiceTotal              MetricConfig `mapstructure:"snowflake.billing.cloud_service.total"`
+	SnowflakeBillingTotalCreditTotal               MetricConfig `mapstructure:"snowflake.billing.total_credit.total"`
+	SnowflakeBillingVirtualWarehouseTotal          MetricConfig `mapstructure:"snowflake.billing.virtual_warehouse.total"`
+	SnowflakeBillingWarehouseCloudServiceTotal     MetricConfig `mapstructure:"snowflake.billing.warehouse.cloud_service.total"`
+	SnowflakeBillingWarehouseTotalCreditTotal      MetricConfig `mapstructure:"snowflake.billing.warehouse.total_credit.total"`
+	SnowflakeBillingWarehouseVirtualWarehouseTotal MetricConfig `mapstructure:"snowflake.billing.warehouse.virtual_warehouse.total"`
+	SnowflakeDatabaseBytesScannedAvg               MetricConfig `mapstructure:"snowflake.database.bytes_scanned.avg"`
+	SnowflakeDatabaseQueryCount                    MetricConfig `mapstructure:"snowflake.database.query.count"`
+	SnowflakeLoginsTotal                           MetricConfig `mapstructure:"snowflake.logins.total"`
+	SnowflakePipeCreditsUsedTotal                  MetricConfig `mapstructure:"snowflake.pipe.credits_used.total"`
+	SnowflakeQueryBlocked                          MetricConfig `mapstructure:"snowflake.query.blocked"`
+	SnowflakeQueryBytesDeletedAvg                  MetricConfig `mapstructure:"snowflake.query.bytes_deleted.avg"`
+	SnowflakeQueryBytesSpilledLocalAvg             MetricConfig `mapstructure:"snowflake.query.bytes_spilled.local.avg"`
+	SnowflakeQueryBytesSpilledRemoteAvg            MetricConfig `mapstructure:"snowflake.query.bytes_spilled.remote.avg"`
+	SnowflakeQueryBytesWrittenAvg                  MetricConfig `mapstructure:"snowflake.query.bytes_written.avg"`
+	SnowflakeQueryCompilationTimeAvg               MetricConfig `mapstructure:"snowflake.query.compilation_time.avg"`
+	SnowflakeQueryDataScannedCacheAvg              MetricConfig `mapstructure:"snowflake.query.data_scanned_cache.avg"`
+	SnowflakeQueryExecuted                         MetricConfig `mapstructure:"snowflake.query.executed"`
+	SnowflakeQueryExecutionTimeAvg                 MetricConfig `mapstructure:"snowflake.query.execution_time.avg"`
+	SnowflakeQueryPartitionsScannedAvg             MetricConfig `mapstructure:"snowflake.query.partitions_scanned.avg"`
+	SnowflakeQueryQueuedOverload                   MetricConfig `mapstructure:"snowflake.query.queued_overload"`
+	SnowflakeQueryQueuedProvision                  MetricConfig `mapstructure:"snowflake.query.queued_provision"`
+	SnowflakeQueuedOverloadTimeAvg                 MetricConfig `mapstructure:"snowflake.queued_overload_time.avg"`
+	SnowflakeQueuedProvisioningTimeAvg             MetricConfig `mapstructure:"snowflake.queued_provisioning_time.avg"`
+	SnowflakeQueuedRepairTimeAvg                   MetricConfig `mapstructure:"snowflake.queued_repair_time.avg"`
+	SnowflakeRowsDeletedAvg                        MetricConfig `mapstructure:"snowflake.rows_deleted.avg"`
+	SnowflakeRowsInsertedAvg                       MetricConfig `mapstructure:"snowflake.rows_inserted.avg"`
+	SnowflakeRowsProducedAvg                       MetricConfig `mapstructure:"snowflake.rows_produced.avg"`
+	SnowflakeRowsUnloadedAvg                       MetricConfig `mapstructure:"snowflake.rows_unloaded.avg"`
+	SnowflakeRowsUpdatedAvg                        MetricConfig `mapstructure:"snowflake.rows_updated.avg"`
+	SnowflakeSessionIDCount                        MetricConfig `mapstructure:"snowflake.session_id.count"`
+	SnowflakeStorageFailsafeBytesTotal             MetricConfig `mapstructure:"snowflake.storage.failsafe_bytes.total"`
+	SnowflakeStorageStageBytesTotal                MetricConfig `mapstructure:"snowflake.storage.stage_bytes.total"`
+	SnowflakeStorageStorageBytesTotal              MetricConfig `mapstructure:"snowflake.storage.storage_bytes.total"`
+	SnowflakeTotalElapsedTimeAvg                   MetricConfig `mapstructure:"snowflake.total_elapsed_time.avg"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		SnowflakeBillingCloudServiceTotal: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		SnowflakeBillingCloudServiceTotal: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeBillingTotalCreditTotal: MetricSettings{
+		SnowflakeBillingTotalCreditTotal: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeBillingVirtualWarehouseTotal: MetricSettings{
+		SnowflakeBillingVirtualWarehouseTotal: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeBillingWarehouseCloudServiceTotal: MetricSettings{
+		SnowflakeBillingWarehouseCloudServiceTotal: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeBillingWarehouseTotalCreditTotal: MetricSettings{
+		SnowflakeBillingWarehouseTotalCreditTotal: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeBillingWarehouseVirtualWarehouseTotal: MetricSettings{
+		SnowflakeBillingWarehouseVirtualWarehouseTotal: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeDatabaseBytesScannedAvg: MetricSettings{
+		SnowflakeDatabaseBytesScannedAvg: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeDatabaseQueryCount: MetricSettings{
+		SnowflakeDatabaseQueryCount: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeLoginsTotal: MetricSettings{
+		SnowflakeLoginsTotal: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakePipeCreditsUsedTotal: MetricSettings{
+		SnowflakePipeCreditsUsedTotal: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeQueryBlocked: MetricSettings{
+		SnowflakeQueryBlocked: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeQueryBytesDeletedAvg: MetricSettings{
+		SnowflakeQueryBytesDeletedAvg: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeQueryBytesSpilledLocalAvg: MetricSettings{
+		SnowflakeQueryBytesSpilledLocalAvg: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeQueryBytesSpilledRemoteAvg: MetricSettings{
+		SnowflakeQueryBytesSpilledRemoteAvg: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeQueryBytesWrittenAvg: MetricSettings{
+		SnowflakeQueryBytesWrittenAvg: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeQueryCompilationTimeAvg: MetricSettings{
+		SnowflakeQueryCompilationTimeAvg: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeQueryDataScannedCacheAvg: MetricSettings{
+		SnowflakeQueryDataScannedCacheAvg: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeQueryExecuted: MetricSettings{
+		SnowflakeQueryExecuted: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeQueryExecutionTimeAvg: MetricSettings{
+		SnowflakeQueryExecutionTimeAvg: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeQueryPartitionsScannedAvg: MetricSettings{
+		SnowflakeQueryPartitionsScannedAvg: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeQueryQueuedOverload: MetricSettings{
+		SnowflakeQueryQueuedOverload: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeQueryQueuedProvision: MetricSettings{
+		SnowflakeQueryQueuedProvision: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeQueuedOverloadTimeAvg: MetricSettings{
+		SnowflakeQueuedOverloadTimeAvg: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeQueuedProvisioningTimeAvg: MetricSettings{
+		SnowflakeQueuedProvisioningTimeAvg: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeQueuedRepairTimeAvg: MetricSettings{
+		SnowflakeQueuedRepairTimeAvg: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeRowsDeletedAvg: MetricSettings{
+		SnowflakeRowsDeletedAvg: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeRowsInsertedAvg: MetricSettings{
+		SnowflakeRowsInsertedAvg: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeRowsProducedAvg: MetricSettings{
+		SnowflakeRowsProducedAvg: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeRowsUnloadedAvg: MetricSettings{
+		SnowflakeRowsUnloadedAvg: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeRowsUpdatedAvg: MetricSettings{
+		SnowflakeRowsUpdatedAvg: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeSessionIDCount: MetricSettings{
+		SnowflakeSessionIDCount: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeStorageFailsafeBytesTotal: MetricSettings{
+		SnowflakeStorageFailsafeBytesTotal: MetricConfig{
 			Enabled: false,
 		},
-		SnowflakeStorageStageBytesTotal: MetricSettings{
+		SnowflakeStorageStageBytesTotal: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeStorageStorageBytesTotal: MetricSettings{
+		SnowflakeStorageStorageBytesTotal: MetricConfig{
 			Enabled: true,
 		},
-		SnowflakeTotalElapsedTimeAvg: MetricSettings{
+		SnowflakeTotalElapsedTimeAvg: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for snowflakereceiver resource attributes.
-type ResourceAttributesSettings struct {
-	SnowflakeAccountName ResourceAttributeSettings `mapstructure:"snowflake.account.name"`
+// ResourceAttributesConfig provides config for snowflakereceiver resource attributes.
+type ResourceAttributesConfig struct {
+	SnowflakeAccountName ResourceAttributeConfig `mapstructure:"snowflake.account.name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		SnowflakeAccountName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		SnowflakeAccountName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -200,7 +200,7 @@ func DefaultResourceAttributesSettings() ResourceAttributesSettings {
 
 type metricSnowflakeBillingCloudServiceTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -214,7 +214,7 @@ func (m *metricSnowflakeBillingCloudServiceTotal) init() {
 }
 
 func (m *metricSnowflakeBillingCloudServiceTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, serviceTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -233,16 +233,16 @@ func (m *metricSnowflakeBillingCloudServiceTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeBillingCloudServiceTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeBillingCloudServiceTotal(settings MetricSettings) metricSnowflakeBillingCloudServiceTotal {
-	m := metricSnowflakeBillingCloudServiceTotal{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeBillingCloudServiceTotal(cfg MetricConfig) metricSnowflakeBillingCloudServiceTotal {
+	m := metricSnowflakeBillingCloudServiceTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -251,7 +251,7 @@ func newMetricSnowflakeBillingCloudServiceTotal(settings MetricSettings) metricS
 
 type metricSnowflakeBillingTotalCreditTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -265,7 +265,7 @@ func (m *metricSnowflakeBillingTotalCreditTotal) init() {
 }
 
 func (m *metricSnowflakeBillingTotalCreditTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, serviceTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -284,16 +284,16 @@ func (m *metricSnowflakeBillingTotalCreditTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeBillingTotalCreditTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeBillingTotalCreditTotal(settings MetricSettings) metricSnowflakeBillingTotalCreditTotal {
-	m := metricSnowflakeBillingTotalCreditTotal{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeBillingTotalCreditTotal(cfg MetricConfig) metricSnowflakeBillingTotalCreditTotal {
+	m := metricSnowflakeBillingTotalCreditTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -302,7 +302,7 @@ func newMetricSnowflakeBillingTotalCreditTotal(settings MetricSettings) metricSn
 
 type metricSnowflakeBillingVirtualWarehouseTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -316,7 +316,7 @@ func (m *metricSnowflakeBillingVirtualWarehouseTotal) init() {
 }
 
 func (m *metricSnowflakeBillingVirtualWarehouseTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, serviceTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -335,16 +335,16 @@ func (m *metricSnowflakeBillingVirtualWarehouseTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeBillingVirtualWarehouseTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeBillingVirtualWarehouseTotal(settings MetricSettings) metricSnowflakeBillingVirtualWarehouseTotal {
-	m := metricSnowflakeBillingVirtualWarehouseTotal{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeBillingVirtualWarehouseTotal(cfg MetricConfig) metricSnowflakeBillingVirtualWarehouseTotal {
+	m := metricSnowflakeBillingVirtualWarehouseTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -353,7 +353,7 @@ func newMetricSnowflakeBillingVirtualWarehouseTotal(settings MetricSettings) met
 
 type metricSnowflakeBillingWarehouseCloudServiceTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -367,7 +367,7 @@ func (m *metricSnowflakeBillingWarehouseCloudServiceTotal) init() {
 }
 
 func (m *metricSnowflakeBillingWarehouseCloudServiceTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, warehouseNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -386,16 +386,16 @@ func (m *metricSnowflakeBillingWarehouseCloudServiceTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeBillingWarehouseCloudServiceTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeBillingWarehouseCloudServiceTotal(settings MetricSettings) metricSnowflakeBillingWarehouseCloudServiceTotal {
-	m := metricSnowflakeBillingWarehouseCloudServiceTotal{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeBillingWarehouseCloudServiceTotal(cfg MetricConfig) metricSnowflakeBillingWarehouseCloudServiceTotal {
+	m := metricSnowflakeBillingWarehouseCloudServiceTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -404,7 +404,7 @@ func newMetricSnowflakeBillingWarehouseCloudServiceTotal(settings MetricSettings
 
 type metricSnowflakeBillingWarehouseTotalCreditTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -418,7 +418,7 @@ func (m *metricSnowflakeBillingWarehouseTotalCreditTotal) init() {
 }
 
 func (m *metricSnowflakeBillingWarehouseTotalCreditTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, warehouseNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -437,16 +437,16 @@ func (m *metricSnowflakeBillingWarehouseTotalCreditTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeBillingWarehouseTotalCreditTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeBillingWarehouseTotalCreditTotal(settings MetricSettings) metricSnowflakeBillingWarehouseTotalCreditTotal {
-	m := metricSnowflakeBillingWarehouseTotalCreditTotal{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeBillingWarehouseTotalCreditTotal(cfg MetricConfig) metricSnowflakeBillingWarehouseTotalCreditTotal {
+	m := metricSnowflakeBillingWarehouseTotalCreditTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -455,7 +455,7 @@ func newMetricSnowflakeBillingWarehouseTotalCreditTotal(settings MetricSettings)
 
 type metricSnowflakeBillingWarehouseVirtualWarehouseTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -469,7 +469,7 @@ func (m *metricSnowflakeBillingWarehouseVirtualWarehouseTotal) init() {
 }
 
 func (m *metricSnowflakeBillingWarehouseVirtualWarehouseTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, warehouseNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -488,16 +488,16 @@ func (m *metricSnowflakeBillingWarehouseVirtualWarehouseTotal) updateCapacity() 
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeBillingWarehouseVirtualWarehouseTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeBillingWarehouseVirtualWarehouseTotal(settings MetricSettings) metricSnowflakeBillingWarehouseVirtualWarehouseTotal {
-	m := metricSnowflakeBillingWarehouseVirtualWarehouseTotal{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeBillingWarehouseVirtualWarehouseTotal(cfg MetricConfig) metricSnowflakeBillingWarehouseVirtualWarehouseTotal {
+	m := metricSnowflakeBillingWarehouseVirtualWarehouseTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -506,7 +506,7 @@ func newMetricSnowflakeBillingWarehouseVirtualWarehouseTotal(settings MetricSett
 
 type metricSnowflakeDatabaseBytesScannedAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -520,7 +520,7 @@ func (m *metricSnowflakeDatabaseBytesScannedAvg) init() {
 }
 
 func (m *metricSnowflakeDatabaseBytesScannedAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -545,16 +545,16 @@ func (m *metricSnowflakeDatabaseBytesScannedAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeDatabaseBytesScannedAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeDatabaseBytesScannedAvg(settings MetricSettings) metricSnowflakeDatabaseBytesScannedAvg {
-	m := metricSnowflakeDatabaseBytesScannedAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeDatabaseBytesScannedAvg(cfg MetricConfig) metricSnowflakeDatabaseBytesScannedAvg {
+	m := metricSnowflakeDatabaseBytesScannedAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -563,7 +563,7 @@ func newMetricSnowflakeDatabaseBytesScannedAvg(settings MetricSettings) metricSn
 
 type metricSnowflakeDatabaseQueryCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -577,7 +577,7 @@ func (m *metricSnowflakeDatabaseQueryCount) init() {
 }
 
 func (m *metricSnowflakeDatabaseQueryCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -602,16 +602,16 @@ func (m *metricSnowflakeDatabaseQueryCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeDatabaseQueryCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeDatabaseQueryCount(settings MetricSettings) metricSnowflakeDatabaseQueryCount {
-	m := metricSnowflakeDatabaseQueryCount{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeDatabaseQueryCount(cfg MetricConfig) metricSnowflakeDatabaseQueryCount {
+	m := metricSnowflakeDatabaseQueryCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -620,7 +620,7 @@ func newMetricSnowflakeDatabaseQueryCount(settings MetricSettings) metricSnowfla
 
 type metricSnowflakeLoginsTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -634,7 +634,7 @@ func (m *metricSnowflakeLoginsTotal) init() {
 }
 
 func (m *metricSnowflakeLoginsTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, errorMessageAttributeValue string, reportedClientTypeAttributeValue string, isSuccessAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -655,16 +655,16 @@ func (m *metricSnowflakeLoginsTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeLoginsTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeLoginsTotal(settings MetricSettings) metricSnowflakeLoginsTotal {
-	m := metricSnowflakeLoginsTotal{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeLoginsTotal(cfg MetricConfig) metricSnowflakeLoginsTotal {
+	m := metricSnowflakeLoginsTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -673,7 +673,7 @@ func newMetricSnowflakeLoginsTotal(settings MetricSettings) metricSnowflakeLogin
 
 type metricSnowflakePipeCreditsUsedTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -687,7 +687,7 @@ func (m *metricSnowflakePipeCreditsUsedTotal) init() {
 }
 
 func (m *metricSnowflakePipeCreditsUsedTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, pipeNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -706,16 +706,16 @@ func (m *metricSnowflakePipeCreditsUsedTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakePipeCreditsUsedTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakePipeCreditsUsedTotal(settings MetricSettings) metricSnowflakePipeCreditsUsedTotal {
-	m := metricSnowflakePipeCreditsUsedTotal{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakePipeCreditsUsedTotal(cfg MetricConfig) metricSnowflakePipeCreditsUsedTotal {
+	m := metricSnowflakePipeCreditsUsedTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -724,7 +724,7 @@ func newMetricSnowflakePipeCreditsUsedTotal(settings MetricSettings) metricSnowf
 
 type metricSnowflakeQueryBlocked struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -738,7 +738,7 @@ func (m *metricSnowflakeQueryBlocked) init() {
 }
 
 func (m *metricSnowflakeQueryBlocked) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, warehouseNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -757,16 +757,16 @@ func (m *metricSnowflakeQueryBlocked) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryBlocked) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryBlocked(settings MetricSettings) metricSnowflakeQueryBlocked {
-	m := metricSnowflakeQueryBlocked{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryBlocked(cfg MetricConfig) metricSnowflakeQueryBlocked {
+	m := metricSnowflakeQueryBlocked{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -775,7 +775,7 @@ func newMetricSnowflakeQueryBlocked(settings MetricSettings) metricSnowflakeQuer
 
 type metricSnowflakeQueryBytesDeletedAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -789,7 +789,7 @@ func (m *metricSnowflakeQueryBytesDeletedAvg) init() {
 }
 
 func (m *metricSnowflakeQueryBytesDeletedAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -814,16 +814,16 @@ func (m *metricSnowflakeQueryBytesDeletedAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryBytesDeletedAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryBytesDeletedAvg(settings MetricSettings) metricSnowflakeQueryBytesDeletedAvg {
-	m := metricSnowflakeQueryBytesDeletedAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryBytesDeletedAvg(cfg MetricConfig) metricSnowflakeQueryBytesDeletedAvg {
+	m := metricSnowflakeQueryBytesDeletedAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -832,7 +832,7 @@ func newMetricSnowflakeQueryBytesDeletedAvg(settings MetricSettings) metricSnowf
 
 type metricSnowflakeQueryBytesSpilledLocalAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -846,7 +846,7 @@ func (m *metricSnowflakeQueryBytesSpilledLocalAvg) init() {
 }
 
 func (m *metricSnowflakeQueryBytesSpilledLocalAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -871,16 +871,16 @@ func (m *metricSnowflakeQueryBytesSpilledLocalAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryBytesSpilledLocalAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryBytesSpilledLocalAvg(settings MetricSettings) metricSnowflakeQueryBytesSpilledLocalAvg {
-	m := metricSnowflakeQueryBytesSpilledLocalAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryBytesSpilledLocalAvg(cfg MetricConfig) metricSnowflakeQueryBytesSpilledLocalAvg {
+	m := metricSnowflakeQueryBytesSpilledLocalAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -889,7 +889,7 @@ func newMetricSnowflakeQueryBytesSpilledLocalAvg(settings MetricSettings) metric
 
 type metricSnowflakeQueryBytesSpilledRemoteAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -903,7 +903,7 @@ func (m *metricSnowflakeQueryBytesSpilledRemoteAvg) init() {
 }
 
 func (m *metricSnowflakeQueryBytesSpilledRemoteAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -928,16 +928,16 @@ func (m *metricSnowflakeQueryBytesSpilledRemoteAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryBytesSpilledRemoteAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryBytesSpilledRemoteAvg(settings MetricSettings) metricSnowflakeQueryBytesSpilledRemoteAvg {
-	m := metricSnowflakeQueryBytesSpilledRemoteAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryBytesSpilledRemoteAvg(cfg MetricConfig) metricSnowflakeQueryBytesSpilledRemoteAvg {
+	m := metricSnowflakeQueryBytesSpilledRemoteAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -946,7 +946,7 @@ func newMetricSnowflakeQueryBytesSpilledRemoteAvg(settings MetricSettings) metri
 
 type metricSnowflakeQueryBytesWrittenAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -960,7 +960,7 @@ func (m *metricSnowflakeQueryBytesWrittenAvg) init() {
 }
 
 func (m *metricSnowflakeQueryBytesWrittenAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -985,16 +985,16 @@ func (m *metricSnowflakeQueryBytesWrittenAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryBytesWrittenAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryBytesWrittenAvg(settings MetricSettings) metricSnowflakeQueryBytesWrittenAvg {
-	m := metricSnowflakeQueryBytesWrittenAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryBytesWrittenAvg(cfg MetricConfig) metricSnowflakeQueryBytesWrittenAvg {
+	m := metricSnowflakeQueryBytesWrittenAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1003,7 +1003,7 @@ func newMetricSnowflakeQueryBytesWrittenAvg(settings MetricSettings) metricSnowf
 
 type metricSnowflakeQueryCompilationTimeAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1017,7 +1017,7 @@ func (m *metricSnowflakeQueryCompilationTimeAvg) init() {
 }
 
 func (m *metricSnowflakeQueryCompilationTimeAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1042,16 +1042,16 @@ func (m *metricSnowflakeQueryCompilationTimeAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryCompilationTimeAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryCompilationTimeAvg(settings MetricSettings) metricSnowflakeQueryCompilationTimeAvg {
-	m := metricSnowflakeQueryCompilationTimeAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryCompilationTimeAvg(cfg MetricConfig) metricSnowflakeQueryCompilationTimeAvg {
+	m := metricSnowflakeQueryCompilationTimeAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1060,7 +1060,7 @@ func newMetricSnowflakeQueryCompilationTimeAvg(settings MetricSettings) metricSn
 
 type metricSnowflakeQueryDataScannedCacheAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1074,7 +1074,7 @@ func (m *metricSnowflakeQueryDataScannedCacheAvg) init() {
 }
 
 func (m *metricSnowflakeQueryDataScannedCacheAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1099,16 +1099,16 @@ func (m *metricSnowflakeQueryDataScannedCacheAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryDataScannedCacheAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryDataScannedCacheAvg(settings MetricSettings) metricSnowflakeQueryDataScannedCacheAvg {
-	m := metricSnowflakeQueryDataScannedCacheAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryDataScannedCacheAvg(cfg MetricConfig) metricSnowflakeQueryDataScannedCacheAvg {
+	m := metricSnowflakeQueryDataScannedCacheAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1117,7 +1117,7 @@ func newMetricSnowflakeQueryDataScannedCacheAvg(settings MetricSettings) metricS
 
 type metricSnowflakeQueryExecuted struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1131,7 +1131,7 @@ func (m *metricSnowflakeQueryExecuted) init() {
 }
 
 func (m *metricSnowflakeQueryExecuted) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, warehouseNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1150,16 +1150,16 @@ func (m *metricSnowflakeQueryExecuted) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryExecuted) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryExecuted(settings MetricSettings) metricSnowflakeQueryExecuted {
-	m := metricSnowflakeQueryExecuted{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryExecuted(cfg MetricConfig) metricSnowflakeQueryExecuted {
+	m := metricSnowflakeQueryExecuted{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1168,7 +1168,7 @@ func newMetricSnowflakeQueryExecuted(settings MetricSettings) metricSnowflakeQue
 
 type metricSnowflakeQueryExecutionTimeAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1182,7 +1182,7 @@ func (m *metricSnowflakeQueryExecutionTimeAvg) init() {
 }
 
 func (m *metricSnowflakeQueryExecutionTimeAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1207,16 +1207,16 @@ func (m *metricSnowflakeQueryExecutionTimeAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryExecutionTimeAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryExecutionTimeAvg(settings MetricSettings) metricSnowflakeQueryExecutionTimeAvg {
-	m := metricSnowflakeQueryExecutionTimeAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryExecutionTimeAvg(cfg MetricConfig) metricSnowflakeQueryExecutionTimeAvg {
+	m := metricSnowflakeQueryExecutionTimeAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1225,7 +1225,7 @@ func newMetricSnowflakeQueryExecutionTimeAvg(settings MetricSettings) metricSnow
 
 type metricSnowflakeQueryPartitionsScannedAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1239,7 +1239,7 @@ func (m *metricSnowflakeQueryPartitionsScannedAvg) init() {
 }
 
 func (m *metricSnowflakeQueryPartitionsScannedAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1264,16 +1264,16 @@ func (m *metricSnowflakeQueryPartitionsScannedAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryPartitionsScannedAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryPartitionsScannedAvg(settings MetricSettings) metricSnowflakeQueryPartitionsScannedAvg {
-	m := metricSnowflakeQueryPartitionsScannedAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryPartitionsScannedAvg(cfg MetricConfig) metricSnowflakeQueryPartitionsScannedAvg {
+	m := metricSnowflakeQueryPartitionsScannedAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1282,7 +1282,7 @@ func newMetricSnowflakeQueryPartitionsScannedAvg(settings MetricSettings) metric
 
 type metricSnowflakeQueryQueuedOverload struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1296,7 +1296,7 @@ func (m *metricSnowflakeQueryQueuedOverload) init() {
 }
 
 func (m *metricSnowflakeQueryQueuedOverload) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, warehouseNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1315,16 +1315,16 @@ func (m *metricSnowflakeQueryQueuedOverload) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryQueuedOverload) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryQueuedOverload(settings MetricSettings) metricSnowflakeQueryQueuedOverload {
-	m := metricSnowflakeQueryQueuedOverload{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryQueuedOverload(cfg MetricConfig) metricSnowflakeQueryQueuedOverload {
+	m := metricSnowflakeQueryQueuedOverload{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1333,7 +1333,7 @@ func newMetricSnowflakeQueryQueuedOverload(settings MetricSettings) metricSnowfl
 
 type metricSnowflakeQueryQueuedProvision struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1347,7 +1347,7 @@ func (m *metricSnowflakeQueryQueuedProvision) init() {
 }
 
 func (m *metricSnowflakeQueryQueuedProvision) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, warehouseNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1366,16 +1366,16 @@ func (m *metricSnowflakeQueryQueuedProvision) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueryQueuedProvision) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueryQueuedProvision(settings MetricSettings) metricSnowflakeQueryQueuedProvision {
-	m := metricSnowflakeQueryQueuedProvision{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueryQueuedProvision(cfg MetricConfig) metricSnowflakeQueryQueuedProvision {
+	m := metricSnowflakeQueryQueuedProvision{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1384,7 +1384,7 @@ func newMetricSnowflakeQueryQueuedProvision(settings MetricSettings) metricSnowf
 
 type metricSnowflakeQueuedOverloadTimeAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1398,7 +1398,7 @@ func (m *metricSnowflakeQueuedOverloadTimeAvg) init() {
 }
 
 func (m *metricSnowflakeQueuedOverloadTimeAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1423,16 +1423,16 @@ func (m *metricSnowflakeQueuedOverloadTimeAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueuedOverloadTimeAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueuedOverloadTimeAvg(settings MetricSettings) metricSnowflakeQueuedOverloadTimeAvg {
-	m := metricSnowflakeQueuedOverloadTimeAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueuedOverloadTimeAvg(cfg MetricConfig) metricSnowflakeQueuedOverloadTimeAvg {
+	m := metricSnowflakeQueuedOverloadTimeAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1441,7 +1441,7 @@ func newMetricSnowflakeQueuedOverloadTimeAvg(settings MetricSettings) metricSnow
 
 type metricSnowflakeQueuedProvisioningTimeAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1455,7 +1455,7 @@ func (m *metricSnowflakeQueuedProvisioningTimeAvg) init() {
 }
 
 func (m *metricSnowflakeQueuedProvisioningTimeAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1480,16 +1480,16 @@ func (m *metricSnowflakeQueuedProvisioningTimeAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueuedProvisioningTimeAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueuedProvisioningTimeAvg(settings MetricSettings) metricSnowflakeQueuedProvisioningTimeAvg {
-	m := metricSnowflakeQueuedProvisioningTimeAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueuedProvisioningTimeAvg(cfg MetricConfig) metricSnowflakeQueuedProvisioningTimeAvg {
+	m := metricSnowflakeQueuedProvisioningTimeAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1498,7 +1498,7 @@ func newMetricSnowflakeQueuedProvisioningTimeAvg(settings MetricSettings) metric
 
 type metricSnowflakeQueuedRepairTimeAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1512,7 +1512,7 @@ func (m *metricSnowflakeQueuedRepairTimeAvg) init() {
 }
 
 func (m *metricSnowflakeQueuedRepairTimeAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1537,16 +1537,16 @@ func (m *metricSnowflakeQueuedRepairTimeAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeQueuedRepairTimeAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeQueuedRepairTimeAvg(settings MetricSettings) metricSnowflakeQueuedRepairTimeAvg {
-	m := metricSnowflakeQueuedRepairTimeAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeQueuedRepairTimeAvg(cfg MetricConfig) metricSnowflakeQueuedRepairTimeAvg {
+	m := metricSnowflakeQueuedRepairTimeAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1555,7 +1555,7 @@ func newMetricSnowflakeQueuedRepairTimeAvg(settings MetricSettings) metricSnowfl
 
 type metricSnowflakeRowsDeletedAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1569,7 +1569,7 @@ func (m *metricSnowflakeRowsDeletedAvg) init() {
 }
 
 func (m *metricSnowflakeRowsDeletedAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1594,16 +1594,16 @@ func (m *metricSnowflakeRowsDeletedAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeRowsDeletedAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeRowsDeletedAvg(settings MetricSettings) metricSnowflakeRowsDeletedAvg {
-	m := metricSnowflakeRowsDeletedAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeRowsDeletedAvg(cfg MetricConfig) metricSnowflakeRowsDeletedAvg {
+	m := metricSnowflakeRowsDeletedAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1612,7 +1612,7 @@ func newMetricSnowflakeRowsDeletedAvg(settings MetricSettings) metricSnowflakeRo
 
 type metricSnowflakeRowsInsertedAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1626,7 +1626,7 @@ func (m *metricSnowflakeRowsInsertedAvg) init() {
 }
 
 func (m *metricSnowflakeRowsInsertedAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1651,16 +1651,16 @@ func (m *metricSnowflakeRowsInsertedAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeRowsInsertedAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeRowsInsertedAvg(settings MetricSettings) metricSnowflakeRowsInsertedAvg {
-	m := metricSnowflakeRowsInsertedAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeRowsInsertedAvg(cfg MetricConfig) metricSnowflakeRowsInsertedAvg {
+	m := metricSnowflakeRowsInsertedAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1669,7 +1669,7 @@ func newMetricSnowflakeRowsInsertedAvg(settings MetricSettings) metricSnowflakeR
 
 type metricSnowflakeRowsProducedAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1683,7 +1683,7 @@ func (m *metricSnowflakeRowsProducedAvg) init() {
 }
 
 func (m *metricSnowflakeRowsProducedAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1708,16 +1708,16 @@ func (m *metricSnowflakeRowsProducedAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeRowsProducedAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeRowsProducedAvg(settings MetricSettings) metricSnowflakeRowsProducedAvg {
-	m := metricSnowflakeRowsProducedAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeRowsProducedAvg(cfg MetricConfig) metricSnowflakeRowsProducedAvg {
+	m := metricSnowflakeRowsProducedAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1726,7 +1726,7 @@ func newMetricSnowflakeRowsProducedAvg(settings MetricSettings) metricSnowflakeR
 
 type metricSnowflakeRowsUnloadedAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1740,7 +1740,7 @@ func (m *metricSnowflakeRowsUnloadedAvg) init() {
 }
 
 func (m *metricSnowflakeRowsUnloadedAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1765,16 +1765,16 @@ func (m *metricSnowflakeRowsUnloadedAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeRowsUnloadedAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeRowsUnloadedAvg(settings MetricSettings) metricSnowflakeRowsUnloadedAvg {
-	m := metricSnowflakeRowsUnloadedAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeRowsUnloadedAvg(cfg MetricConfig) metricSnowflakeRowsUnloadedAvg {
+	m := metricSnowflakeRowsUnloadedAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1783,7 +1783,7 @@ func newMetricSnowflakeRowsUnloadedAvg(settings MetricSettings) metricSnowflakeR
 
 type metricSnowflakeRowsUpdatedAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1797,7 +1797,7 @@ func (m *metricSnowflakeRowsUpdatedAvg) init() {
 }
 
 func (m *metricSnowflakeRowsUpdatedAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1822,16 +1822,16 @@ func (m *metricSnowflakeRowsUpdatedAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeRowsUpdatedAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeRowsUpdatedAvg(settings MetricSettings) metricSnowflakeRowsUpdatedAvg {
-	m := metricSnowflakeRowsUpdatedAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeRowsUpdatedAvg(cfg MetricConfig) metricSnowflakeRowsUpdatedAvg {
+	m := metricSnowflakeRowsUpdatedAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1840,7 +1840,7 @@ func newMetricSnowflakeRowsUpdatedAvg(settings MetricSettings) metricSnowflakeRo
 
 type metricSnowflakeSessionIDCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1854,7 +1854,7 @@ func (m *metricSnowflakeSessionIDCount) init() {
 }
 
 func (m *metricSnowflakeSessionIDCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, userNameAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1873,16 +1873,16 @@ func (m *metricSnowflakeSessionIDCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeSessionIDCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeSessionIDCount(settings MetricSettings) metricSnowflakeSessionIDCount {
-	m := metricSnowflakeSessionIDCount{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeSessionIDCount(cfg MetricConfig) metricSnowflakeSessionIDCount {
+	m := metricSnowflakeSessionIDCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1891,7 +1891,7 @@ func newMetricSnowflakeSessionIDCount(settings MetricSettings) metricSnowflakeSe
 
 type metricSnowflakeStorageFailsafeBytesTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1904,7 +1904,7 @@ func (m *metricSnowflakeStorageFailsafeBytesTotal) init() {
 }
 
 func (m *metricSnowflakeStorageFailsafeBytesTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1922,16 +1922,16 @@ func (m *metricSnowflakeStorageFailsafeBytesTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeStorageFailsafeBytesTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeStorageFailsafeBytesTotal(settings MetricSettings) metricSnowflakeStorageFailsafeBytesTotal {
-	m := metricSnowflakeStorageFailsafeBytesTotal{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeStorageFailsafeBytesTotal(cfg MetricConfig) metricSnowflakeStorageFailsafeBytesTotal {
+	m := metricSnowflakeStorageFailsafeBytesTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1940,7 +1940,7 @@ func newMetricSnowflakeStorageFailsafeBytesTotal(settings MetricSettings) metric
 
 type metricSnowflakeStorageStageBytesTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1953,7 +1953,7 @@ func (m *metricSnowflakeStorageStageBytesTotal) init() {
 }
 
 func (m *metricSnowflakeStorageStageBytesTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1971,16 +1971,16 @@ func (m *metricSnowflakeStorageStageBytesTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeStorageStageBytesTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeStorageStageBytesTotal(settings MetricSettings) metricSnowflakeStorageStageBytesTotal {
-	m := metricSnowflakeStorageStageBytesTotal{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeStorageStageBytesTotal(cfg MetricConfig) metricSnowflakeStorageStageBytesTotal {
+	m := metricSnowflakeStorageStageBytesTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1989,7 +1989,7 @@ func newMetricSnowflakeStorageStageBytesTotal(settings MetricSettings) metricSno
 
 type metricSnowflakeStorageStorageBytesTotal struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2002,7 +2002,7 @@ func (m *metricSnowflakeStorageStorageBytesTotal) init() {
 }
 
 func (m *metricSnowflakeStorageStorageBytesTotal) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2020,16 +2020,16 @@ func (m *metricSnowflakeStorageStorageBytesTotal) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeStorageStorageBytesTotal) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeStorageStorageBytesTotal(settings MetricSettings) metricSnowflakeStorageStorageBytesTotal {
-	m := metricSnowflakeStorageStorageBytesTotal{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeStorageStorageBytesTotal(cfg MetricConfig) metricSnowflakeStorageStorageBytesTotal {
+	m := metricSnowflakeStorageStorageBytesTotal{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2038,7 +2038,7 @@ func newMetricSnowflakeStorageStorageBytesTotal(settings MetricSettings) metricS
 
 type metricSnowflakeTotalElapsedTimeAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2052,7 +2052,7 @@ func (m *metricSnowflakeTotalElapsedTimeAvg) init() {
 }
 
 func (m *metricSnowflakeTotalElapsedTimeAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, schemaNameAttributeValue string, executionStatusAttributeValue string, errorMessageAttributeValue string, queryTypeAttributeValue string, warehouseNameAttributeValue string, databaseNameAttributeValue string, warehouseSizeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -2077,16 +2077,16 @@ func (m *metricSnowflakeTotalElapsedTimeAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSnowflakeTotalElapsedTimeAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSnowflakeTotalElapsedTimeAvg(settings MetricSettings) metricSnowflakeTotalElapsedTimeAvg {
-	m := metricSnowflakeTotalElapsedTimeAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSnowflakeTotalElapsedTimeAvg(cfg MetricConfig) metricSnowflakeTotalElapsedTimeAvg {
+	m := metricSnowflakeTotalElapsedTimeAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2095,19 +2095,19 @@ func newMetricSnowflakeTotalElapsedTimeAvg(settings MetricSettings) metricSnowfl
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                            pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                                      int                 // maximum observed number of metrics per resource.
 	resourceCapacity                                     int                 // maximum observed number of resource attributes.
 	metricsBuffer                                        pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                                            component.BuildInfo // contains version information
-	resourceAttributesSettings                           ResourceAttributesSettings
+	resourceAttributesConfig                             ResourceAttributesConfig
 	metricSnowflakeBillingCloudServiceTotal              metricSnowflakeBillingCloudServiceTotal
 	metricSnowflakeBillingTotalCreditTotal               metricSnowflakeBillingTotalCreditTotal
 	metricSnowflakeBillingVirtualWarehouseTotal          metricSnowflakeBillingVirtualWarehouseTotal
@@ -2157,8 +2157,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -2167,7 +2167,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                                            pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                                        pmetric.NewMetrics(),
 		buildInfo:                                            settings.BuildInfo,
-		resourceAttributesSettings:                           mbc.ResourceAttributes,
+		resourceAttributesConfig:                             mbc.ResourceAttributes,
 		metricSnowflakeBillingCloudServiceTotal:              newMetricSnowflakeBillingCloudServiceTotal(mbc.Metrics.SnowflakeBillingCloudServiceTotal),
 		metricSnowflakeBillingTotalCreditTotal:               newMetricSnowflakeBillingTotalCreditTotal(mbc.Metrics.SnowflakeBillingTotalCreditTotal),
 		metricSnowflakeBillingVirtualWarehouseTotal:          newMetricSnowflakeBillingVirtualWarehouseTotal(mbc.Metrics.SnowflakeBillingVirtualWarehouseTotal),
@@ -2221,12 +2221,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithSnowflakeAccountName sets provided value as "snowflake.account.name" attribute for current resource.
 func WithSnowflakeAccountName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.SnowflakeAccountName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.SnowflakeAccountName.Enabled {
 			rm.Resource().Attributes().PutStr("snowflake.account.name", val)
 		}
 	}
@@ -2235,7 +2235,7 @@ func WithSnowflakeAccountName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -2301,7 +2301,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricSnowflakeTotalElapsedTimeAvg.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -2311,7 +2311,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/snowflakereceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/snowflakereceiver/internal/metadata/generated_metrics_test.go
@@ -192,8 +192,8 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("snowflake.account.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.SnowflakeAccountName.Enabled, ok)
-			if mb.resourceAttributesSettings.SnowflakeAccountName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.SnowflakeAccountName.Enabled, ok)
+			if mb.resourceAttributesConfig.SnowflakeAccountName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/sqlserverreceiver/config_test.go
+++ b/receiver/sqlserverreceiver/config_test.go
@@ -77,15 +77,15 @@ func TestLoadConfig(t *testing.T) {
 
 		expected := factory.CreateDefaultConfig().(*Config)
 		expected.MetricsBuilderConfig = metadata.MetricsBuilderConfig{
-			Metrics: metadata.DefaultMetricsSettings(),
-			ResourceAttributes: metadata.ResourceAttributesSettings{
-				SqlserverDatabaseName: metadata.ResourceAttributeSettings{
+			Metrics: metadata.DefaultMetricsConfig(),
+			ResourceAttributes: metadata.ResourceAttributesConfig{
+				SqlserverDatabaseName: metadata.ResourceAttributeConfig{
 					Enabled: true,
 				},
-				SqlserverInstanceName: metadata.ResourceAttributeSettings{
+				SqlserverInstanceName: metadata.ResourceAttributeConfig{
 					Enabled: true,
 				},
-				SqlserverComputerName: metadata.ResourceAttributeSettings{
+				SqlserverComputerName: metadata.ResourceAttributeConfig{
 					Enabled: true,
 				},
 			},

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,116 +31,116 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for sqlserverreceiver metrics.
-type MetricsSettings struct {
-	SqlserverBatchRequestRate            MetricSettings `mapstructure:"sqlserver.batch.request.rate"`
-	SqlserverBatchSQLCompilationRate     MetricSettings `mapstructure:"sqlserver.batch.sql_compilation.rate"`
-	SqlserverBatchSQLRecompilationRate   MetricSettings `mapstructure:"sqlserver.batch.sql_recompilation.rate"`
-	SqlserverLockWaitRate                MetricSettings `mapstructure:"sqlserver.lock.wait.rate"`
-	SqlserverLockWaitTimeAvg             MetricSettings `mapstructure:"sqlserver.lock.wait_time.avg"`
-	SqlserverPageBufferCacheHitRatio     MetricSettings `mapstructure:"sqlserver.page.buffer_cache.hit_ratio"`
-	SqlserverPageCheckpointFlushRate     MetricSettings `mapstructure:"sqlserver.page.checkpoint.flush.rate"`
-	SqlserverPageLazyWriteRate           MetricSettings `mapstructure:"sqlserver.page.lazy_write.rate"`
-	SqlserverPageLifeExpectancy          MetricSettings `mapstructure:"sqlserver.page.life_expectancy"`
-	SqlserverPageOperationRate           MetricSettings `mapstructure:"sqlserver.page.operation.rate"`
-	SqlserverPageSplitRate               MetricSettings `mapstructure:"sqlserver.page.split.rate"`
-	SqlserverTransactionRate             MetricSettings `mapstructure:"sqlserver.transaction.rate"`
-	SqlserverTransactionWriteRate        MetricSettings `mapstructure:"sqlserver.transaction.write.rate"`
-	SqlserverTransactionLogFlushDataRate MetricSettings `mapstructure:"sqlserver.transaction_log.flush.data.rate"`
-	SqlserverTransactionLogFlushRate     MetricSettings `mapstructure:"sqlserver.transaction_log.flush.rate"`
-	SqlserverTransactionLogFlushWaitRate MetricSettings `mapstructure:"sqlserver.transaction_log.flush.wait.rate"`
-	SqlserverTransactionLogGrowthCount   MetricSettings `mapstructure:"sqlserver.transaction_log.growth.count"`
-	SqlserverTransactionLogShrinkCount   MetricSettings `mapstructure:"sqlserver.transaction_log.shrink.count"`
-	SqlserverTransactionLogUsage         MetricSettings `mapstructure:"sqlserver.transaction_log.usage"`
-	SqlserverUserConnectionCount         MetricSettings `mapstructure:"sqlserver.user.connection.count"`
+// MetricsConfig provides config for sqlserverreceiver metrics.
+type MetricsConfig struct {
+	SqlserverBatchRequestRate            MetricConfig `mapstructure:"sqlserver.batch.request.rate"`
+	SqlserverBatchSQLCompilationRate     MetricConfig `mapstructure:"sqlserver.batch.sql_compilation.rate"`
+	SqlserverBatchSQLRecompilationRate   MetricConfig `mapstructure:"sqlserver.batch.sql_recompilation.rate"`
+	SqlserverLockWaitRate                MetricConfig `mapstructure:"sqlserver.lock.wait.rate"`
+	SqlserverLockWaitTimeAvg             MetricConfig `mapstructure:"sqlserver.lock.wait_time.avg"`
+	SqlserverPageBufferCacheHitRatio     MetricConfig `mapstructure:"sqlserver.page.buffer_cache.hit_ratio"`
+	SqlserverPageCheckpointFlushRate     MetricConfig `mapstructure:"sqlserver.page.checkpoint.flush.rate"`
+	SqlserverPageLazyWriteRate           MetricConfig `mapstructure:"sqlserver.page.lazy_write.rate"`
+	SqlserverPageLifeExpectancy          MetricConfig `mapstructure:"sqlserver.page.life_expectancy"`
+	SqlserverPageOperationRate           MetricConfig `mapstructure:"sqlserver.page.operation.rate"`
+	SqlserverPageSplitRate               MetricConfig `mapstructure:"sqlserver.page.split.rate"`
+	SqlserverTransactionRate             MetricConfig `mapstructure:"sqlserver.transaction.rate"`
+	SqlserverTransactionWriteRate        MetricConfig `mapstructure:"sqlserver.transaction.write.rate"`
+	SqlserverTransactionLogFlushDataRate MetricConfig `mapstructure:"sqlserver.transaction_log.flush.data.rate"`
+	SqlserverTransactionLogFlushRate     MetricConfig `mapstructure:"sqlserver.transaction_log.flush.rate"`
+	SqlserverTransactionLogFlushWaitRate MetricConfig `mapstructure:"sqlserver.transaction_log.flush.wait.rate"`
+	SqlserverTransactionLogGrowthCount   MetricConfig `mapstructure:"sqlserver.transaction_log.growth.count"`
+	SqlserverTransactionLogShrinkCount   MetricConfig `mapstructure:"sqlserver.transaction_log.shrink.count"`
+	SqlserverTransactionLogUsage         MetricConfig `mapstructure:"sqlserver.transaction_log.usage"`
+	SqlserverUserConnectionCount         MetricConfig `mapstructure:"sqlserver.user.connection.count"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		SqlserverBatchRequestRate: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		SqlserverBatchRequestRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverBatchSQLCompilationRate: MetricSettings{
+		SqlserverBatchSQLCompilationRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverBatchSQLRecompilationRate: MetricSettings{
+		SqlserverBatchSQLRecompilationRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverLockWaitRate: MetricSettings{
+		SqlserverLockWaitRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverLockWaitTimeAvg: MetricSettings{
+		SqlserverLockWaitTimeAvg: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverPageBufferCacheHitRatio: MetricSettings{
+		SqlserverPageBufferCacheHitRatio: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverPageCheckpointFlushRate: MetricSettings{
+		SqlserverPageCheckpointFlushRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverPageLazyWriteRate: MetricSettings{
+		SqlserverPageLazyWriteRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverPageLifeExpectancy: MetricSettings{
+		SqlserverPageLifeExpectancy: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverPageOperationRate: MetricSettings{
+		SqlserverPageOperationRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverPageSplitRate: MetricSettings{
+		SqlserverPageSplitRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverTransactionRate: MetricSettings{
+		SqlserverTransactionRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverTransactionWriteRate: MetricSettings{
+		SqlserverTransactionWriteRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverTransactionLogFlushDataRate: MetricSettings{
+		SqlserverTransactionLogFlushDataRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverTransactionLogFlushRate: MetricSettings{
+		SqlserverTransactionLogFlushRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverTransactionLogFlushWaitRate: MetricSettings{
+		SqlserverTransactionLogFlushWaitRate: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverTransactionLogGrowthCount: MetricSettings{
+		SqlserverTransactionLogGrowthCount: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverTransactionLogShrinkCount: MetricSettings{
+		SqlserverTransactionLogShrinkCount: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverTransactionLogUsage: MetricSettings{
+		SqlserverTransactionLogUsage: MetricConfig{
 			Enabled: true,
 		},
-		SqlserverUserConnectionCount: MetricSettings{
+		SqlserverUserConnectionCount: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for sqlserverreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	SqlserverComputerName ResourceAttributeSettings `mapstructure:"sqlserver.computer.name"`
-	SqlserverDatabaseName ResourceAttributeSettings `mapstructure:"sqlserver.database.name"`
-	SqlserverInstanceName ResourceAttributeSettings `mapstructure:"sqlserver.instance.name"`
+// ResourceAttributesConfig provides config for sqlserverreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	SqlserverComputerName ResourceAttributeConfig `mapstructure:"sqlserver.computer.name"`
+	SqlserverDatabaseName ResourceAttributeConfig `mapstructure:"sqlserver.database.name"`
+	SqlserverInstanceName ResourceAttributeConfig `mapstructure:"sqlserver.instance.name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		SqlserverComputerName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		SqlserverComputerName: ResourceAttributeConfig{
 			Enabled: false,
 		},
-		SqlserverDatabaseName: ResourceAttributeSettings{
+		SqlserverDatabaseName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		SqlserverInstanceName: ResourceAttributeSettings{
+		SqlserverInstanceName: ResourceAttributeConfig{
 			Enabled: false,
 		},
 	}
@@ -174,7 +174,7 @@ var MapAttributePageOperations = map[string]AttributePageOperations{
 
 type metricSqlserverBatchRequestRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -187,7 +187,7 @@ func (m *metricSqlserverBatchRequestRate) init() {
 }
 
 func (m *metricSqlserverBatchRequestRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -205,16 +205,16 @@ func (m *metricSqlserverBatchRequestRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverBatchRequestRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverBatchRequestRate(settings MetricSettings) metricSqlserverBatchRequestRate {
-	m := metricSqlserverBatchRequestRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverBatchRequestRate(cfg MetricConfig) metricSqlserverBatchRequestRate {
+	m := metricSqlserverBatchRequestRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -223,7 +223,7 @@ func newMetricSqlserverBatchRequestRate(settings MetricSettings) metricSqlserver
 
 type metricSqlserverBatchSQLCompilationRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -236,7 +236,7 @@ func (m *metricSqlserverBatchSQLCompilationRate) init() {
 }
 
 func (m *metricSqlserverBatchSQLCompilationRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -254,16 +254,16 @@ func (m *metricSqlserverBatchSQLCompilationRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverBatchSQLCompilationRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverBatchSQLCompilationRate(settings MetricSettings) metricSqlserverBatchSQLCompilationRate {
-	m := metricSqlserverBatchSQLCompilationRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverBatchSQLCompilationRate(cfg MetricConfig) metricSqlserverBatchSQLCompilationRate {
+	m := metricSqlserverBatchSQLCompilationRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -272,7 +272,7 @@ func newMetricSqlserverBatchSQLCompilationRate(settings MetricSettings) metricSq
 
 type metricSqlserverBatchSQLRecompilationRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -285,7 +285,7 @@ func (m *metricSqlserverBatchSQLRecompilationRate) init() {
 }
 
 func (m *metricSqlserverBatchSQLRecompilationRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -303,16 +303,16 @@ func (m *metricSqlserverBatchSQLRecompilationRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverBatchSQLRecompilationRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverBatchSQLRecompilationRate(settings MetricSettings) metricSqlserverBatchSQLRecompilationRate {
-	m := metricSqlserverBatchSQLRecompilationRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverBatchSQLRecompilationRate(cfg MetricConfig) metricSqlserverBatchSQLRecompilationRate {
+	m := metricSqlserverBatchSQLRecompilationRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -321,7 +321,7 @@ func newMetricSqlserverBatchSQLRecompilationRate(settings MetricSettings) metric
 
 type metricSqlserverLockWaitRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -334,7 +334,7 @@ func (m *metricSqlserverLockWaitRate) init() {
 }
 
 func (m *metricSqlserverLockWaitRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -352,16 +352,16 @@ func (m *metricSqlserverLockWaitRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverLockWaitRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverLockWaitRate(settings MetricSettings) metricSqlserverLockWaitRate {
-	m := metricSqlserverLockWaitRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverLockWaitRate(cfg MetricConfig) metricSqlserverLockWaitRate {
+	m := metricSqlserverLockWaitRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -370,7 +370,7 @@ func newMetricSqlserverLockWaitRate(settings MetricSettings) metricSqlserverLock
 
 type metricSqlserverLockWaitTimeAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -383,7 +383,7 @@ func (m *metricSqlserverLockWaitTimeAvg) init() {
 }
 
 func (m *metricSqlserverLockWaitTimeAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -401,16 +401,16 @@ func (m *metricSqlserverLockWaitTimeAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverLockWaitTimeAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverLockWaitTimeAvg(settings MetricSettings) metricSqlserverLockWaitTimeAvg {
-	m := metricSqlserverLockWaitTimeAvg{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverLockWaitTimeAvg(cfg MetricConfig) metricSqlserverLockWaitTimeAvg {
+	m := metricSqlserverLockWaitTimeAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -419,7 +419,7 @@ func newMetricSqlserverLockWaitTimeAvg(settings MetricSettings) metricSqlserverL
 
 type metricSqlserverPageBufferCacheHitRatio struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -432,7 +432,7 @@ func (m *metricSqlserverPageBufferCacheHitRatio) init() {
 }
 
 func (m *metricSqlserverPageBufferCacheHitRatio) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -450,16 +450,16 @@ func (m *metricSqlserverPageBufferCacheHitRatio) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverPageBufferCacheHitRatio) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverPageBufferCacheHitRatio(settings MetricSettings) metricSqlserverPageBufferCacheHitRatio {
-	m := metricSqlserverPageBufferCacheHitRatio{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverPageBufferCacheHitRatio(cfg MetricConfig) metricSqlserverPageBufferCacheHitRatio {
+	m := metricSqlserverPageBufferCacheHitRatio{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -468,7 +468,7 @@ func newMetricSqlserverPageBufferCacheHitRatio(settings MetricSettings) metricSq
 
 type metricSqlserverPageCheckpointFlushRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -481,7 +481,7 @@ func (m *metricSqlserverPageCheckpointFlushRate) init() {
 }
 
 func (m *metricSqlserverPageCheckpointFlushRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -499,16 +499,16 @@ func (m *metricSqlserverPageCheckpointFlushRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverPageCheckpointFlushRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverPageCheckpointFlushRate(settings MetricSettings) metricSqlserverPageCheckpointFlushRate {
-	m := metricSqlserverPageCheckpointFlushRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverPageCheckpointFlushRate(cfg MetricConfig) metricSqlserverPageCheckpointFlushRate {
+	m := metricSqlserverPageCheckpointFlushRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -517,7 +517,7 @@ func newMetricSqlserverPageCheckpointFlushRate(settings MetricSettings) metricSq
 
 type metricSqlserverPageLazyWriteRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -530,7 +530,7 @@ func (m *metricSqlserverPageLazyWriteRate) init() {
 }
 
 func (m *metricSqlserverPageLazyWriteRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -548,16 +548,16 @@ func (m *metricSqlserverPageLazyWriteRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverPageLazyWriteRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverPageLazyWriteRate(settings MetricSettings) metricSqlserverPageLazyWriteRate {
-	m := metricSqlserverPageLazyWriteRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverPageLazyWriteRate(cfg MetricConfig) metricSqlserverPageLazyWriteRate {
+	m := metricSqlserverPageLazyWriteRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -566,7 +566,7 @@ func newMetricSqlserverPageLazyWriteRate(settings MetricSettings) metricSqlserve
 
 type metricSqlserverPageLifeExpectancy struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -579,7 +579,7 @@ func (m *metricSqlserverPageLifeExpectancy) init() {
 }
 
 func (m *metricSqlserverPageLifeExpectancy) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -597,16 +597,16 @@ func (m *metricSqlserverPageLifeExpectancy) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverPageLifeExpectancy) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverPageLifeExpectancy(settings MetricSettings) metricSqlserverPageLifeExpectancy {
-	m := metricSqlserverPageLifeExpectancy{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverPageLifeExpectancy(cfg MetricConfig) metricSqlserverPageLifeExpectancy {
+	m := metricSqlserverPageLifeExpectancy{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -615,7 +615,7 @@ func newMetricSqlserverPageLifeExpectancy(settings MetricSettings) metricSqlserv
 
 type metricSqlserverPageOperationRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -629,7 +629,7 @@ func (m *metricSqlserverPageOperationRate) init() {
 }
 
 func (m *metricSqlserverPageOperationRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64, pageOperationsAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -648,16 +648,16 @@ func (m *metricSqlserverPageOperationRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverPageOperationRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverPageOperationRate(settings MetricSettings) metricSqlserverPageOperationRate {
-	m := metricSqlserverPageOperationRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverPageOperationRate(cfg MetricConfig) metricSqlserverPageOperationRate {
+	m := metricSqlserverPageOperationRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -666,7 +666,7 @@ func newMetricSqlserverPageOperationRate(settings MetricSettings) metricSqlserve
 
 type metricSqlserverPageSplitRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -679,7 +679,7 @@ func (m *metricSqlserverPageSplitRate) init() {
 }
 
 func (m *metricSqlserverPageSplitRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -697,16 +697,16 @@ func (m *metricSqlserverPageSplitRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverPageSplitRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverPageSplitRate(settings MetricSettings) metricSqlserverPageSplitRate {
-	m := metricSqlserverPageSplitRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverPageSplitRate(cfg MetricConfig) metricSqlserverPageSplitRate {
+	m := metricSqlserverPageSplitRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -715,7 +715,7 @@ func newMetricSqlserverPageSplitRate(settings MetricSettings) metricSqlserverPag
 
 type metricSqlserverTransactionRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -728,7 +728,7 @@ func (m *metricSqlserverTransactionRate) init() {
 }
 
 func (m *metricSqlserverTransactionRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -746,16 +746,16 @@ func (m *metricSqlserverTransactionRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverTransactionRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverTransactionRate(settings MetricSettings) metricSqlserverTransactionRate {
-	m := metricSqlserverTransactionRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverTransactionRate(cfg MetricConfig) metricSqlserverTransactionRate {
+	m := metricSqlserverTransactionRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -764,7 +764,7 @@ func newMetricSqlserverTransactionRate(settings MetricSettings) metricSqlserverT
 
 type metricSqlserverTransactionWriteRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -777,7 +777,7 @@ func (m *metricSqlserverTransactionWriteRate) init() {
 }
 
 func (m *metricSqlserverTransactionWriteRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -795,16 +795,16 @@ func (m *metricSqlserverTransactionWriteRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverTransactionWriteRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverTransactionWriteRate(settings MetricSettings) metricSqlserverTransactionWriteRate {
-	m := metricSqlserverTransactionWriteRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverTransactionWriteRate(cfg MetricConfig) metricSqlserverTransactionWriteRate {
+	m := metricSqlserverTransactionWriteRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -813,7 +813,7 @@ func newMetricSqlserverTransactionWriteRate(settings MetricSettings) metricSqlse
 
 type metricSqlserverTransactionLogFlushDataRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -826,7 +826,7 @@ func (m *metricSqlserverTransactionLogFlushDataRate) init() {
 }
 
 func (m *metricSqlserverTransactionLogFlushDataRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -844,16 +844,16 @@ func (m *metricSqlserverTransactionLogFlushDataRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverTransactionLogFlushDataRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverTransactionLogFlushDataRate(settings MetricSettings) metricSqlserverTransactionLogFlushDataRate {
-	m := metricSqlserverTransactionLogFlushDataRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverTransactionLogFlushDataRate(cfg MetricConfig) metricSqlserverTransactionLogFlushDataRate {
+	m := metricSqlserverTransactionLogFlushDataRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -862,7 +862,7 @@ func newMetricSqlserverTransactionLogFlushDataRate(settings MetricSettings) metr
 
 type metricSqlserverTransactionLogFlushRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -875,7 +875,7 @@ func (m *metricSqlserverTransactionLogFlushRate) init() {
 }
 
 func (m *metricSqlserverTransactionLogFlushRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -893,16 +893,16 @@ func (m *metricSqlserverTransactionLogFlushRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverTransactionLogFlushRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverTransactionLogFlushRate(settings MetricSettings) metricSqlserverTransactionLogFlushRate {
-	m := metricSqlserverTransactionLogFlushRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverTransactionLogFlushRate(cfg MetricConfig) metricSqlserverTransactionLogFlushRate {
+	m := metricSqlserverTransactionLogFlushRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -911,7 +911,7 @@ func newMetricSqlserverTransactionLogFlushRate(settings MetricSettings) metricSq
 
 type metricSqlserverTransactionLogFlushWaitRate struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -924,7 +924,7 @@ func (m *metricSqlserverTransactionLogFlushWaitRate) init() {
 }
 
 func (m *metricSqlserverTransactionLogFlushWaitRate) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -942,16 +942,16 @@ func (m *metricSqlserverTransactionLogFlushWaitRate) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverTransactionLogFlushWaitRate) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverTransactionLogFlushWaitRate(settings MetricSettings) metricSqlserverTransactionLogFlushWaitRate {
-	m := metricSqlserverTransactionLogFlushWaitRate{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverTransactionLogFlushWaitRate(cfg MetricConfig) metricSqlserverTransactionLogFlushWaitRate {
+	m := metricSqlserverTransactionLogFlushWaitRate{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -960,7 +960,7 @@ func newMetricSqlserverTransactionLogFlushWaitRate(settings MetricSettings) metr
 
 type metricSqlserverTransactionLogGrowthCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -975,7 +975,7 @@ func (m *metricSqlserverTransactionLogGrowthCount) init() {
 }
 
 func (m *metricSqlserverTransactionLogGrowthCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -993,16 +993,16 @@ func (m *metricSqlserverTransactionLogGrowthCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverTransactionLogGrowthCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverTransactionLogGrowthCount(settings MetricSettings) metricSqlserverTransactionLogGrowthCount {
-	m := metricSqlserverTransactionLogGrowthCount{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverTransactionLogGrowthCount(cfg MetricConfig) metricSqlserverTransactionLogGrowthCount {
+	m := metricSqlserverTransactionLogGrowthCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1011,7 +1011,7 @@ func newMetricSqlserverTransactionLogGrowthCount(settings MetricSettings) metric
 
 type metricSqlserverTransactionLogShrinkCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1026,7 +1026,7 @@ func (m *metricSqlserverTransactionLogShrinkCount) init() {
 }
 
 func (m *metricSqlserverTransactionLogShrinkCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1044,16 +1044,16 @@ func (m *metricSqlserverTransactionLogShrinkCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverTransactionLogShrinkCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverTransactionLogShrinkCount(settings MetricSettings) metricSqlserverTransactionLogShrinkCount {
-	m := metricSqlserverTransactionLogShrinkCount{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverTransactionLogShrinkCount(cfg MetricConfig) metricSqlserverTransactionLogShrinkCount {
+	m := metricSqlserverTransactionLogShrinkCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1062,7 +1062,7 @@ func newMetricSqlserverTransactionLogShrinkCount(settings MetricSettings) metric
 
 type metricSqlserverTransactionLogUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1075,7 +1075,7 @@ func (m *metricSqlserverTransactionLogUsage) init() {
 }
 
 func (m *metricSqlserverTransactionLogUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1093,16 +1093,16 @@ func (m *metricSqlserverTransactionLogUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverTransactionLogUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverTransactionLogUsage(settings MetricSettings) metricSqlserverTransactionLogUsage {
-	m := metricSqlserverTransactionLogUsage{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverTransactionLogUsage(cfg MetricConfig) metricSqlserverTransactionLogUsage {
+	m := metricSqlserverTransactionLogUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1111,7 +1111,7 @@ func newMetricSqlserverTransactionLogUsage(settings MetricSettings) metricSqlser
 
 type metricSqlserverUserConnectionCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1124,7 +1124,7 @@ func (m *metricSqlserverUserConnectionCount) init() {
 }
 
 func (m *metricSqlserverUserConnectionCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1142,16 +1142,16 @@ func (m *metricSqlserverUserConnectionCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSqlserverUserConnectionCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSqlserverUserConnectionCount(settings MetricSettings) metricSqlserverUserConnectionCount {
-	m := metricSqlserverUserConnectionCount{settings: settings}
-	if settings.Enabled {
+func newMetricSqlserverUserConnectionCount(cfg MetricConfig) metricSqlserverUserConnectionCount {
+	m := metricSqlserverUserConnectionCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1160,19 +1160,19 @@ func newMetricSqlserverUserConnectionCount(settings MetricSettings) metricSqlser
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                  pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                            int                 // maximum observed number of metrics per resource.
 	resourceCapacity                           int                 // maximum observed number of resource attributes.
 	metricsBuffer                              pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                                  component.BuildInfo // contains version information
-	resourceAttributesSettings                 ResourceAttributesSettings
+	resourceAttributesConfig                   ResourceAttributesConfig
 	metricSqlserverBatchRequestRate            metricSqlserverBatchRequestRate
 	metricSqlserverBatchSQLCompilationRate     metricSqlserverBatchSQLCompilationRate
 	metricSqlserverBatchSQLRecompilationRate   metricSqlserverBatchSQLRecompilationRate
@@ -1207,8 +1207,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -1217,7 +1217,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                                  pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                              pmetric.NewMetrics(),
 		buildInfo:                                  settings.BuildInfo,
-		resourceAttributesSettings:                 mbc.ResourceAttributes,
+		resourceAttributesConfig:                   mbc.ResourceAttributes,
 		metricSqlserverBatchRequestRate:            newMetricSqlserverBatchRequestRate(mbc.Metrics.SqlserverBatchRequestRate),
 		metricSqlserverBatchSQLCompilationRate:     newMetricSqlserverBatchSQLCompilationRate(mbc.Metrics.SqlserverBatchSQLCompilationRate),
 		metricSqlserverBatchSQLRecompilationRate:   newMetricSqlserverBatchSQLRecompilationRate(mbc.Metrics.SqlserverBatchSQLRecompilationRate),
@@ -1256,12 +1256,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithSqlserverComputerName sets provided value as "sqlserver.computer.name" attribute for current resource.
 func WithSqlserverComputerName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.SqlserverComputerName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.SqlserverComputerName.Enabled {
 			rm.Resource().Attributes().PutStr("sqlserver.computer.name", val)
 		}
 	}
@@ -1269,8 +1269,8 @@ func WithSqlserverComputerName(val string) ResourceMetricsOption {
 
 // WithSqlserverDatabaseName sets provided value as "sqlserver.database.name" attribute for current resource.
 func WithSqlserverDatabaseName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.SqlserverDatabaseName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.SqlserverDatabaseName.Enabled {
 			rm.Resource().Attributes().PutStr("sqlserver.database.name", val)
 		}
 	}
@@ -1278,8 +1278,8 @@ func WithSqlserverDatabaseName(val string) ResourceMetricsOption {
 
 // WithSqlserverInstanceName sets provided value as "sqlserver.instance.name" attribute for current resource.
 func WithSqlserverInstanceName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.SqlserverInstanceName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.SqlserverInstanceName.Enabled {
 			rm.Resource().Attributes().PutStr("sqlserver.instance.name", val)
 		}
 	}
@@ -1288,7 +1288,7 @@ func WithSqlserverInstanceName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -1339,7 +1339,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricSqlserverUserConnectionCount.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -1349,7 +1349,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics_test.go
@@ -151,22 +151,22 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("sqlserver.computer.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.SqlserverComputerName.Enabled, ok)
-			if mb.resourceAttributesSettings.SqlserverComputerName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.SqlserverComputerName.Enabled, ok)
+			if mb.resourceAttributesConfig.SqlserverComputerName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("sqlserver.database.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.SqlserverDatabaseName.Enabled, ok)
-			if mb.resourceAttributesSettings.SqlserverDatabaseName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.SqlserverDatabaseName.Enabled, ok)
+			if mb.resourceAttributesConfig.SqlserverDatabaseName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("sqlserver.instance.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.SqlserverInstanceName.Enabled, ok)
-			if mb.resourceAttributesSettings.SqlserverInstanceName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.SqlserverInstanceName.Enabled, ok)
+			if mb.resourceAttributesConfig.SqlserverInstanceName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/sqlserverreceiver/scraper_test.go
+++ b/receiver/sqlserverreceiver/scraper_test.go
@@ -156,15 +156,15 @@ func TestScrape(t *testing.T) {
 		factory := NewFactory()
 		cfg := factory.CreateDefaultConfig().(*Config)
 		cfg.MetricsBuilderConfig = metadata.MetricsBuilderConfig{
-			Metrics: metadata.DefaultMetricsSettings(),
-			ResourceAttributes: metadata.ResourceAttributesSettings{
-				SqlserverDatabaseName: metadata.ResourceAttributeSettings{
+			Metrics: metadata.DefaultMetricsConfig(),
+			ResourceAttributes: metadata.ResourceAttributesConfig{
+				SqlserverDatabaseName: metadata.ResourceAttributeConfig{
 					Enabled: true,
 				},
-				SqlserverInstanceName: metadata.ResourceAttributeSettings{
+				SqlserverInstanceName: metadata.ResourceAttributeConfig{
 					Enabled: true,
 				},
-				SqlserverComputerName: metadata.ResourceAttributeSettings{
+				SqlserverComputerName: metadata.ResourceAttributeConfig{
 					Enabled: true,
 				},
 			},

--- a/receiver/sshcheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sshcheckreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,52 +31,52 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for sshcheckreceiver metrics.
-type MetricsSettings struct {
-	SshcheckDuration     MetricSettings `mapstructure:"sshcheck.duration"`
-	SshcheckError        MetricSettings `mapstructure:"sshcheck.error"`
-	SshcheckSftpDuration MetricSettings `mapstructure:"sshcheck.sftp_duration"`
-	SshcheckSftpError    MetricSettings `mapstructure:"sshcheck.sftp_error"`
-	SshcheckSftpStatus   MetricSettings `mapstructure:"sshcheck.sftp_status"`
-	SshcheckStatus       MetricSettings `mapstructure:"sshcheck.status"`
+// MetricsConfig provides config for sshcheckreceiver metrics.
+type MetricsConfig struct {
+	SshcheckDuration     MetricConfig `mapstructure:"sshcheck.duration"`
+	SshcheckError        MetricConfig `mapstructure:"sshcheck.error"`
+	SshcheckSftpDuration MetricConfig `mapstructure:"sshcheck.sftp_duration"`
+	SshcheckSftpError    MetricConfig `mapstructure:"sshcheck.sftp_error"`
+	SshcheckSftpStatus   MetricConfig `mapstructure:"sshcheck.sftp_status"`
+	SshcheckStatus       MetricConfig `mapstructure:"sshcheck.status"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		SshcheckDuration: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		SshcheckDuration: MetricConfig{
 			Enabled: true,
 		},
-		SshcheckError: MetricSettings{
+		SshcheckError: MetricConfig{
 			Enabled: true,
 		},
-		SshcheckSftpDuration: MetricSettings{
+		SshcheckSftpDuration: MetricConfig{
 			Enabled: false,
 		},
-		SshcheckSftpError: MetricSettings{
+		SshcheckSftpError: MetricConfig{
 			Enabled: false,
 		},
-		SshcheckSftpStatus: MetricSettings{
+		SshcheckSftpStatus: MetricConfig{
 			Enabled: false,
 		},
-		SshcheckStatus: MetricSettings{
+		SshcheckStatus: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for sshcheckreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	SSHEndpoint ResourceAttributeSettings `mapstructure:"ssh.endpoint"`
+// ResourceAttributesConfig provides config for sshcheckreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	SSHEndpoint ResourceAttributeConfig `mapstructure:"ssh.endpoint"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		SSHEndpoint: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		SSHEndpoint: ResourceAttributeConfig{
 			Enabled: false,
 		},
 	}
@@ -84,7 +84,7 @@ func DefaultResourceAttributesSettings() ResourceAttributesSettings {
 
 type metricSshcheckDuration struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -97,7 +97,7 @@ func (m *metricSshcheckDuration) init() {
 }
 
 func (m *metricSshcheckDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -115,16 +115,16 @@ func (m *metricSshcheckDuration) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSshcheckDuration) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSshcheckDuration(settings MetricSettings) metricSshcheckDuration {
-	m := metricSshcheckDuration{settings: settings}
-	if settings.Enabled {
+func newMetricSshcheckDuration(cfg MetricConfig) metricSshcheckDuration {
+	m := metricSshcheckDuration{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -133,7 +133,7 @@ func newMetricSshcheckDuration(settings MetricSettings) metricSshcheckDuration {
 
 type metricSshcheckError struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -149,7 +149,7 @@ func (m *metricSshcheckError) init() {
 }
 
 func (m *metricSshcheckError) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, errorMessageAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -168,16 +168,16 @@ func (m *metricSshcheckError) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSshcheckError) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSshcheckError(settings MetricSettings) metricSshcheckError {
-	m := metricSshcheckError{settings: settings}
-	if settings.Enabled {
+func newMetricSshcheckError(cfg MetricConfig) metricSshcheckError {
+	m := metricSshcheckError{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -186,7 +186,7 @@ func newMetricSshcheckError(settings MetricSettings) metricSshcheckError {
 
 type metricSshcheckSftpDuration struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -199,7 +199,7 @@ func (m *metricSshcheckSftpDuration) init() {
 }
 
 func (m *metricSshcheckSftpDuration) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -217,16 +217,16 @@ func (m *metricSshcheckSftpDuration) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSshcheckSftpDuration) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSshcheckSftpDuration(settings MetricSettings) metricSshcheckSftpDuration {
-	m := metricSshcheckSftpDuration{settings: settings}
-	if settings.Enabled {
+func newMetricSshcheckSftpDuration(cfg MetricConfig) metricSshcheckSftpDuration {
+	m := metricSshcheckSftpDuration{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -235,7 +235,7 @@ func newMetricSshcheckSftpDuration(settings MetricSettings) metricSshcheckSftpDu
 
 type metricSshcheckSftpError struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -251,7 +251,7 @@ func (m *metricSshcheckSftpError) init() {
 }
 
 func (m *metricSshcheckSftpError) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, errorMessageAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -270,16 +270,16 @@ func (m *metricSshcheckSftpError) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSshcheckSftpError) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSshcheckSftpError(settings MetricSettings) metricSshcheckSftpError {
-	m := metricSshcheckSftpError{settings: settings}
-	if settings.Enabled {
+func newMetricSshcheckSftpError(cfg MetricConfig) metricSshcheckSftpError {
+	m := metricSshcheckSftpError{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -288,7 +288,7 @@ func newMetricSshcheckSftpError(settings MetricSettings) metricSshcheckSftpError
 
 type metricSshcheckSftpStatus struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -303,7 +303,7 @@ func (m *metricSshcheckSftpStatus) init() {
 }
 
 func (m *metricSshcheckSftpStatus) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -321,16 +321,16 @@ func (m *metricSshcheckSftpStatus) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSshcheckSftpStatus) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSshcheckSftpStatus(settings MetricSettings) metricSshcheckSftpStatus {
-	m := metricSshcheckSftpStatus{settings: settings}
-	if settings.Enabled {
+func newMetricSshcheckSftpStatus(cfg MetricConfig) metricSshcheckSftpStatus {
+	m := metricSshcheckSftpStatus{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -339,7 +339,7 @@ func newMetricSshcheckSftpStatus(settings MetricSettings) metricSshcheckSftpStat
 
 type metricSshcheckStatus struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -354,7 +354,7 @@ func (m *metricSshcheckStatus) init() {
 }
 
 func (m *metricSshcheckStatus) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -372,16 +372,16 @@ func (m *metricSshcheckStatus) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricSshcheckStatus) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricSshcheckStatus(settings MetricSettings) metricSshcheckStatus {
-	m := metricSshcheckStatus{settings: settings}
-	if settings.Enabled {
+func newMetricSshcheckStatus(cfg MetricConfig) metricSshcheckStatus {
+	m := metricSshcheckStatus{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -390,19 +390,19 @@ func newMetricSshcheckStatus(settings MetricSettings) metricSshcheckStatus {
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                  pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity            int                 // maximum observed number of metrics per resource.
 	resourceCapacity           int                 // maximum observed number of resource attributes.
 	metricsBuffer              pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                  component.BuildInfo // contains version information
-	resourceAttributesSettings ResourceAttributesSettings
+	resourceAttributesConfig   ResourceAttributesConfig
 	metricSshcheckDuration     metricSshcheckDuration
 	metricSshcheckError        metricSshcheckError
 	metricSshcheckSftpDuration metricSshcheckSftpDuration
@@ -423,8 +423,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -433,7 +433,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                  pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:              pmetric.NewMetrics(),
 		buildInfo:                  settings.BuildInfo,
-		resourceAttributesSettings: mbc.ResourceAttributes,
+		resourceAttributesConfig:   mbc.ResourceAttributes,
 		metricSshcheckDuration:     newMetricSshcheckDuration(mbc.Metrics.SshcheckDuration),
 		metricSshcheckError:        newMetricSshcheckError(mbc.Metrics.SshcheckError),
 		metricSshcheckSftpDuration: newMetricSshcheckSftpDuration(mbc.Metrics.SshcheckSftpDuration),
@@ -458,12 +458,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithSSHEndpoint sets provided value as "ssh.endpoint" attribute for current resource.
 func WithSSHEndpoint(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.SSHEndpoint.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.SSHEndpoint.Enabled {
 			rm.Resource().Attributes().PutStr("ssh.endpoint", val)
 		}
 	}
@@ -472,7 +472,7 @@ func WithSSHEndpoint(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -509,7 +509,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricSshcheckStatus.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -519,7 +519,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/sshcheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/sshcheckreceiver/internal/metadata/generated_metrics_test.go
@@ -92,8 +92,8 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("ssh.endpoint")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.SSHEndpoint.Enabled, ok)
-			if mb.resourceAttributesSettings.SSHEndpoint.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.SSHEndpoint.Enabled, ok)
+			if mb.resourceAttributesConfig.SSHEndpoint.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/vcenterreceiver/config_test.go
+++ b/receiver/vcenterreceiver/config_test.go
@@ -112,7 +112,7 @@ func TestLoadConfig(t *testing.T) {
 	expected.MetricsBuilderConfig.Metrics.VcenterHostCPUUtilization.Enabled = false
 	expected.CollectionInterval = 5 * time.Minute
 
-	if diff := cmp.Diff(expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricSettings{})); diff != "" {
+	if diff := cmp.Diff(expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricConfig{})); diff != "" {
 		t.Errorf("Config mismatch (-expected +actual):\n%s", diff)
 	}
 

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,200 +31,200 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for vcenterreceiver metrics.
-type MetricsSettings struct {
-	VcenterClusterCPUEffective      MetricSettings `mapstructure:"vcenter.cluster.cpu.effective"`
-	VcenterClusterCPULimit          MetricSettings `mapstructure:"vcenter.cluster.cpu.limit"`
-	VcenterClusterHostCount         MetricSettings `mapstructure:"vcenter.cluster.host.count"`
-	VcenterClusterMemoryEffective   MetricSettings `mapstructure:"vcenter.cluster.memory.effective"`
-	VcenterClusterMemoryLimit       MetricSettings `mapstructure:"vcenter.cluster.memory.limit"`
-	VcenterClusterMemoryUsed        MetricSettings `mapstructure:"vcenter.cluster.memory.used"`
-	VcenterClusterVMCount           MetricSettings `mapstructure:"vcenter.cluster.vm.count"`
-	VcenterDatastoreDiskUsage       MetricSettings `mapstructure:"vcenter.datastore.disk.usage"`
-	VcenterDatastoreDiskUtilization MetricSettings `mapstructure:"vcenter.datastore.disk.utilization"`
-	VcenterHostCPUUsage             MetricSettings `mapstructure:"vcenter.host.cpu.usage"`
-	VcenterHostCPUUtilization       MetricSettings `mapstructure:"vcenter.host.cpu.utilization"`
-	VcenterHostDiskLatencyAvg       MetricSettings `mapstructure:"vcenter.host.disk.latency.avg"`
-	VcenterHostDiskLatencyMax       MetricSettings `mapstructure:"vcenter.host.disk.latency.max"`
-	VcenterHostDiskThroughput       MetricSettings `mapstructure:"vcenter.host.disk.throughput"`
-	VcenterHostMemoryUsage          MetricSettings `mapstructure:"vcenter.host.memory.usage"`
-	VcenterHostMemoryUtilization    MetricSettings `mapstructure:"vcenter.host.memory.utilization"`
-	VcenterHostNetworkPacketCount   MetricSettings `mapstructure:"vcenter.host.network.packet.count"`
-	VcenterHostNetworkPacketErrors  MetricSettings `mapstructure:"vcenter.host.network.packet.errors"`
-	VcenterHostNetworkThroughput    MetricSettings `mapstructure:"vcenter.host.network.throughput"`
-	VcenterHostNetworkUsage         MetricSettings `mapstructure:"vcenter.host.network.usage"`
-	VcenterResourcePoolCPUShares    MetricSettings `mapstructure:"vcenter.resource_pool.cpu.shares"`
-	VcenterResourcePoolCPUUsage     MetricSettings `mapstructure:"vcenter.resource_pool.cpu.usage"`
-	VcenterResourcePoolMemoryShares MetricSettings `mapstructure:"vcenter.resource_pool.memory.shares"`
-	VcenterResourcePoolMemoryUsage  MetricSettings `mapstructure:"vcenter.resource_pool.memory.usage"`
-	VcenterVMCPUUsage               MetricSettings `mapstructure:"vcenter.vm.cpu.usage"`
-	VcenterVMCPUUtilization         MetricSettings `mapstructure:"vcenter.vm.cpu.utilization"`
-	VcenterVMDiskLatencyAvg         MetricSettings `mapstructure:"vcenter.vm.disk.latency.avg"`
-	VcenterVMDiskLatencyMax         MetricSettings `mapstructure:"vcenter.vm.disk.latency.max"`
-	VcenterVMDiskThroughput         MetricSettings `mapstructure:"vcenter.vm.disk.throughput"`
-	VcenterVMDiskUsage              MetricSettings `mapstructure:"vcenter.vm.disk.usage"`
-	VcenterVMDiskUtilization        MetricSettings `mapstructure:"vcenter.vm.disk.utilization"`
-	VcenterVMMemoryBallooned        MetricSettings `mapstructure:"vcenter.vm.memory.ballooned"`
-	VcenterVMMemorySwapped          MetricSettings `mapstructure:"vcenter.vm.memory.swapped"`
-	VcenterVMMemorySwappedSsd       MetricSettings `mapstructure:"vcenter.vm.memory.swapped_ssd"`
-	VcenterVMMemoryUsage            MetricSettings `mapstructure:"vcenter.vm.memory.usage"`
-	VcenterVMNetworkPacketCount     MetricSettings `mapstructure:"vcenter.vm.network.packet.count"`
-	VcenterVMNetworkThroughput      MetricSettings `mapstructure:"vcenter.vm.network.throughput"`
-	VcenterVMNetworkUsage           MetricSettings `mapstructure:"vcenter.vm.network.usage"`
+// MetricsConfig provides config for vcenterreceiver metrics.
+type MetricsConfig struct {
+	VcenterClusterCPUEffective      MetricConfig `mapstructure:"vcenter.cluster.cpu.effective"`
+	VcenterClusterCPULimit          MetricConfig `mapstructure:"vcenter.cluster.cpu.limit"`
+	VcenterClusterHostCount         MetricConfig `mapstructure:"vcenter.cluster.host.count"`
+	VcenterClusterMemoryEffective   MetricConfig `mapstructure:"vcenter.cluster.memory.effective"`
+	VcenterClusterMemoryLimit       MetricConfig `mapstructure:"vcenter.cluster.memory.limit"`
+	VcenterClusterMemoryUsed        MetricConfig `mapstructure:"vcenter.cluster.memory.used"`
+	VcenterClusterVMCount           MetricConfig `mapstructure:"vcenter.cluster.vm.count"`
+	VcenterDatastoreDiskUsage       MetricConfig `mapstructure:"vcenter.datastore.disk.usage"`
+	VcenterDatastoreDiskUtilization MetricConfig `mapstructure:"vcenter.datastore.disk.utilization"`
+	VcenterHostCPUUsage             MetricConfig `mapstructure:"vcenter.host.cpu.usage"`
+	VcenterHostCPUUtilization       MetricConfig `mapstructure:"vcenter.host.cpu.utilization"`
+	VcenterHostDiskLatencyAvg       MetricConfig `mapstructure:"vcenter.host.disk.latency.avg"`
+	VcenterHostDiskLatencyMax       MetricConfig `mapstructure:"vcenter.host.disk.latency.max"`
+	VcenterHostDiskThroughput       MetricConfig `mapstructure:"vcenter.host.disk.throughput"`
+	VcenterHostMemoryUsage          MetricConfig `mapstructure:"vcenter.host.memory.usage"`
+	VcenterHostMemoryUtilization    MetricConfig `mapstructure:"vcenter.host.memory.utilization"`
+	VcenterHostNetworkPacketCount   MetricConfig `mapstructure:"vcenter.host.network.packet.count"`
+	VcenterHostNetworkPacketErrors  MetricConfig `mapstructure:"vcenter.host.network.packet.errors"`
+	VcenterHostNetworkThroughput    MetricConfig `mapstructure:"vcenter.host.network.throughput"`
+	VcenterHostNetworkUsage         MetricConfig `mapstructure:"vcenter.host.network.usage"`
+	VcenterResourcePoolCPUShares    MetricConfig `mapstructure:"vcenter.resource_pool.cpu.shares"`
+	VcenterResourcePoolCPUUsage     MetricConfig `mapstructure:"vcenter.resource_pool.cpu.usage"`
+	VcenterResourcePoolMemoryShares MetricConfig `mapstructure:"vcenter.resource_pool.memory.shares"`
+	VcenterResourcePoolMemoryUsage  MetricConfig `mapstructure:"vcenter.resource_pool.memory.usage"`
+	VcenterVMCPUUsage               MetricConfig `mapstructure:"vcenter.vm.cpu.usage"`
+	VcenterVMCPUUtilization         MetricConfig `mapstructure:"vcenter.vm.cpu.utilization"`
+	VcenterVMDiskLatencyAvg         MetricConfig `mapstructure:"vcenter.vm.disk.latency.avg"`
+	VcenterVMDiskLatencyMax         MetricConfig `mapstructure:"vcenter.vm.disk.latency.max"`
+	VcenterVMDiskThroughput         MetricConfig `mapstructure:"vcenter.vm.disk.throughput"`
+	VcenterVMDiskUsage              MetricConfig `mapstructure:"vcenter.vm.disk.usage"`
+	VcenterVMDiskUtilization        MetricConfig `mapstructure:"vcenter.vm.disk.utilization"`
+	VcenterVMMemoryBallooned        MetricConfig `mapstructure:"vcenter.vm.memory.ballooned"`
+	VcenterVMMemorySwapped          MetricConfig `mapstructure:"vcenter.vm.memory.swapped"`
+	VcenterVMMemorySwappedSsd       MetricConfig `mapstructure:"vcenter.vm.memory.swapped_ssd"`
+	VcenterVMMemoryUsage            MetricConfig `mapstructure:"vcenter.vm.memory.usage"`
+	VcenterVMNetworkPacketCount     MetricConfig `mapstructure:"vcenter.vm.network.packet.count"`
+	VcenterVMNetworkThroughput      MetricConfig `mapstructure:"vcenter.vm.network.throughput"`
+	VcenterVMNetworkUsage           MetricConfig `mapstructure:"vcenter.vm.network.usage"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		VcenterClusterCPUEffective: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		VcenterClusterCPUEffective: MetricConfig{
 			Enabled: true,
 		},
-		VcenterClusterCPULimit: MetricSettings{
+		VcenterClusterCPULimit: MetricConfig{
 			Enabled: true,
 		},
-		VcenterClusterHostCount: MetricSettings{
+		VcenterClusterHostCount: MetricConfig{
 			Enabled: true,
 		},
-		VcenterClusterMemoryEffective: MetricSettings{
+		VcenterClusterMemoryEffective: MetricConfig{
 			Enabled: true,
 		},
-		VcenterClusterMemoryLimit: MetricSettings{
+		VcenterClusterMemoryLimit: MetricConfig{
 			Enabled: true,
 		},
-		VcenterClusterMemoryUsed: MetricSettings{
+		VcenterClusterMemoryUsed: MetricConfig{
 			Enabled: true,
 		},
-		VcenterClusterVMCount: MetricSettings{
+		VcenterClusterVMCount: MetricConfig{
 			Enabled: true,
 		},
-		VcenterDatastoreDiskUsage: MetricSettings{
+		VcenterDatastoreDiskUsage: MetricConfig{
 			Enabled: true,
 		},
-		VcenterDatastoreDiskUtilization: MetricSettings{
+		VcenterDatastoreDiskUtilization: MetricConfig{
 			Enabled: true,
 		},
-		VcenterHostCPUUsage: MetricSettings{
+		VcenterHostCPUUsage: MetricConfig{
 			Enabled: true,
 		},
-		VcenterHostCPUUtilization: MetricSettings{
+		VcenterHostCPUUtilization: MetricConfig{
 			Enabled: true,
 		},
-		VcenterHostDiskLatencyAvg: MetricSettings{
+		VcenterHostDiskLatencyAvg: MetricConfig{
 			Enabled: true,
 		},
-		VcenterHostDiskLatencyMax: MetricSettings{
+		VcenterHostDiskLatencyMax: MetricConfig{
 			Enabled: true,
 		},
-		VcenterHostDiskThroughput: MetricSettings{
+		VcenterHostDiskThroughput: MetricConfig{
 			Enabled: true,
 		},
-		VcenterHostMemoryUsage: MetricSettings{
+		VcenterHostMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		VcenterHostMemoryUtilization: MetricSettings{
+		VcenterHostMemoryUtilization: MetricConfig{
 			Enabled: true,
 		},
-		VcenterHostNetworkPacketCount: MetricSettings{
+		VcenterHostNetworkPacketCount: MetricConfig{
 			Enabled: true,
 		},
-		VcenterHostNetworkPacketErrors: MetricSettings{
+		VcenterHostNetworkPacketErrors: MetricConfig{
 			Enabled: true,
 		},
-		VcenterHostNetworkThroughput: MetricSettings{
+		VcenterHostNetworkThroughput: MetricConfig{
 			Enabled: true,
 		},
-		VcenterHostNetworkUsage: MetricSettings{
+		VcenterHostNetworkUsage: MetricConfig{
 			Enabled: true,
 		},
-		VcenterResourcePoolCPUShares: MetricSettings{
+		VcenterResourcePoolCPUShares: MetricConfig{
 			Enabled: true,
 		},
-		VcenterResourcePoolCPUUsage: MetricSettings{
+		VcenterResourcePoolCPUUsage: MetricConfig{
 			Enabled: true,
 		},
-		VcenterResourcePoolMemoryShares: MetricSettings{
+		VcenterResourcePoolMemoryShares: MetricConfig{
 			Enabled: true,
 		},
-		VcenterResourcePoolMemoryUsage: MetricSettings{
+		VcenterResourcePoolMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMCPUUsage: MetricSettings{
+		VcenterVMCPUUsage: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMCPUUtilization: MetricSettings{
+		VcenterVMCPUUtilization: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMDiskLatencyAvg: MetricSettings{
+		VcenterVMDiskLatencyAvg: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMDiskLatencyMax: MetricSettings{
+		VcenterVMDiskLatencyMax: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMDiskThroughput: MetricSettings{
+		VcenterVMDiskThroughput: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMDiskUsage: MetricSettings{
+		VcenterVMDiskUsage: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMDiskUtilization: MetricSettings{
+		VcenterVMDiskUtilization: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMMemoryBallooned: MetricSettings{
+		VcenterVMMemoryBallooned: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMMemorySwapped: MetricSettings{
+		VcenterVMMemorySwapped: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMMemorySwappedSsd: MetricSettings{
+		VcenterVMMemorySwappedSsd: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMMemoryUsage: MetricSettings{
+		VcenterVMMemoryUsage: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMNetworkPacketCount: MetricSettings{
+		VcenterVMNetworkPacketCount: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMNetworkThroughput: MetricSettings{
+		VcenterVMNetworkThroughput: MetricConfig{
 			Enabled: true,
 		},
-		VcenterVMNetworkUsage: MetricSettings{
+		VcenterVMNetworkUsage: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for vcenterreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	VcenterClusterName      ResourceAttributeSettings `mapstructure:"vcenter.cluster.name"`
-	VcenterDatastoreName    ResourceAttributeSettings `mapstructure:"vcenter.datastore.name"`
-	VcenterHostName         ResourceAttributeSettings `mapstructure:"vcenter.host.name"`
-	VcenterResourcePoolName ResourceAttributeSettings `mapstructure:"vcenter.resource_pool.name"`
-	VcenterVMID             ResourceAttributeSettings `mapstructure:"vcenter.vm.id"`
-	VcenterVMName           ResourceAttributeSettings `mapstructure:"vcenter.vm.name"`
+// ResourceAttributesConfig provides config for vcenterreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	VcenterClusterName      ResourceAttributeConfig `mapstructure:"vcenter.cluster.name"`
+	VcenterDatastoreName    ResourceAttributeConfig `mapstructure:"vcenter.datastore.name"`
+	VcenterHostName         ResourceAttributeConfig `mapstructure:"vcenter.host.name"`
+	VcenterResourcePoolName ResourceAttributeConfig `mapstructure:"vcenter.resource_pool.name"`
+	VcenterVMID             ResourceAttributeConfig `mapstructure:"vcenter.vm.id"`
+	VcenterVMName           ResourceAttributeConfig `mapstructure:"vcenter.vm.name"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		VcenterClusterName: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		VcenterClusterName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		VcenterDatastoreName: ResourceAttributeSettings{
+		VcenterDatastoreName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		VcenterHostName: ResourceAttributeSettings{
+		VcenterHostName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		VcenterResourcePoolName: ResourceAttributeSettings{
+		VcenterResourcePoolName: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		VcenterVMID: ResourceAttributeSettings{
+		VcenterVMID: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		VcenterVMName: ResourceAttributeSettings{
+		VcenterVMName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -362,7 +362,7 @@ var MapAttributeVMCountPowerState = map[string]AttributeVMCountPowerState{
 
 type metricVcenterClusterCPUEffective struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -377,7 +377,7 @@ func (m *metricVcenterClusterCPUEffective) init() {
 }
 
 func (m *metricVcenterClusterCPUEffective) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -395,16 +395,16 @@ func (m *metricVcenterClusterCPUEffective) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterClusterCPUEffective) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterClusterCPUEffective(settings MetricSettings) metricVcenterClusterCPUEffective {
-	m := metricVcenterClusterCPUEffective{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterClusterCPUEffective(cfg MetricConfig) metricVcenterClusterCPUEffective {
+	m := metricVcenterClusterCPUEffective{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -413,7 +413,7 @@ func newMetricVcenterClusterCPUEffective(settings MetricSettings) metricVcenterC
 
 type metricVcenterClusterCPULimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -428,7 +428,7 @@ func (m *metricVcenterClusterCPULimit) init() {
 }
 
 func (m *metricVcenterClusterCPULimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -446,16 +446,16 @@ func (m *metricVcenterClusterCPULimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterClusterCPULimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterClusterCPULimit(settings MetricSettings) metricVcenterClusterCPULimit {
-	m := metricVcenterClusterCPULimit{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterClusterCPULimit(cfg MetricConfig) metricVcenterClusterCPULimit {
+	m := metricVcenterClusterCPULimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -464,7 +464,7 @@ func newMetricVcenterClusterCPULimit(settings MetricSettings) metricVcenterClust
 
 type metricVcenterClusterHostCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -480,7 +480,7 @@ func (m *metricVcenterClusterHostCount) init() {
 }
 
 func (m *metricVcenterClusterHostCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, hostEffectiveAttributeValue bool) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -499,16 +499,16 @@ func (m *metricVcenterClusterHostCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterClusterHostCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterClusterHostCount(settings MetricSettings) metricVcenterClusterHostCount {
-	m := metricVcenterClusterHostCount{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterClusterHostCount(cfg MetricConfig) metricVcenterClusterHostCount {
+	m := metricVcenterClusterHostCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -517,7 +517,7 @@ func newMetricVcenterClusterHostCount(settings MetricSettings) metricVcenterClus
 
 type metricVcenterClusterMemoryEffective struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -532,7 +532,7 @@ func (m *metricVcenterClusterMemoryEffective) init() {
 }
 
 func (m *metricVcenterClusterMemoryEffective) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -550,16 +550,16 @@ func (m *metricVcenterClusterMemoryEffective) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterClusterMemoryEffective) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterClusterMemoryEffective(settings MetricSettings) metricVcenterClusterMemoryEffective {
-	m := metricVcenterClusterMemoryEffective{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterClusterMemoryEffective(cfg MetricConfig) metricVcenterClusterMemoryEffective {
+	m := metricVcenterClusterMemoryEffective{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -568,7 +568,7 @@ func newMetricVcenterClusterMemoryEffective(settings MetricSettings) metricVcent
 
 type metricVcenterClusterMemoryLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -583,7 +583,7 @@ func (m *metricVcenterClusterMemoryLimit) init() {
 }
 
 func (m *metricVcenterClusterMemoryLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -601,16 +601,16 @@ func (m *metricVcenterClusterMemoryLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterClusterMemoryLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterClusterMemoryLimit(settings MetricSettings) metricVcenterClusterMemoryLimit {
-	m := metricVcenterClusterMemoryLimit{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterClusterMemoryLimit(cfg MetricConfig) metricVcenterClusterMemoryLimit {
+	m := metricVcenterClusterMemoryLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -619,7 +619,7 @@ func newMetricVcenterClusterMemoryLimit(settings MetricSettings) metricVcenterCl
 
 type metricVcenterClusterMemoryUsed struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -634,7 +634,7 @@ func (m *metricVcenterClusterMemoryUsed) init() {
 }
 
 func (m *metricVcenterClusterMemoryUsed) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -652,16 +652,16 @@ func (m *metricVcenterClusterMemoryUsed) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterClusterMemoryUsed) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterClusterMemoryUsed(settings MetricSettings) metricVcenterClusterMemoryUsed {
-	m := metricVcenterClusterMemoryUsed{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterClusterMemoryUsed(cfg MetricConfig) metricVcenterClusterMemoryUsed {
+	m := metricVcenterClusterMemoryUsed{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -670,7 +670,7 @@ func newMetricVcenterClusterMemoryUsed(settings MetricSettings) metricVcenterClu
 
 type metricVcenterClusterVMCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -686,7 +686,7 @@ func (m *metricVcenterClusterVMCount) init() {
 }
 
 func (m *metricVcenterClusterVMCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, vmCountPowerStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -705,16 +705,16 @@ func (m *metricVcenterClusterVMCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterClusterVMCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterClusterVMCount(settings MetricSettings) metricVcenterClusterVMCount {
-	m := metricVcenterClusterVMCount{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterClusterVMCount(cfg MetricConfig) metricVcenterClusterVMCount {
+	m := metricVcenterClusterVMCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -723,7 +723,7 @@ func newMetricVcenterClusterVMCount(settings MetricSettings) metricVcenterCluste
 
 type metricVcenterDatastoreDiskUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -739,7 +739,7 @@ func (m *metricVcenterDatastoreDiskUsage) init() {
 }
 
 func (m *metricVcenterDatastoreDiskUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -758,16 +758,16 @@ func (m *metricVcenterDatastoreDiskUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterDatastoreDiskUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterDatastoreDiskUsage(settings MetricSettings) metricVcenterDatastoreDiskUsage {
-	m := metricVcenterDatastoreDiskUsage{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterDatastoreDiskUsage(cfg MetricConfig) metricVcenterDatastoreDiskUsage {
+	m := metricVcenterDatastoreDiskUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -776,7 +776,7 @@ func newMetricVcenterDatastoreDiskUsage(settings MetricSettings) metricVcenterDa
 
 type metricVcenterDatastoreDiskUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -789,7 +789,7 @@ func (m *metricVcenterDatastoreDiskUtilization) init() {
 }
 
 func (m *metricVcenterDatastoreDiskUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -807,16 +807,16 @@ func (m *metricVcenterDatastoreDiskUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterDatastoreDiskUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterDatastoreDiskUtilization(settings MetricSettings) metricVcenterDatastoreDiskUtilization {
-	m := metricVcenterDatastoreDiskUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterDatastoreDiskUtilization(cfg MetricConfig) metricVcenterDatastoreDiskUtilization {
+	m := metricVcenterDatastoreDiskUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -825,7 +825,7 @@ func newMetricVcenterDatastoreDiskUtilization(settings MetricSettings) metricVce
 
 type metricVcenterHostCPUUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -840,7 +840,7 @@ func (m *metricVcenterHostCPUUsage) init() {
 }
 
 func (m *metricVcenterHostCPUUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -858,16 +858,16 @@ func (m *metricVcenterHostCPUUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterHostCPUUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterHostCPUUsage(settings MetricSettings) metricVcenterHostCPUUsage {
-	m := metricVcenterHostCPUUsage{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterHostCPUUsage(cfg MetricConfig) metricVcenterHostCPUUsage {
+	m := metricVcenterHostCPUUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -876,7 +876,7 @@ func newMetricVcenterHostCPUUsage(settings MetricSettings) metricVcenterHostCPUU
 
 type metricVcenterHostCPUUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -889,7 +889,7 @@ func (m *metricVcenterHostCPUUtilization) init() {
 }
 
 func (m *metricVcenterHostCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -907,16 +907,16 @@ func (m *metricVcenterHostCPUUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterHostCPUUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterHostCPUUtilization(settings MetricSettings) metricVcenterHostCPUUtilization {
-	m := metricVcenterHostCPUUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterHostCPUUtilization(cfg MetricConfig) metricVcenterHostCPUUtilization {
+	m := metricVcenterHostCPUUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -925,7 +925,7 @@ func newMetricVcenterHostCPUUtilization(settings MetricSettings) metricVcenterHo
 
 type metricVcenterHostDiskLatencyAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -939,7 +939,7 @@ func (m *metricVcenterHostDiskLatencyAvg) init() {
 }
 
 func (m *metricVcenterHostDiskLatencyAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -958,16 +958,16 @@ func (m *metricVcenterHostDiskLatencyAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterHostDiskLatencyAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterHostDiskLatencyAvg(settings MetricSettings) metricVcenterHostDiskLatencyAvg {
-	m := metricVcenterHostDiskLatencyAvg{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterHostDiskLatencyAvg(cfg MetricConfig) metricVcenterHostDiskLatencyAvg {
+	m := metricVcenterHostDiskLatencyAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -976,7 +976,7 @@ func newMetricVcenterHostDiskLatencyAvg(settings MetricSettings) metricVcenterHo
 
 type metricVcenterHostDiskLatencyMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -989,7 +989,7 @@ func (m *metricVcenterHostDiskLatencyMax) init() {
 }
 
 func (m *metricVcenterHostDiskLatencyMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1007,16 +1007,16 @@ func (m *metricVcenterHostDiskLatencyMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterHostDiskLatencyMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterHostDiskLatencyMax(settings MetricSettings) metricVcenterHostDiskLatencyMax {
-	m := metricVcenterHostDiskLatencyMax{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterHostDiskLatencyMax(cfg MetricConfig) metricVcenterHostDiskLatencyMax {
+	m := metricVcenterHostDiskLatencyMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1025,7 +1025,7 @@ func newMetricVcenterHostDiskLatencyMax(settings MetricSettings) metricVcenterHo
 
 type metricVcenterHostDiskThroughput struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1041,7 +1041,7 @@ func (m *metricVcenterHostDiskThroughput) init() {
 }
 
 func (m *metricVcenterHostDiskThroughput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1060,16 +1060,16 @@ func (m *metricVcenterHostDiskThroughput) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterHostDiskThroughput) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterHostDiskThroughput(settings MetricSettings) metricVcenterHostDiskThroughput {
-	m := metricVcenterHostDiskThroughput{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterHostDiskThroughput(cfg MetricConfig) metricVcenterHostDiskThroughput {
+	m := metricVcenterHostDiskThroughput{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1078,7 +1078,7 @@ func newMetricVcenterHostDiskThroughput(settings MetricSettings) metricVcenterHo
 
 type metricVcenterHostMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1093,7 +1093,7 @@ func (m *metricVcenterHostMemoryUsage) init() {
 }
 
 func (m *metricVcenterHostMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1111,16 +1111,16 @@ func (m *metricVcenterHostMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterHostMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterHostMemoryUsage(settings MetricSettings) metricVcenterHostMemoryUsage {
-	m := metricVcenterHostMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterHostMemoryUsage(cfg MetricConfig) metricVcenterHostMemoryUsage {
+	m := metricVcenterHostMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1129,7 +1129,7 @@ func newMetricVcenterHostMemoryUsage(settings MetricSettings) metricVcenterHostM
 
 type metricVcenterHostMemoryUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1142,7 +1142,7 @@ func (m *metricVcenterHostMemoryUtilization) init() {
 }
 
 func (m *metricVcenterHostMemoryUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1160,16 +1160,16 @@ func (m *metricVcenterHostMemoryUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterHostMemoryUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterHostMemoryUtilization(settings MetricSettings) metricVcenterHostMemoryUtilization {
-	m := metricVcenterHostMemoryUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterHostMemoryUtilization(cfg MetricConfig) metricVcenterHostMemoryUtilization {
+	m := metricVcenterHostMemoryUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1178,7 +1178,7 @@ func newMetricVcenterHostMemoryUtilization(settings MetricSettings) metricVcente
 
 type metricVcenterHostNetworkPacketCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1194,7 +1194,7 @@ func (m *metricVcenterHostNetworkPacketCount) init() {
 }
 
 func (m *metricVcenterHostNetworkPacketCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, throughputDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1213,16 +1213,16 @@ func (m *metricVcenterHostNetworkPacketCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterHostNetworkPacketCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterHostNetworkPacketCount(settings MetricSettings) metricVcenterHostNetworkPacketCount {
-	m := metricVcenterHostNetworkPacketCount{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterHostNetworkPacketCount(cfg MetricConfig) metricVcenterHostNetworkPacketCount {
+	m := metricVcenterHostNetworkPacketCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1231,7 +1231,7 @@ func newMetricVcenterHostNetworkPacketCount(settings MetricSettings) metricVcent
 
 type metricVcenterHostNetworkPacketErrors struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1247,7 +1247,7 @@ func (m *metricVcenterHostNetworkPacketErrors) init() {
 }
 
 func (m *metricVcenterHostNetworkPacketErrors) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, throughputDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1266,16 +1266,16 @@ func (m *metricVcenterHostNetworkPacketErrors) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterHostNetworkPacketErrors) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterHostNetworkPacketErrors(settings MetricSettings) metricVcenterHostNetworkPacketErrors {
-	m := metricVcenterHostNetworkPacketErrors{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterHostNetworkPacketErrors(cfg MetricConfig) metricVcenterHostNetworkPacketErrors {
+	m := metricVcenterHostNetworkPacketErrors{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1284,7 +1284,7 @@ func newMetricVcenterHostNetworkPacketErrors(settings MetricSettings) metricVcen
 
 type metricVcenterHostNetworkThroughput struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1300,7 +1300,7 @@ func (m *metricVcenterHostNetworkThroughput) init() {
 }
 
 func (m *metricVcenterHostNetworkThroughput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, throughputDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1319,16 +1319,16 @@ func (m *metricVcenterHostNetworkThroughput) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterHostNetworkThroughput) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterHostNetworkThroughput(settings MetricSettings) metricVcenterHostNetworkThroughput {
-	m := metricVcenterHostNetworkThroughput{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterHostNetworkThroughput(cfg MetricConfig) metricVcenterHostNetworkThroughput {
+	m := metricVcenterHostNetworkThroughput{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1337,7 +1337,7 @@ func newMetricVcenterHostNetworkThroughput(settings MetricSettings) metricVcente
 
 type metricVcenterHostNetworkUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1352,7 +1352,7 @@ func (m *metricVcenterHostNetworkUsage) init() {
 }
 
 func (m *metricVcenterHostNetworkUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1370,16 +1370,16 @@ func (m *metricVcenterHostNetworkUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterHostNetworkUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterHostNetworkUsage(settings MetricSettings) metricVcenterHostNetworkUsage {
-	m := metricVcenterHostNetworkUsage{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterHostNetworkUsage(cfg MetricConfig) metricVcenterHostNetworkUsage {
+	m := metricVcenterHostNetworkUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1388,7 +1388,7 @@ func newMetricVcenterHostNetworkUsage(settings MetricSettings) metricVcenterHost
 
 type metricVcenterResourcePoolCPUShares struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1403,7 +1403,7 @@ func (m *metricVcenterResourcePoolCPUShares) init() {
 }
 
 func (m *metricVcenterResourcePoolCPUShares) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1421,16 +1421,16 @@ func (m *metricVcenterResourcePoolCPUShares) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterResourcePoolCPUShares) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterResourcePoolCPUShares(settings MetricSettings) metricVcenterResourcePoolCPUShares {
-	m := metricVcenterResourcePoolCPUShares{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterResourcePoolCPUShares(cfg MetricConfig) metricVcenterResourcePoolCPUShares {
+	m := metricVcenterResourcePoolCPUShares{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1439,7 +1439,7 @@ func newMetricVcenterResourcePoolCPUShares(settings MetricSettings) metricVcente
 
 type metricVcenterResourcePoolCPUUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1454,7 +1454,7 @@ func (m *metricVcenterResourcePoolCPUUsage) init() {
 }
 
 func (m *metricVcenterResourcePoolCPUUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1472,16 +1472,16 @@ func (m *metricVcenterResourcePoolCPUUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterResourcePoolCPUUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterResourcePoolCPUUsage(settings MetricSettings) metricVcenterResourcePoolCPUUsage {
-	m := metricVcenterResourcePoolCPUUsage{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterResourcePoolCPUUsage(cfg MetricConfig) metricVcenterResourcePoolCPUUsage {
+	m := metricVcenterResourcePoolCPUUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1490,7 +1490,7 @@ func newMetricVcenterResourcePoolCPUUsage(settings MetricSettings) metricVcenter
 
 type metricVcenterResourcePoolMemoryShares struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1505,7 +1505,7 @@ func (m *metricVcenterResourcePoolMemoryShares) init() {
 }
 
 func (m *metricVcenterResourcePoolMemoryShares) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1523,16 +1523,16 @@ func (m *metricVcenterResourcePoolMemoryShares) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterResourcePoolMemoryShares) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterResourcePoolMemoryShares(settings MetricSettings) metricVcenterResourcePoolMemoryShares {
-	m := metricVcenterResourcePoolMemoryShares{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterResourcePoolMemoryShares(cfg MetricConfig) metricVcenterResourcePoolMemoryShares {
+	m := metricVcenterResourcePoolMemoryShares{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1541,7 +1541,7 @@ func newMetricVcenterResourcePoolMemoryShares(settings MetricSettings) metricVce
 
 type metricVcenterResourcePoolMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1556,7 +1556,7 @@ func (m *metricVcenterResourcePoolMemoryUsage) init() {
 }
 
 func (m *metricVcenterResourcePoolMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1574,16 +1574,16 @@ func (m *metricVcenterResourcePoolMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterResourcePoolMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterResourcePoolMemoryUsage(settings MetricSettings) metricVcenterResourcePoolMemoryUsage {
-	m := metricVcenterResourcePoolMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterResourcePoolMemoryUsage(cfg MetricConfig) metricVcenterResourcePoolMemoryUsage {
+	m := metricVcenterResourcePoolMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1592,7 +1592,7 @@ func newMetricVcenterResourcePoolMemoryUsage(settings MetricSettings) metricVcen
 
 type metricVcenterVMCPUUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1607,7 +1607,7 @@ func (m *metricVcenterVMCPUUsage) init() {
 }
 
 func (m *metricVcenterVMCPUUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1625,16 +1625,16 @@ func (m *metricVcenterVMCPUUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMCPUUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMCPUUsage(settings MetricSettings) metricVcenterVMCPUUsage {
-	m := metricVcenterVMCPUUsage{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMCPUUsage(cfg MetricConfig) metricVcenterVMCPUUsage {
+	m := metricVcenterVMCPUUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1643,7 +1643,7 @@ func newMetricVcenterVMCPUUsage(settings MetricSettings) metricVcenterVMCPUUsage
 
 type metricVcenterVMCPUUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1656,7 +1656,7 @@ func (m *metricVcenterVMCPUUtilization) init() {
 }
 
 func (m *metricVcenterVMCPUUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1674,16 +1674,16 @@ func (m *metricVcenterVMCPUUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMCPUUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMCPUUtilization(settings MetricSettings) metricVcenterVMCPUUtilization {
-	m := metricVcenterVMCPUUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMCPUUtilization(cfg MetricConfig) metricVcenterVMCPUUtilization {
+	m := metricVcenterVMCPUUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1692,7 +1692,7 @@ func newMetricVcenterVMCPUUtilization(settings MetricSettings) metricVcenterVMCP
 
 type metricVcenterVMDiskLatencyAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1706,7 +1706,7 @@ func (m *metricVcenterVMDiskLatencyAvg) init() {
 }
 
 func (m *metricVcenterVMDiskLatencyAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskDirectionAttributeValue string, diskTypeAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1726,16 +1726,16 @@ func (m *metricVcenterVMDiskLatencyAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMDiskLatencyAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMDiskLatencyAvg(settings MetricSettings) metricVcenterVMDiskLatencyAvg {
-	m := metricVcenterVMDiskLatencyAvg{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMDiskLatencyAvg(cfg MetricConfig) metricVcenterVMDiskLatencyAvg {
+	m := metricVcenterVMDiskLatencyAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1744,7 +1744,7 @@ func newMetricVcenterVMDiskLatencyAvg(settings MetricSettings) metricVcenterVMDi
 
 type metricVcenterVMDiskLatencyMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1757,7 +1757,7 @@ func (m *metricVcenterVMDiskLatencyMax) init() {
 }
 
 func (m *metricVcenterVMDiskLatencyMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1775,16 +1775,16 @@ func (m *metricVcenterVMDiskLatencyMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMDiskLatencyMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMDiskLatencyMax(settings MetricSettings) metricVcenterVMDiskLatencyMax {
-	m := metricVcenterVMDiskLatencyMax{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMDiskLatencyMax(cfg MetricConfig) metricVcenterVMDiskLatencyMax {
+	m := metricVcenterVMDiskLatencyMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1793,7 +1793,7 @@ func newMetricVcenterVMDiskLatencyMax(settings MetricSettings) metricVcenterVMDi
 
 type metricVcenterVMDiskThroughput struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1808,7 +1808,7 @@ func (m *metricVcenterVMDiskThroughput) init() {
 }
 
 func (m *metricVcenterVMDiskThroughput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1826,16 +1826,16 @@ func (m *metricVcenterVMDiskThroughput) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMDiskThroughput) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMDiskThroughput(settings MetricSettings) metricVcenterVMDiskThroughput {
-	m := metricVcenterVMDiskThroughput{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMDiskThroughput(cfg MetricConfig) metricVcenterVMDiskThroughput {
+	m := metricVcenterVMDiskThroughput{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1844,7 +1844,7 @@ func newMetricVcenterVMDiskThroughput(settings MetricSettings) metricVcenterVMDi
 
 type metricVcenterVMDiskUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1860,7 +1860,7 @@ func (m *metricVcenterVMDiskUsage) init() {
 }
 
 func (m *metricVcenterVMDiskUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, diskStateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1879,16 +1879,16 @@ func (m *metricVcenterVMDiskUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMDiskUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMDiskUsage(settings MetricSettings) metricVcenterVMDiskUsage {
-	m := metricVcenterVMDiskUsage{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMDiskUsage(cfg MetricConfig) metricVcenterVMDiskUsage {
+	m := metricVcenterVMDiskUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1897,7 +1897,7 @@ func newMetricVcenterVMDiskUsage(settings MetricSettings) metricVcenterVMDiskUsa
 
 type metricVcenterVMDiskUtilization struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1910,7 +1910,7 @@ func (m *metricVcenterVMDiskUtilization) init() {
 }
 
 func (m *metricVcenterVMDiskUtilization) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val float64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -1928,16 +1928,16 @@ func (m *metricVcenterVMDiskUtilization) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMDiskUtilization) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMDiskUtilization(settings MetricSettings) metricVcenterVMDiskUtilization {
-	m := metricVcenterVMDiskUtilization{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMDiskUtilization(cfg MetricConfig) metricVcenterVMDiskUtilization {
+	m := metricVcenterVMDiskUtilization{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1946,7 +1946,7 @@ func newMetricVcenterVMDiskUtilization(settings MetricSettings) metricVcenterVMD
 
 type metricVcenterVMMemoryBallooned struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -1961,7 +1961,7 @@ func (m *metricVcenterVMMemoryBallooned) init() {
 }
 
 func (m *metricVcenterVMMemoryBallooned) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -1979,16 +1979,16 @@ func (m *metricVcenterVMMemoryBallooned) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMMemoryBallooned) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMMemoryBallooned(settings MetricSettings) metricVcenterVMMemoryBallooned {
-	m := metricVcenterVMMemoryBallooned{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMMemoryBallooned(cfg MetricConfig) metricVcenterVMMemoryBallooned {
+	m := metricVcenterVMMemoryBallooned{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -1997,7 +1997,7 @@ func newMetricVcenterVMMemoryBallooned(settings MetricSettings) metricVcenterVMM
 
 type metricVcenterVMMemorySwapped struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2012,7 +2012,7 @@ func (m *metricVcenterVMMemorySwapped) init() {
 }
 
 func (m *metricVcenterVMMemorySwapped) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2030,16 +2030,16 @@ func (m *metricVcenterVMMemorySwapped) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMMemorySwapped) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMMemorySwapped(settings MetricSettings) metricVcenterVMMemorySwapped {
-	m := metricVcenterVMMemorySwapped{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMMemorySwapped(cfg MetricConfig) metricVcenterVMMemorySwapped {
+	m := metricVcenterVMMemorySwapped{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2048,7 +2048,7 @@ func newMetricVcenterVMMemorySwapped(settings MetricSettings) metricVcenterVMMem
 
 type metricVcenterVMMemorySwappedSsd struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2063,7 +2063,7 @@ func (m *metricVcenterVMMemorySwappedSsd) init() {
 }
 
 func (m *metricVcenterVMMemorySwappedSsd) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2081,16 +2081,16 @@ func (m *metricVcenterVMMemorySwappedSsd) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMMemorySwappedSsd) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMMemorySwappedSsd(settings MetricSettings) metricVcenterVMMemorySwappedSsd {
-	m := metricVcenterVMMemorySwappedSsd{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMMemorySwappedSsd(cfg MetricConfig) metricVcenterVMMemorySwappedSsd {
+	m := metricVcenterVMMemorySwappedSsd{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2099,7 +2099,7 @@ func newMetricVcenterVMMemorySwappedSsd(settings MetricSettings) metricVcenterVM
 
 type metricVcenterVMMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2114,7 +2114,7 @@ func (m *metricVcenterVMMemoryUsage) init() {
 }
 
 func (m *metricVcenterVMMemoryUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2132,16 +2132,16 @@ func (m *metricVcenterVMMemoryUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMMemoryUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMMemoryUsage(settings MetricSettings) metricVcenterVMMemoryUsage {
-	m := metricVcenterVMMemoryUsage{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMMemoryUsage(cfg MetricConfig) metricVcenterVMMemoryUsage {
+	m := metricVcenterVMMemoryUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2150,7 +2150,7 @@ func newMetricVcenterVMMemoryUsage(settings MetricSettings) metricVcenterVMMemor
 
 type metricVcenterVMNetworkPacketCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2166,7 +2166,7 @@ func (m *metricVcenterVMNetworkPacketCount) init() {
 }
 
 func (m *metricVcenterVMNetworkPacketCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, throughputDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2185,16 +2185,16 @@ func (m *metricVcenterVMNetworkPacketCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMNetworkPacketCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMNetworkPacketCount(settings MetricSettings) metricVcenterVMNetworkPacketCount {
-	m := metricVcenterVMNetworkPacketCount{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMNetworkPacketCount(cfg MetricConfig) metricVcenterVMNetworkPacketCount {
+	m := metricVcenterVMNetworkPacketCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2203,7 +2203,7 @@ func newMetricVcenterVMNetworkPacketCount(settings MetricSettings) metricVcenter
 
 type metricVcenterVMNetworkThroughput struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2219,7 +2219,7 @@ func (m *metricVcenterVMNetworkThroughput) init() {
 }
 
 func (m *metricVcenterVMNetworkThroughput) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, throughputDirectionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2238,16 +2238,16 @@ func (m *metricVcenterVMNetworkThroughput) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMNetworkThroughput) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMNetworkThroughput(settings MetricSettings) metricVcenterVMNetworkThroughput {
-	m := metricVcenterVMNetworkThroughput{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMNetworkThroughput(cfg MetricConfig) metricVcenterVMNetworkThroughput {
+	m := metricVcenterVMNetworkThroughput{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2256,7 +2256,7 @@ func newMetricVcenterVMNetworkThroughput(settings MetricSettings) metricVcenterV
 
 type metricVcenterVMNetworkUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -2271,7 +2271,7 @@ func (m *metricVcenterVMNetworkUsage) init() {
 }
 
 func (m *metricVcenterVMNetworkUsage) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -2289,16 +2289,16 @@ func (m *metricVcenterVMNetworkUsage) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricVcenterVMNetworkUsage) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricVcenterVMNetworkUsage(settings MetricSettings) metricVcenterVMNetworkUsage {
-	m := metricVcenterVMNetworkUsage{settings: settings}
-	if settings.Enabled {
+func newMetricVcenterVMNetworkUsage(cfg MetricConfig) metricVcenterVMNetworkUsage {
+	m := metricVcenterVMNetworkUsage{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -2307,19 +2307,19 @@ func newMetricVcenterVMNetworkUsage(settings MetricSettings) metricVcenterVMNetw
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                             pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                       int                 // maximum observed number of metrics per resource.
 	resourceCapacity                      int                 // maximum observed number of resource attributes.
 	metricsBuffer                         pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                             component.BuildInfo // contains version information
-	resourceAttributesSettings            ResourceAttributesSettings
+	resourceAttributesConfig              ResourceAttributesConfig
 	metricVcenterClusterCPUEffective      metricVcenterClusterCPUEffective
 	metricVcenterClusterCPULimit          metricVcenterClusterCPULimit
 	metricVcenterClusterHostCount         metricVcenterClusterHostCount
@@ -2372,8 +2372,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -2382,7 +2382,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                             pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                         pmetric.NewMetrics(),
 		buildInfo:                             settings.BuildInfo,
-		resourceAttributesSettings:            mbc.ResourceAttributes,
+		resourceAttributesConfig:              mbc.ResourceAttributes,
 		metricVcenterClusterCPUEffective:      newMetricVcenterClusterCPUEffective(mbc.Metrics.VcenterClusterCPUEffective),
 		metricVcenterClusterCPULimit:          newMetricVcenterClusterCPULimit(mbc.Metrics.VcenterClusterCPULimit),
 		metricVcenterClusterHostCount:         newMetricVcenterClusterHostCount(mbc.Metrics.VcenterClusterHostCount),
@@ -2439,12 +2439,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithVcenterClusterName sets provided value as "vcenter.cluster.name" attribute for current resource.
 func WithVcenterClusterName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.VcenterClusterName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.VcenterClusterName.Enabled {
 			rm.Resource().Attributes().PutStr("vcenter.cluster.name", val)
 		}
 	}
@@ -2452,8 +2452,8 @@ func WithVcenterClusterName(val string) ResourceMetricsOption {
 
 // WithVcenterDatastoreName sets provided value as "vcenter.datastore.name" attribute for current resource.
 func WithVcenterDatastoreName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.VcenterDatastoreName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.VcenterDatastoreName.Enabled {
 			rm.Resource().Attributes().PutStr("vcenter.datastore.name", val)
 		}
 	}
@@ -2461,8 +2461,8 @@ func WithVcenterDatastoreName(val string) ResourceMetricsOption {
 
 // WithVcenterHostName sets provided value as "vcenter.host.name" attribute for current resource.
 func WithVcenterHostName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.VcenterHostName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.VcenterHostName.Enabled {
 			rm.Resource().Attributes().PutStr("vcenter.host.name", val)
 		}
 	}
@@ -2470,8 +2470,8 @@ func WithVcenterHostName(val string) ResourceMetricsOption {
 
 // WithVcenterResourcePoolName sets provided value as "vcenter.resource_pool.name" attribute for current resource.
 func WithVcenterResourcePoolName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.VcenterResourcePoolName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.VcenterResourcePoolName.Enabled {
 			rm.Resource().Attributes().PutStr("vcenter.resource_pool.name", val)
 		}
 	}
@@ -2479,8 +2479,8 @@ func WithVcenterResourcePoolName(val string) ResourceMetricsOption {
 
 // WithVcenterVMID sets provided value as "vcenter.vm.id" attribute for current resource.
 func WithVcenterVMID(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.VcenterVMID.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.VcenterVMID.Enabled {
 			rm.Resource().Attributes().PutStr("vcenter.vm.id", val)
 		}
 	}
@@ -2488,8 +2488,8 @@ func WithVcenterVMID(val string) ResourceMetricsOption {
 
 // WithVcenterVMName sets provided value as "vcenter.vm.name" attribute for current resource.
 func WithVcenterVMName(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.VcenterVMName.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.VcenterVMName.Enabled {
 			rm.Resource().Attributes().PutStr("vcenter.vm.name", val)
 		}
 	}
@@ -2498,7 +2498,7 @@ func WithVcenterVMName(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -2567,7 +2567,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricVcenterVMNetworkUsage.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -2577,7 +2577,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
@@ -223,43 +223,43 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("vcenter.cluster.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.VcenterClusterName.Enabled, ok)
-			if mb.resourceAttributesSettings.VcenterClusterName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.VcenterClusterName.Enabled, ok)
+			if mb.resourceAttributesConfig.VcenterClusterName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("vcenter.datastore.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.VcenterDatastoreName.Enabled, ok)
-			if mb.resourceAttributesSettings.VcenterDatastoreName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.VcenterDatastoreName.Enabled, ok)
+			if mb.resourceAttributesConfig.VcenterDatastoreName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("vcenter.host.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.VcenterHostName.Enabled, ok)
-			if mb.resourceAttributesSettings.VcenterHostName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.VcenterHostName.Enabled, ok)
+			if mb.resourceAttributesConfig.VcenterHostName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("vcenter.resource_pool.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.VcenterResourcePoolName.Enabled, ok)
-			if mb.resourceAttributesSettings.VcenterResourcePoolName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.VcenterResourcePoolName.Enabled, ok)
+			if mb.resourceAttributesConfig.VcenterResourcePoolName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("vcenter.vm.id")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.VcenterVMID.Enabled, ok)
-			if mb.resourceAttributesSettings.VcenterVMID.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.VcenterVMID.Enabled, ok)
+			if mb.resourceAttributesConfig.VcenterVMID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("vcenter.vm.name")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.VcenterVMName.Enabled, ok)
-			if mb.resourceAttributesSettings.VcenterVMName.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.VcenterVMName.Enabled, ok)
+			if mb.resourceAttributesConfig.VcenterVMName.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics.go
@@ -12,14 +12,14 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 )
 
-// MetricSettings provides common settings for a particular metric.
-type MetricSettings struct {
+// MetricConfig provides common config for a particular metric.
+type MetricConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 
 	enabledSetByUser bool
 }
 
-func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
+func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
@@ -31,92 +31,92 @@ func (ms *MetricSettings) Unmarshal(parser *confmap.Conf) error {
 	return nil
 }
 
-// MetricsSettings provides settings for zookeeperreceiver metrics.
-type MetricsSettings struct {
-	ZookeeperConnectionActive            MetricSettings `mapstructure:"zookeeper.connection.active"`
-	ZookeeperDataTreeEphemeralNodeCount  MetricSettings `mapstructure:"zookeeper.data_tree.ephemeral_node.count"`
-	ZookeeperDataTreeSize                MetricSettings `mapstructure:"zookeeper.data_tree.size"`
-	ZookeeperFileDescriptorLimit         MetricSettings `mapstructure:"zookeeper.file_descriptor.limit"`
-	ZookeeperFileDescriptorOpen          MetricSettings `mapstructure:"zookeeper.file_descriptor.open"`
-	ZookeeperFollowerCount               MetricSettings `mapstructure:"zookeeper.follower.count"`
-	ZookeeperFsyncExceededThresholdCount MetricSettings `mapstructure:"zookeeper.fsync.exceeded_threshold.count"`
-	ZookeeperLatencyAvg                  MetricSettings `mapstructure:"zookeeper.latency.avg"`
-	ZookeeperLatencyMax                  MetricSettings `mapstructure:"zookeeper.latency.max"`
-	ZookeeperLatencyMin                  MetricSettings `mapstructure:"zookeeper.latency.min"`
-	ZookeeperPacketCount                 MetricSettings `mapstructure:"zookeeper.packet.count"`
-	ZookeeperRequestActive               MetricSettings `mapstructure:"zookeeper.request.active"`
-	ZookeeperSyncPending                 MetricSettings `mapstructure:"zookeeper.sync.pending"`
-	ZookeeperWatchCount                  MetricSettings `mapstructure:"zookeeper.watch.count"`
-	ZookeeperZnodeCount                  MetricSettings `mapstructure:"zookeeper.znode.count"`
+// MetricsConfig provides config for zookeeperreceiver metrics.
+type MetricsConfig struct {
+	ZookeeperConnectionActive            MetricConfig `mapstructure:"zookeeper.connection.active"`
+	ZookeeperDataTreeEphemeralNodeCount  MetricConfig `mapstructure:"zookeeper.data_tree.ephemeral_node.count"`
+	ZookeeperDataTreeSize                MetricConfig `mapstructure:"zookeeper.data_tree.size"`
+	ZookeeperFileDescriptorLimit         MetricConfig `mapstructure:"zookeeper.file_descriptor.limit"`
+	ZookeeperFileDescriptorOpen          MetricConfig `mapstructure:"zookeeper.file_descriptor.open"`
+	ZookeeperFollowerCount               MetricConfig `mapstructure:"zookeeper.follower.count"`
+	ZookeeperFsyncExceededThresholdCount MetricConfig `mapstructure:"zookeeper.fsync.exceeded_threshold.count"`
+	ZookeeperLatencyAvg                  MetricConfig `mapstructure:"zookeeper.latency.avg"`
+	ZookeeperLatencyMax                  MetricConfig `mapstructure:"zookeeper.latency.max"`
+	ZookeeperLatencyMin                  MetricConfig `mapstructure:"zookeeper.latency.min"`
+	ZookeeperPacketCount                 MetricConfig `mapstructure:"zookeeper.packet.count"`
+	ZookeeperRequestActive               MetricConfig `mapstructure:"zookeeper.request.active"`
+	ZookeeperSyncPending                 MetricConfig `mapstructure:"zookeeper.sync.pending"`
+	ZookeeperWatchCount                  MetricConfig `mapstructure:"zookeeper.watch.count"`
+	ZookeeperZnodeCount                  MetricConfig `mapstructure:"zookeeper.znode.count"`
 }
 
-func DefaultMetricsSettings() MetricsSettings {
-	return MetricsSettings{
-		ZookeeperConnectionActive: MetricSettings{
+func DefaultMetricsConfig() MetricsConfig {
+	return MetricsConfig{
+		ZookeeperConnectionActive: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperDataTreeEphemeralNodeCount: MetricSettings{
+		ZookeeperDataTreeEphemeralNodeCount: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperDataTreeSize: MetricSettings{
+		ZookeeperDataTreeSize: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperFileDescriptorLimit: MetricSettings{
+		ZookeeperFileDescriptorLimit: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperFileDescriptorOpen: MetricSettings{
+		ZookeeperFileDescriptorOpen: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperFollowerCount: MetricSettings{
+		ZookeeperFollowerCount: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperFsyncExceededThresholdCount: MetricSettings{
+		ZookeeperFsyncExceededThresholdCount: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperLatencyAvg: MetricSettings{
+		ZookeeperLatencyAvg: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperLatencyMax: MetricSettings{
+		ZookeeperLatencyMax: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperLatencyMin: MetricSettings{
+		ZookeeperLatencyMin: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperPacketCount: MetricSettings{
+		ZookeeperPacketCount: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperRequestActive: MetricSettings{
+		ZookeeperRequestActive: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperSyncPending: MetricSettings{
+		ZookeeperSyncPending: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperWatchCount: MetricSettings{
+		ZookeeperWatchCount: MetricConfig{
 			Enabled: true,
 		},
-		ZookeeperZnodeCount: MetricSettings{
+		ZookeeperZnodeCount: MetricConfig{
 			Enabled: true,
 		},
 	}
 }
 
-// ResourceAttributeSettings provides common settings for a particular resource attribute.
-type ResourceAttributeSettings struct {
+// ResourceAttributeConfig provides common config for a particular resource attribute.
+type ResourceAttributeConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 
-// ResourceAttributesSettings provides settings for zookeeperreceiver resource attributes.
-type ResourceAttributesSettings struct {
-	ServerState ResourceAttributeSettings `mapstructure:"server.state"`
-	ZkVersion   ResourceAttributeSettings `mapstructure:"zk.version"`
+// ResourceAttributesConfig provides config for zookeeperreceiver resource attributes.
+type ResourceAttributesConfig struct {
+	ServerState ResourceAttributeConfig `mapstructure:"server.state"`
+	ZkVersion   ResourceAttributeConfig `mapstructure:"zk.version"`
 }
 
-func DefaultResourceAttributesSettings() ResourceAttributesSettings {
-	return ResourceAttributesSettings{
-		ServerState: ResourceAttributeSettings{
+func DefaultResourceAttributesConfig() ResourceAttributesConfig {
+	return ResourceAttributesConfig{
+		ServerState: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ZkVersion: ResourceAttributeSettings{
+		ZkVersion: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}
@@ -176,7 +176,7 @@ var MapAttributeState = map[string]AttributeState{
 
 type metricZookeeperConnectionActive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -191,7 +191,7 @@ func (m *metricZookeeperConnectionActive) init() {
 }
 
 func (m *metricZookeeperConnectionActive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -209,16 +209,16 @@ func (m *metricZookeeperConnectionActive) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperConnectionActive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperConnectionActive(settings MetricSettings) metricZookeeperConnectionActive {
-	m := metricZookeeperConnectionActive{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperConnectionActive(cfg MetricConfig) metricZookeeperConnectionActive {
+	m := metricZookeeperConnectionActive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -227,7 +227,7 @@ func newMetricZookeeperConnectionActive(settings MetricSettings) metricZookeeper
 
 type metricZookeeperDataTreeEphemeralNodeCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -242,7 +242,7 @@ func (m *metricZookeeperDataTreeEphemeralNodeCount) init() {
 }
 
 func (m *metricZookeeperDataTreeEphemeralNodeCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -260,16 +260,16 @@ func (m *metricZookeeperDataTreeEphemeralNodeCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperDataTreeEphemeralNodeCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperDataTreeEphemeralNodeCount(settings MetricSettings) metricZookeeperDataTreeEphemeralNodeCount {
-	m := metricZookeeperDataTreeEphemeralNodeCount{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperDataTreeEphemeralNodeCount(cfg MetricConfig) metricZookeeperDataTreeEphemeralNodeCount {
+	m := metricZookeeperDataTreeEphemeralNodeCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -278,7 +278,7 @@ func newMetricZookeeperDataTreeEphemeralNodeCount(settings MetricSettings) metri
 
 type metricZookeeperDataTreeSize struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -293,7 +293,7 @@ func (m *metricZookeeperDataTreeSize) init() {
 }
 
 func (m *metricZookeeperDataTreeSize) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -311,16 +311,16 @@ func (m *metricZookeeperDataTreeSize) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperDataTreeSize) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperDataTreeSize(settings MetricSettings) metricZookeeperDataTreeSize {
-	m := metricZookeeperDataTreeSize{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperDataTreeSize(cfg MetricConfig) metricZookeeperDataTreeSize {
+	m := metricZookeeperDataTreeSize{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -329,7 +329,7 @@ func newMetricZookeeperDataTreeSize(settings MetricSettings) metricZookeeperData
 
 type metricZookeeperFileDescriptorLimit struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -342,7 +342,7 @@ func (m *metricZookeeperFileDescriptorLimit) init() {
 }
 
 func (m *metricZookeeperFileDescriptorLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -360,16 +360,16 @@ func (m *metricZookeeperFileDescriptorLimit) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperFileDescriptorLimit) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperFileDescriptorLimit(settings MetricSettings) metricZookeeperFileDescriptorLimit {
-	m := metricZookeeperFileDescriptorLimit{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperFileDescriptorLimit(cfg MetricConfig) metricZookeeperFileDescriptorLimit {
+	m := metricZookeeperFileDescriptorLimit{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -378,7 +378,7 @@ func newMetricZookeeperFileDescriptorLimit(settings MetricSettings) metricZookee
 
 type metricZookeeperFileDescriptorOpen struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -393,7 +393,7 @@ func (m *metricZookeeperFileDescriptorOpen) init() {
 }
 
 func (m *metricZookeeperFileDescriptorOpen) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -411,16 +411,16 @@ func (m *metricZookeeperFileDescriptorOpen) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperFileDescriptorOpen) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperFileDescriptorOpen(settings MetricSettings) metricZookeeperFileDescriptorOpen {
-	m := metricZookeeperFileDescriptorOpen{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperFileDescriptorOpen(cfg MetricConfig) metricZookeeperFileDescriptorOpen {
+	m := metricZookeeperFileDescriptorOpen{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -429,7 +429,7 @@ func newMetricZookeeperFileDescriptorOpen(settings MetricSettings) metricZookeep
 
 type metricZookeeperFollowerCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -445,7 +445,7 @@ func (m *metricZookeeperFollowerCount) init() {
 }
 
 func (m *metricZookeeperFollowerCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, stateAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -464,16 +464,16 @@ func (m *metricZookeeperFollowerCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperFollowerCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperFollowerCount(settings MetricSettings) metricZookeeperFollowerCount {
-	m := metricZookeeperFollowerCount{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperFollowerCount(cfg MetricConfig) metricZookeeperFollowerCount {
+	m := metricZookeeperFollowerCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -482,7 +482,7 @@ func newMetricZookeeperFollowerCount(settings MetricSettings) metricZookeeperFol
 
 type metricZookeeperFsyncExceededThresholdCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -497,7 +497,7 @@ func (m *metricZookeeperFsyncExceededThresholdCount) init() {
 }
 
 func (m *metricZookeeperFsyncExceededThresholdCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -515,16 +515,16 @@ func (m *metricZookeeperFsyncExceededThresholdCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperFsyncExceededThresholdCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperFsyncExceededThresholdCount(settings MetricSettings) metricZookeeperFsyncExceededThresholdCount {
-	m := metricZookeeperFsyncExceededThresholdCount{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperFsyncExceededThresholdCount(cfg MetricConfig) metricZookeeperFsyncExceededThresholdCount {
+	m := metricZookeeperFsyncExceededThresholdCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -533,7 +533,7 @@ func newMetricZookeeperFsyncExceededThresholdCount(settings MetricSettings) metr
 
 type metricZookeeperLatencyAvg struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -546,7 +546,7 @@ func (m *metricZookeeperLatencyAvg) init() {
 }
 
 func (m *metricZookeeperLatencyAvg) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -564,16 +564,16 @@ func (m *metricZookeeperLatencyAvg) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperLatencyAvg) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperLatencyAvg(settings MetricSettings) metricZookeeperLatencyAvg {
-	m := metricZookeeperLatencyAvg{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperLatencyAvg(cfg MetricConfig) metricZookeeperLatencyAvg {
+	m := metricZookeeperLatencyAvg{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -582,7 +582,7 @@ func newMetricZookeeperLatencyAvg(settings MetricSettings) metricZookeeperLatenc
 
 type metricZookeeperLatencyMax struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -595,7 +595,7 @@ func (m *metricZookeeperLatencyMax) init() {
 }
 
 func (m *metricZookeeperLatencyMax) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -613,16 +613,16 @@ func (m *metricZookeeperLatencyMax) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperLatencyMax) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperLatencyMax(settings MetricSettings) metricZookeeperLatencyMax {
-	m := metricZookeeperLatencyMax{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperLatencyMax(cfg MetricConfig) metricZookeeperLatencyMax {
+	m := metricZookeeperLatencyMax{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -631,7 +631,7 @@ func newMetricZookeeperLatencyMax(settings MetricSettings) metricZookeeperLatenc
 
 type metricZookeeperLatencyMin struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -644,7 +644,7 @@ func (m *metricZookeeperLatencyMin) init() {
 }
 
 func (m *metricZookeeperLatencyMin) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Gauge().DataPoints().AppendEmpty()
@@ -662,16 +662,16 @@ func (m *metricZookeeperLatencyMin) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperLatencyMin) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Gauge().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperLatencyMin(settings MetricSettings) metricZookeeperLatencyMin {
-	m := metricZookeeperLatencyMin{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperLatencyMin(cfg MetricConfig) metricZookeeperLatencyMin {
+	m := metricZookeeperLatencyMin{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -680,7 +680,7 @@ func newMetricZookeeperLatencyMin(settings MetricSettings) metricZookeeperLatenc
 
 type metricZookeeperPacketCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -696,7 +696,7 @@ func (m *metricZookeeperPacketCount) init() {
 }
 
 func (m *metricZookeeperPacketCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, directionAttributeValue string) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -715,16 +715,16 @@ func (m *metricZookeeperPacketCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperPacketCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperPacketCount(settings MetricSettings) metricZookeeperPacketCount {
-	m := metricZookeeperPacketCount{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperPacketCount(cfg MetricConfig) metricZookeeperPacketCount {
+	m := metricZookeeperPacketCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -733,7 +733,7 @@ func newMetricZookeeperPacketCount(settings MetricSettings) metricZookeeperPacke
 
 type metricZookeeperRequestActive struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -748,7 +748,7 @@ func (m *metricZookeeperRequestActive) init() {
 }
 
 func (m *metricZookeeperRequestActive) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -766,16 +766,16 @@ func (m *metricZookeeperRequestActive) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperRequestActive) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperRequestActive(settings MetricSettings) metricZookeeperRequestActive {
-	m := metricZookeeperRequestActive{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperRequestActive(cfg MetricConfig) metricZookeeperRequestActive {
+	m := metricZookeeperRequestActive{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -784,7 +784,7 @@ func newMetricZookeeperRequestActive(settings MetricSettings) metricZookeeperReq
 
 type metricZookeeperSyncPending struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -799,7 +799,7 @@ func (m *metricZookeeperSyncPending) init() {
 }
 
 func (m *metricZookeeperSyncPending) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -817,16 +817,16 @@ func (m *metricZookeeperSyncPending) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperSyncPending) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperSyncPending(settings MetricSettings) metricZookeeperSyncPending {
-	m := metricZookeeperSyncPending{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperSyncPending(cfg MetricConfig) metricZookeeperSyncPending {
+	m := metricZookeeperSyncPending{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -835,7 +835,7 @@ func newMetricZookeeperSyncPending(settings MetricSettings) metricZookeeperSyncP
 
 type metricZookeeperWatchCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -850,7 +850,7 @@ func (m *metricZookeeperWatchCount) init() {
 }
 
 func (m *metricZookeeperWatchCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -868,16 +868,16 @@ func (m *metricZookeeperWatchCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperWatchCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperWatchCount(settings MetricSettings) metricZookeeperWatchCount {
-	m := metricZookeeperWatchCount{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperWatchCount(cfg MetricConfig) metricZookeeperWatchCount {
+	m := metricZookeeperWatchCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -886,7 +886,7 @@ func newMetricZookeeperWatchCount(settings MetricSettings) metricZookeeperWatchC
 
 type metricZookeeperZnodeCount struct {
 	data     pmetric.Metric // data buffer for generated metric.
-	settings MetricSettings // metric settings provided by user.
+	config   MetricConfig   // metric config provided by user.
 	capacity int            // max observed number of data points added to the metric.
 }
 
@@ -901,7 +901,7 @@ func (m *metricZookeeperZnodeCount) init() {
 }
 
 func (m *metricZookeeperZnodeCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
-	if !m.settings.Enabled {
+	if !m.config.Enabled {
 		return
 	}
 	dp := m.data.Sum().DataPoints().AppendEmpty()
@@ -919,16 +919,16 @@ func (m *metricZookeeperZnodeCount) updateCapacity() {
 
 // emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
 func (m *metricZookeeperZnodeCount) emit(metrics pmetric.MetricSlice) {
-	if m.settings.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
 		m.updateCapacity()
 		m.data.MoveTo(metrics.AppendEmpty())
 		m.init()
 	}
 }
 
-func newMetricZookeeperZnodeCount(settings MetricSettings) metricZookeeperZnodeCount {
-	m := metricZookeeperZnodeCount{settings: settings}
-	if settings.Enabled {
+func newMetricZookeeperZnodeCount(cfg MetricConfig) metricZookeeperZnodeCount {
+	m := metricZookeeperZnodeCount{config: cfg}
+	if cfg.Enabled {
 		m.data = pmetric.NewMetric()
 		m.init()
 	}
@@ -937,19 +937,19 @@ func newMetricZookeeperZnodeCount(settings MetricSettings) metricZookeeperZnodeC
 
 // MetricsBuilderConfig is a structural subset of an otherwise 1-1 copy of metadata.yaml
 type MetricsBuilderConfig struct {
-	Metrics            MetricsSettings            `mapstructure:"metrics"`
-	ResourceAttributes ResourceAttributesSettings `mapstructure:"resource_attributes"`
+	Metrics            MetricsConfig            `mapstructure:"metrics"`
+	ResourceAttributes ResourceAttributesConfig `mapstructure:"resource_attributes"`
 }
 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
-// required to produce metric representation defined in metadata and user settings.
+// required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
 	startTime                                  pcommon.Timestamp   // start time that will be applied to all recorded data points.
 	metricsCapacity                            int                 // maximum observed number of metrics per resource.
 	resourceCapacity                           int                 // maximum observed number of resource attributes.
 	metricsBuffer                              pmetric.Metrics     // accumulates metrics data before emitting.
 	buildInfo                                  component.BuildInfo // contains version information
-	resourceAttributesSettings                 ResourceAttributesSettings
+	resourceAttributesConfig                   ResourceAttributesConfig
 	metricZookeeperConnectionActive            metricZookeeperConnectionActive
 	metricZookeeperDataTreeEphemeralNodeCount  metricZookeeperDataTreeEphemeralNodeCount
 	metricZookeeperDataTreeSize                metricZookeeperDataTreeSize
@@ -979,8 +979,8 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 	return MetricsBuilderConfig{
-		Metrics:            DefaultMetricsSettings(),
-		ResourceAttributes: DefaultResourceAttributesSettings(),
+		Metrics:            DefaultMetricsConfig(),
+		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
 
@@ -989,7 +989,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		startTime:                       pcommon.NewTimestampFromTime(time.Now()),
 		metricsBuffer:                   pmetric.NewMetrics(),
 		buildInfo:                       settings.BuildInfo,
-		resourceAttributesSettings:      mbc.ResourceAttributes,
+		resourceAttributesConfig:        mbc.ResourceAttributes,
 		metricZookeeperConnectionActive: newMetricZookeeperConnectionActive(mbc.Metrics.ZookeeperConnectionActive),
 		metricZookeeperDataTreeEphemeralNodeCount:  newMetricZookeeperDataTreeEphemeralNodeCount(mbc.Metrics.ZookeeperDataTreeEphemeralNodeCount),
 		metricZookeeperDataTreeSize:                newMetricZookeeperDataTreeSize(mbc.Metrics.ZookeeperDataTreeSize),
@@ -1023,12 +1023,12 @@ func (mb *MetricsBuilder) updateCapacity(rm pmetric.ResourceMetrics) {
 }
 
 // ResourceMetricsOption applies changes to provided resource metrics.
-type ResourceMetricsOption func(ResourceAttributesSettings, pmetric.ResourceMetrics)
+type ResourceMetricsOption func(ResourceAttributesConfig, pmetric.ResourceMetrics)
 
 // WithServerState sets provided value as "server.state" attribute for current resource.
 func WithServerState(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ServerState.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ServerState.Enabled {
 			rm.Resource().Attributes().PutStr("server.state", val)
 		}
 	}
@@ -1036,8 +1036,8 @@ func WithServerState(val string) ResourceMetricsOption {
 
 // WithZkVersion sets provided value as "zk.version" attribute for current resource.
 func WithZkVersion(val string) ResourceMetricsOption {
-	return func(ras ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
-		if ras.ZkVersion.Enabled {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ZkVersion.Enabled {
 			rm.Resource().Attributes().PutStr("zk.version", val)
 		}
 	}
@@ -1046,7 +1046,7 @@ func WithZkVersion(val string) ResourceMetricsOption {
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
-	return func(_ ResourceAttributesSettings, rm pmetric.ResourceMetrics) {
+	return func(_ ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
 		var dps pmetric.NumberDataPointSlice
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		for i := 0; i < metrics.Len(); i++ {
@@ -1092,7 +1092,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	mb.metricZookeeperZnodeCount.emit(ils.Metrics())
 
 	for _, op := range rmo {
-		op(mb.resourceAttributesSettings, rm)
+		op(mb.resourceAttributesConfig, rm)
 	}
 	if ils.Metrics().Len() > 0 {
 		mb.updateCapacity(rm)
@@ -1102,7 +1102,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 
 // Emit returns all the metrics accumulated by the metrics builder and updates the internal state to be ready for
 // recording another set of metrics. This function will be responsible for applying all the transformations required to
-// produce metric representation defined in metadata and user settings, e.g. delta or cumulative.
+// produce metric representation defined in metadata and user config, e.g. delta or cumulative.
 func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	mb.EmitForResource(rmo...)
 	metrics := mb.metricsBuffer

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics_test.go
@@ -131,15 +131,15 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("server.state")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ServerState.Enabled, ok)
-			if mb.resourceAttributesSettings.ServerState.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ServerState.Enabled, ok)
+			if mb.resourceAttributesConfig.ServerState.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("zk.version")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.ZkVersion.Enabled, ok)
-			if mb.resourceAttributesSettings.ZkVersion.Enabled {
+			assert.Equal(t, mb.resourceAttributesConfig.ZkVersion.Enabled, ok)
+			if mb.resourceAttributesConfig.ZkVersion.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -53,7 +53,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 		name                         string
 		expectedMetricsFilename      string
 		expectedResourceAttributes   map[string]string
-		metricsSettings              func() metadata.MetricsSettings
+		metricsConfig                func() metadata.MetricsConfig
 		mockedZKOutputSourceFilename string
 		mockZKConnectionErr          bool
 		expectedLogs                 []logMsg
@@ -191,8 +191,8 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 		},
 		{
 			name: "Disable zookeeper.watches metric",
-			metricsSettings: func() metadata.MetricsSettings {
-				ms := metadata.DefaultMetricsSettings()
+			metricsConfig: func() metadata.MetricsConfig {
+				ms := metadata.DefaultMetricsConfig()
 				ms.ZookeeperWatchCount.Enabled = false
 				return ms
 			},
@@ -222,8 +222,8 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 
 			cfg := createDefaultConfig().(*Config)
 			cfg.TCPAddr.Endpoint = localAddr
-			if tt.metricsSettings != nil {
-				cfg.MetricsBuilderConfig.Metrics = tt.metricsSettings()
+			if tt.metricsConfig != nil {
+				cfg.MetricsBuilderConfig.Metrics = tt.metricsConfig()
 			}
 
 			core, observedLogs := observer.New(zap.DebugLevel)


### PR DESCRIPTION
Rename generated structs for consistency with other structs representing user configuration in the collector codebase.
- MetricsSettings -> MetricsConfig
- MetricSettings -> MetricConfig
- ResourceAttributesSettings -> ResourceAttributesConfig
- ResourceAttributeSettings -> ResourceAttributeConfig

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector/issues/6767
