### PR TITLE
[pkg/stanza] Ability to configure the worker count.

### DIFF
--- a/.chloggen/internal_stanza.yaml
+++ b/.chloggen/internal_stanza.yaml
@@ -1,0 +1,21 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Internal log entry converter with a worker count is now tied to configured GOMAXPROCS.
+
+# One or more tracking issues related to the change
+issues: [21740]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Within pkg/stanza, there is a log entry converter that starts off with a worker count equal to the 
+  CPU count divided by 4. Having a number of workers tied to the number of operating system threads, 
+  that can execute user-level Go code simultaneously (Configured using GOMAXPROCS), is more reasonable.
+  The fix will factor in GOMAXPROCS inplace of the CPU count. An unset GOMAXPROCS will result in the
+  old behavior, thus having no effect on other users.

--- a/pkg/stanza/adapter/converter.go
+++ b/pkg/stanza/adapter/converter.go
@@ -73,6 +73,7 @@ type Converter struct {
 	// entries from Batch() calls and it receives the data in workerLoop().
 	workerChan chan []*entry.Entry
 	// workerCount configures the amount of workers started.
+	// Defaults to GOMAXPROCS/4. If GOMAXPROCS is not set, defaults to the number of logical CPUs
 	workerCount int
 
 	// flushChan is an internal channel used for transporting batched plog.Logs.
@@ -88,7 +89,7 @@ type Converter struct {
 func NewConverter(logger *zap.Logger) *Converter {
 	return &Converter{
 		workerChan:  make(chan []*entry.Entry),
-		workerCount: int(math.Max(1, float64(runtime.NumCPU()/4))),
+		workerCount: int(math.Max(1, float64(runtime.GOMAXPROCS(-1)/4))),
 		pLogsChan:   make(chan plog.Logs),
 		stopChan:    make(chan struct{}),
 		flushChan:   make(chan plog.Logs),


### PR DESCRIPTION
The configuration is not exposed today, and it is beneficial to have the ability to tune the value.

**Description:** 
The stanza adapter today has multiple configurations some of which are not exposed.
One component within the adapter is the Converter which has an attribute to define the number of parallel consumers which has a rather arbitrary value.
The value of the parallel consumers defaults to "CPU count/4" and given that this configuration does not get exposed you end up being forced to have it as a non-configurable value.
Today, the client has no handle on the value in case there is a need to tune it. 
We had a case in which we wanted to force the number of consumers to always be 1. In our case that was needed when working with the filelog receiver.

With this change, the old behavior isn't really impacted. By default, the value will be the same "CPU count/4". When desired the client can have a handle over that value.

**Link to tracking Issue:** 
Inspiration for this PR arises from this ticket. That being said, it can be beneficial for other use cases.
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21740


**Testing:** 
In my opinion, no additional tests are needed. No extra lines needed to be covered. And, the used method is from the GO SDK.

**Documentation:** 
Added comment to cover the default value