### PR TITLE
[chore] [exporter/splunkhec] Split the profiling data before processing

### DIFF
--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -183,7 +183,12 @@ func createLogsExporter(
 
 	wrapped := &baseLogsExporter{
 		Component: logsExporter,
-		Logs:      batchperresourceattr.NewBatchPerResourceLogs(splunk.HecTokenLabel, logsExporter),
+		Logs: batchperresourceattr.NewBatchPerResourceLogs(splunk.HecTokenLabel, &perScopeBatcher{
+			logsEnabled:      cfg.LogDataEnabled,
+			profilingEnabled: cfg.ProfilingDataEnabled,
+			logger:           set.Logger,
+			next:             logsExporter,
+		}),
 	}
 
 	return wrapped, nil

--- a/exporter/splunkhecexporter/testdata/batchperscope/combined.yaml
+++ b/exporter/splunkhecexporter/testdata/batchperscope/combined.yaml
@@ -10,43 +10,50 @@ resourceLogs:
     scopeLogs:
       - scope:
           name: otel.profiling
-          logRecords:
-            - attributes:
-                - key: resource1_prof_scope_log1_attr1
-                  value:
-                    stringValue: value1
-              body:
-                stringValue: resource1_prof_scope_log1_body
-              timeUnixNano: "11651379494838206464"
-            - attributes:
-                - key: resource1_prof_scope_log1_attr1
-                  value:
-                    stringValue: value1
-              body:
-                stringValue: resource1_prof_scope_log2_body
-              timeUnixNano: "11651379494838206472"
+        logRecords:
+          - attributes:
+              - key: resource1_prof_scope_log1_attr1
+                value:
+                  stringValue: value1
+            body:
+              stringValue: resource1_prof_scope_log1_body
+            timeUnixNano: "11651379494838206464"
+          - attributes:
+              - key: resource1_prof_scope_log1_attr1
+                value:
+                  stringValue: value1
+            body:
+              stringValue: resource1_prof_scope_log2_body
+            timeUnixNano: "11651379494838206472"
       - scope:
           name: otel_collector
           version: 0.1.0
-          logRecords:
-            - attributes:
-                - key: resource1_scope1_attr1
-                  value:
-                    stringValue: value1
-              body:
-                stringValue: resource1_scope1_body
-              timeUnixNano: "11651379494838207123"
+        logRecords:
+          - attributes:
+              - key: resource1_scope1_attr1
+                value:
+                  stringValue: value1
+            body:
+              stringValue: resource1_scope1_body
+            timeUnixNano: "11651379494838207123"
       - scope:
           name: external_service
           version: 0.2.0
-          logRecords:
-            - attributes:
-                - key: resource1_scope2_attr1
-                  value:
-                    stringValue: value1
-              body:
-                stringValue: resource1_log2_body
-              timeUnixNano: "11651379494838207153"
+        logRecords:
+          - attributes:
+              - key: resource1_scope2_log1_attr1
+                value:
+                  stringValue: value1
+            body:
+              stringValue: resource1_scope2_log1_body
+            timeUnixNano: "11651379494838207153"
+          - attributes:
+              - key: resource1_scope2_log2_attr1
+                value:
+                  stringValue: value1
+            body:
+              stringValue: resource1_scope2_log2_body
+            timeUnixNano: "11651379494838208553"
   - resource:
       attributes:
         - key: resource2_attribute1

--- a/exporter/splunkhecexporter/testdata/batchperscope/profiling_only.yaml
+++ b/exporter/splunkhecexporter/testdata/batchperscope/profiling_only.yaml
@@ -10,21 +10,21 @@ resourceLogs:
     scopeLogs:
       - scope:
           name: otel.profiling
-          logRecords:
-            - attributes:
-                - key: resource1_prof_scope_log1_attr1
-                  value:
-                    stringValue: value1
-              body:
-                stringValue: resource1_prof_scope_log1_body
-              timeUnixNano: "11651379494838206464"
-            - attributes:
-                - key: resource1_prof_scope_log1_attr1
-                  value:
-                    stringValue: value1
-              body:
-                stringValue: resource1_prof_scope_log2_body
-              timeUnixNano: "11651379494838206472"
+        logRecords:
+          - attributes:
+              - key: resource1_prof_scope_log1_attr1
+                value:
+                  stringValue: value1
+            body:
+              stringValue: resource1_prof_scope_log1_body
+            timeUnixNano: "11651379494838206464"
+          - attributes:
+              - key: resource1_prof_scope_log1_attr1
+                value:
+                  stringValue: value1
+            body:
+              stringValue: resource1_prof_scope_log2_body
+            timeUnixNano: "11651379494838206472"
   - resource:
       attributes:
         - key: resource2_attribute1

--- a/exporter/splunkhecexporter/testdata/batchperscope/regular_logs_only.yaml
+++ b/exporter/splunkhecexporter/testdata/batchperscope/regular_logs_only.yaml
@@ -11,25 +11,32 @@ resourceLogs:
       - scope:
           name: otel_collector
           version: 0.1.0
-          logRecords:
-            - attributes:
-                - key: resource1_scope1_attr1
-                  value:
-                    stringValue: value1
-              body:
-                stringValue: resource1_scope1_body
-              timeUnixNano: "11651379494838207123"
+        logRecords:
+          - attributes:
+              - key: resource1_scope1_attr1
+                value:
+                  stringValue: value1
+            body:
+              stringValue: resource1_scope1_body
+            timeUnixNano: "11651379494838207123"
       - scope:
           name: external_service
           version: 0.2.0
-          logRecords:
-            - attributes:
-                - key: resource1_scope2_attr1
-                  value:
-                    stringValue: value1
-              body:
-                stringValue: resource1_log2_body
-              timeUnixNano: "11651379494838207153"
+        logRecords:
+          - attributes:
+              - key: resource1_scope2_log1_attr1
+                value:
+                  stringValue: value1
+            body:
+              stringValue: resource1_scope2_log1_body
+            timeUnixNano: "11651379494838207153"
+          - attributes:
+              - key: resource1_scope2_log2_attr1
+                value:
+                  stringValue: value1
+            body:
+              stringValue: resource1_scope2_log2_body
+            timeUnixNano: "11651379494838208553"
   - resource:
       attributes:
         - key: resource2_attribute1


### PR DESCRIPTION
To simplify the logic and make future improvements possible. Benchmarks shows no performance degradation for typical use cases (regular logs or profiling only) with small improvement on memory allocation. Benchmarks were adjusted to be applied on `ConsumeLogs` in both for before/after states. The only performance hit can be found for batches with both regular and profiling logs, but given that that use case is pretty rare, we can ignore it.

Before:

```
Benchmark_pushLogData_10_10_1024-10    	   12537	     95205 ns/op	   90389 B/op	    1302 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-10      	   12655	     95779 ns/op	   90434 B/op	    1302 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-10      	   12558	     95977 ns/op	   90488 B/op	    1302 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-10     	     566	   2069811 ns/op	 1829148 B/op	   26006 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-10    	      57	  18608189 ns/op	18349427 B/op	  259920 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-10    	      56	  18389893 ns/op	18463404 B/op	  259919 allocs/op
```

After:

```
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-10    	   12786	     93612 ns/op	   90023 B/op	    1299 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-10      	   12909	     93867 ns/op	   90060 B/op	    1299 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-10      	   12782	     94140 ns/op	   90085 B/op	    1299 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-10     	     577	   2069041 ns/op	 1824640 B/op	   26003 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-10    	      58	  18362833 ns/op	18347102 B/op	  259916 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-10    	      56	  18378540 ns/op	18687600 B/op	  259916 allocs/op
```
