### PR TITLE
fix(influxdbexporter): handle empty attribute values

### DIFF
--- a/.chloggen/fix-influx-empty-tag-values.yaml
+++ b/.chloggen/fix-influx-empty-tag-values.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: influxdbexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: handle empty attribute values emitted by hostmetricsreceiver with logger.Debug instead of PermanentError
+
+# One or more tracking issues related to the change
+issues: [21474]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/influxdbexporter/writer.go
+++ b/exporter/influxdbexporter/writer.go
@@ -140,7 +140,7 @@ func newInfluxHTTPWriterBatch(w *influxHTTPWriter) *influxHTTPWriterBatch {
 // to the internal line protocol buffer. This method implements otel2influx.InfluxWriter.
 func (b *influxHTTPWriterBatch) WritePoint(_ context.Context, measurement string, tags map[string]string, fields map[string]interface{}, ts time.Time, _ common.InfluxMetricValueType) error {
 	b.encoder.StartLine(measurement)
-	for _, tag := range b.sortTags(tags) {
+	for _, tag := range b.optimizeTags(tags) {
 		b.encoder.AddTag(tag.k, tag.v)
 	}
 	for k, v := range b.convertFields(fields) {
@@ -194,11 +194,14 @@ type tag struct {
 	k, v string
 }
 
-func (b *influxHTTPWriterBatch) sortTags(m map[string]string) []tag {
+// optimizeTags sorts tags by key and removes tags with empty keys or values
+func (b *influxHTTPWriterBatch) optimizeTags(m map[string]string) []tag {
 	tags := make([]tag, 0, len(m))
 	for k, v := range m {
 		if k == "" {
 			b.logger.Debug("empty tag key")
+		} else if v == "" {
+			b.logger.Debug("empty tag value", "key", k)
 		} else {
 			tags = append(tags, tag{k, v})
 		}

--- a/exporter/influxdbexporter/writer.go
+++ b/exporter/influxdbexporter/writer.go
@@ -198,11 +198,12 @@ type tag struct {
 func (b *influxHTTPWriterBatch) optimizeTags(m map[string]string) []tag {
 	tags := make([]tag, 0, len(m))
 	for k, v := range m {
-		if k == "" {
+		switch {
+		case k == "":
 			b.logger.Debug("empty tag key")
-		} else if v == "" {
+		case v == "":
 			b.logger.Debug("empty tag value", "key", k)
-		} else {
+		default:
 			tags = append(tags, tag{k, v})
 		}
 	}

--- a/exporter/influxdbexporter/writer_test.go
+++ b/exporter/influxdbexporter/writer_test.go
@@ -1,3 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package influxdbexporter
 
 import (

--- a/exporter/influxdbexporter/writer_test.go
+++ b/exporter/influxdbexporter/writer_test.go
@@ -1,0 +1,65 @@
+package influxdbexporter
+
+import (
+	"testing"
+
+	"github.com/influxdata/influxdb-observability/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_influxHTTPWriterBatch_optimizeTags(t *testing.T) {
+	batch := &influxHTTPWriterBatch{
+		influxHTTPWriter: &influxHTTPWriter{
+			logger: common.NoopLogger{},
+		},
+	}
+
+	for _, testCase := range []struct {
+		name         string
+		m            map[string]string
+		expectedTags []tag
+	}{
+		{
+			name:         "empty map",
+			m:            map[string]string{},
+			expectedTags: []tag{},
+		},
+		{
+			name: "one tag",
+			m: map[string]string{
+				"k": "v",
+			},
+			expectedTags: []tag{
+				{"k", "v"},
+			},
+		},
+		{
+			name: "empty tag key",
+			m: map[string]string{
+				"": "v",
+			},
+			expectedTags: []tag{},
+		},
+		{
+			name: "empty tag value",
+			m: map[string]string{
+				"k": "",
+			},
+			expectedTags: []tag{},
+		},
+		{
+			name: "seventeen tags",
+			m: map[string]string{
+				"k00": "v00", "k01": "v01", "k02": "v02", "k03": "v03", "k04": "v04", "k05": "v05", "k06": "v06", "k07": "v07", "k08": "v08", "k09": "v09", "k10": "v10", "k11": "v11", "k12": "v12", "k13": "v13", "k14": "v14", "k15": "v15", "k16": "v16",
+			},
+			expectedTags: []tag{
+				{"k00", "v00"}, {"k01", "v01"}, {"k02", "v02"}, {"k03", "v03"}, {"k04", "v04"}, {"k05", "v05"}, {"k06", "v06"}, {"k07", "v07"}, {"k08", "v08"}, {"k09", "v09"}, {"k10", "v10"}, {"k11", "v11"}, {"k12", "v12"}, {"k13", "v13"}, {"k14", "v14"}, {"k15", "v15"}, {"k16", "v16"},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			gotTags := batch.optimizeTags(testCase.m)
+			assert.Equal(t, testCase.expectedTags, gotTags)
+		})
+	}
+}


### PR DESCRIPTION
**Description:**
Since otelcol-contrib v0.75.0, the hostmetrics receiver is emitting metrics with empty string attribute values, such as `device = string("")`. I've confirmed that this behavior started in v0.75.0.

I'm not certain that empty attribute values are disallowed in the otel spec, but this error is emitted by [the InfluxDB line protocol encoder, which has rejected empty tag values for at least three years](https://github.com/influxdata/line-protocol/blame/v2.2.1/lineprotocol/encoder.go#L168).

Nevertheless, the InfluxDB exporter can do better by quietly dropping these attributes (which is semantically equivalent in InfluxDB).

**Link to tracking Issue:**
Closes #21474

**Testing:**
Unit tested the changed method.

**Documentation:** n/a