### PR TITLE
[pkg/ottl] Add Log() to ottlfuncs

### DIFF
--- a/.chloggen/add-logarithm-to-ottlfuncs.yaml
+++ b/.chloggen/add-logarithm-to-ottlfuncs.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add Log function
+
+# One or more tracking issues related to the change
+issues: [18076]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -34,6 +34,7 @@ Available Functions:
 - [delete_matching_keys](#delete_matching_keys)
 - [keep_keys](#keep_keys)
 - [limit](#limit)
+- [log](#log)
 - [merge_maps](#merge_maps)
 - [replace_all_matches](#replace_all_matches)
 - [replace_all_patterns](#replace_all_patterns)
@@ -115,6 +116,29 @@ Examples:
 
 
 - `limit(resource.attributes, 50, ["http.host", "http.method"])`
+
+### Log
+
+`Log(value)`
+
+The `Log` factory function takes a logarithm of the value if it's numeric.
+
+The returned type is float64.
+
+The input `value` types:
+* float64, string, and Int64. Converts to a Float64 and returns `math.Log()` of the converted value
+* bool. Returns `nil` because log(1) is zero and log(0) is undefined so neither are useful.
+
+If `value` is another type or parsing failed nil is always returned.
+
+The `value` is either a path expression to a telemetry field to retrieve or a literal.
+
+Examples:
+
+- `Log(attributes["duration_ms"])`
+
+
+- `Int(Log(attributes["duration_ms"])`
 
 ### merge_maps
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -34,7 +34,6 @@ Available Functions:
 - [delete_matching_keys](#delete_matching_keys)
 - [keep_keys](#keep_keys)
 - [limit](#limit)
-- [log](#log)
 - [merge_maps](#merge_maps)
 - [replace_all_matches](#replace_all_matches)
 - [replace_all_patterns](#replace_all_patterns)
@@ -116,29 +115,6 @@ Examples:
 
 
 - `limit(resource.attributes, 50, ["http.host", "http.method"])`
-
-### Log
-
-`Log(value)`
-
-The `Log` factory function takes a logarithm of the value if it's numeric.
-
-The returned type is float64.
-
-The input `value` types:
-* float64, string, and Int64. Converts to a Float64 and returns `math.Log()` of the converted value
-* bool. Returns `nil` because log(1) is zero and log(0) is undefined so neither are useful.
-
-If `value` is another type or parsing failed nil is always returned.
-
-The `value` is either a path expression to a telemetry field to retrieve or a literal.
-
-Examples:
-
-- `Log(attributes["duration_ms"])`
-
-
-- `Int(Log(attributes["duration_ms"])`
 
 ### merge_maps
 
@@ -288,6 +264,7 @@ Available Converters:
 - [ConvertCase](#convertcase)
 - [Int](#int)
 - [IsMatch](#ismatch)
+- [Log](#log)
 - [ParseJSON](#parsejson)
 - [SpanID](#spanid)
 - [Split](#split)
@@ -387,6 +364,29 @@ Examples:
 
 
 - `IsMatch("string", ".*ring")`
+
+### Log
+
+`Log(value)`
+
+The `Log` factory function takes a logarithm of the value if it's numeric.
+
+The returned type is float64.
+
+The input `value` types:
+* float64, string, and Int64. Converts to a Float64 and returns `math.Log()` of the converted value
+* bool. Returns `nil` because log(1) is zero and log(0) is undefined so neither are useful.
+
+If `value` is another type or parsing failed nil is always returned.
+
+The `value` is either a path expression to a telemetry field to retrieve or a literal.
+
+Examples:
+
+- `Log(attributes["duration_ms"])`
+
+
+- `Int(Log(attributes["duration_ms"])`
 
 ### ParseJSON
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -369,17 +369,20 @@ Examples:
 
 `Log(value)`
 
-The `Log` factory function takes a logarithm of the value if it's numeric.
+The `Log` Converter returns the logarithm of the `target`.
 
-The returned type is float64.
+`target` is either a path expression to a telemetry field to retrieve or a literal.
 
-The input `value` types:
-* float64, string, and Int64. Converts to a Float64 and returns `math.Log()` of the converted value
-* bool. Returns `nil` because log(1) is zero and log(0) is undefined so neither are useful.
+The function take the logarithm of the target, returning an error if the target is less than or equal to zero.
 
-If `value` is another type or parsing failed nil is always returned.
+If target is not a float64, it will be converted to one:
 
-The `value` is either a path expression to a telemetry field to retrieve or a literal.
+- int64s are converted to float64s
+- strings are converted using `strconv`
+- booleans are converted using `1` for `true` and `0` for `false`.  This means passing `false` to the function will cause an error.
+- int, float, string, and bool OTLP Values are converted following the above rules depending on their type.  Other types cause an error.
+
+If target is nil an error is returned.
 
 Examples:
 

--- a/pkg/ottl/ottlfuncs/func_log.go
+++ b/pkg/ottl/ottlfuncs/func_log.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"math"
+	"strconv"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Log[K any](target ottl.Getter[K]) (ottl.ExprFunc[K], error) {
+	return func(ctx context.Context, tCtx K) (interface{}, error) {
+		value, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		
+		switch value := value.(type) {
+		case int64:
+			return math.Log((float64)(value)), nil
+		case string:
+			fltValue, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return nil, nil
+			}
+
+			return math.Log(fltValue), nil
+		case float64:
+			return math.Log(value), nil
+		default:
+			return nil, nil
+		}
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_log.go
+++ b/pkg/ottl/ottlfuncs/func_log.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strconv"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -47,9 +46,12 @@ func logFunc[K any](target ottl.FloatLikeGetter[K]) ottl.ExprFunc[K] {
 		if err != nil {
 			return nil, err
 		}
+		if value == nil {
+			return nil, fmt.Errorf("invalid input: %v", value)
+		}
 
 		if *value <= 0 {
-			return nil, fmt.Errorf("expected value greater than zero but got nil %v", *value)
+			return nil, fmt.Errorf("invalid input: expected number greater than zero but got %v", *value)
 		}
 		return math.Log(*value), nil
 	}

--- a/pkg/ottl/ottlfuncs/func_log.go
+++ b/pkg/ottl/ottlfuncs/func_log.go
@@ -24,7 +24,7 @@ import (
 )
 
 type LogArguments[K any] struct {
-	Target ottl.Getter[K] `ottlarg:"0"`
+	Target ottl.FloatLikeGetter[K] `ottlarg:"0"`
 }
 
 func NewLogFactory[K any]() ottl.Factory[K] {
@@ -41,35 +41,16 @@ func createLogFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ott
 	return logFunc(args.Target), nil
 }
 
-func logFunc[K any](target ottl.Getter[K]) ottl.ExprFunc[K] {
+func logFunc[K any](target ottl.FloatLikeGetter[K]) ottl.ExprFunc[K] {
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
 		value, err := target.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
 
-		switch value := value.(type) {
-		case int64:
-			if value <= 0 {
-				return nil, fmt.Errorf("expected value greater than zero but got nil %v", value)
-			}
-			return math.Log((float64)(value)), nil
-		case string:
-			fltValue, err := strconv.ParseFloat(value, 64)
-			if err != nil {
-				return nil, err
-			}
-			if fltValue <= 0 {
-				return nil, fmt.Errorf("expected value greater than zero but got nil %v", fltValue)
-			}
-			return math.Log(fltValue), nil
-		case float64:
-			if value <= 0 {
-				return nil, fmt.Errorf("expected value greater than zero but got nil %v", value)
-			}
-			return math.Log(value), nil
-		default:
-			return nil, fmt.Errorf("unhanlded type %T", value)
+		if *value <= 0 {
+			return nil, fmt.Errorf("expected value greater than zero but got nil %v", *value)
 		}
+		return math.Log(*value), nil
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_log.go
+++ b/pkg/ottl/ottlfuncs/func_log.go
@@ -50,18 +50,26 @@ func logFunc[K any](target ottl.Getter[K]) ottl.ExprFunc[K] {
 
 		switch value := value.(type) {
 		case int64:
+			if value <= 0 {
+				return nil, fmt.Errorf("expected value greater than zero but got nil %v", value)
+			}
 			return math.Log((float64)(value)), nil
 		case string:
 			fltValue, err := strconv.ParseFloat(value, 64)
 			if err != nil {
-				return nil, nil
+				return nil, err
 			}
-
+			if fltValue <= 0 {
+				return nil, fmt.Errorf("expected value greater than zero but got nil %v", fltValue)
+			}
 			return math.Log(fltValue), nil
 		case float64:
+			if value <= 0 {
+				return nil, fmt.Errorf("expected value greater than zero but got nil %v", value)
+			}
 			return math.Log(value), nil
 		default:
-			return nil, nil
+			return nil, fmt.Errorf("unhanlded type %T", value)
 		}
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_log_test.go
+++ b/pkg/ottl/ottlfuncs/func_log_test.go
@@ -50,10 +50,15 @@ func Test_Log(t *testing.T) {
 			value:    float64(55),
 			expected: math.Log(55),
 		},
+		{
+			name:     "true",
+			value:    true, // casts to 1 which Log(1) is 0 so it works.
+			expected: float64(0),
+		},
 	}
 	for _, tt := range noErrorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			exprFunc := logFunc[interface{}](&ottl.StandardGetSetter[interface{}]{
+			exprFunc := logFunc[interface{}](&ottl.StandardFloatLikeGetter[interface{}]{
 				Getter: func(context.Context, interface{}) (interface{}, error) {
 					return tt.value, nil
 				},
@@ -66,53 +71,48 @@ func Test_Log(t *testing.T) {
 	errorTests := []struct {
 		name     string
 		value    interface{}
-		expected interface{}
+		errorStr string
 	}{
 		{
 			name:     "not a number string",
 			value:    "test",
-			expected: nil,
-		},
-		{
-			name:     "true",
-			value:    true,
-			expected: nil,
+			errorStr: "invalid",
 		},
 		{
 			name:     "false",
 			value:    false,
-			expected: nil,
+			errorStr: "invalid",
 		},
 		{
 			name:     "zero is undefined",
-			value:    0,
-			expected: "greater than zero",
+			value:    0.0,
+			errorStr: "greater than zero",
 		},
 		{
 			name:     "negative is undefined",
 			value:    -30.3,
-			expected: "greater than zero",
+			errorStr: "greater than zero",
 		},
 		{
 			name:     "nil",
 			value:    nil,
-			expected: nil,
+			errorStr: "invalid",
 		},
 		{
 			name:     "some struct",
 			value:    struct{}{},
-			expected: nil,
+			errorStr: "unsupported",
 		},
 	}
 	for _, tt := range errorTests {
 		t.Run(tt.name, func(t *testing.T) {
-			exprFunc := logFunc[interface{}](&ottl.StandardGetSetter[interface{}]{
+			exprFunc := logFunc[interface{}](&ottl.StandardFloatLikeGetter[interface{}]{
 				Getter: func(context.Context, interface{}) (interface{}, error) {
 					return tt.value, nil
 				},
 			})
 			result, err := exprFunc(nil, nil)
-			assert.ErrorContains(t, err, tt.expected)
+			assert.ErrorContains(t, err, tt.errorStr)
 			assert.Equal(t, nil, result)
 		})
 	}

--- a/pkg/ottl/ottlfuncs/func_log_test.go
+++ b/pkg/ottl/ottlfuncs/func_log_test.go
@@ -1,0 +1,97 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ottlfuncs
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_Log(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected interface{}
+	}{
+		{
+			name:     "string",
+			value:    "50",
+			expected: math.Log(50),
+		},
+		{
+			name:     "empty string",
+			value:    "",
+			expected: nil,
+		},
+		{
+			name:     "not a number string",
+			value:    "test",
+			expected: nil,
+		},
+		{
+			name:     "int64",
+			value:    int64(333),
+			expected: float64(math.Log(333)),
+		},
+		{
+			name:     "float64",
+			value:    float64(2.7),
+			expected: math.Log(2.7),
+		},
+		{
+			name:     "float64 without decimal",
+			value:    float64(55),
+			expected: math.Log(55),
+		},
+		{
+			name:     "true",
+			value:    true,
+			expected: nil,
+		},
+		{
+			name:     "false",
+			value:    false,
+			expected: nil,
+		},
+		{
+			name:     "nil",
+			value:    nil,
+			expected: nil,
+		},
+		{
+			name:     "some struct",
+			value:    struct{}{},
+			expected: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := Log[interface{}](&ottl.StandardGetSetter[interface{}]{
+				Getter: func(context.Context, interface{}) (interface{}, error) {
+					return tt.value, nil
+				},
+			})
+			assert.NoError(t, err)
+			result, err := exprFunc(nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_log_test.go
+++ b/pkg/ottl/ottlfuncs/func_log_test.go
@@ -48,7 +48,7 @@ func Test_Log(t *testing.T) {
 		{
 			name:     "int64",
 			value:    int64(333),
-			expected: float64(math.Log(333)),
+			expected: math.Log(333),
 		},
 		{
 			name:     "float64",
@@ -83,12 +83,11 @@ func Test_Log(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exprFunc, err := Log[interface{}](&ottl.StandardGetSetter[interface{}]{
+			exprFunc := logFunc[interface{}](&ottl.StandardGetSetter[interface{}]{
 				Getter: func(context.Context, interface{}) (interface{}, error) {
 					return tt.value, nil
 				},
 			})
-			assert.NoError(t, err)
 			result, err := exprFunc(nil, nil)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)


### PR DESCRIPTION
Addresses issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18076

Description:

Adds a feature to allow OTTL expressions to get a logarithm of a value.

Link to tracking Issue: 18076

Testing: Tests were added in the same way the Int() function is tested

Documentation: Added a readme section following the same pattern as Int() which covers type for inputs and return values and examples.