### PR TITLE
[processor/cumulativetodelta] make first point drop configurable

### DIFF
--- a/.chloggen/cumulativetodelta-configfirstpoint.yaml
+++ b/.chloggen/cumulativetodelta-configfirstpoint.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cumulativetodelta
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Makes handling of the first observed point configurable. Defaults to auto based on start time.
+
+# One or more tracking issues related to the change
+issues: [20770]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/cumulativetodeltaprocessor/README.md
+++ b/processor/cumulativetodeltaprocessor/README.md
@@ -23,10 +23,15 @@ The following settings can be optionally configured:
 - `include`: List of metrics names or patterns to convert to delta.
 - `exclude`: List of metrics names or patterns to not convert to delta.  **If a metric name matches both include and exclude, exclude takes precedence.**
 - `max_staleness`: The total time a state entry will live past the time it was last seen. Set to 0 to retain state indefinitely. Default: 0
-- `initial_value`: Handling of the first observed point for a given metric identity. Default: `auto`.
-  - `auto`: send if and only if the startime is set AND the starttime happens after the component started AND the starttime is different from the timestamp.
-  - `keep`: send the observed value as the delta value
-  - `drop`: keep the observed value but don't send
+- `initial_value`: Handling of the first observed point for a given metric identity.
+  When the collector (re)starts, there's no record of how much of a given cumulative counter has already been converted to delta values.
+  - `auto` (default): Send if and only if the startime is set AND the starttime happens after the component started AND the starttime is different from the timestamp.
+    Suitable for gateway deployments, this heuristic is like `drop`, but keeps values for newly started counters (which could not have had previous observed values).
+  - `keep`: Send the observed value as the delta value.
+    Suitable for when the incoming metrics have not been observed before,
+    e.g. running the collector as a sidecar, the collector lifecycle is tied to the metric source.
+  - `drop`: Keep the observed value but don't send.
+    Suitable for gateway deployments, guarantees that all delta counts it produces haven't been observed before, but loses the values between thir first 2 observations.
 
 If neither include nor exclude are supplied, no filtering is applied.
 

--- a/processor/cumulativetodeltaprocessor/README.md
+++ b/processor/cumulativetodeltaprocessor/README.md
@@ -23,6 +23,10 @@ The following settings can be optionally configured:
 - `include`: List of metrics names or patterns to convert to delta.
 - `exclude`: List of metrics names or patterns to not convert to delta.  **If a metric name matches both include and exclude, exclude takes precedence.**
 - `max_staleness`: The total time a state entry will live past the time it was last seen. Set to 0 to retain state indefinitely. Default: 0
+- `initial_value`: Handling of the first observed point for a given metric identity. Default: `auto`.
+  - `auto`: send iff the startime is set AND the starttime happens after the component started AND the starttime is different from the timestamp.
+  - `keep`: send the observed value as the delta value
+  - `drop`: keep the observed value but don't send
 
 If neither include nor exclude are supplied, no filtering is applied.
 

--- a/processor/cumulativetodeltaprocessor/README.md
+++ b/processor/cumulativetodeltaprocessor/README.md
@@ -24,7 +24,7 @@ The following settings can be optionally configured:
 - `exclude`: List of metrics names or patterns to not convert to delta.  **If a metric name matches both include and exclude, exclude takes precedence.**
 - `max_staleness`: The total time a state entry will live past the time it was last seen. Set to 0 to retain state indefinitely. Default: 0
 - `initial_value`: Handling of the first observed point for a given metric identity. Default: `auto`.
-  - `auto`: send iff the startime is set AND the starttime happens after the component started AND the starttime is different from the timestamp.
+  - `auto`: send if and only if the startime is set AND the starttime happens after the component started AND the starttime is different from the timestamp.
   - `keep`: send the observed value as the delta value
   - `drop`: keep the observed value but don't send
 

