### PR TITLE
[internal/filter] Update standardFuncs list for filterottl

### DIFF
--- a/.chloggen/filter-add-log.yaml
+++ b/.chloggen/filter-add-log.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: internal/filter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `Log`, `UUID`, and `ParseJSON` converters to filterottl standard functions
+
+# One or more tracking issues related to the change
+issues: [21970]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -172,6 +172,9 @@ func standardFuncs[K any]() map[string]ottl.Factory[K] {
 		ottlfuncs.NewIntFactory[K](),
 		ottlfuncs.NewConvertCaseFactory[K](),
 		ottlfuncs.NewSubstringFactory[K](),
+		ottlfuncs.NewLogFactory[K](),
+		ottlfuncs.NewUUIDFactory[K](),
+		ottlfuncs.NewParseJSONFactory[K](),
 		newDropFactory[K](),
 	)
 }


### PR DESCRIPTION
**Description:**
Adds new `UUID` and `Log` convert funcs to standard filterottl funcs.

With the new complex index capability now available I'm also adding `ParseJSON`.  This will facilitate conditions like `IsMatch(ParseJSON(body)["host"], "127.*")`