### PR TITLE
[spanmetrics] Fix initialization of the default histogram buckets when the `seconds` unit is provided.

### DIFF
--- a/.chloggen/spanmetrics-fix-default-bounds.yaml
+++ b/.chloggen/spanmetrics-fix-default-bounds.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix initialization of the default histogram buckets when the `seconds` unit is provided.
+
+# One or more tracking issues related to the change
+issues: [21797]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -116,7 +116,7 @@ func newConnector(logger *zap.Logger, config component.Config, ticker *clock.Tic
 	}, nil
 }
 
-func initHistogramMetrics(cfg *Config) metrics.HistogramMetrics {
+func initHistogramMetrics(cfg Config) metrics.HistogramMetrics {
 	if cfg.Histogram.Exponential != nil {
 		maxSize := structure.DefaultMaxSize
 		if cfg.Histogram.Exponential.MaxSize != 0 {
@@ -325,7 +325,7 @@ func (p *connectorImp) getOrCreateResourceMetrics(attr pcommon.Map) *resourceMet
 	v, ok := p.resourceMetrics[key]
 	if !ok {
 		v = &resourceMetrics{
-			histograms: initHistogramMetrics(&p.config),
+			histograms: initHistogramMetrics(p.config),
 			sums:       metrics.NewSumMetrics(),
 			attributes: attr,
 		}

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -992,17 +992,17 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		config *Config
+		config Config
 		want   metrics.HistogramMetrics
 	}{
 		{
 			name:   "initialize histogram with no config provided",
-			config: &Config{},
+			config: Config{},
 			want:   metrics.NewExplicitHistogramMetrics(defaultHistogramBucketsMs),
 		},
 		{
 			name: "initialize explicit histogram with default bounds (ms)",
-			config: &Config{
+			config: Config{
 				Histogram: HistogramConfig{
 					Unit: metrics.Milliseconds,
 				},
@@ -1011,7 +1011,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 		},
 		{
 			name: "initialize explicit histogram with default bounds (seconds)",
-			config: &Config{
+			config: Config{
 				Histogram: HistogramConfig{
 					Unit: metrics.Seconds,
 				},
@@ -1020,7 +1020,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 		},
 		{
 			name: "initialize explicit histogram with bounds (seconds)",
-			config: &Config{
+			config: Config{
 				Histogram: HistogramConfig{
 					Unit: metrics.Seconds,
 					Explicit: &ExplicitHistogramConfig{
@@ -1035,7 +1035,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 		},
 		{
 			name: "initialize explicit histogram with bounds (ms)",
-			config: &Config{
+			config: Config{
 				Histogram: HistogramConfig{
 					Unit: metrics.Milliseconds,
 					Explicit: &ExplicitHistogramConfig{
@@ -1050,7 +1050,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 		},
 		{
 			name: "initialize exponential histogram",
-			config: &Config{
+			config: Config{
 				Histogram: HistogramConfig{
 					Unit: metrics.Milliseconds,
 					Exponential: &ExponentialHistogramConfig{
@@ -1062,7 +1062,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 		},
 		{
 			name: "initialize exponential histogram with default max buckets count",
-			config: &Config{
+			config: Config{
 				Histogram: HistogramConfig{
 					Unit:        metrics.Milliseconds,
 					Exponential: &ExponentialHistogramConfig{},
@@ -1072,7 +1072,7 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run("", func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			got := initHistogramMetrics(tt.config)
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Fix initialization of the default histogram buckets when the `seconds` unit is provided.

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21797

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests