### PR TITLE
[pkg/ottl] Fix the factory name for the limit function

### DIFF
--- a/.chloggen/fix_ottl_limit.yaml
+++ b/.chloggen/fix_ottl_limit.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the factory name for the limit function
+
+# One or more tracking issues related to the change
+issues: [21920]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/ottlfuncs/func_limit.go
+++ b/pkg/ottl/ottlfuncs/func_limit.go
@@ -30,7 +30,7 @@ type LimitArguments[K any] struct {
 }
 
 func NewLimitFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("Limit", &LimitArguments[K]{}, createLimitFunction[K])
+	return ottl.NewFactory("limit", &LimitArguments[K]{}, createLimitFunction[K])
 }
 
 func createLimitFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -328,6 +328,12 @@ func Test_ProcessLogs_LogContext(t *testing.T) {
 				td.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().PutStr("json_test", "pass")
 			},
 		},
+		{
+			statement: `limit(attributes, 0, []) where body == "operationA"`,
+			want: func(td plog.Logs) {
+				td.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().RemoveIf(func(s string, v pcommon.Value) bool { return true })
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -505,6 +505,13 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().PutStr("json_test", "pass")
 			},
 		},
+		{
+			statements: []string{`limit(attributes, 0, []) where metric.name == "operationA"`},
+			want: func(td pmetric.Metrics) {
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().RemoveIf(func(s string, v pcommon.Value) bool { return true })
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().RemoveIf(func(s string, v pcommon.Value) bool { return true })
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -373,6 +373,12 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().PutStr("json_test", "pass")
 			},
 		},
+		{
+			statement: `limit(attributes, 0, []) where name == "operationA"`,
+			want: func(td ptrace.Traces) {
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().RemoveIf(func(s string, v pcommon.Value) bool { return true })
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Description:**
The factory name for the `limit` function is uppercase, but OTTL requires functions to be lowercase. As a result, it can't be used in OTTL statements.

**Link to tracking Issue:** #21920

**Testing:**
I built the contrib binary and tested against the config from the issue.
I wanted to add a unit test for this as well, but wasn't sure where it should live. Seems like we should have tests like this (which verify that a particular invocation of a function or converter can indeed be parsed end-to-end) for every function.
