### PR TITLE
[chore][receiver/vcenter] Standardize integration test

### DIFF
--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -38,7 +38,9 @@ type vcenterClient struct {
 	cfg       *Config
 }
 
-func newVcenterClient(c *Config) *vcenterClient {
+var newVcenterClient = defaultNewVcenterClient
+
+func defaultNewVcenterClient(c *Config) *vcenterClient {
 	return &vcenterClient{
 		cfg: c,
 	}

--- a/receiver/vcenterreceiver/integration_test.go
+++ b/receiver/vcenterreceiver/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/vmware/govmomi"
@@ -31,59 +32,72 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/golden"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/scraperinttest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver/internal/metadata"
 )
 
 func TestIntegrationESX(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
 		pw, set := simulator.DefaultLogin.Password()
 		require.True(t, set)
-		cfg := &Config{
-			Endpoint: fmt.Sprintf("%s://%s", c.URL().Scheme, c.URL().Host),
-			Username: simulator.DefaultLogin.Username(),
-			Password: pw,
-			TLSClientSetting: configtls.TLSClientSetting{
-				Insecure: true,
-			},
-			MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
+
+		f := NewFactory()
+		cfg := f.CreateDefaultConfig().(*Config)
+		cfg.CollectionInterval = 2 * time.Second
+		cfg.Endpoint = fmt.Sprintf("%s://%s", c.URL().Scheme, c.URL().Host)
+		cfg.Username = simulator.DefaultLogin.Username()
+		cfg.Password = pw
+		cfg.TLSClientSetting = configtls.TLSClientSetting{
+			Insecure: true,
 		}
+
 		s := session.NewManager(c)
-
-		scraper := newVmwareVcenterScraper(zap.NewNop(), cfg, receivertest.NewNopCreateSettings())
-		scraper.client.moClient = &govmomi.Client{
-			Client:         c,
-			SessionManager: s,
+		newVcenterClient = func(cfg *Config) *vcenterClient {
+			client := &vcenterClient{
+				cfg: cfg,
+				moClient: &govmomi.Client{
+					Client:         c,
+					SessionManager: s,
+				},
+			}
+			require.NoError(t, client.EnsureConnection(context.Background()))
+			client.vimDriver = c
+			client.finder = find.NewFinder(c)
+			// Performance metrics rely on time based publishing so this is inherently flaky for an
+			// integration test, so setting the performance manager to nil to not attempt to compare
+			// performance metrcs. Coverage for this is encompassed in ./scraper_test.go
+			client.pm = nil
+			return client
 		}
-		require.NoError(t, scraper.client.EnsureConnection(context.Background()))
-		scraper.client.vimDriver = c
-		scraper.client.finder = find.NewFinder(c)
-		// Performance metrics rely on time based publishing so this is inherently flaky for an
-		// integration test, so setting the performance manager to nil to not attempt to compare
-		// performance metrcs. Coverage for this is encompassed in ./scraper_test.go
-		scraper.client.pm = nil
-		err := scraper.Start(ctx, componenttest.NewNopHost())
-		require.NoError(t, err)
+		defer func() {
+			newVcenterClient = defaultNewVcenterClient
+		}()
 
-		metrics, err := scraper.scrape(ctx)
-		require.NoError(t, err)
-		require.NotEmpty(t, metrics)
+		consumer := new(consumertest.MetricsSink)
+		settings := receivertest.NewNopCreateSettings()
+		rcvr, err := f.CreateMetricsReceiver(context.Background(), settings, cfg, consumer)
+		require.NoError(t, err, "failed creating metrics receiver")
+
+		require.NoError(t, rcvr.Start(context.Background(), componenttest.NewNopHost()))
+		defer func() {
+			require.NoError(t, rcvr.Shutdown(context.Background()))
+		}()
 
 		goldenPath := filepath.Join("testdata", "metrics", "integration-metrics.yaml")
 		expectedMetrics, err := golden.ReadMetrics(goldenPath)
 		require.NoError(t, err)
-		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, metrics,
+
+		compareOpts := []pmetrictest.CompareMetricsOption{
 			// the simulator will auto assign which host a VM is on, so it will be inconsistent which vm is on which host
 			pmetrictest.IgnoreResourceAttributeValue("vcenter.host.name"),
 			pmetrictest.IgnoreTimestamp(),
 			pmetrictest.IgnoreStartTimestamp(),
-			pmetrictest.IgnoreMetricValues()))
+			pmetrictest.IgnoreMetricValues()}
 
-		err = scraper.Shutdown(ctx)
-		require.NoError(t, err)
+		require.Eventually(t, scraperinttest.EqualsLatestMetrics(expectedMetrics, consumer, compareOpts), 30*time.Second, time.Second)
 	})
 }


### PR DESCRIPTION
- Use new `scraperinttest` package
- Instantiate and run receiver, rather than just the scraper