### PR TITLE
[chore] [mysqlreceiver] Fix example config for statement events

### DIFF
--- a/receiver/mysqlreceiver/README.md
+++ b/receiver/mysqlreceiver/README.md
@@ -46,7 +46,7 @@ receivers:
     password: ${env:MYSQL_PASSWORD}
     database: otel
     collection_interval: 10s
-    perf_events_statements:
+    statement_events:
       digest_text_limit: 120
       time_limit: 24h
       limit: 250


### PR DESCRIPTION
**Description:** Fixes outdated example config in the documentation. `perf_events_statements` should be `statement_events`.

**Link to tracking Issue:** N/A

**Testing:** Ran collector with example config.

**Documentation:** N/A