### PR TITLE
[receiver/prometheus] set user agent

### DIFF
--- a/.chloggen/prometheus-useragent.yaml
+++ b/.chloggen/prometheus-useragent.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The prometheus receiver now sets a full, versioned user agent.
+
+# One or more tracking issues related to the change
+issues: [21910]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/mitchellh/hashstructure/v2"
+	commonconfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery"
@@ -281,7 +282,12 @@ func (r *pReceiver) initPrometheusComponents(ctx context.Context, host component
 	if err != nil {
 		return err
 	}
-	r.scrapeManager = scrape.NewManager(&scrape.Options{PassMetadataInContext: true}, logger, store)
+	r.scrapeManager = scrape.NewManager(&scrape.Options{
+		PassMetadataInContext: true,
+		HTTPClientOptions: []commonconfig.HTTPClientOption{
+			commonconfig.WithUserAgent(r.settings.BuildInfo.Command + "/" + r.settings.BuildInfo.Version),
+		},
+	}, logger, store)
 
 	go func() {
 		// The scrape manager needs to wait for the configuration to be loaded before beginning

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -15,14 +15,24 @@
 package prometheusreceiver
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	gokitlog "github.com/go-kit/log"
 	"github.com/prometheus/common/model"
 	promConfig "github.com/prometheus/prometheus/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver/receivertest"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -1428,7 +1438,6 @@ func TestUntypedMetrics(t *testing.T) {
 	}
 
 	testComponent(t, targets, false, "", featuregate.GlobalRegistry())
-
 }
 
 func verifyUntypedMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.ResourceMetrics) {
@@ -1522,4 +1531,39 @@ func TestGCInterval(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUserAgent(t *testing.T) {
+	uaCh := make(chan string, 1)
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case uaCh <- r.UserAgent():
+		default:
+		}
+	}))
+	defer svr.Close()
+
+	cfg, err := promConfig.Load(fmt.Sprintf(`
+scrape_configs:
+- job_name: foo
+  scrape_interval: 100ms
+  static_configs:
+    - targets:
+      - %s
+        `, strings.TrimPrefix(svr.URL, "http://")), false, gokitlog.NewNopLogger())
+	require.NoError(t, err)
+	set := receivertest.NewNopCreateSettings()
+	receiver := newPrometheusReceiver(set, &Config{
+		PrometheusConfig: cfg,
+	}, new(consumertest.MetricsSink), featuregate.GlobalRegistry())
+
+	ctx := context.Background()
+
+	require.NoError(t, receiver.Start(ctx, componenttest.NewNopHost()))
+	defer receiver.Shutdown(ctx)
+
+	gotUA := <-uaCh
+
+	require.Contains(t, gotUA, set.BuildInfo.Command)
+	require.Contains(t, gotUA, set.BuildInfo.Version)
 }

--- a/receiver/prometheusreceiver/metrics_receiver_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_test.go
@@ -1560,7 +1560,9 @@ scrape_configs:
 	ctx := context.Background()
 
 	require.NoError(t, receiver.Start(ctx, componenttest.NewNopHost()))
-	defer receiver.Shutdown(ctx)
+	t.Cleanup(func() {
+		require.NoError(t, receiver.Shutdown(ctx))
+	})
 
 	gotUA := <-uaCh
 


### PR DESCRIPTION
**Description:**
Sets the user-agent when the prometheus receiver performs scrapes

**Link to tracking Issue:** #21910

**Testing:** run collector locally and log request:

```
GET /metrics HTTP/1.1
Host: 127.0.0.1:8080
Accept: application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1;q=0.75,text/plain;version=0.0.4;q=0.5,*/*;q=0.1
Accept-Encoding: gzip
User-Agent: otelcol-custom/1.0.0
X-Prometheus-Scrape-Timeout-Seconds: 5
```

**Documentation:** changelog