### PR TITLE
[chore] [receiver/elasticsearch] Refactor and add retry to integration test

### DIFF
--- a/receiver/elasticsearchreceiver/integration_test.go
+++ b/receiver/elasticsearchreceiver/integration_test.go
@@ -36,160 +36,106 @@ import (
 )
 
 var (
-	containerRequest7_0_0 = testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context:    filepath.Join("testdata", "integration"),
-			Dockerfile: "Dockerfile.elasticsearch.7_0_0",
+	test7_0_0 = &testCase{
+		request: testcontainers.ContainerRequest{
+			FromDockerfile: testcontainers.FromDockerfile{
+				Context:    filepath.Join("testdata", "integration"),
+				Dockerfile: "Dockerfile.elasticsearch.7_0_0",
+			},
+			ExposedPorts: []string{"9600:9200"},
+			WaitingFor: wait.ForListeningPort("9200").
+				WithStartupTimeout(2 * time.Minute),
 		},
-		ExposedPorts: []string{"9600:9200"},
-		WaitingFor: wait.ForListeningPort("9200").
-			WithStartupTimeout(2 * time.Minute),
+		port:     9600,
+		expected: "expected.7_0_0.yaml",
 	}
-	containerRequest7_9_3 = testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context:    filepath.Join("testdata", "integration"),
-			Dockerfile: "Dockerfile.elasticsearch.7_9_3",
+
+	test7_9_3 = &testCase{
+		request: testcontainers.ContainerRequest{
+			FromDockerfile: testcontainers.FromDockerfile{
+				Context:    filepath.Join("testdata", "integration"),
+				Dockerfile: "Dockerfile.elasticsearch.7_9_3",
+			},
+			ExposedPorts: []string{"9200:9200"},
+			WaitingFor: wait.ForListeningPort("9200").
+				WithStartupTimeout(2 * time.Minute),
 		},
-		ExposedPorts: []string{"9200:9200"},
-		WaitingFor: wait.ForListeningPort("9200").
-			WithStartupTimeout(2 * time.Minute),
+		port:     9200,
+		expected: "expected.7_9_3.yaml",
 	}
-	containerRequest7_16_3 = testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context:    filepath.Join("testdata", "integration"),
-			Dockerfile: "Dockerfile.elasticsearch.7_16_3",
+
+	test7_16_3 = &testCase{
+		request: testcontainers.ContainerRequest{
+			FromDockerfile: testcontainers.FromDockerfile{
+				Context:    filepath.Join("testdata", "integration"),
+				Dockerfile: "Dockerfile.elasticsearch.7_16_3",
+			},
+			ExposedPorts: []string{"9300:9200"},
+			WaitingFor: wait.ForListeningPort("9200").
+				WithStartupTimeout(2 * time.Minute),
 		},
-		ExposedPorts: []string{"9300:9200"},
-		WaitingFor: wait.ForListeningPort("9200").
-			WithStartupTimeout(2 * time.Minute),
+		port:     9300,
+		expected: "expected.7_16_3.yaml",
+	}
+
+	compareOpts = []pmetrictest.CompareMetricsOption{
+		pmetrictest.IgnoreResourceAttributeValue("elasticsearch.node.name"),
+		pmetrictest.IgnoreTimestamp(),
+		pmetrictest.IgnoreStartTimestamp(),
+		pmetrictest.IgnoreMetricValues(),
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+		pmetrictest.IgnoreResourceMetricsOrder(),
 	}
 )
 
 func TestElasticsearchIntegration(t *testing.T) {
-	// Starts an elasticsearch docker container
-	t.Run("Running elasticsearch 7.0.0", func(t *testing.T) {
-		t.Skip("Skipping as the test fails intermittently, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19755")
-		t.Parallel()
-		container := getContainer(t, containerRequest7_0_0)
-		defer func() {
-			require.NoError(t, container.Terminate(context.Background()))
-		}()
-		hostname, err := container.Host(context.Background())
-		require.NoError(t, err)
+	t.Run("7.0.0", test7_0_0.run)
+	t.Run("7.9.3", test7_9_3.run)
+	t.Run("7.16.3", test7_16_3.run)
+}
 
-		f := NewFactory()
-		cfg := f.CreateDefaultConfig().(*Config)
-		cfg.Endpoint = fmt.Sprintf("http://%s:9600", hostname)
+type testCase struct {
+	request  testcontainers.ContainerRequest
+	port     int
+	expected string
+}
 
-		consumer := new(consumertest.MetricsSink)
-		settings := receivertest.NewNopCreateSettings()
-		rcvr, err := f.CreateMetricsReceiver(context.Background(), settings, cfg, consumer)
-		require.NoError(t, err, "failed creating metrics receiver")
+func (tt *testCase) run(t *testing.T) {
+	container := getContainer(t, tt.request)
+	defer func() {
+		require.NoError(t, container.Terminate(context.Background()))
+	}()
+	hostname, err := container.Host(context.Background())
+	require.NoError(t, err)
 
-		require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
-		require.Eventuallyf(t, func() bool {
-			return len(consumer.AllMetrics()) > 0
-		}, 2*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
+	f := NewFactory()
+	cfg := f.CreateDefaultConfig().(*Config)
+	cfg.CollectionInterval = 2 * time.Second
+	cfg.Endpoint = fmt.Sprintf("http://%s:%d", hostname, tt.port)
+
+	consumer := new(consumertest.MetricsSink)
+	settings := receivertest.NewNopCreateSettings()
+	rcvr, err := f.CreateMetricsReceiver(context.Background(), settings, cfg, consumer)
+	require.NoError(t, err, "failed creating metrics receiver")
+
+	require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
 		require.NoError(t, rcvr.Shutdown(context.Background()))
+	}()
 
-		actualMetrics := consumer.AllMetrics()[0]
+	expectedFile := filepath.Join("testdata", "integration", tt.expected)
+	expectedMetrics, err := golden.ReadMetrics(expectedFile)
+	require.NoError(t, err)
 
-		expectedFile := filepath.Join("testdata", "integration", "expected.7_0_0.yaml")
-		expectedMetrics, err := golden.ReadMetrics(expectedFile)
-		require.NoError(t, err)
-
-		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
-			pmetrictest.IgnoreResourceAttributeValue("elasticsearch.node.name"),
-			pmetrictest.IgnoreTimestamp(),
-			pmetrictest.IgnoreStartTimestamp(),
-			pmetrictest.IgnoreMetricValues(),
-			pmetrictest.IgnoreMetricDataPointsOrder(),
-			pmetrictest.IgnoreScopeMetricsOrder(),
-			pmetrictest.IgnoreResourceMetricsOrder(),
-		))
-	})
-	t.Run("Running elasticsearch 7.9.3", func(t *testing.T) {
-		t.Skip("Skipping as the test fails intermittently, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19755")
-		t.Parallel()
-		container := getContainer(t, containerRequest7_9_3)
-		defer func() {
-			require.NoError(t, container.Terminate(context.Background()))
-		}()
-		hostname, err := container.Host(context.Background())
-		require.NoError(t, err)
-
-		f := NewFactory()
-		cfg := f.CreateDefaultConfig().(*Config)
-		cfg.Endpoint = fmt.Sprintf("http://%s:9200", hostname)
-
-		consumer := new(consumertest.MetricsSink)
-		settings := receivertest.NewNopCreateSettings()
-		rcvr, err := f.CreateMetricsReceiver(context.Background(), settings, cfg, consumer)
-		require.NoError(t, err, "failed creating metrics receiver")
-
-		require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
-		require.Eventuallyf(t, func() bool {
-			return len(consumer.AllMetrics()) > 0
-		}, 2*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
-		require.NoError(t, rcvr.Shutdown(context.Background()))
-
-		actualMetrics := consumer.AllMetrics()[0]
-
-		expectedFile := filepath.Join("testdata", "integration", "expected.7_9_3.yaml")
-		expectedMetrics, err := golden.ReadMetrics(expectedFile)
-		require.NoError(t, err)
-
-		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
-			pmetrictest.IgnoreResourceAttributeValue("elasticsearch.node.name"),
-			pmetrictest.IgnoreTimestamp(),
-			pmetrictest.IgnoreStartTimestamp(),
-			pmetrictest.IgnoreMetricValues(),
-			pmetrictest.IgnoreMetricDataPointsOrder(),
-			pmetrictest.IgnoreScopeMetricsOrder(),
-			pmetrictest.IgnoreResourceMetricsOrder(),
-		))
-	})
-	t.Run("Running elasticsearch 7.16.3", func(t *testing.T) {
-		t.Skip("Skipping as the test fails intermittently, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19755")
-		t.Parallel()
-		container := getContainer(t, containerRequest7_16_3)
-		defer func() {
-			require.NoError(t, container.Terminate(context.Background()))
-		}()
-		hostname, err := container.Host(context.Background())
-		require.NoError(t, err)
-
-		f := NewFactory()
-		cfg := f.CreateDefaultConfig().(*Config)
-		cfg.Endpoint = fmt.Sprintf("http://%s:9300", hostname)
-
-		consumer := new(consumertest.MetricsSink)
-		settings := receivertest.NewNopCreateSettings()
-		rcvr, err := f.CreateMetricsReceiver(context.Background(), settings, cfg, consumer)
-		require.NoError(t, err, "failed creating metrics receiver")
-
-		require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
-		require.Eventuallyf(t, func() bool {
-			return len(consumer.AllMetrics()) > 0
-		}, 2*time.Minute, 1*time.Second, "failed to receive more than 0 metrics")
-		require.NoError(t, rcvr.Shutdown(context.Background()))
-
-		actualMetrics := consumer.AllMetrics()[0]
-
-		expectedFile := filepath.Join("testdata", "integration", "expected.7_16_3.yaml")
-		expectedMetrics, err := golden.ReadMetrics(expectedFile)
-		require.NoError(t, err)
-
-		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
-			pmetrictest.IgnoreResourceAttributeValue("elasticsearch.node.name"),
-			pmetrictest.IgnoreTimestamp(),
-			pmetrictest.IgnoreStartTimestamp(),
-			pmetrictest.IgnoreMetricValues(),
-			pmetrictest.IgnoreMetricDataPointsOrder(),
-			pmetrictest.IgnoreScopeMetricsOrder(),
-			pmetrictest.IgnoreResourceMetricsOrder(),
-		))
-	})
+	require.Eventually(t, func() bool {
+		allMetrics := consumer.AllMetrics()
+		if len(allMetrics) == 0 {
+			return false
+		}
+		latestMetrics := allMetrics[len(allMetrics)-1]
+		return nil == pmetrictest.CompareMetrics(expectedMetrics, latestMetrics, compareOpts...)
+	}, 30*time.Second, time.Second)
 }
 
 func getContainer(t *testing.T, req testcontainers.ContainerRequest) testcontainers.Container {


### PR DESCRIPTION
This adds robustness to the tests by allowing the scraper to run until the most recent result matches the expected result. The theory here is that the target is sometimes interrogated before it fully starts up, so may be returning an incomplete result.