### PR TITLE
[chore] [exporter/splunkhec] Simplify the batching process

### DIFF
--- a/exporter/splunkhecexporter/buffer.go
+++ b/exporter/splunkhecexporter/buffer.go
@@ -36,9 +36,6 @@ type bufferState struct {
 	maxEventLength       uint
 	writer               io.Writer
 	buf                  *bytes.Buffer
-	resource             int // index in ResourceLogs/ResourceMetrics/ResourceSpans list
-	library              int // index in ScopeLogs/ScopeMetrics/ScopeSpans list
-	record               int // index in Logs/Metrics/Spans list
 	rawLength            int
 }
 
@@ -190,9 +187,7 @@ type bufferStatePool struct {
 
 // get returns a bufferState from the pool.
 func (p bufferStatePool) get() *bufferState {
-	bf := p.pool.Get().(*bufferState)
-	bf.reset()
-	return bf
+	return p.pool.Get().(*bufferState)
 }
 
 // put returns a bufferState to the pool.

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -1499,7 +1499,7 @@ func TestSubLogs(t *testing.T) {
 	logs := createLogData(2, 2, 3)
 
 	// Logs subset from leftmost index (resource 0, library 0, record 0).
-	_0_0_0 := &bufferState{resource: 0, library: 0, record: 0} //revive:disable-line:var-naming
+	_0_0_0 := iterState{resource: 0, library: 0, record: 0} //revive:disable-line:var-naming
 	got := subLogs(logs, _0_0_0)
 
 	// Number of logs in subset should equal original logs.
@@ -1513,7 +1513,7 @@ func TestSubLogs(t *testing.T) {
 	assert.Equal(t, "1_1_2", val.AsString())
 
 	// Logs subset from some mid index (resource 0, library 1, log 2).
-	_0_1_2 := &bufferState{resource: 0, library: 1, record: 2} //revive:disable-line:var-naming
+	_0_1_2 := iterState{resource: 0, library: 1, record: 2} //revive:disable-line:var-naming
 	got = subLogs(logs, _0_1_2)
 
 	assert.Equal(t, 7, got.LogRecordCount())
@@ -1526,7 +1526,7 @@ func TestSubLogs(t *testing.T) {
 	assert.Equal(t, "1_1_2", val.AsString())
 
 	// Logs subset from rightmost index (resource 1, library 1, log 2).
-	_1_1_2 := &bufferState{resource: 1, library: 1, record: 2} //revive:disable-line:var-naming
+	_1_1_2 := iterState{resource: 1, library: 1, record: 2} //revive:disable-line:var-naming
 	got = subLogs(logs, _1_1_2)
 
 	// Number of logs in subset should be 1.
@@ -1537,30 +1537,48 @@ func TestSubLogs(t *testing.T) {
 	assert.Equal(t, "1_1_2", val.AsString())
 }
 
-func TestPushLogRecordsBufferCounters(t *testing.T) {
+func TestPushLogsPartialSuccess(t *testing.T) {
 	cfg := NewFactory().CreateDefaultConfig().(*Config)
 	cfg.ExportRaw = true
-	c := client{
-		config:          cfg,
-		logger:          zap.NewNop(),
-		hecWorker:       &mockHecWorker{},
-		bufferStatePool: newBufferStatePool(6, false, 10),
-	}
+	cfg.MaxContentLengthLogs = 6
+	c := newLogsClient(exportertest.NewNopCreateSettings(), cfg)
 
-	logs := plog.NewResourceLogsSlice()
-	logRecords := logs.AppendEmpty().ScopeLogs().AppendEmpty().LogRecords()
-	logRecords.AppendEmpty().Body().SetStr("12345")    // the first log record should be accepted and sent
-	logRecords.AppendEmpty().Body().SetStr("12345678") // the second log record should be rejected as it's too big
-	logRecords.AppendEmpty().Body().SetStr("12345")    // the third log record should be just accepted
-	bs := c.bufferStatePool.get()
-	defer c.bufferStatePool.put(bs)
+	// The first request succeeds, the second fails.
+	httpClient, _ := newTestClientWithPresetResponses([]int{200, 503}, []string{"OK", "NOK"})
+	url := &url.URL{Scheme: "http", Host: "splunk"}
+	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(cfg, component.NewDefaultBuildInfo())}
 
-	permErrs, err := c.pushLogRecords(context.Background(), logs, bs, nil)
-	assert.NoError(t, err)
-	assert.Len(t, permErrs, 1)
-	assert.ErrorContains(t, permErrs[0], "bytes larger than configured max content length")
+	logs := plog.NewLogs()
+	logRecords := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords()
+	logRecords.AppendEmpty().Body().SetStr("log-1")         // should be successfully sent
+	logRecords.AppendEmpty().Body().SetStr("log-2-too-big") // should be permanently rejected as it's too big
+	logRecords.AppendEmpty().Body().SetStr("log-3")         // should be rejected and returned to for retry
 
-	assert.Equal(t, 2, bs.record, "the buffer counter must be at the latest log record")
+	err := c.pushLogData(context.Background(), logs)
+	expectedErr := consumererror.Logs{}
+	require.ErrorContains(t, err, "503")
+	require.ErrorAs(t, err, &expectedErr)
+	require.Equal(t, 1, expectedErr.Data().LogRecordCount())
+	assert.Equal(t, "log-3", expectedErr.Data().ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().Str())
+}
+
+func TestPushLogsRetryableFailureMultipleResources(t *testing.T) {
+	c := newLogsClient(exportertest.NewNopCreateSettings(), NewFactory().CreateDefaultConfig().(*Config))
+
+	httpClient, _ := newTestClientWithPresetResponses([]int{503}, []string{"NOK"})
+	url := &url.URL{Scheme: "http", Host: "splunk"}
+	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(c.config, component.NewDefaultBuildInfo())}
+
+	logs := plog.NewLogs()
+	logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("log-1")
+	logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("log-2")
+	logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("log-3")
+
+	err := c.pushLogData(context.Background(), logs)
+	expectedErr := consumererror.Logs{}
+	require.ErrorContains(t, err, "503")
+	require.ErrorAs(t, err, &expectedErr)
+	assert.Equal(t, logs, expectedErr.Data())
 }
 
 // validateCompressedEqual validates that GZipped `got` contains `expected` strings


### PR DESCRIPTION
Rework how the batches are created and sent to the backend to make it easier to read the code.

Also, this change fixes an issue introduced by removing the additional `index` field of the `bufferState` struct in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/21765: if a hec batch combining several OTel resources gets rejected with a retriable error, only the latest read resource/scope records were sent for retry. The fix is confirmed by an additional `TestPushLogsRetryableFailureMultipleResources` test.

This also significantly improves performance by removing a bunch of memory allocations in cases where the incoming data ends up being sent in several HEC batches.

Before:

```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-10    	   12033	     99060 ns/op	   90027 B/op	    1299 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-10      	   12072	     96328 ns/op	   90065 B/op	    1299 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-10      	   12306	     97606 ns/op	   90114 B/op	    1299 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-10     	     572	   2104811 ns/op	 1828672 B/op	   26003 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-10    	      56	  19257562 ns/op	18350930 B/op	  259916 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-10    	      55	  19130223 ns/op	18467195 B/op	  259916 allocs/op
PASS
```

After:

```
Benchmark_pushLogData_10_10_1024
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-10    	   34998	     34225 ns/op	   30894 B/op	     450 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-10      	   12380	     94922 ns/op	   87420 B/op	    1264 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-10      	   12411	     96700 ns/op	   90155 B/op	    1299 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-10     	     560	   2088985 ns/op	 1827450 B/op	   26003 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-10    	      70	  15065196 ns/op	14020531 B/op	  198538 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-10    	      55	  18660002 ns/op	18467047 B/op	  259916 allocs/op
PASS
```