### PR TITLE
issue-21715 fetching metric values with composite(all) dimension keys

### DIFF
--- a/.chloggen/azure_monitor_receiver-composite-dimensions.yaml
+++ b/.chloggen/azure_monitor_receiver-composite-dimensions.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/azuremonitorreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Retrieve metric values with all dimension keys in filter
+
+# One or more tracking issues related to the change
+issues: [21715]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -80,6 +81,7 @@ type metricsCompositeKey struct {
 func (s metricsCompositeKey) Hash() string {
 	h := sha256.New()
 	h.Write([]byte(s.timeGrain))
+	sort.Strings(s.dimensions)
 	h.Write([]byte(strings.Join(s.dimensions, ",")))
 	return string(h.Sum(nil))
 }

--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -389,7 +389,7 @@ func getResourceMetricsValuesRequestOptions(
 		for i, dimension := range dimensions {
 			dimensionsFilter.WriteString(dimension)
 			dimensionsFilter.WriteString(" eq '*' ")
-			if i != len(dimensions) {
+			if i < len(dimensions)-1 {
 				dimensionsFilter.WriteString(" and ")
 			}
 		}

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -231,7 +231,6 @@ func TestAzureScraperScrape(t *testing.T) {
 			expectedFile := filepath.Join("testdata", "expected_metrics", tt.name+".yaml")
 			expectedMetrics, err := golden.ReadMetrics(expectedFile)
 			require.NoError(t, err)
-
 			require.NoError(t, pmetrictest.CompareMetrics(
 				expectedMetrics,
 				metrics,
@@ -279,8 +278,8 @@ func getResourcesMockData(tags bool) []armresources.ClientListResponse {
 }
 
 func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.MetricDefinitionsClientListResponse) {
-	name1, name2, name3, name4, name5, name6, name7, timeGrain1, timeGrain2, dimension := "metric1",
-		"metric2", "metric3", "metric4", "metric5", "metric6", "metric7", "PT1M", "PT1H", "dimension"
+	name1, name2, name3, name4, name5, name6, name7, timeGrain1, timeGrain2, dimension1, dimension2 := "metric1",
+		"metric2", "metric3", "metric4", "metric5", "metric6", "metric7", "PT1M", "PT1H", "dimension1", "dimension2"
 
 	counters := map[string]int{
 		"resourceId1": 0,
@@ -352,7 +351,10 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 							},
 							Dimensions: []*armmonitor.LocalizableString{
 								{
-									Value: &dimension,
+									Value: &dimension1,
+								},
+								{
+									Value: &dimension2,
 								},
 							},
 						},
@@ -367,7 +369,7 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 							},
 							Dimensions: []*armmonitor.LocalizableString{
 								{
-									Value: &dimension,
+									Value: &dimension1,
 								},
 							},
 						},
@@ -390,7 +392,7 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 							},
 							Dimensions: []*armmonitor.LocalizableString{
 								{
-									Value: &dimension,
+									Value: &dimension1,
 								},
 							},
 						},
@@ -403,8 +405,8 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 }
 
 func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientListResponse {
-	name1, name2, name3, name4, name5, name6, name7, dimension, dimensionValue := "metric1", "metric2",
-		"metric3", "metric4", "metric5", "metric6", "metric7", "dimension", "dimension value"
+	name1, name2, name3, name4, name5, name6, name7, dimension1, dimension2, dimensionValue := "metric1", "metric2",
+		"metric3", "metric4", "metric5", "metric6", "metric7", "dimension1", "dimension2", "dimension value"
 	var unit1 armmonitor.MetricUnit = "unit1"
 	var value1 float64 = 1
 
@@ -506,7 +508,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 					},
 				},
 			},
