### PR TITLE
[exporter/splunkhec] Fix logic tracking partial errors data

### DIFF
--- a/.chloggen/splunkhec-fix-partial-error-data.yaml
+++ b/.chloggen/splunkhec-fix-partial-error-data.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/splunkhec
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a bug causing incorrect data in the partial error returned by the exporter
+
+# One or more tracking issues related to the change
+issues: [21720]


### PR DESCRIPTION
The counters tracking the sent data did not capture the state when the buffer rejected overflown data. The issue leads to incorrect data in the partial error returned by the exporter.