### PR TITLE
[pkg/batchperresourceattr] Mark as not mutating

### DIFF
--- a/.chloggen/batchbyres-not-mutating.yaml
+++ b/.chloggen/batchbyres-not-mutating.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/batchperresourceattr
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Mark as not mutating as it does defensive copying.
+
+# One or more tracking issues related to the change
+issues: [21885]

--- a/pkg/batchperresourceattr/batchperresourceattr.go
+++ b/pkg/batchperresourceattr/batchperresourceattr.go
@@ -38,7 +38,7 @@ func NewBatchPerResourceTraces(attrKey string, next consumer.Traces) consumer.Tr
 
 // Capabilities implements the consumer interface.
 func (bt *batchTraces) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: true}
+	return consumer.Capabilities{MutatesData: false}
 }
 
 func (bt *batchTraces) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
@@ -90,7 +90,7 @@ func NewBatchPerResourceMetrics(attrKey string, next consumer.Metrics) consumer.
 
 // Capabilities implements the consumer interface.
 func (bt *batchMetrics) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: true}
+	return consumer.Capabilities{MutatesData: false}
 }
 
 func (bt *batchMetrics) ConsumeMetrics(ctx context.Context, td pmetric.Metrics) error {
@@ -142,7 +142,7 @@ func NewBatchPerResourceLogs(attrKey string, next consumer.Logs) consumer.Logs {
 
 // Capabilities implements the consumer interface.
 func (bt *batchLogs) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: true}
+	return consumer.Capabilities{MutatesData: false}
 }
 
 func (bt *batchLogs) ConsumeLogs(ctx context.Context, td plog.Logs) error {


### PR DESCRIPTION
The consumer does not mutate the original data, it does defensive copying after https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17835. This change improves performance of exporters using it (signalfx, sapm, splunkhec) in forked pipelines