### PR TITLE
[receiver/mongodbatlas] Fix mongodbatlas access log paging

### DIFF
--- a/receiver/mongodbatlasreceiver/access_logs.go
+++ b/receiver/mongodbatlasreceiver/access_logs.go
@@ -420,22 +420,19 @@ func (alr *accessLogsReceiver) getClusterCheckpoint(groupID, clusterName string)
 }
 
 func (alr *accessLogsReceiver) setClusterCheckpoint(groupID string, clusterCheckpoint *accessLogStorageRecord) {
-	value, ok := alr.record[groupID]
+	groupCheckpoints, ok := alr.record[groupID]
 	if !ok {
-	alr.record[groupID] = []*accessLogStorageRecord{clusterCheckpoint}
+		alr.record[groupID] = []*accessLogStorageRecord{clusterCheckpoint}
 	}
-	
-	if key == groupID {
-		var found bool
-		for idx, v := range value {
-			if v.ClusterName == clusterCheckpoint.ClusterName {
-				found = true
-				alr.record[groupID][idx] = clusterCheckpoint
-			}
+
+	var found bool
+	for idx, v := range groupCheckpoints {
+		if v.ClusterName == clusterCheckpoint.ClusterName {
+			found = true
+			alr.record[groupID][idx] = clusterCheckpoint
 		}
-		if !found {
-			alr.record[groupID] = append(alr.record[groupID], clusterCheckpoint)
-		}
-		return
+	}
+	if !found {
+		alr.record[groupID] = append(alr.record[groupID], clusterCheckpoint)
 	}
 }

--- a/receiver/mongodbatlasreceiver/access_logs.go
+++ b/receiver/mongodbatlasreceiver/access_logs.go
@@ -167,7 +167,7 @@ func (alr *accessLogsReceiver) pollAccessLogs(ctx context.Context, pc *LogsProje
 				ClusterName:       cluster.Name,
 				NextPollStartTime: st,
 			}
-			alr.record[project.ID] = append(alr.record[project.ID], clusterCheckpoint)
+			alr.setClusterCheckpoint(project.ID, clusterCheckpoint)
 		}
 		clusterCheckpoint.NextPollStartTime = alr.pollCluster(ctx, pc, project, cluster, clusterCheckpoint.NextPollStartTime, et)
 		if err = alr.checkpoint(ctx, project.ID); err != nil {
@@ -227,7 +227,7 @@ func (alr *accessLogsReceiver) pollCluster(ctx context.Context, pc *LogsProjectC
 				// data and don't want to risk duplicated data by re-polling the same data again.
 				nextPollStartTime = now
 			} else {
-				nextPollStartTime = mostRecentLogTimestamp.Add(1 * time.Millisecond)
+				nextPollStartTime = mostRecentLogTimestamp.Add(100 * time.Millisecond)
 			}
 		}
 
@@ -417,4 +417,25 @@ func (alr *accessLogsReceiver) getClusterCheckpoint(groupID, clusterName string)
 		}
 	}
 	return nil
+}
+
+func (alr *accessLogsReceiver) setClusterCheckpoint(groupID string, clusterCheckpoint *accessLogStorageRecord) {
+	for key, value := range alr.record {
+		if key == groupID {
+			found := false
+			for idx, v := range value {
+				if v.ClusterName == clusterCheckpoint.ClusterName {
+					found = true
+					alr.record[groupID][idx] = clusterCheckpoint
+				}
+			}
+			if !found {
+				alr.record[groupID] = append(alr.record[groupID], clusterCheckpoint)
+			}
+			return
+		}
+	}
+
+	// If we get here, we didn't find the groupID in the map, so we need to add it
+	alr.record[groupID] = []*accessLogStorageRecord{clusterCheckpoint}
 }

--- a/receiver/mongodbatlasreceiver/access_logs.go
+++ b/receiver/mongodbatlasreceiver/access_logs.go
@@ -420,22 +420,22 @@ func (alr *accessLogsReceiver) getClusterCheckpoint(groupID, clusterName string)
 }
 
 func (alr *accessLogsReceiver) setClusterCheckpoint(groupID string, clusterCheckpoint *accessLogStorageRecord) {
-	for key, value := range alr.record {
-		if key == groupID {
-			found := false
-			for idx, v := range value {
-				if v.ClusterName == clusterCheckpoint.ClusterName {
-					found = true
-					alr.record[groupID][idx] = clusterCheckpoint
-				}
-			}
-			if !found {
-				alr.record[groupID] = append(alr.record[groupID], clusterCheckpoint)
-			}
-			return
-		}
-	}
-
-	// If we get here, we didn't find the groupID in the map, so we need to add it
+	value, ok := alr.record[groupID]
+	if !ok {
 	alr.record[groupID] = []*accessLogStorageRecord{clusterCheckpoint}
+	}
+	
+	if key == groupID {
+		var found bool
+		for idx, v := range value {
+			if v.ClusterName == clusterCheckpoint.ClusterName {
+				found = true
+				alr.record[groupID][idx] = clusterCheckpoint
+			}
+		}
+		if !found {
+			alr.record[groupID] = append(alr.record[groupID], clusterCheckpoint)
+		}
+		return
+	}
 }


### PR DESCRIPTION
**Description:** 
1. There was an issue with the checkpointing per project as utilized in access log access.
2. Access Logs API was returning data prior to the requested start date when the start time was only stepped by 1ms, leading to the last Access Log being retrieved repeatedly until new data was available in the API.

**Testing:** Tested manually against the Mongo Atlas Access Tracking API. Added unit test for point 1. As point 2 addressed strange behavior in the API, it can not be meaningfully validated in unit tests.

**Documentation:** None.