### PR TITLE
[exporter/splunkhec] Introduce pools for buffers states

### DIFF
--- a/.chloggen/splunkhec-improve-performance.yaml
+++ b/.chloggen/splunkhec-improve-performance.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/splunkhec
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Improve performance and reduce memory consumption.
+
+# One or more tracking issues related to the change
+issues: [21765, 21791]

--- a/exporter/splunkhecexporter/buffer.go
+++ b/exporter/splunkhecexporter/buffer.go
@@ -19,6 +19,7 @@ import (
 	"compress/gzip"
 	"errors"
 	"io"
+	"sync"
 )
 
 var (
@@ -52,7 +53,9 @@ func (b *bufferState) containsData() bool {
 
 func (b *bufferState) reset() {
 	b.buf.Reset()
-	b.writer = &cancellableBytesWriter{innerWriter: b.buf, maxCapacity: b.bufferMaxLen}
+	if _, ok := b.writer.(*cancellableBytesWriter); !ok {
+		b.writer = &cancellableBytesWriter{innerWriter: b.buf, maxCapacity: b.bufferMaxLen}
+	}
 	b.rawLength = 0
 }
 
@@ -180,18 +183,36 @@ func (c *cancellableGzipWriter) close() error {
 	return c.innerWriter.Close()
 }
 
-func makeBlankBufferState(bufCap uint, compressionAvailable bool, maxEventLength uint) *bufferState {
-	// Buffer of JSON encoded Splunk events, last record is expected to overflow bufCap, hence the padding
-	buf := bytes.NewBuffer(make([]byte, 0, bufCap+bufCapPadding))
+// bufferStatePool is a pool of bufferState objects.
+type bufferStatePool struct {
+	pool *sync.Pool
+}
 
-	return &bufferState{
-		compressionAvailable: compressionAvailable,
-		writer:               &cancellableBytesWriter{innerWriter: buf, maxCapacity: bufCap},
-		buf:                  buf,
-		bufferMaxLen:         bufCap,
-		maxEventLength:       maxEventLength,
-		resource:             0,
-		library:              0,
-		record:               0,
+// get returns a bufferState from the pool.
+func (p bufferStatePool) get() *bufferState {
+	bf := p.pool.Get().(*bufferState)
+	bf.reset()
+	return bf
+}
+
+// put returns a bufferState to the pool.
+func (p bufferStatePool) put(bf *bufferState) {
+	p.pool.Put(bf)
+}
+
+func newBufferStatePool(bufCap uint, compressionAvailable bool, maxEventLength uint) bufferStatePool {
+	return bufferStatePool{
+		&sync.Pool{
+			New: func() interface{} {
+				buf := new(bytes.Buffer)
+				return &bufferState{
+					compressionAvailable: compressionAvailable,
+					writer:               &cancellableBytesWriter{innerWriter: buf, maxCapacity: bufCap},
+					buf:                  buf,
+					bufferMaxLen:         bufCap,
+					maxEventLength:       maxEventLength,
+				}
+			},
+		},
 	}
 }

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -44,7 +44,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
@@ -1033,11 +1032,8 @@ func Test_PushMetricsData_Histogram_NaN_Sum(t *testing.T) {
 	dp := histogram.SetEmptyHistogram().DataPoints().AppendEmpty()
 	dp.SetSum(math.NaN())
 
-	c := client{
-		config:    NewFactory().CreateDefaultConfig().(*Config),
-		logger:    zap.NewNop(),
-		hecWorker: &mockHecWorker{},
-	}
+	c := newMetricsClient(exportertest.NewNopCreateSettings(), NewFactory().CreateDefaultConfig().(*Config))
+	c.hecWorker = &mockHecWorker{}
 
 	permanentErrors := c.pushMetricsDataInBatches(context.Background(), metrics, map[string]string{})
 	assert.NoError(t, permanentErrors)
@@ -1052,11 +1048,8 @@ func Test_PushMetricsData_Summary_NaN_Sum(t *testing.T) {
 	dp := summary.SetEmptySummary().DataPoints().AppendEmpty()
 	dp.SetSum(math.NaN())
 
-	c := client{
-		config:    NewFactory().CreateDefaultConfig().(*Config),
-		logger:    zap.NewNop(),
-		hecWorker: &mockHecWorker{},
-	}
+	c := newMetricsClient(exportertest.NewNopCreateSettings(), NewFactory().CreateDefaultConfig().(*Config))
+	c.hecWorker = &mockHecWorker{}
 
 	permanentErrors := c.pushMetricsDataInBatches(context.Background(), metrics, map[string]string{})
 	assert.NoError(t, permanentErrors)
@@ -1213,10 +1206,7 @@ func Test_pushLogData_nil_Logs(t *testing.T) {
 		},
 	}
 
-	c := client{
-		config: NewFactory().CreateDefaultConfig().(*Config),
-		logger: zaptest.NewLogger(t),
-	}
+	c := newLogsClient(exportertest.NewNopCreateSettings(), NewFactory().CreateDefaultConfig().(*Config))
 
 	for _, test := range tests {
 		for _, disabled := range []bool{true, false} {
@@ -1231,10 +1221,7 @@ func Test_pushLogData_nil_Logs(t *testing.T) {
 }
 
 func Test_pushLogData_InvalidLog(t *testing.T) {
-	c := client{
-		config: NewFactory().CreateDefaultConfig().(*Config),
-		logger: zaptest.NewLogger(t),
-	}
+	c := newLogsClient(exportertest.NewNopCreateSettings(), NewFactory().CreateDefaultConfig().(*Config))
 
 	logs := plog.NewLogs()
 	log := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
@@ -1247,11 +1234,8 @@ func Test_pushLogData_InvalidLog(t *testing.T) {
 }
 
 func Test_pushLogData_PostError(t *testing.T) {
-	c := client{
-		config:    NewFactory().CreateDefaultConfig().(*Config),
-		logger:    zaptest.NewLogger(t),
-		hecWorker: &defaultHecWorker{url: &url.URL{Host: "in va lid"}},
-	}
+	c := newLogsClient(exportertest.NewNopCreateSettings(), NewFactory().CreateDefaultConfig().(*Config))
+	c.hecWorker = &defaultHecWorker{url: &url.URL{Host: "in va lid"}}
 
 	// 2000 log records -> ~371888 bytes when JSON encoded.
 	logs := createLogData(1, 1, 2000)
@@ -1289,10 +1273,7 @@ func Test_pushLogData_PostError(t *testing.T) {
 func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 	config := NewFactory().CreateDefaultConfig().(*Config)
 	url := &url.URL{Scheme: "http", Host: "splunk"}
-	splunkClient := client{
-		config: config,
-		logger: zaptest.NewLogger(t),
-	}
+	splunkClient := newLogsClient(exportertest.NewNopCreateSettings(), NewFactory().CreateDefaultConfig().(*Config))
 	logs := createLogData(1, 1, 1)
 
 	responseBody := `some error occurred`
@@ -1320,17 +1301,15 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 
 func Test_pushLogData_ShouldReturnUnsentLogsOnly(t *testing.T) {
 	config := NewFactory().CreateDefaultConfig().(*Config)
+
+	// Each record is about 200 bytes, so the 250-byte buffer will fit only one at a time
+	config.MaxContentLengthLogs, config.DisableCompression = 250, true
+
 	url := &url.URL{Scheme: "http", Host: "splunk"}
-	c := client{
-		config: config,
-		logger: zaptest.NewLogger(t),
-	}
+	c := newLogsClient(exportertest.NewNopCreateSettings(), config)
 
 	// Just two records
 	logs := createLogData(2, 1, 1)
-
-	// Each record is about 200 bytes, so the 250-byte buffer will fit only one at a time
-	c.config.MaxContentLengthLogs, c.config.DisableCompression = 250, true
 
 	// The first record is to be sent successfully, the second one should not
 	httpClient, _ := newTestClientWithPresetResponses([]int{200, 400}, []string{"OK", "NOK"})
@@ -1349,20 +1328,18 @@ func Test_pushLogData_ShouldReturnUnsentLogsOnly(t *testing.T) {
 
 func Test_pushLogData_ShouldAddHeadersForProfilingData(t *testing.T) {
 	config := NewFactory().CreateDefaultConfig().(*Config)
-	url := &url.URL{Scheme: "http", Host: "splunk"}
-	c := client{
-		config: config,
-		logger: zaptest.NewLogger(t),
-	}
+
+	// A 300-byte buffer only fits one record (around 200 bytes), so each record will be sent separately
+	config.MaxContentLengthLogs, config.DisableCompression = 300, true
+
+	c := newLogsClient(exportertest.NewNopCreateSettings(), config)
 
 	logs := createLogDataWithCustomLibraries(1, []string{"otel.logs", "otel.profiling"}, []int{10, 20})
 	var headers *[]http.Header
 
 	httpClient, headers := newTestClient(200, "OK")
+	url := &url.URL{Scheme: "http", Host: "splunk"}
 	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo())}
-
-	// A 300-byte buffer only fits one record (around 200 bytes), so each record will be sent separately
-	c.config.MaxContentLengthLogs, c.config.DisableCompression = 300, true
 
 	err := c.pushLogData(context.Background(), logs)
 	require.NoError(t, err)
@@ -1412,22 +1389,34 @@ func Benchmark_pushLogData_10_10_10_8K(b *testing.B) {
 func Benchmark_pushLogData_10_10_10_1M(b *testing.B) {
 	benchPushLogData(b, 10, 10, 10, 1024*1024)
 }
+
+func Benchmark_pushLogData_5_0_20_2M(b *testing.B) {
+	benchPushLogData(b, 5, 0, 20, 2*1024*1024)
+}
+
+func Benchmark_pushLogData_10_0_100_2M(b *testing.B) {
+	benchPushLogData(b, 10, 0, 100, 2*1024*1024)
+}
+
+func Benchmark_pushLogData_50_0_200_2M(b *testing.B) {
+	benchPushLogData(b, 50, 0, 200, 2*1024*1024)
+}
+
+func Benchmark_pushLogData_50_0_200_5M(b *testing.B) {
+	benchPushLogData(b, 50, 0, 200, 5*1024*1024)
+}
+
 func Benchmark_pushLogData_10_1_1_1024(b *testing.B) {
 	benchPushLogData(b, 10, 1, 1, 1024)
 }
 
 func benchPushLogData(b *testing.B, numResources int, numProfiling int, numNonProfiling int, bufSize uint) {
 	config := NewFactory().CreateDefaultConfig().(*Config)
-	url := &url.URL{Scheme: "http", Host: "splunk"}
-	c := client{
-		config: config,
-		logger: zaptest.NewLogger(b),
-	}
+	config.MaxContentLengthLogs = bufSize
+	config.DisableCompression = true
+	c := newLogsClient(exportertest.NewNopCreateSettings(), config)
+	c.hecWorker = &mockHecWorker{}
 
-	httpClient, _ := newTestClient(200, "OK")
-	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo())}
-
-	c.config.MaxContentLengthLogs = bufSize
 	logs := createLogDataWithCustomLibraries(numResources, []string{"otel.logs", "otel.profiling"}, []int{numNonProfiling, numProfiling})
 
 	b.ReportAllocs()
@@ -1441,17 +1430,15 @@ func benchPushLogData(b *testing.B, numResources int, numProfiling int, numNonPr
 
 func Test_pushLogData_Small_MaxContentLength(t *testing.T) {
 	config := NewFactory().CreateDefaultConfig().(*Config)
-	c := client{
-		config:    config,
-		logger:    zaptest.NewLogger(t),
-		hecWorker: &defaultHecWorker{&url.URL{Scheme: "http", Host: "splunk"}, http.DefaultClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo())},
-	}
-	c.config.MaxContentLengthLogs = 1
+	config.MaxContentLengthLogs = 1
 
 	logs := createLogData(1, 1, 2000)
 
 	for _, disable := range []bool{true, false} {
-		c.config.DisableCompression = disable
+		config.DisableCompression = disable
+
+		c := newLogsClient(exportertest.NewNopCreateSettings(), config)
+		c.hecWorker = &defaultHecWorker{&url.URL{Scheme: "http", Host: "splunk"}, http.DefaultClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo())}
 
 		err := c.pushLogData(context.Background(), logs)
 		require.Error(t, err)
@@ -1590,9 +1577,10 @@ func TestPushLogRecordsBufferCounters(t *testing.T) {
 	cfg := NewFactory().CreateDefaultConfig().(*Config)
 	cfg.ExportRaw = true
 	c := client{
-		config:    cfg,
-		logger:    zap.NewNop(),
-		hecWorker: &mockHecWorker{},
+		config:          cfg,
+		logger:          zap.NewNop(),
+		hecWorker:       &mockHecWorker{},
+		bufferStatePool: newBufferStatePool(6, false, 10),
 	}
 
 	logs := plog.NewResourceLogsSlice()
@@ -1600,7 +1588,8 @@ func TestPushLogRecordsBufferCounters(t *testing.T) {
 	logRecords.AppendEmpty().Body().SetStr("12345")    // the first log record should be accepted and sent
 	logRecords.AppendEmpty().Body().SetStr("12345678") // the second log record should be rejected as it's too big
 	logRecords.AppendEmpty().Body().SetStr("12345")    // the third log record should be just accepted
-	bs := makeBlankBufferState(6, false, 10)
+	bs := c.bufferStatePool.get()
+	defer c.bufferStatePool.put(bs)
 
 	permErrs, err := c.pushLogRecords(context.Background(), logs, bs, nil)
 	assert.NoError(t, err)
@@ -1627,15 +1616,16 @@ func validateCompressedContains(t *testing.T, expected []string, got []byte) {
 func BenchmarkPushLogRecords(b *testing.B) {
 	logs := createLogData(1, 1, 1)
 	c := client{
-		config:    NewFactory().CreateDefaultConfig().(*Config),
-		logger:    zap.NewNop(),
-		hecWorker: &mockHecWorker{},
+		config:          NewFactory().CreateDefaultConfig().(*Config),
+		logger:          zap.NewNop(),
+		hecWorker:       &mockHecWorker{},
+		bufferStatePool: newBufferStatePool(4096, true, 4096),
 	}
 
 	b.ReportAllocs()
 	b.ResetTimer()
 
-	state := makeBlankBufferState(4096, true, 4096)
+	state := c.bufferStatePool.get()
 	for n := 0; n < b.N; n++ {
 		permanentErrs, sendingErr := c.pushLogRecords(context.Background(), logs.ResourceLogs(), state, map[string]string{})
 		assert.NoError(b, sendingErr)

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -109,12 +109,7 @@ func createTracesExporter(
 ) (exporter.Traces, error) {
 	cfg := config.(*Config)
 
-	c := &client{
-		config:            cfg,
-		logger:            set.Logger,
-		telemetrySettings: set.TelemetrySettings,
-		buildInfo:         set.BuildInfo,
-	}
+	c := newTracesClient(set, cfg)
 
 	return exporterhelper.NewTracesExporter(
 		ctx,
@@ -136,12 +131,7 @@ func createMetricsExporter(
 ) (exporter.Metrics, error) {
 	cfg := config.(*Config)
 
-	c := &client{
-		config:            cfg,
-		logger:            set.Logger,
-		telemetrySettings: set.TelemetrySettings,
-		buildInfo:         set.BuildInfo,
-	}
+	c := newMetricsClient(set, cfg)
 
 	exporter, err := exporterhelper.NewMetricsExporter(
 		ctx,
@@ -173,12 +163,7 @@ func createLogsExporter(
 ) (exporter exporter.Logs, err error) {
 	cfg := config.(*Config)
 
-	c := &client{
-		config:            cfg,
-		logger:            set.Logger,
-		telemetrySettings: set.TelemetrySettings,
-		buildInfo:         set.BuildInfo,
-	}
+	c := newLogsClient(set, cfg)
 
 	logsExporter, err := exporterhelper.NewLogsExporter(
 		ctx,

--- a/exporter/splunkhecexporter/go.mod
+++ b/exporter/splunkhecexporter/go.mod
@@ -22,7 +22,6 @@ require (
 )
 
 require (
-	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/exporter/splunkhecexporter/go.sum
+++ b/exporter/splunkhecexporter/go.sum
@@ -23,7 +23,6 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+
 github.com/aws/aws-sdk-go-v2/service/sts v1.7.2/go.mod h1:8EzeIqfWt2wWT4rJVu3f21TfrhJ8AEMzVybRNSb/b4g=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
-github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
To improve performance and reduce memory consumption. 

Mostly applicable to configurations with disabled encryption.

Before:

```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_100_10_10_1024
Benchmark_pushLogData_100_10_10_1024-10     	     544	   2265471 ns/op	 1834813 B/op	   26147 allocs/op
Benchmark_pushLogData_10_100_100_1024
Benchmark_pushLogData_10_100_100_1024-10    	     538	   2251496 ns/op	 1836345 B/op	   26327 allocs/op
Benchmark_pushLogData_10_0_100_1024
Benchmark_pushLogData_10_0_100_1024-10      	    1158	   1044071 ns/op	  923662 B/op	   13168 allocs/op
Benchmark_pushLogData_10_100_0_1024
Benchmark_pushLogData_10_100_0_1024-10      	    1168	   1051447 ns/op	  923645 B/op	   13168 allocs/op
Benchmark_pushLogData_10_10_10_256
Benchmark_pushLogData_10_10_10_256-10       	    6034	    203278 ns/op	  192722 B/op	    2789 allocs/op
Benchmark_pushLogData_10_10_10_1024
Benchmark_pushLogData_10_10_10_1024-10      	    6188	    196455 ns/op	  191089 B/op	    2623 allocs/op
Benchmark_pushLogData_10_10_10_8K
Benchmark_pushLogData_10_10_10_8K-10        	    6066	    194614 ns/op	  204441 B/op	    2593 allocs/op
Benchmark_pushLogData_10_10_10_1M
Benchmark_pushLogData_10_10_10_1M-10        	    2432	    449211 ns/op	 2294672 B/op	    2593 allocs/op
Benchmark_pushLogData_5_0_20_2M
Benchmark_pushLogData_5_0_20_2M-10          	    3075	    346789 ns/op	 4303053 B/op	    1308 allocs/op
Benchmark_pushLogData_10_0_100_2M
Benchmark_pushLogData_10_0_100_2M-10        	     825	   1382169 ns/op	 5122079 B/op	   13005 allocs/op
Benchmark_pushLogData_50_0_200_2M
Benchmark_pushLogData_50_0_200_2M-10        	     100	  10067283 ns/op	13329647 B/op	  129966 allocs/op
Benchmark_pushLogData_50_0_200_5M
Benchmark_pushLogData_50_0_200_5M-10        	     100	  10150482 ns/op	19620303 B/op	  129964 allocs/op
Benchmark_pushLogData_10_1_1_1024
Benchmark_pushLogData_10_1_1_1024-10        	   61316	     20100 ns/op	   29232 B/op	     253 allocs/op
BenchmarkPushLogRecords
BenchmarkPushLogRecords-10                  	  213103	      5393 ns/op	   31409 B/op	      13 allocs/op
PASS
```


After:
```
Benchmark_pushLogData_100_10_10_1024
Benchmark_pushLogData_100_10_10_1024-10     	     540	   2153153 ns/op	 1819994 B/op	   25813 allocs/op
Benchmark_pushLogData_10_100_100_1024
Benchmark_pushLogData_10_100_100_1024-10    	     541	   2295616 ns/op	 1821203 B/op	   25992 allocs/op
Benchmark_pushLogData_10_0_100_1024
Benchmark_pushLogData_10_0_100_1024-10      	    1162	   1035513 ns/op	  910593 B/op	   12998 allocs/op
Benchmark_pushLogData_10_100_0_1024
Benchmark_pushLogData_10_100_0_1024-10      	    1164	   1030327 ns/op	  910577 B/op	   12998 allocs/op
Benchmark_pushLogData_10_10_10_256
Benchmark_pushLogData_10_10_10_256-10       	    6300	    191156 ns/op	  179660 B/op	    2585 allocs/op
Benchmark_pushLogData_10_10_10_1024
Benchmark_pushLogData_10_10_10_1024-10      	    6360	    189267 ns/op	  179666 B/op	    2585 allocs/op
Benchmark_pushLogData_10_10_10_8K
Benchmark_pushLogData_10_10_10_8K-10        	    6318	    188939 ns/op	  179718 B/op	    2585 allocs/op
Benchmark_pushLogData_10_10_10_1M
Benchmark_pushLogData_10_10_10_1M-10        	    6441	    188881 ns/op	  179766 B/op	    2585 allocs/op
Benchmark_pushLogData_5_0_20_2M
Benchmark_pushLogData_5_0_20_2M-10          	   12639	     94466 ns/op	   90858 B/op	    1300 allocs/op
Benchmark_pushLogData_10_0_100_2M
Benchmark_pushLogData_10_0_100_2M-10        	    1142	   1058587 ns/op	  911518 B/op	   12998 allocs/op
Benchmark_pushLogData_50_0_200_2M
Benchmark_pushLogData_50_0_200_2M-10        	     128	   9315838 ns/op	 9217021 B/op	  129961 allocs/op
Benchmark_pushLogData_50_0_200_5M
Benchmark_pushLogData_50_0_200_5M-10        	     128	   9915882 ns/op	 9217032 B/op	  129961 allocs/op
Benchmark_pushLogData_10_1_1_1024
Benchmark_pushLogData_10_1_1_1024-10        	   64129	     18532 ns/op	   18213 B/op	     245 allocs/op
BenchmarkPushLogRecords
BenchmarkPushLogRecords-10    	  187494	      5394 ns/op	   31407 B/op	      13 allocs/op
PASS
```

Several changes were applied to the benchmarks in both before/after states:
- Disable encryption
- Setup a mock worker not to benchmark unrelated http stuff 
- Add 4 more benchmark tests that better represent real-world load with 2Mb (default) and 5Mb MaxContentLengh configuration:
  - Benchmark_pushLogData_5_0_20_2M
  - Benchmark_pushLogData_10_0_100_2M
  - Benchmark_pushLogData_50_0_200_2M
  - Benchmark_pushLogData_50_0_200_5M