### PR TITLE
[pkg/ottl] Add new FloatLikeGetter and FloatGetter

### DIFF
--- a/.chloggen/ottl-floatlikegetter.yaml
+++ b/.chloggen/ottl-floatlikegetter.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `FloatLikeGetter` and `FloatGetter` to facilitate float retrival for functions.
+
+# One or more tracking issues related to the change
+issues: [21896]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -262,6 +262,12 @@ func (g StandardFloatLikeGetter[K]) Get(ctx context.Context, tCtx K) (*float64, 
 		if err != nil {
 			return nil, err
 		}
+	case bool:
+		if v {
+			result = float64(1)
+		} else {
+			result = float64(0)
+		}
 	case pcommon.Value:
 		switch v.Type() {
 		case pcommon.ValueTypeDouble:
@@ -273,6 +279,14 @@ func (g StandardFloatLikeGetter[K]) Get(ctx context.Context, tCtx K) (*float64, 
 			if err != nil {
 				return nil, err
 			}
+		case pcommon.ValueTypeBool:
+			if v.Bool() {
+				result = float64(1)
+			} else {
+				result = float64(0)
+			}
+		default:
+			return nil, fmt.Errorf("unsupported value type: %v", v.Type())
 		}
 	default:
 		return nil, fmt.Errorf("unsupported type: %T", v)

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -848,6 +848,26 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "float64 bool true",
+			getter: StandardFloatLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return true, nil
+				},
+			},
+			want:  float64(1),
+			valid: true,
+		},
+		{
+			name: "float64 bool false",
+			getter: StandardFloatLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return false, nil
+				},
+			},
+			want:  float64(0),
+			valid: true,
+		},
+		{
 			name: "pcommon.value type int",
 			getter: StandardFloatLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
@@ -881,6 +901,28 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "pcommon.value type bool true",
+			getter: StandardFloatLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					v := pcommon.NewValueBool(true)
+					return v, nil
+				},
+			},
+			want:  float64(1),
+			valid: true,
+		},
+		{
+			name: "pcommon.value type bool false",
+			getter: StandardFloatLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					v := pcommon.NewValueBool(false)
+					return v, nil
+				},
+			},
+			want:  float64(0),
+			valid: true,
+		},
+		{
 			name: "nil",
 			getter: StandardFloatLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
@@ -894,11 +936,22 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 			name: "invalid type",
 			getter: StandardFloatLikeGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
-					return true, nil
+					return []byte{}, nil
 				},
 			},
 			valid:            false,
-			expectedErrorMsg: "unsupported type: bool",
+			expectedErrorMsg: "unsupported type: []uint8",
+		},
+		{
+			name: "invalid pcommon.Value type",
+			getter: StandardFloatLikeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					v := pcommon.NewValueMap()
+					return v, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "unsupported value type: Map",
 		},
 	}
 

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -199,6 +199,12 @@ func (p *Parser[K]) buildArg(argVal value, argType reflect.Type) (any, error) {
 			return nil, err
 		}
 		return StandardStringLikeGetter[K]{Getter: arg.Get}, nil
+	case strings.HasPrefix(name, "FloatGetter"):
+		arg, err := p.newGetter(argVal)
+		if err != nil {
+			return nil, err
+		}
+		return StandardTypeGetter[K, float64]{Getter: arg.Get}, nil
 	case strings.HasPrefix(name, "FloatLikeGetter"):
 		arg, err := p.newGetter(argVal)
 		if err != nil {

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -155,6 +155,12 @@ func (p *Parser[K]) buildSliceArg(argVal value, argType reflect.Type) (any, erro
 			return nil, err
 		}
 		return arg, nil
+	case strings.HasPrefix(name, "FloatLikeGetter"):
+		arg, err := buildSlice[FloatLikeGetter[K]](argVal, argType, p.buildArg, name)
+		if err != nil {
+			return nil, err
+		}
+		return arg, nil
 	default:
 		return nil, fmt.Errorf("unsupported slice type '%s' for function", argType.Elem().Name())
 	}
