### PR TITLE
[chore][pkg/stanza/adapter] Fix converter benchmark

### DIFF
--- a/pkg/stanza/adapter/converter.go
+++ b/pkg/stanza/adapter/converter.go
@@ -85,8 +85,24 @@ type Converter struct {
 	logger *zap.Logger
 }
 
-func NewConverter(logger *zap.Logger) *Converter {
-	return &Converter{
+type converterOption interface {
+	apply(*Converter)
+}
+
+func withWorkerCount(workerCount int) converterOption {
+	return workerCountOption{workerCount}
+}
+
+type workerCountOption struct {
+	workerCount int
+}
+
+func (o workerCountOption) apply(c *Converter) {
+	c.workerCount = o.workerCount
+}
+
+func NewConverter(logger *zap.Logger, opts ...converterOption) *Converter {
+	c := &Converter{
 		workerChan:  make(chan []*entry.Entry),
 		workerCount: int(math.Max(1, float64(runtime.NumCPU()/4))),
 		pLogsChan:   make(chan plog.Logs),
@@ -94,6 +110,10 @@ func NewConverter(logger *zap.Logger) *Converter {
 		flushChan:   make(chan plog.Logs),
 		logger:      logger,
 	}
+	for _, opt := range opts {
+		opt.apply(c)
+	}
+	return c
 }
 
 func (c *Converter) Start() {

--- a/pkg/stanza/adapter/converter_test.go
+++ b/pkg/stanza/adapter/converter_test.go
@@ -833,12 +833,11 @@ func BenchmarkConverter(b *testing.B) {
 		b.Run(fmt.Sprintf("worker_count=%d", wc), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 
-				converter := NewConverter(zap.NewNop())
+				converter := NewConverter(zap.NewNop(), withWorkerCount(wc))
 				converter.Start()
 				defer converter.Stop()
 
 				b.ReportAllocs()
-				b.ResetTimer()
 
 				go func() {
 					for from := 0; from < entryCount; from += int(batchSize) {


### PR DESCRIPTION
This benchmark was not actually controlling the number of workers used in the converter.

This is part of an effort to evaluate whether or not we are actually benefiting from non-configurable options such as workers and batching logic. (See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/21889 and https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/21184)