### PR TITLE
[datadog receiver] Update translations to align with semantic conventions.

### DIFF
--- a/.chloggen/msg_update-datadog-receiver.yaml
+++ b/.chloggen/msg_update-datadog-receiver.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadog receiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Updating datadog translations to align more closely to semantic convention
+
+# One or more tracking issues related to the change
+issues: [21210, 21525]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - `service.name` is moved from assigned from span attributes to resource attributes
+  - Moved from using datadog's `span.Resouce` to `span.Name` to set span name
+  - Exported traces are now grouped by `service.name` by default

--- a/receiver/datadogreceiver/go.mod
+++ b/receiver/datadogreceiver/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0011
 	go.opentelemetry.io/collector/receiver v0.77.0
 	go.opentelemetry.io/collector/semconv v0.77.0
+	go.uber.org/multierr v1.11.0
 )
 
 require (
@@ -36,7 +37,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.9.0 // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect
-	github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector/confmap v0.77.0 // indirect
@@ -47,7 +47,6 @@ require (
 	go.opentelemetry.io/otel/metric v0.38.1 // indirect
 	go.opentelemetry.io/otel/trace v1.15.1 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect

--- a/receiver/datadogreceiver/go.mod
+++ b/receiver/datadogreceiver/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.9.0 // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect
+	github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector/confmap v0.77.0 // indirect

--- a/receiver/datadogreceiver/go.sum
+++ b/receiver/datadogreceiver/go.sum
@@ -284,6 +284,8 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tinylib/msgp v1.1.8 h1:FCXC1xanKO4I8plpHGH2P7koL/RzZs12l/+r7vakfm0=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
+github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb h1:Ywfo8sUltxogBpFuMOFRrrSifO788kAFxmvVw31PtQQ=
+github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb/go.mod h1:ikPs9bRWicNw3S7XpJ8sK/smGwU9WcSVU3dy9qahYBM=
 github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvCazn8G65U=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=

--- a/receiver/datadogreceiver/go.sum
+++ b/receiver/datadogreceiver/go.sum
@@ -284,8 +284,6 @@ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tinylib/msgp v1.1.8 h1:FCXC1xanKO4I8plpHGH2P7koL/RzZs12l/+r7vakfm0=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
-github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb h1:Ywfo8sUltxogBpFuMOFRrrSifO788kAFxmvVw31PtQQ=
-github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb/go.mod h1:ikPs9bRWicNw3S7XpJ8sK/smGwU9WcSVU3dy9qahYBM=
 github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvCazn8G65U=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=

--- a/receiver/datadogreceiver/translator.go
+++ b/receiver/datadogreceiver/translator.go
@@ -66,7 +66,7 @@ func toTraces(payload *pb.TracerPayload, req *http.Request) ptrace.Traces {
 	}
 
 	for k, v := range payload.Tags {
-		if k := translateDataDogKeyToOtel(k); v != "" {
+		if k = translateDataDogKeyToOtel(k); v != "" {
 			sharedAttributes.PutStr(k, v)
 		}
 	}

--- a/receiver/datadogreceiver/translator.go
+++ b/receiver/datadogreceiver/translator.go
@@ -28,20 +28,19 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv "go.opentelemetry.io/collector/semconv/v1.16.0"
+	"go.uber.org/multierr"
 )
 
-func addResourceData(req *http.Request, rs *pcommon.Resource) {
-	attrs := rs.Attributes()
-	attrs.Clear()
-	attrs.EnsureCapacity(3)
-	attrs.PutStr("telemetry.sdk.name", "Datadog")
-	ddTracerVersion := req.Header.Get("Datadog-Meta-Tracer-Version")
-	if ddTracerVersion != "" {
-		attrs.PutStr("telemetry.sdk.version", "Datadog-"+ddTracerVersion)
+const (
+	datadogSpanKindKey = "span.kind"
+)
+
+func upsertHeadersAttributes(req *http.Request, attrs pcommon.Map) {
+	if ddTracerVersion := req.Header.Get("Datadog-Meta-Tracer-Version"); ddTracerVersion != "" {
+		attrs.PutStr(semconv.AttributeTelemetrySDKVersion, "Datadog-"+ddTracerVersion)
 	}
-	ddTracerLang := req.Header.Get("Datadog-Meta-Lang")
-	if ddTracerLang != "" {
-		attrs.PutStr("telemetry.sdk.language", ddTracerLang)
+	if ddTracerLang := req.Header.Get("Datadog-Meta-Lang"); ddTracerLang != "" {
+		attrs.PutStr(semconv.AttributeTelemetrySDKLanguage, ddTracerLang)
 	}
 }
 
@@ -50,60 +49,75 @@ func toTraces(payload *pb.TracerPayload, req *http.Request) ptrace.Traces {
 	for _, p := range payload.GetChunks() {
 		traces = append(traces, p.GetSpans())
 	}
-	dest := ptrace.NewTraces()
-	resSpans := dest.ResourceSpans().AppendEmpty()
-	resource := resSpans.Resource()
-	addResourceData(req, &resource)
-	resSpans.SetSchemaUrl(semconv.SchemaURL)
+	sharedAttributes := pcommon.NewMap()
+	for k, v := range map[string]string{
+		semconv.AttributeContainerID:           payload.ContainerID,
+		semconv.AttributeTelemetrySDKLanguage:  payload.LanguageName,
+		semconv.AttributeProcessRuntimeVersion: payload.LanguageVersion,
+		semconv.AttributeDeploymentEnvironment: payload.Env,
+		semconv.AttributeHostName:              payload.Hostname,
+		semconv.AttributeServiceVersion:        payload.AppVersion,
+		semconv.AttributeTelemetrySDKName:      "Datadog",
+		semconv.AttributeTelemetrySDKVersion:   payload.TracerVersion,
+	} {
+		if v != "" {
+			sharedAttributes.PutStr(k, v)
+		}
+	}
+
+	for k, v := range payload.Tags {
+		if k := translateDataDogKeyToOtel(k); v != "" {
+			sharedAttributes.PutStr(k, v)
+		}
+	}
+
+	upsertHeadersAttributes(req, sharedAttributes)
+
+	// Creating a map of service spans to slices
+	// since the expectation is that `service.name`
+	// is added as a resource attribute in most systems
+	// now instead of being a span level attribute.
+	groupByService := make(map[string]ptrace.SpanSlice)
 
 	for _, trace := range traces {
-		ils := resSpans.ScopeSpans().AppendEmpty()
-		ils.Scope().SetName("Datadog-" + req.Header.Get("Datadog-Meta-Lang"))
-		ils.Scope().SetVersion(req.Header.Get("Datadog-Meta-Tracer-Version"))
-		spans := ptrace.NewSpanSlice()
-		spans.EnsureCapacity(len(trace))
 		for _, span := range trace {
-			newSpan := spans.AppendEmpty()
+			slice, exist := groupByService[span.Service]
+			if !exist {
+				slice = ptrace.NewSpanSlice()
+				groupByService[span.Service] = slice
+			}
+			newSpan := slice.AppendEmpty()
 
 			newSpan.SetTraceID(uInt64ToTraceID(0, span.TraceID))
 			newSpan.SetSpanID(uInt64ToSpanID(span.SpanID))
 			newSpan.SetStartTimestamp(pcommon.Timestamp(span.Start))
 			newSpan.SetEndTimestamp(pcommon.Timestamp(span.Start + span.Duration))
 			newSpan.SetParentSpanID(uInt64ToSpanID(span.ParentID))
-			newSpan.SetName(span.Resource)
+			newSpan.SetName(span.Name)
+			newSpan.Status().SetCode(ptrace.StatusCodeOk)
 
 			if span.Error > 0 {
 				newSpan.Status().SetCode(ptrace.StatusCodeError)
-			} else {
-				newSpan.Status().SetCode(ptrace.StatusCodeOk)
 			}
 
-			attrs := newSpan.Attributes()
-			attrs.EnsureCapacity(len(span.GetMeta()) + 1)
-			attrs.PutStr(semconv.AttributeServiceName, span.Service)
 			for k, v := range span.GetMeta() {
-				k = translateDataDogKeyToOtel(k)
-				if len(k) > 0 {
-					attrs.PutStr(k, v)
+				if k = translateDataDogKeyToOtel(k); len(k) > 0 {
+					newSpan.Attributes().PutStr(k, v)
 				}
 			}
 
-			if span.Meta["span.kind"] != "" {
-				switch span.Meta["span.kind"] {
-				case "server":
-					newSpan.SetKind(ptrace.SpanKindServer)
-				case "client":
-					newSpan.SetKind(ptrace.SpanKindClient)
-				case "producer":
-					newSpan.SetKind(ptrace.SpanKindProducer)
-				case "consumer":
-					newSpan.SetKind(ptrace.SpanKindConsumer)
-				case "internal":
-					newSpan.SetKind(ptrace.SpanKindInternal)
-				default:
-					newSpan.SetKind(ptrace.SpanKindUnspecified)
-				}
-			} else {
+			switch span.Meta[datadogSpanKindKey] {
+			case "server":
+				newSpan.SetKind(ptrace.SpanKindServer)
+			case "client":
+				newSpan.SetKind(ptrace.SpanKindClient)
+			case "producer":
+				newSpan.SetKind(ptrace.SpanKindProducer)
+			case "consumer":
+				newSpan.SetKind(ptrace.SpanKindConsumer)
+			case "internal":
+				newSpan.SetKind(ptrace.SpanKindInternal)
+			default:
 				switch span.Type {
 				case "web":
 					newSpan.SetKind(ptrace.SpanKindServer)
@@ -114,10 +128,22 @@ func toTraces(payload *pb.TracerPayload, req *http.Request) ptrace.Traces {
 				}
 			}
 		}
-		spans.MoveAndAppendTo(ils.Spans())
 	}
 
-	return dest
+	results := ptrace.NewTraces()
+	for service, spans := range groupByService {
+		rs := results.ResourceSpans().AppendEmpty()
+		rs.SetSchemaUrl(semconv.SchemaURL)
+		sharedAttributes.CopyTo(rs.Resource().Attributes())
+		rs.Resource().Attributes().PutStr(semconv.AttributeServiceName, service)
+
+		in := rs.ScopeSpans().AppendEmpty()
+		in.Scope().SetName("Datadog")
+		in.Scope().SetVersion(payload.TracerVersion)
+		spans.CopyTo(in.Spans())
+	}
+
+	return results
 }
 
 func translateDataDogKeyToOtel(k string) string {
@@ -163,6 +189,11 @@ func putBuffer(buffer *bytes.Buffer) {
 }
 
 func handlePayload(req *http.Request) (tp *pb.TracerPayload, err error) {
+	defer func() {
+		_, errs := io.Copy(io.Discard, req.Body)
+		err = multierr.Combine(err, errs, req.Body.Close())
+	}()
+
 	switch {
 	case strings.HasPrefix(req.URL.Path, "/v0.7"):
 		buf := getBuffer()
@@ -184,8 +215,8 @@ func handlePayload(req *http.Request) (tp *pb.TracerPayload, err error) {
 		return &pb.TracerPayload{
 			LanguageName:    req.Header.Get("Datadog-Meta-Lang"),
 			LanguageVersion: req.Header.Get("Datadog-Meta-Lang-Version"),
-			Chunks:          traceChunksFromTraces(traces),
 			TracerVersion:   req.Header.Get("Datadog-Meta-Tracer-Version"),
+			Chunks:          traceChunksFromTraces(traces),
 		}, err
 	case strings.HasPrefix(req.URL.Path, "/v0.1"):
 		var spans []pb.Span
@@ -195,8 +226,8 @@ func handlePayload(req *http.Request) (tp *pb.TracerPayload, err error) {
 		return &pb.TracerPayload{
 			LanguageName:    req.Header.Get("Datadog-Meta-Lang"),
 			LanguageVersion: req.Header.Get("Datadog-Meta-Lang-Version"),
-			Chunks:          traceChunksFromSpans(spans),
 			TracerVersion:   req.Header.Get("Datadog-Meta-Tracer-Version"),
+			Chunks:          traceChunksFromSpans(spans),
 		}, nil
 
 	default:
@@ -207,8 +238,8 @@ func handlePayload(req *http.Request) (tp *pb.TracerPayload, err error) {
 		return &pb.TracerPayload{
 			LanguageName:    req.Header.Get("Datadog-Meta-Lang"),
 			LanguageVersion: req.Header.Get("Datadog-Meta-Lang-Version"),
-			Chunks:          traceChunksFromTraces(traces),
 			TracerVersion:   req.Header.Get("Datadog-Meta-Tracer-Version"),
+			Chunks:          traceChunksFromTraces(traces),
 		}, err
 	}
 }

--- a/receiver/datadogreceiver/translator_test.go
+++ b/receiver/datadogreceiver/translator_test.go
@@ -70,11 +70,11 @@ var data = [2]interface{}{
 
 func TestTracePayloadV05Unmarshalling(t *testing.T) {
 	var traces pb.Traces
-	
+
 	payload, err := vmsgp.Marshal(&data)
 	assert.NoError(t, err)
-	
-	require.NoError(t, traces.UnmarshalMsgDictionary(payload), "Must not error when marshalling content")
+
+	require.NoError(t, traces.UnmarshalMsgDictionary(payload), "Must not error when marshaling content")
 	req, _ := http.NewRequest(http.MethodPost, "/v0.5/traces", io.NopCloser(bytes.NewReader(payload)))
 	translated := toTraces(&pb.TracerPayload{
 		LanguageName:    req.Header.Get("Datadog-Meta-Lang"),
@@ -89,7 +89,7 @@ func TestTracePayloadV05Unmarshalling(t *testing.T) {
 	value, exists := span.Attributes().Get("service.name")
 	assert.True(t, exists, "service.name missing")
 	assert.Equal(t, "my-service", value.AsString(), "service.name tag value incorrect")
-	assert.Equal(t, span.Name(), "my-resource")
+	assert.Equal(t, "my-name", span.Name())
 }
 
 func TestTracePayloadV07Unmarshalling(t *testing.T) {


### PR DESCRIPTION
**Description:**

Updating the translations for the datadog receiver to be more align with Otel Semantic Conventions to ensure integrations with other applications will work

**Link to tracking Issue:** 
Resolves issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21525
And https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21210

**Testing:**

Updated tests where approperiate.

**Documentation:** 

No documentation has been updated since this should be the expected behaviour.