### PR TITLE
[Prometheus Receiver] Make prometheus receiver behavior compatible with Prometheus when sd_file does not exist

### DIFF
--- a/.chloggen/ecs_observer_issue.yaml
+++ b/.chloggen/ecs_observer_issue.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove sd_file validations from config.go in Prometheus Receiver to avoid failing Collector with error as this behaviour is incompatible with the Prometheus.
+
+# One or more tracking issues related to the change
+issues: [21509]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -160,8 +160,7 @@ func (cfg *Config) validatePromConfig(promConfig *promconfig.Config) error {
 		}
 
 		for _, c := range sc.ServiceDiscoveryConfigs {
-			switch c := c.(type) {
-			case *kubernetes.SDConfig:
+			if c, ok := c.(*kubernetes.SDConfig); ok {
 				if err := checkTLSConfig(c.HTTPClientConfig.TLSConfig); err != nil {
 					return err
 				}

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -4,22 +4,18 @@
 package prometheusreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
 	commonconfig "github.com/prometheus/common/config"
 	promconfig "github.com/prometheus/prometheus/config"
-	"github.com/prometheus/prometheus/discovery/file"
 	promHTTP "github.com/prometheus/prometheus/discovery/http"
 	"github.com/prometheus/prometheus/discovery/kubernetes"
-	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"gopkg.in/yaml.v2"
@@ -91,37 +87,6 @@ func checkTLSConfig(tlsConfig commonconfig.TLSConfig) error {
 	}
 	if len(tlsConfig.KeyFile) > 0 && len(tlsConfig.CertFile) == 0 {
 		return fmt.Errorf("client key file %q specified without client cert file", tlsConfig.KeyFile)
-	}
-	return nil
-}
-
-// Method to exercise the prometheus file discovery behavior to ensure there are no errors
-// - reference https://github.com/prometheus/prometheus/blob/c0c22ed04200a8d24d1d5719f605c85710f0d008/discovery/file/file.go#L372
-func checkSDFile(filename string) error {
-	content, err := os.ReadFile(filepath.Clean(filename))
-	if err != nil {
-		return err
-	}
-
-	var targetGroups []*targetgroup.Group
-
-	switch ext := filepath.Ext(filename); strings.ToLower(ext) {
-	case ".json":
-		if err := json.Unmarshal(content, &targetGroups); err != nil {
-			return fmt.Errorf("error in unmarshaling json file extension: %w", err)
-		}
-	case ".yml", ".yaml":
-		if err := yaml.UnmarshalStrict(content, &targetGroups); err != nil {
-			return fmt.Errorf("error in unmarshaling yaml file extension: %w", err)
-		}
-	default:
-		return fmt.Errorf("invalid file extension: %q", ext)
-	}
-
-	for i, tg := range targetGroups {
-		if tg == nil {
-			return fmt.Errorf("nil target group item found (index %d)", i)
-		}
 	}
 	return nil
 }
@@ -199,23 +164,6 @@ func (cfg *Config) validatePromConfig(promConfig *promconfig.Config) error {
 			case *kubernetes.SDConfig:
 				if err := checkTLSConfig(c.HTTPClientConfig.TLSConfig); err != nil {
 					return err
-				}
-			case *file.SDConfig:
-				for _, file := range c.Files {
-					files, err := filepath.Glob(file)
-					if err != nil {
-						return err
-					}
-					if len(files) != 0 {
-						for _, f := range files {
-							err = checkSDFile(f)
-							if err != nil {
-								return fmt.Errorf("checking SD file %q: %w", file, err)
-							}
-						}
-						continue
-					}
-					return fmt.Errorf("file %q for file_sd in scrape job %q does not exist", file, sc.JobName)
 				}
 			}
 		}

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -281,12 +281,7 @@ func TestFileSDConfigJsonNilTargetGroup(t *testing.T) {
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	err = component.ValidateConfig(cfg)
-	require.NotNil(t, err, "Expected a non-nil error")
-
-	wantErrMsg := `checking SD file "./testdata/sd-config-with-null-target-group.json": nil target group item found (index 1)`
-
-	gotErrMsg := err.Error()
-	require.Equal(t, wantErrMsg, gotErrMsg)
+	require.NoError(t, err)
 }
 
 func TestFileSDConfigYamlNilTargetGroup(t *testing.T) {
@@ -300,10 +295,19 @@ func TestFileSDConfigYamlNilTargetGroup(t *testing.T) {
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	err = component.ValidateConfig(cfg)
-	require.NotNil(t, err, "Expected a non-nil error")
+	require.NoError(t, err)
+}
 
-	wantErrMsg := `checking SD file "./testdata/sd-config-with-null-target-group.yaml": nil target group item found (index 1)`
+func TestFileSDConfigYamlWithoutSDFile(t *testing.T) {
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "non-existent-prometheus-sd-file-config.yaml"))
+	require.NoError(t, err)
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
 
-	gotErrMsg := err.Error()
-	require.Equal(t, wantErrMsg, gotErrMsg)
+	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
+	require.NoError(t, err)
+	require.NoError(t, component.UnmarshalConfig(sub, cfg))
+
+	err = component.ValidateConfig(cfg)
+	require.NoError(t, err)
 }

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -298,7 +298,7 @@ func TestFileSDConfigYamlNilTargetGroup(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestFileSDConfigYamlWithoutSDFile(t *testing.T) {
+func TestFileSDConfigWithoutSDFile(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "non-existent-prometheus-sd-file-config.yaml"))
 	require.NoError(t, err)
 	factory := NewFactory()

--- a/receiver/prometheusreceiver/testdata/non-existent-prometheus-sd-file-config.yaml
+++ b/receiver/prometheusreceiver/testdata/non-existent-prometheus-sd-file-config.yaml
@@ -1,0 +1,7 @@
+prometheus:
+  config:
+    scrape_configs:
+      - job_name: 'test'
+        scrape_interval: 5s
+        file_sd_configs:
+        - files: ["./testdata/non-existent-sd-file.json"]


### PR DESCRIPTION
**Description:** <Describe what has changed.>

This PR achieves the compatibility between Prometheus Receiver and Prometheus when `sd_file` or `targetgroups` are not present at the startup:

1. With this PR, Collector should log error message (but not fail) if the `sd_file_path` is not [watchable](https://github.com/prometheus/prometheus/blob/3c4802635d05af47ddf7358c0c079961b011c47b/discovery/file/file.go#L235). 
2. With this PR, Collector should continue watching path if `sd_file_path` (and not fail with error) when when `sd_file` or `targetgroups` are not present at the startup.

In order to achieve the above objective, this PR reverts some of the changes made in [this](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/5052) PR to add additional config validation for `file_sd` configs. These additional [config validation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/5f47f5b182ce4fdcaf0ce40fd08bf3b64420bbbd/receiver/prometheusreceiver/config.go#L214) creates incompatibility in the Prometheus and Prometheus Receiver behaviour as also highlighted in this [issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21509):

1. The [config validation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/5f47f5b182ce4fdcaf0ce40fd08bf3b64420bbbd/receiver/prometheusreceiver/config.go#L111) for `sd_file` fails Collector in error when at the startup `sd_file` is not present or the `targetgroup` inside this `sd_file` is not present. However, this is not the behaviour of Prometheus- Prometheus has functionality (discovery) which continues to watch the `sd_file_path` provided in the config for the updates and subsequent validation. 
Also, Prometheus doesnt't crash the application at runtime when `sd_file` or `targetgroup` are not present or `sd_file_path` does not exist (as originally thought [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/4862#issue-978449593)). Prometheus only logs the error and continues to receive update on this `sd_file_path`. - so additionally ensuring the presence of `sd_file` and `tagretgroup` and otherwise failing with error  in config validation in Collector (like [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/5f47f5b182ce4fdcaf0ce40fd08bf3b64420bbbd/receiver/prometheusreceiver/config.go#L111)) disrupts that process. 
3. The check to validate presence of `sd_file_path` with the right naming and extension is already done in [unmarshal](https://github.com/prometheus/prometheus/blob/3c4802635d05af47ddf7358c0c079961b011c47b/discovery/file/file.go#L95) stage in [Collector](https://github.com/open-telemetry/opentelemetry-collector/blob/a8a01efbb713d67ce58315aa1a3ec22d36adc7a0/otelcol/collector.go#L157) (before config validation) - so providing it again in the [config validation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/67ffaf57845575fa2a2339403b7324b4b4530c35/receiver/prometheusreceiver/config.go#L121) is redundant. 

**Link to tracking Issue:** <Issue number if applicable>
#21509
https://github.com/aws-observability/aws-otel-collector/issues/2039
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5373
https://github.com/aws-observability/aws-otel-collector/issues/1636


**Testing:** <Describe what testing was performed and which tests were added.>
Manual testing