### PR TITLE
exporter/datadogexporter: update k8s examples to include k8s attributes

### DIFF
--- a/exporter/datadogexporter/examples/k8s-chart/configmap.yaml
+++ b/exporter/datadogexporter/examples/k8s-chart/configmap.yaml
@@ -66,6 +66,59 @@ data:
         override: false
       # adds various tags related to k8s
       k8sattributes:
+        passthrough: false
+        auth_type: "serviceAccount"
+
+        pod_association:
+        - sources:
+          - from: resource_attribute
+            name: k8s.pod.ip
+
+        extract:
+          metadata:
+            - k8s.pod.name
+            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.node.name
+            - k8s.namespace.name
+            - k8s.pod.start_time
+            - k8s.replicaset.name
+            - k8s.replicaset.uid
+            - k8s.daemonset.name
+            - k8s.daemonset.uid
+            - k8s.job.name
+            - k8s.job.uid
+            - k8s.cronjob.name
+            - k8s.statefulset.name
+            - k8s.statefulset.uid
+            - container.image.name
+            - container.image.tag
+            - container.id
+            - k8s.container.name
+            - container.image.name
+            - container.image.tag
+            - container.id
+
+          labels:
+          - tag_name: kube_app_name
+            key: app.kubernetes.io/name
+            from: pod
+          - tag_name: kube_app_instance
+            key: app.kubernetes.io/instance
+            from: pod
+          - tag_name: kube_app_version
+            key: app.kubernetes.io/version
+            from: pod
+          - tag_name: kube_app_component
+            key: app.kubernetes.io/component
+            from: pod
+          - tag_name: kube_app_part_of
+            key: app.kubernetes.io/part-of
+            from: pod
+          - tag_name: kube_app_managed_by
+            key: app.kubernetes.io/managed-by
+            from: pod
+
       batch:
         # Datadog APM Intake limit is 3.2MB. Let's make sure the batches do not
         # go over that.

--- a/exporter/datadogexporter/examples/k8s-chart/daemonset.yaml
+++ b/exporter/datadogexporter/examples/k8s-chart/daemonset.yaml
@@ -42,6 +42,9 @@ spec:
             - name: varlogpods
               mountPath: /var/log/pods
               readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
       volumes:
         - name: otlpgen
           hostPath:
@@ -56,3 +59,6 @@ spec:
         - name: varlogpods
           hostPath:
             path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers

--- a/exporter/datadogexporter/examples/k8s-chart/daemonset.yaml
+++ b/exporter/datadogexporter/examples/k8s-chart/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
           command:
             - "/otelcol-contrib"
             - "--config=/conf/otel-agent-config.yaml"
-          image: otel/opentelemetry-collector-contrib:0.61.0
+          image: otel/opentelemetry-collector-contrib:0.77.0
           resources:
             limits:
               cpu: 1
@@ -30,14 +30,6 @@ spec:
             requests:
               cpu: 200m
               memory: 400Mi
-          env:
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            # The k8s.pod.ip is used to associate pods for k8sattributes
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "k8s.pod.ip=$(POD_IP)"
           ports:
             - containerPort: 4318 # default port for OpenTelemetry HTTP receiver.
               hostPort: 4318
@@ -49,9 +41,6 @@ spec:
               mountPath: /conf
             - name: varlogpods
               mountPath: /var/log/pods
-              readOnly: true
-            - name: varlibdockercontainers
-              mountPath: /var/lib/docker/containers
               readOnly: true
       volumes:
         - name: otlpgen
@@ -67,6 +56,3 @@ spec:
         - name: varlogpods
           hostPath:
             path: /var/log/pods
-        - name: varlibdockercontainers
-          hostPath:
-            path: /var/lib/docker/containers

--- a/exporter/datadogexporter/examples/k8s-chart/deployment.yaml
+++ b/exporter/datadogexporter/examples/k8s-chart/deployment.yaml
@@ -22,6 +22,13 @@ spec:
         # ...
 
         env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        # The k8s.pod.ip is used to associate pods for k8sattributes
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: "k8s.pod.ip=$(POD_IP)"
         - name: HOST_IP
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Correct example for adding Kubernetes attributes to the exporter, allowing the correct functioning of container tags and trace/metrics correlation.