### PR TITLE
[exporter/loki] Add flags field to lokiEntry

### DIFF
--- a/.chloggen/lokiexporter-add-flags.yaml
+++ b/.chloggen/lokiexporter-add-flags.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: lokiexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added `flags` field from plog.LogRecord into Loki entry
+
+# One or more tracking issues related to the change
+issues: [21650]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/translator/loki/encode.go
+++ b/pkg/translator/loki/encode.go
@@ -34,6 +34,7 @@ type lokiEntry struct {
 	TraceID              string                 `json:"traceid,omitempty"`
 	SpanID               string                 `json:"spanid,omitempty"`
 	Severity             string                 `json:"severity,omitempty"`
+	Flags                uint32                 `json:"flags,omitempty"`
 	Attributes           map[string]interface{} `json:"attributes,omitempty"`
 	Resources            map[string]interface{} `json:"resources,omitempty"`
 	InstrumentationScope *instrumentationScope  `json:"instrumentation_scope,omitempty"`
@@ -64,6 +65,7 @@ func Encode(lr plog.LogRecord, res pcommon.Resource, scope pcommon.Instrumentati
 		Severity:   lr.SeverityText(),
 		Attributes: lr.Attributes().AsRaw(),
 		Resources:  res.Attributes().AsRaw(),
+		Flags:      uint32(lr.Flags()),
 	}
 
 	scopeName := scope.Name()
@@ -101,6 +103,11 @@ func EncodeLogfmt(lr plog.LogRecord, res pcommon.Resource, scope pcommon.Instrum
 	severity := lr.SeverityText()
 	if severity != "" {
 		keyvals = keyvalsReplaceOrAppend(keyvals, "severity", severity)
+	}
+
+	flags := lr.Flags()
+	if flags != 0 {
+		keyvals = keyvalsReplaceOrAppend(keyvals, "flags", lr.Flags())
 	}
 
 	lr.Attributes().Range(func(k string, v pcommon.Value) bool {

--- a/pkg/translator/loki/encode_test.go
+++ b/pkg/translator/loki/encode_test.go
@@ -152,6 +152,16 @@ func TestSerializeComplexBody(t *testing.T) {
 	}
 }
 
+func TestEncodeWithFlags(t *testing.T) {
+	in := `{"body":"Example log","traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","flags":1,"attributes":{"attr1":"1","attr2":"2"},"resources":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
+	log, resource, scope := exampleLog()
+	log.SetFlags(plog.DefaultLogRecordFlags.WithIsSampled(true))
+
+	out, err := Encode(log, resource, scope)
+	assert.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
 func TestEncodeLogfmtWithStringBody(t *testing.T) {
 	in := `msg="hello world" traceID=01020304000000000000000000000000 spanID=0506070800000000 severity=error attribute_attr1=1 attribute_attr2=2 resource_host.name=something instrumentation_scope_name=example-logger-name instrumentation_scope_version=v1`
 	log, resource, scope := exampleLog()
@@ -202,6 +212,16 @@ func TestEncodeLogfmtWithComplexAttributes(t *testing.T) {
 	sliceVal.CopyTo(log.Attributes().PutEmpty("aslice"))
 	sliceVal.CopyTo(resource.Attributes().PutEmpty("bslice"))
 
+	out, err := EncodeLogfmt(log, resource, scope)
+	assert.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
+func TestEncodeLogfmtWithFlags(t *testing.T) {
+	in := `msg="hello world" traceID=01020304000000000000000000000000 spanID=0506070800000000 severity=error flags=1 attribute_attr1=1 attribute_attr2=2 resource_host.name=something instrumentation_scope_name=example-logger-name instrumentation_scope_version=v1`
+	log, resource, scope := exampleLog()
+	log.Body().SetStr("msg=\"hello world\"")
+	log.SetFlags(plog.DefaultLogRecordFlags.WithIsSampled(true))
 	out, err := EncodeLogfmt(log, resource, scope)
 	assert.NoError(t, err)
 	assert.Equal(t, in, out)


### PR DESCRIPTION
**Description:** 
There is currently no way to get the [Flags](https://github.com/open-telemetry/opentelemetry-collector/blob/main/pdata/internal/data/protogen/logs/v1/logs.pb.go#L396) field from plog.LogRecord into Loki.
Added Flags field to lokiEntry in this PR

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21650

**Testing:** Added unit tests