-			strings.Join([]string{name5, name6}, ","): {
+			name5: {
 				Response: armmonitor.Response{
 					Value: []*armmonitor.Metric{
 						{
@@ -528,7 +530,13 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									Metadatavalues: []*armmonitor.MetadataValue{
 										{
 											Name: &armmonitor.LocalizableString{
-												Value: &dimension,
+												Value: &dimension1,
+											},
+											Value: &dimensionValue,
+										},
+										{
+											Name: &armmonitor.LocalizableString{
+												Value: &dimension2,
 											},
 											Value: &dimensionValue,
 										},
@@ -536,6 +544,12 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 								},
 							},
 						},
+					},
+				},
+			},
+			name6: {
+				Response: armmonitor.Response{
+					Value: []*armmonitor.Metric{
 						{
 							Name: &armmonitor.LocalizableString{
 								Value: &name6,
@@ -555,7 +569,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									Metadatavalues: []*armmonitor.MetadataValue{
 										{
 											Name: &armmonitor.LocalizableString{
-												Value: &dimension,
+												Value: &dimension1,
 											},
 											Value: &dimensionValue,
 										},
@@ -586,7 +600,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									Metadatavalues: []*armmonitor.MetadataValue{
 										{
 											Name: &armmonitor.LocalizableString{
-												Value: &dimension,
+												Value: &dimension1,
 											},
 											Value: &dimensionValue,
 										},

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -16,7 +16,10 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -30,7 +33,10 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -44,7 +50,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -167,7 +173,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -181,7 +187,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -220,7 +226,10 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -234,7 +243,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -284,7 +293,10 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -326,7 +338,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId3
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -340,7 +352,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -393,7 +405,10 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_tags_golden.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_tags_golden.yaml
@@ -16,7 +16,10 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -30,7 +33,10 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -44,7 +50,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -188,7 +194,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -202,7 +208,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -244,7 +250,10 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -258,7 +267,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -311,7 +320,10 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -359,7 +371,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId3
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -373,7 +385,7 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"
@@ -432,7 +444,10 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: resourceId2
-                    - key: metadata_dimension
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
                       value:
                         stringValue: dimension value
                   startTimeUnixNano: "1681790471654481953"


### PR DESCRIPTION
**Description:**

If metric has multiple dimensions, metricValues are fetched by single dimension instead of combining all dimensions. With single dimension metric value is average value of other dimensions.

In below example without all dimensions in the filter, 'metadata_nodepool' provides average value of 2 'metadata_node' datapoints. But cannot combine dimensions of metadata_node under 'metadata_nodepool' dimensions.

```
Metric #44
Descriptor:
     -> Name: azure_node_cpu_usage_millicores_total
NumberDataPoints #0
Data point attributes:
     -> azuremonitor.resource_id: Str(/subscriptions/test/resourceGroups/aks-dev2-blue/providers/Microsoft.ContainerService/managedClusters/aks-dev2-blue)
     -> metadata_nodepool: Str(general1)
Value: 625.500000

NumberDataPoints #1
Data point attributes:
     -> azuremonitor.resource_id: Str(/subscriptions/test/resourceGroups/aks-dev2-blue/providers/Microsoft.ContainerService/managedClusters/aks-dev2-blue)
     -> metadata_node: Str(aks-general1-vmss00006x)
Value: 506.000000

NumberDataPoints #2
Data point attributes:
     -> azuremonitor.resource_id: Str(/subscriptions/test/resourceGroups/aks-dev2-blue/providers/Microsoft.ContainerService/managedClusters/aks-dev2-blue)
     -> metadata_node: Str(aks-general1-vmss000062)
Value: 745.000000
```
With all Dimensions applied:
Here each datapoint provides all related dimension values. With this information, it is easy to apply multiple filters.

```
Metric #44
Descriptor:
     -> Name: azure_node_cpu_usage_millicores_total

NumberDataPoints #0
Data point attributes:
     -> azuremonitor.resource_id: Str(/subscriptions/test/resourceGroups/aks-dev2-blue/providers/Microsoft.ContainerService/managedClusters/aks-dev2-blue)
     -> metadata_node: Str(aks-general1-vmss00006x)
     -> metadata_nodepool: Str(general1)
Value: 506.000000

NumberDataPoints #1
Data point attributes:
     -> azuremonitor.resource_id: Str(/subscriptions/test/resourceGroups/aks-dev2-blue/providers/Microsoft.ContainerService/managedClusters/aks-dev2-blue)
     -> metadata_node: Str(aks-general1-vmss000062)
     -> metadata_nodepool: Str(general1)
Value: 745.000000
```

In Azuremonitor receiver, [getResourceMetricsValuesRequestOptions](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/azuremonitorreceiver/scraper.go#L372-L374) func, single dimension key alone provided. Instead all possible dimension keys for the metric have to be given. 
Solution:
    with metricresource definitions,  Generate hash string with all dimensions and store the metrics based on hash instead of single dimension + timegrain filter.

Sample MetricClient REST Request with all dimensions in filter:

`https://management.azure.com/subscriptions/test/resourceGroups/aks-dev2-blue/providers/Microsoft.ContainerService/managedClusters/aks-dev2-blue/providers/Microsoft.Insights/metrics?timespan=2023-04-29T02:20:00Z/2023-05-04T04:20:00Z&interval=PT1H&api-version=2018-01-01&metricnamespace=Microsoft.ContainerService/managedClusters&metricnames=node_cpu_usage_millicores&$filter=nodepool eq '*' and node eq '*'`

Fixes #21715

**Testing:** Testdata with multiple dimensions are working.

**Documentation:** <Describe the documentation added.>