### PR TITLE
[chore] [CI] Update NoMemoryLimit load test parameters

### DIFF
--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -159,8 +159,8 @@ func TestTraceNoBackend10kSPS(t *testing.T) {
 		{
 			Name:                "NoMemoryLimit",
 			Processor:           noLimitProcessors,
-			ExpectedMaxRAM:      190,
-			ExpectedMinFinalRAM: 100,
+			ExpectedMaxRAM:      100,
+			ExpectedMinFinalRAM: 80,
 		},
 		{
 			Name:                "MemoryLimit",


### PR DESCRIPTION
After dropping default value for queue_size from 5000 to 1000 batches, update NoMemoryLimit load test parameters accordingly