### PR TITLE
[chore] [exporter/splunkhec] Remove redundant state data and allocation

### DIFF
--- a/exporter/splunkhecexporter/buffer.go
+++ b/exporter/splunkhecexporter/buffer.go
@@ -28,16 +28,6 @@ var (
 // Minimum number of bytes to compress. 1500 is the MTU of an ethernet frame.
 const minCompressionLen = 1500
 
-// Composite index of a record.
-type index struct {
-	// Index in orig list (i.e. root parent index).
-	resource int
-	// Index in ScopeLogs/ScopeMetrics list (i.e. immediate parent index).
-	library int
-	// Index in Logs list (i.e. the log record index).
-	record int
-}
-
 // bufferState encapsulates intermediate buffer state when pushing data
 type bufferState struct {
 	compressionAvailable bool
@@ -46,9 +36,9 @@ type bufferState struct {
 	maxEventLength       uint
 	writer               io.Writer
 	buf                  *bytes.Buffer
-	bufFront             *index
-	resource             int
-	library              int
+	resource             int // index in ResourceLogs/ResourceMetrics/ResourceSpans list
+	library              int // index in ScopeLogs/ScopeMetrics/ScopeSpans list
+	record               int // index in Logs/Metrics/Spans list
 	containsData         bool
 	rawLength            int
 }
@@ -199,8 +189,8 @@ func makeBlankBufferState(bufCap uint, compressionAvailable bool, maxEventLength
 		buf:                  buf,
 		bufferMaxLen:         bufCap,
 		maxEventLength:       maxEventLength,
-		bufFront:             nil, // Index of the log record of the first unsent event in buffer.
-		resource:             0,   // Index of currently processed Resource
-		library:              0,   // Index of currently processed Library
+		resource:             0,
+		library:              0,
+		record:               0,
 	}
 }


### PR DESCRIPTION
Remove redundant bufferState.index field and avoid an allocation when profiling and logs data are not send together which is the most common case

Before:

```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_100_10_10_1024
Benchmark_pushLogData_100_10_10_1024-10     	     410	   2702689 ns/op	 2441942 B/op	   34326 allocs/op
Benchmark_pushLogData_10_100_100_1024
Benchmark_pushLogData_10_100_100_1024-10    	     409	   2672872 ns/op	 2443447 B/op	   34506 allocs/op
Benchmark_pushLogData_10_0_100_1024
Benchmark_pushLogData_10_0_100_1024-10      	     840	   1331842 ns/op	 1226277 B/op	   17175 allocs/op
Benchmark_pushLogData_10_100_0_1024
Benchmark_pushLogData_10_100_0_1024-10      	     836	   1336186 ns/op	 1231659 B/op	   17342 allocs/op
Benchmark_pushLogData_10_10_10_256
Benchmark_pushLogData_10_10_10_256-10       	    2034	    568102 ns/op	  557723 B/op	    7689 allocs/op
Benchmark_pushLogData_10_10_10_1024
Benchmark_pushLogData_10_10_10_1024-10      	    4033	    267946 ns/op	  252992 B/op	    3456 allocs/op
Benchmark_pushLogData_10_10_10_8K
Benchmark_pushLogData_10_10_10_8K-10        	    1746	    687386 ns/op	 1861394 B/op	    2683 allocs/op
Benchmark_pushLogData_10_10_10_1M
Benchmark_pushLogData_10_10_10_1M-10        	    1555	    988593 ns/op	 6039903 B/op	    2684 allocs/op
Benchmark_pushLogData_10_1_1_1024
Benchmark_pushLogData_10_1_1_1024-10        	   41257	     27364 ns/op	   36548 B/op	     351 allocs/op
BenchmarkPushLogRecords
BenchmarkPushLogRecords-10                  	  205251	      5427 ns/op	   31409 B/op	      13 allocs/op
PASS
```


After:

```
Benchmark_pushLogData_100_10_10_1024
Benchmark_pushLogData_100_10_10_1024-10     	     446	   2550308 ns/op	 2436061 B/op	   33992 allocs/op
Benchmark_pushLogData_10_100_100_1024
Benchmark_pushLogData_10_100_100_1024-10    	     447	   2605696 ns/op	 2437463 B/op	   34172 allocs/op
Benchmark_pushLogData_10_0_100_1024
Benchmark_pushLogData_10_0_100_1024-10      	     852	   1307304 ns/op	 1222155 B/op	   17008 allocs/op
Benchmark_pushLogData_10_100_0_1024
Benchmark_pushLogData_10_100_0_1024-10      	     836	   1300739 ns/op	 1227657 B/op	   17175 allocs/op
Benchmark_pushLogData_10_10_10_256
Benchmark_pushLogData_10_10_10_256-10       	    1970	    530659 ns/op	  553186 B/op	    7489 allocs/op
Benchmark_pushLogData_10_10_10_1024
Benchmark_pushLogData_10_10_10_1024-10      	    4017	    258693 ns/op	  252180 B/op	    3422 allocs/op
Benchmark_pushLogData_10_10_10_8K
Benchmark_pushLogData_10_10_10_8K-10        	    1958	    666062 ns/op	 1861313 B/op	    2681 allocs/op
Benchmark_pushLogData_10_10_10_1M
Benchmark_pushLogData_10_10_10_1M-10        	    1567	    936454 ns/op	 6039842 B/op	    2682 allocs/op
Benchmark_pushLogData_10_1_1_1024
Benchmark_pushLogData_10_1_1_1024-10        	   41476	     27076 ns/op	   36451 B/op	     347 allocs/op
BenchmarkPushLogRecords
BenchmarkPushLogRecords-10                  	  213703	      5317 ns/op	   31408 B/op	      13 allocs/op
PASS
```