### PR TITLE
[chore] add Splunk distribution URL to supported distributions for mdatagen

### DIFF
--- a/cmd/mdatagen/statusdata.go
+++ b/cmd/mdatagen/statusdata.go
@@ -21,6 +21,7 @@ package main
 var distros = map[string]string{
 	"core":    "https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol",
 	"contrib": "https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib",
+	"splunk":  "https://github.com/signalfx/splunk-otel-collector",
 }
 
 type Status struct {


### PR DESCRIPTION
This adds the "splunk" distribution as an option for components when they list their distributions.