### PR TITLE
[chore] Switch to codeql job to run on macos to have more resources

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   CodeQL-Build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     env:
       # Force CodeQL to run the extraction on the files compiled by our custom
       # build command, as opposed to letting the autobuilder figure it out.


### PR DESCRIPTION
**Description:** 
Updates the codeql job to run on macos instead of ubuntu in order to take advantage of the [increased resources the macos runners provide](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).

![image](https://github.com/open-telemetry/opentelemetry-collector-contrib/assets/12352919/d999eef7-f44d-465d-9c78-517462aec0ce)

I tested this in my fork and while the job still takes about 30 minutes, I never saw it fail.  It produced the same results as the current job.  I propose we try it out and if it doesn't actually solve the problem we revert.

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19393

**Testing:**
Here is one of the runs: https://github.com/TylerHelmuth/opentelemetry-collector-contrib/actions/runs/4939630224

