### PR TITLE
Updated to handle http receiver metadata

### DIFF
--- a/.chloggen/support-client-info-metadata.yaml
+++ b/.chloggen/support-client-info-metadata.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: routingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enables processor to extract metadata from client.Info
+
+# One or more tracking issues related to the change
+issues: [20913]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+  Enables processor to perform context based routing for payloads on the http server of otlp receiver

--- a/processor/routingprocessor/README.md
+++ b/processor/routingprocessor/README.md
@@ -104,6 +104,7 @@ It is also possible to mix both the conventional routing configuration and the r
 
 - [OTTL] statements can be applied only to resource attributes.
 - Currently, it is not possible to specify the boolean statements without function invocation as the routing condition. It is required to provide the NOOP `route()` or any other supported function as part of the routing statement, see [#13545](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545) for more information.
+- If data is received on OTLP http server, `include_metadata` must be set to true in order to use context based routing.
 - Supported [OTTL] functions:
   - [IsMatch](../../pkg/ottl/ottlfuncs/README.md#IsMatch)
   - [delete_key](../../pkg/ottl/ottlfuncs/README.md#delete_key)

--- a/processor/routingprocessor/extract_test.go
+++ b/processor/routingprocessor/extract_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/client"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/metadata"
 )
@@ -54,6 +55,34 @@ func TestExtractorForTraces_FromContext(t *testing.T) {
 			},
 			fromAttr:      "X-Tenant",
 			expectedValue: "globex",
+		},
+		{
+			name: "value from existing HTTP attribute",
+			ctxFunc: func() context.Context {
+				return client.NewContext(context.Background(),
+					client.Info{Metadata: client.NewMetadata(map[string][]string{
+						"X-Tenant": {"acme"},
+					})})
+			},
+			fromAttr:      "X-Tenant",
+			expectedValue: "acme",
+		},
+		{
+			name:          "no values from empty context",
+			ctxFunc:       context.Background,
+			fromAttr:      "X-Tenant",
+			expectedValue: "",
+		},
+		{
+			name: "no values from existing HTTP attribute",
+			ctxFunc: func() context.Context {
+				return client.NewContext(context.Background(),
+					client.Info{Metadata: client.NewMetadata(map[string][]string{
+						"X-Tenant": {""},
+					})})
+			},
+			fromAttr:      "X-Tenant",
+			expectedValue: "",
 		},
 	}
 

--- a/processor/routingprocessor/extract_test.go
+++ b/processor/routingprocessor/extract_test.go
@@ -68,6 +68,17 @@ func TestExtractorForTraces_FromContext(t *testing.T) {
 			expectedValue: "acme",
 		},
 		{
+			name: "value from existing HTTP attribute: case insensitive",
+			ctxFunc: func() context.Context {
+				return client.NewContext(context.Background(),
+					client.Info{Metadata: client.NewMetadata(map[string][]string{
+						"X-Tenant": {"acme"},
+					})})
+			},
+			fromAttr:      "x-tenant",
+			expectedValue: "acme",
+		},
+		{
 			name:          "no values from empty context",
 			ctxFunc:       context.Background,
 			fromAttr:      "X-Tenant",

--- a/processor/routingprocessor/go.mod
+++ b/processor/routingprocessor/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.81.0
 	github.com/stretchr/testify v1.8.4
+	go.opentelemetry.io/collector v0.81.0
 	go.opentelemetry.io/collector/component v0.81.0
 	go.opentelemetry.io/collector/config/configgrpc v0.81.0
 	go.opentelemetry.io/collector/confmap v0.81.0
@@ -47,7 +48,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.81.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.81.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.81.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v0.81.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.81.0 // indirect


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Hi all,

This enables the processor to perform context based routing for payloads that are received on the http server of the otlp receiver. It  defaults to the original grpc metadata extraction but if it is not able to extract the grpc metadata, it will then attempt to extract it from client.Info. Currently the routing processor will always use the default route if the payload was received through the http server.

**Link to tracking Issue:** <Issue number if applicable>
resolves #20913 
**Testing:** <Describe what testing was performed and which tests were added.>
Added test cases for traces, metrics and logs to includes testing context based routing when the metadata is in client.Info
**Documentation:** <Describe the documentation added.>