### PR TITLE
[receiver/skywalking]: fix parentSpanId lost when crossing segments

### DIFF
--- a/.chloggen/fix-skywalking-receiver-parent-span-id.yaml
+++ b/.chloggen/fix-skywalking-receiver-parent-span-id.yaml
@@ -1,0 +1,21 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/skywalking
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the issue where `ParentSpanId` is lost when crossing segments.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [21799]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+


### PR DESCRIPTION
**Description:** Fix receiver/skywalking `parentSpanId` lost when crossing segments

In Skywalking, parentSpanId == -1 indicates that the span is [the first span within the current segment](https://github.com/apache/skywalking-data-collect-protocol/blob/0da9c8b3e111fb51c9f8854cae16d4519462ecfe/language-agent/Tracing.proto#L119), rather than within the entire trace. Leaving parentSpanId blank can cause the call relationship to be lost when crossing segments.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>