### PR TITLE
Fix container image for k8sclusterreceiver example

### DIFF
--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -266,7 +266,7 @@ spec:
       serviceAccountName: otelcontribcol
       containers:
       - name: otelcontribcol
-        image: otel/opentelemetry-collector-contrib-dev:latest # specify image
+        image: otel/opentelemetry-collector-contrib
         args: ["--config", "/etc/config/config.yaml"]
         volumeMounts:
         - name: config

--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -266,7 +266,7 @@ spec:
       serviceAccountName: otelcontribcol
       containers:
       - name: otelcontribcol
-        image: otelcontribcol:latest # specify image
+        image: otel/opentelemetry-collector-contrib-dev:latest # specify image
         args: ["--config", "/etc/config/config.yaml"]
         volumeMounts:
         - name: config


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

The example for using the k8sclusterreceiver provided at https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/README.md#example does not work out of the box. This is because of the container image that is used for the [Deployment](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/README.md#deployment).

When using the `otelcontribcol` the Pod fails to start with `pull access denied for otelcontribcol, repository does not exist or may require 'docker login': denied: requested access to the resource is denied`.

Instead, using `otel/opentelemetry-collector-contrib-dev:latest` works as expected and seems to be right one to use in this examples?

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>

Makes the documentation example at https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/README.md#example work as is.