--- a/processor/cumulativetodeltaprocessor/config.go
+++ b/processor/cumulativetodeltaprocessor/config.go
@@ -21,13 +21,20 @@ import (
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor/internal/tracking"
 )
 
 // Config defines the configuration for the processor.
 type Config struct {
-
 	// MaxStaleness is the total time a state entry will live past the time it was last seen. Set to 0 to retain state indefinitely.
 	MaxStaleness time.Duration `mapstructure:"max_staleness"`
+
+	// InitialValue determines how to handle the first datapoint for a given metric. Valid values:
+	//
+	//   - auto: (default) send the first point iff the startime is set AND the starttime happens after the component started AND the starttime is different from the timestamp
+	//   - keep: always send the first point
+	//   - drop: don't send the first point, but store it for subsequent delta calculations
+	InitialValue tracking.InitialValue `mapstructure:"initial_value"`
 
 	// Include specifies a filter on the metrics that should be converted.
 	// Exclude specifies a filter on the metrics that should not be converted.

--- a/processor/cumulativetodeltaprocessor/config_test.go
+++ b/processor/cumulativetodeltaprocessor/config_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor/internal/tracking"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -97,6 +98,24 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id:           component.NewIDWithName(metadata.Type, "missing_name"),
 			errorMessage: "metrics must be supplied if match_type is set",
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "auto"),
+			expected: &Config{
+				InitialValue: tracking.InitialValueAuto,
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "keep"),
+			expected: &Config{
+				InitialValue: tracking.InitialValueKeep,
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "drop"),
+			expected: &Config{
+				InitialValue: tracking.InitialValueDrop,
+			},
 		},
 	}
 

--- a/processor/cumulativetodeltaprocessor/config_test.go
+++ b/processor/cumulativetodeltaprocessor/config_test.go
@@ -61,6 +61,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 				MaxStaleness: 10 * time.Second,
+				InitialValue: tracking.InitialValueAuto,
 			},
 		},
 		{
@@ -89,6 +90,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 				MaxStaleness: 10 * time.Second,
+				InitialValue: tracking.InitialValueAuto,
 			},
 		},
 		{

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
@@ -132,16 +132,12 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool) {
 		case InitialValueDrop:
 			return
 		case InitialValueAuto:
-			if metricID.StartTimestamp < t.startTime || metricPoint.ObservedTimestamp < metricID.StartTimestamp {
+			if metricID.StartTimestamp < t.startTime || metricPoint.ObservedTimestamp == metricID.StartTimestamp {
 				return
 			}
 			out.StartTimestamp = metricID.StartTimestamp
 			keep = true
 		case InitialValueKeep:
-			out.StartTimestamp = metricID.StartTimestamp
-			if metricID.StartTimestamp == 0 {
-				out.StartTimestamp = t.startTime
-			}
 			keep = true
 		}
 	}
