### PR TITLE
[chore] [exporter/splunkhec] Do not copy all the data in case of error

### DIFF
--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -48,6 +48,10 @@ type iterState struct {
 	done     bool
 }
 
+func (s iterState) empty() bool {
+	return s.resource == 0 && s.library == 0 && s.record == 0
+}
+
 // client sends the data to the splunk backend.
 type client struct {
 	config            *Config
@@ -397,6 +401,10 @@ func (c *client) postEvents(ctx context.Context, bufState *bufferState, headers 
 
 // subLogs returns a subset of logs starting from the state.
 func subLogs(src plog.Logs, state iterState) plog.Logs {
+	if state.empty() {
+		return src
+	}
+
 	dst := plog.NewLogs()
 	resources := src.ResourceLogs()
 	resourcesSub := dst.ResourceLogs()
@@ -439,6 +447,10 @@ func subLogs(src plog.Logs, state iterState) plog.Logs {
 
 // subMetrics returns a subset of metrics starting from the state.
 func subMetrics(src pmetric.Metrics, state iterState) pmetric.Metrics {
+	if state.empty() {
+		return src
+	}
+
 	dst := pmetric.NewMetrics()
 	resources := src.ResourceMetrics()
 	resourcesSub := dst.ResourceMetrics()
@@ -480,6 +492,10 @@ func subMetrics(src pmetric.Metrics, state iterState) pmetric.Metrics {
 }
 
 func subTraces(src ptrace.Traces, state iterState) ptrace.Traces {
+	if state.empty() {
+		return src
+	}
+
 	dst := ptrace.NewTraces()
 	resources := src.ResourceSpans()
 	resourcesSub := dst.ResourceSpans()

--- a/exporter/splunkhecexporter/hec_worker_test.go
+++ b/exporter/splunkhecexporter/hec_worker_test.go
@@ -16,11 +16,19 @@ package splunkhecexporter
 
 import (
 	"context"
+	"errors"
 )
 
-type mockHecWorker struct{}
+var errHecSendFailed = errors.New("hec send failed")
 
-func (m *mockHecWorker) send(ctx context.Context, bufferState *bufferState, headers map[string]string) error {
+type mockHecWorker struct {
+	failSend bool
+}
+
+func (m *mockHecWorker) send(_ context.Context, _ *bufferState, _ map[string]string) error {
+	if m.failSend {
+		return errHecSendFailed
+	}
 	return nil
 }
 


### PR DESCRIPTION
If the backend replies with a retriable error, do not copy all the data to be included in the error, use the original data instead

Before:

````
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-10    	     939	   1282819 ns/op	 1244725 B/op	   15121 allocs/op
PASS
```

After:

```
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-10    	    1098	   1108847 ns/op	  912892 B/op	   13004 allocs/op
```