### PR TITLE
[receiver/nsxt] Remove incorrect resource attributes fields from config

### DIFF
--- a/.chloggen/nsx-receiver-fix-config.yaml
+++ b/.chloggen/nsx-receiver-fix-config.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/nsx
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove incorrectly exposed resource attributes from the user configuration interface.
+
+# One or more tracking issues related to the change
+issues: [21523]

--- a/receiver/nsxtreceiver/config.go
+++ b/receiver/nsxtreceiver/config.go
@@ -31,9 +31,8 @@ type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 	confighttp.HTTPClientSettings           `mapstructure:",squash"`
 	metadata.MetricsBuilderConfig           `mapstructure:",squash"`
-	ResourceAttributes                      metadata.ResourceAttributesConfig `mapstructure:",squash"`
-	Username                                string                            `mapstructure:"username"`
-	Password                                string                            `mapstructure:"password"`
+	Username                                string `mapstructure:"username"`
+	Password                                string `mapstructure:"password"`
 }
 
 // Validate returns if the NSX configuration is valid


### PR DESCRIPTION
Remove incorrectly exposed resource attribute fields from the user configuration interface. They are already exposed under `resource_attributes` with `metadata.MetricsBuilderConfig`