@@ -163,7 +159,9 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool) {
 	state.Lock()
 	defer state.Unlock()
 
-	out.StartTimestamp = state.PrevPoint.ObservedTimestamp
+	if ok {
+		out.StartTimestamp = state.PrevPoint.ObservedTimestamp
+	}
 
 	switch metricID.MetricType {
 	case pmetric.MetricTypeHistogram:

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
@@ -129,7 +129,8 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool) {
 	if !ok {
 		switch metricID.MetricType {
 		case pmetric.MetricTypeHistogram:
-			*out.HistogramValue = metricPoint.HistogramValue.Clone()
+			val := metricPoint.HistogramValue.Clone()
+			out.HistogramValue = &val
 		case pmetric.MetricTypeSum:
 			out.IntValue = metricPoint.IntValue
 			out.FloatValue = metricPoint.FloatValue
@@ -143,7 +144,6 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool) {
 			valid = true
 		case InitialValueKeep:
 			valid = true
-		case InitialValueDrop:
 		}
 		return
 	}

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker.go
@@ -140,28 +140,26 @@ func (t *MetricTracker) Convert(in MetricPoint) (out DeltaValue, valid bool) {
 		case InitialValueKeep:
 			keep = true
 		}
+		if keep {
+			switch metricID.MetricType {
+			case pmetric.MetricTypeHistogram:
+				*out.HistogramValue = metricPoint.HistogramValue.Clone()
+			case pmetric.MetricTypeSum:
+				out.IntValue = metricPoint.IntValue
+				out.FloatValue = metricPoint.FloatValue
+			}
+			return
+		}
+
 	}
 
 	valid = true
-
-	if keep {
-		switch metricID.MetricType {
-		case pmetric.MetricTypeHistogram:
-			*out.HistogramValue = metricPoint.HistogramValue.Clone()
-		case pmetric.MetricTypeSum:
-			out.IntValue = metricPoint.IntValue
-			out.FloatValue = metricPoint.FloatValue
-		}
-		return
-	}
 
 	state := s.(*State)
 	state.Lock()
 	defer state.Unlock()
 
-	if ok {
-		out.StartTimestamp = state.PrevPoint.ObservedTimestamp
-	}
+	out.StartTimestamp = state.PrevPoint.ObservedTimestamp
 
 	switch metricID.MetricType {
 	case pmetric.MetricTypeHistogram:

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
@@ -81,9 +81,8 @@ func TestMetricTracker_Convert(t *testing.T) {
 						IntValue:          100,
 					},
 					wantOut: DeltaValue{
-						StartTimestamp: pcommon.NewTimestampFromTime(future.Add(-time.Minute)),
-						FloatValue:     100,
-						IntValue:       100,
+						FloatValue: 100,
+						IntValue:   100,
 					},
 				},
 				keepSubsequentTest,

--- a/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/tracker_test.go
@@ -41,100 +41,209 @@ func TestMetricTracker_Convert(t *testing.T) {
 	miIntSum.MetricValueType = pmetric.NumberDataPointValueTypeInt
 	miSum.MetricValueType = pmetric.NumberDataPointValueTypeDouble
 
-	m := NewMetricTracker(context.Background(), zap.NewNop(), 0)
-
-	tests := []struct {
+	type subTest struct {
 		name    string
 		value   ValuePoint
 		wantOut DeltaValue
 		noOut   bool
+	}
+
+	future := time.Now().Add(1 * time.Hour)
+
+	keepSubsequentTest := subTest{
+		name: "keep subsequet value",
+		value: ValuePoint{
+			ObservedTimestamp: pcommon.NewTimestampFromTime(future.Add(time.Minute)),
+			FloatValue:        225,
+			IntValue:          225,
+		},
+		wantOut: DeltaValue{
+			StartTimestamp: pcommon.NewTimestampFromTime(future),
+			FloatValue:     125,
+			IntValue:       125,
+		},
+	}
+
+	tests := []struct {
+		initValue       InitialValue
+		metricStartTime pcommon.Timestamp
+		tests           []subTest
 	}{
 		{
-			name: "Initial Value Omitted",
-			value: ValuePoint{
-				ObservedTimestamp: 10,
-				FloatValue:        100.0,
-				IntValue:          100,
-			},
-			noOut: true,
-		},
-		{
-			name: "Higher Value Converted",
-			value: ValuePoint{
-				ObservedTimestamp: 50,
-				FloatValue:        225.0,
-				IntValue:          225,
-			},
-			wantOut: DeltaValue{
-				StartTimestamp: 10,
-				FloatValue:     125.0,
-				IntValue:       125,
+			initValue:       InitialValueKeep,
+			metricStartTime: pcommon.NewTimestampFromTime(future.Add(-time.Minute)),
+			tests: []subTest{
+				{
+					name: "keep initial value",
+					value: ValuePoint{
+						ObservedTimestamp: pcommon.NewTimestampFromTime(future),
+						FloatValue:        100,
+						IntValue:          100,
+					},
+					wantOut: DeltaValue{
+						StartTimestamp: pcommon.NewTimestampFromTime(future.Add(-time.Minute)),
+						FloatValue:     100,
+						IntValue:       100,
+					},
+				},
+				keepSubsequentTest,
 			},
 		},
 		{
-			name: "Lower Value not Converted - Restart",
-			value: ValuePoint{
-				ObservedTimestamp: 100,
-				FloatValue:        75.0,
-				IntValue:          75,
-			},
-			noOut: true,
-		},
-		{
-			name: "Convert delta above previous not Converted Value",
-			value: ValuePoint{
-				ObservedTimestamp: 150,
-				FloatValue:        300.0,
-				IntValue:          300,
-			},
-			wantOut: DeltaValue{
-				StartTimestamp: 100,
-				FloatValue:     225.0,
-				IntValue:       225,
+			initValue: InitialValueDrop,
+			tests: []subTest{
+				{
+					name: "drop initial value",
+					value: ValuePoint{
+						ObservedTimestamp: pcommon.NewTimestampFromTime(future),
+						FloatValue:        100,
+						IntValue:          100,
+					},
+					noOut: true,
+				},
+				keepSubsequentTest,
 			},
 		},
 		{
-			name: "Higher Value Converted - Previous Offset Recorded",
-			value: ValuePoint{
-				ObservedTimestamp: 200,
-				FloatValue:        325.0,
-				IntValue:          325,
+			initValue: InitialValueAuto,
+			tests: []subTest{
+				{
+					name: "drop on unset start time",
+					value: ValuePoint{
+						ObservedTimestamp: pcommon.NewTimestampFromTime(future),
+						FloatValue:        100,
+						IntValue:          100,
+					},
+					noOut: true,
+				},
+				keepSubsequentTest,
 			},
-			wantOut: DeltaValue{
-				StartTimestamp: 150,
-				FloatValue:     25.0,
-				IntValue:       25,
+		},
+		{
+			initValue:       InitialValueAuto,
+			metricStartTime: pcommon.NewTimestampFromTime(future),
+			tests: []subTest{
+				{
+					name: "drop on equal start and observed time",
+					value: ValuePoint{
+						ObservedTimestamp: pcommon.NewTimestampFromTime(future),
+						FloatValue:        100,
+						IntValue:          100,
+					},
+					noOut: true,
+				},
+				keepSubsequentTest,
+			},
+		},
+		{
+			initValue:       InitialValueAuto,
+			metricStartTime: pcommon.NewTimestampFromTime(future),
+			tests: []subTest{
+				{
+					name: "keep on observed after start",
+					value: ValuePoint{
+						ObservedTimestamp: pcommon.NewTimestampFromTime(future.Add(time.Minute)),
+						FloatValue:        100.0,
+						IntValue:          100,
+					},
+					wantOut: DeltaValue{
+						StartTimestamp: pcommon.NewTimestampFromTime(future),
+						FloatValue:     100.0,
+						IntValue:       100,
+					},
+				},
+				{
+					name: "higher value converted",
+					value: ValuePoint{
+						ObservedTimestamp: pcommon.NewTimestampFromTime(future.Add(2 * time.Minute)),
+						FloatValue:        225.0,
+						IntValue:          225,
+					},
+					wantOut: DeltaValue{
+						StartTimestamp: pcommon.NewTimestampFromTime(future.Add(time.Minute)),
+						FloatValue:     125.0,
+						IntValue:       125,
+					},
+				},
+				{
+					name: "lower value not converted - restart",
+					value: ValuePoint{
+						ObservedTimestamp: pcommon.NewTimestampFromTime(future.Add(3 * time.Minute)),
+						FloatValue:        75.0,
+						IntValue:          75,
+					},
+					noOut: true,
+				},
+				{
+					name: "Convert delta above previous not Converted Value",
+					value: ValuePoint{
+						ObservedTimestamp: pcommon.NewTimestampFromTime(future.Add(4 * time.Minute)),
+						FloatValue:        300.0,
+						IntValue:          300,
+					},
+					wantOut: DeltaValue{
+						StartTimestamp: pcommon.NewTimestampFromTime(future.Add(3 * time.Minute)),
+						FloatValue:     225.0,
+						IntValue:       225,
+					},
+				},
+				{
+					name: "higher value converted - previous offset recorded",
+					value: ValuePoint{
+						ObservedTimestamp: pcommon.NewTimestampFromTime(future.Add(5 * time.Minute)),
+						FloatValue:        325.0,
+						IntValue:          325,
+					},
+					wantOut: DeltaValue{
+						StartTimestamp: pcommon.NewTimestampFromTime(future.Add(4 * time.Minute)),
+						FloatValue:     25.0,
+						IntValue:       25,
+					},
+				},
 			},
 		},
 	}
+
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			floatPoint := MetricPoint{
-				Identity: miSum,
-				Value:    tt.value,
-			}
-			intPoint := MetricPoint{
-				Identity: miIntSum,
-				Value:    tt.value,
-			}
+		t.Run(tt.initValue.String(), func(t *testing.T) {
+			m := NewMetricTracker(context.Background(), zap.NewNop(), 0, tt.initValue)
 
-			gotOut, valid := m.Convert(floatPoint)
-			if !tt.noOut {
-				require.True(t, valid)
-				assert.Equal(t, tt.wantOut.StartTimestamp, gotOut.StartTimestamp)
-				assert.Equal(t, tt.wantOut.FloatValue, gotOut.FloatValue)
-			}
+			miSum := miSum
+			miSum.StartTimestamp = tt.metricStartTime
+			miIntSum := miIntSum
+			miIntSum.StartTimestamp = tt.metricStartTime
 
-			gotOut, valid = m.Convert(intPoint)
-			if !tt.noOut {
-				require.True(t, valid)
-				assert.Equal(t, tt.wantOut.StartTimestamp, gotOut.StartTimestamp)
-				assert.Equal(t, tt.wantOut.IntValue, gotOut.IntValue)
+			for _, ttt := range tt.tests {
+				t.Run(ttt.name, func(t *testing.T) {
+					floatPoint := MetricPoint{
+						Identity: miSum,
+						Value:    ttt.value,
+					}
+					intPoint := MetricPoint{
+						Identity: miIntSum,
+						Value:    ttt.value,
+					}
+
+					gotOut, valid := m.Convert(floatPoint)
+					if !ttt.noOut {
+						require.True(t, valid)
+						assert.Equal(t, ttt.wantOut.StartTimestamp, gotOut.StartTimestamp)
+						assert.Equal(t, ttt.wantOut.FloatValue, gotOut.FloatValue)
+					}
+
+					gotOut, valid = m.Convert(intPoint)
+					if !ttt.noOut {
+						require.True(t, valid)
+						assert.Equal(t, ttt.wantOut.StartTimestamp, gotOut.StartTimestamp)
+						assert.Equal(t, ttt.wantOut.IntValue, gotOut.IntValue)
+					}
+				})
 			}
 		})
 	}
 
 	t.Run("Invalid metric identity", func(t *testing.T) {
+		m := NewMetricTracker(context.Background(), zap.NewNop(), 0, InitialValueAuto)
 		invalidID := miIntSum
 		invalidID.MetricType = pmetric.MetricTypeGauge
 		_, valid := m.Convert(MetricPoint{

--- a/processor/cumulativetodeltaprocessor/processor.go
+++ b/processor/cumulativetodeltaprocessor/processor.go
@@ -37,7 +37,7 @@ func newCumulativeToDeltaProcessor(config *Config, logger *zap.Logger) *cumulati
 	ctx, cancel := context.WithCancel(context.Background())
 	p := &cumulativeToDeltaProcessor{
 		logger:          logger,
-		deltaCalculator: tracking.NewMetricTracker(ctx, logger, config.MaxStaleness),
+		deltaCalculator: tracking.NewMetricTracker(ctx, logger, config.MaxStaleness, config.InitialValue),
 		cancelFunc:      cancel,
 	}
 	if len(config.Include.Metrics) > 0 {

--- a/processor/cumulativetodeltaprocessor/testdata/config.yaml
+++ b/processor/cumulativetodeltaprocessor/testdata/config.yaml
@@ -41,3 +41,12 @@ cumulativetodelta/regexp:
     metrics:
       - b*
   max_staleness: 10s
+
+cumulativetodelta/auto:
+  initial_value: auto
+
+cumulativetodelta/keep:
+  initial_value: keep
+
+cumulativetodelta/drop:
+  initial_value: drop


### PR DESCRIPTION
**Description:**

Make the first handling of the first observed point configurable to be applicable in different usecases.

**Link to tracking Issue:** ##20770

**Testing:** updated tests

**Documentation:** Readme added