@@ -193,6 +199,12 @@ func (p *Parser[K]) buildArg(argVal value, argType reflect.Type) (any, error) {
 			return nil, err
 		}
 		return StandardStringLikeGetter[K]{Getter: arg.Get}, nil
+	case strings.HasPrefix(name, "FloatLikeGetter"):
+		arg, err := p.newGetter(argVal)
+		if err != nil {
+			return nil, err
+		}
+		return StandardFloatLikeGetter[K]{Getter: arg.Get}, nil
 	case strings.HasPrefix(name, "IntGetter"):
 		arg, err := p.newGetter(argVal)
 		if err != nil {

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -155,6 +155,12 @@ func (p *Parser[K]) buildSliceArg(argVal value, argType reflect.Type) (any, erro
 			return nil, err
 		}
 		return arg, nil
+	case strings.HasPrefix(name, "FloatGetter"):
+		arg, err := buildSlice[FloatGetter[K]](argVal, argType, p.buildArg, name)
+		if err != nil {
+			return nil, err
+		}
+		return arg, nil
 	case strings.HasPrefix(name, "FloatLikeGetter"):
 		arg, err := buildSlice[FloatLikeGetter[K]](argVal, argType, p.buildArg, name)
 		if err != nil {

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -648,18 +648,20 @@ func Test_NewFunctionCall(t *testing.T) {
 			want: 2,
 		},
 		{
-			name: "stringgetter slice arg",
+			name: "floatgetter slice arg",
 			inv: invocation{
-				Function: "testing_stringgetter_slice",
+				Function: "testing_floatgetter_slice",
 				Arguments: []value{
 					{
 						List: &list{
 							Values: []value{
 								{
-									String: ottltest.Strp("test"),
+									String: ottltest.Strp("1.1"),
 								},
 								{
-									String: ottltest.Strp("also test"),
+									Literal: &mathExprLiteral{
+										Float: ottltest.Floatp(1),
+									},
 								},
 							},
 						},
@@ -1159,6 +1161,16 @@ func functionWithStringGetterSlice(getters []StringGetter[interface{}]) (ExprFun
 	}, nil
 }
 
+type floatGetterSliceArguments struct {
+	FloatGetters []FloatGetter[any] `ottlarg:"0"`
+}
+
+func functionWithFloatGetterSlice(getters []FloatGetter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return len(getters), nil
+	}, nil
+}
+
 type pMapGetterSliceArguments struct {
 	PMapGetters []PMapGetter[any] `ottlarg:"0"`
 }
@@ -1447,6 +1459,11 @@ func defaultFunctionsForTests() map[string]Factory[any] {
 			"testing_stringlikegetter_slice",
 			&stringLikeGetterSliceArguments{},
 			functionWithStringLikeGetterSlice,
+		),
+		createFactory[any](
+			"testing_floatgetter_slice",
+			&floatGetterSliceArguments{},
+			functionWithFloatGetterSlice,
 		),
 		createFactory[any](
 			"testing_floatlikegetter_slice",

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -708,6 +708,29 @@ func Test_NewFunctionCall(t *testing.T) {
 			want: 2,
 		},
 		{
+			name: "floatlikegetter slice arg",
+			inv: invocation{
+				Function: "testing_floatlikegetter_slice",
+				Arguments: []value{
+					{
+						List: &list{
+							Values: []value{
+								{
+									String: ottltest.Strp("1.1"),
+								},
+								{
+									Literal: &mathExprLiteral{
+										Float: ottltest.Floatp(1.1),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: 2,
+		},
+		{
 			name: "setter arg",
 			inv: invocation{
 				Function: "testing_setter",
@@ -860,6 +883,18 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "stringlikegetter arg",
 			inv: invocation{
 				Function: "testing_stringlikegetter",
+				Arguments: []value{
+					{
+						Bool: (*boolean)(ottltest.Boolp(false)),
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "floatlikegetter arg",
+			inv: invocation{
+				Function: "testing_floatlikegetter",
 				Arguments: []value{
 					{
 						Bool: (*boolean)(ottltest.Boolp(false)),
@@ -1111,6 +1146,16 @@ func functionWithStringLikeGetterSlice(getters []StringLikeGetter[interface{}]) 
 	}, nil
 }
 
+type floatLikeGetterSliceArguments struct {
+	FloatLikeGetters []FloatLikeGetter[any] `ottlarg:"0"`
+}
+
+func functionWithFloatLikeGetterSlice(getters []FloatLikeGetter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return len(getters), nil
+	}, nil
+}
+
 type setterArguments struct {
 	SetterArg Setter[any] `ottlarg:"0"`
 }
@@ -1156,6 +1201,16 @@ type stringLikeGetterArguments struct {
 }
 
 func functionWithStringLikeGetter(StringLikeGetter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return "anything", nil
+	}, nil
+}
+
+type floatLikeGetterArguments struct {
+	FloatLikeGetterArg FloatLikeGetter[any] `ottlarg:"0"`
+}
+
+func functionWithFloatLikeGetter(FloatLikeGetter[interface{}]) (ExprFunc[interface{}], error) {
 	return func(context.Context, interface{}) (interface{}, error) {
 		return "anything", nil
 	}, nil
@@ -1351,6 +1406,11 @@ func defaultFunctionsForTests() map[string]Factory[any] {
 			functionWithStringLikeGetterSlice,
 		),
 		createFactory[any](
+			"testing_floatlikegetter_slice",
+			&floatLikeGetterSliceArguments{},
+			functionWithFloatLikeGetterSlice,
+		),
+		createFactory[any](
 			"testing_pmapgetter_slice",
 			&pMapGetterSliceArguments{},
 			functionWithPMapGetterSlice,
@@ -1379,6 +1439,11 @@ func defaultFunctionsForTests() map[string]Factory[any] {
 			"testing_stringlikegetter",
 			&stringLikeGetterArguments{},
 			functionWithStringLikeGetter,
+		),
+		createFactory[any](
+			"testing_floatlikegetter",
+			&floatLikeGetterArguments{},
+			functionWithFloatLikeGetter,
 		),
 		createFactory[any](
 			"testing_intgetter",

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -648,6 +648,27 @@ func Test_NewFunctionCall(t *testing.T) {
 			want: 2,
 		},
 		{
+			name: "stringgetter slice arg",
+			inv: invocation{
+				Function: "testing_stringgetter_slice",
+				Arguments: []value{
+					{
+						List: &list{
+							Values: []value{
+								{
+									String: ottltest.Strp("test"),
+								},
+								{
+									String: ottltest.Strp("also test"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: 2,
+		},
+		{
 			name: "pmapgetter slice arg",
 			inv: invocation{
 				Function: "testing_pmapgetter_slice",
@@ -886,6 +907,18 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []value{
 					{
 						Bool: (*boolean)(ottltest.Boolp(false)),
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "floatgetter arg",
+			inv: invocation{
+				Function: "testing_floatgetter",
+				Arguments: []value{
+					{
+						String: ottltest.Strp("1.1"),
 					},
 				},
 			},
@@ -1206,6 +1239,16 @@ func functionWithStringLikeGetter(StringLikeGetter[interface{}]) (ExprFunc[inter
 	}, nil
 }
 
+type floatGetterArguments struct {
+	FloatGetterArg FloatGetter[any] `ottlarg:"0"`
+}
+
+func functionWithFloatGetter(FloatGetter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return "anything", nil
+	}, nil
+}
+
 type floatLikeGetterArguments struct {
 	FloatLikeGetterArg FloatLikeGetter[any] `ottlarg:"0"`
 }
@@ -1439,6 +1482,11 @@ func defaultFunctionsForTests() map[string]Factory[any] {
 			"testing_stringlikegetter",
 			&stringLikeGetterArguments{},
 			functionWithStringLikeGetter,
+		),
+		createFactory[any](
+			"testing_floatgetter",
+			&floatGetterArguments{},
+			functionWithFloatGetter,
 		),
 		createFactory[any](
 			"testing_floatlikegetter",


### PR DESCRIPTION
**Description:** 
Adds new `FloatLikeGetter` and `FloatGetter` getters to facilitate float retrieval for functions who need floats.

**Link to tracking Issue:** 
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/21825

**Testing:** 
Added new tests

**Documentation:** 
Added godoc strings