### PR TITLE
[chore] [exporter/splunkhec] Reuse jsoniter stream/buffer

### DIFF
--- a/exporter/splunkhecexporter/testdata/hec_log_event.json
+++ b/exporter/splunkhecexporter/testdata/hec_log_event.json
@@ -1,0 +1,11 @@
+{
+  "host": "myhost",
+  "source": "myapp",
+  "sourcetype": "myapp-type",
+  "index": "myindex",
+  "event": "mylog",
+  "fields": {
+    "otel.log.name": "0_0_0",
+    "custom": "custom"
+  }
+}

--- a/exporter/splunkhecexporter/testdata/hec_metric_event.json
+++ b/exporter/splunkhecexporter/testdata/hec_metric_event.json
@@ -1,0 +1,14 @@
+{
+  "host": "unknown",
+  "event": "metric",
+  "fields": {
+    "k/n1": "vn1",
+    "k/r0": "vr0",
+    "k/r1": "vr1",
+    "metric_name:gauge_double_with_dims": 1234.5678,
+    "metric_type": "Gauge",
+    "k0": "v0",
+    "k1": "v1",
+    "k/n0": "vn0"
+  }
+}

--- a/exporter/splunkhecexporter/testdata/hec_span_event.json
+++ b/exporter/splunkhecexporter/testdata/hec_span_event.json
@@ -1,0 +1,20 @@
+{
+  "time": 1,
+  "host": "unknown",
+  "event": {
+    "trace_id": "01010101010101010101010101010101",
+    "span_id": "0000000000000001",
+    "parent_span_id": "0102030405060708",
+    "name": "root",
+    "end_time": 2000000000,
+    "kind": "SPAN_KIND_UNSPECIFIED",
+    "status": {
+      "message": "ok",
+      "code": "STATUS_CODE_OK"
+    },
+    "start_time": 1000000000
+  },
+  "fields": {
+    "resource": "R1"
+  }
+}


### PR DESCRIPTION
This improves performance by avoiding buffer allocation for every json encoded HEC event.

Before:

Before:

```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-10    	   35157	     35594 ns/op	   30895 B/op	     450 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-10      	   12478	     96064 ns/op	   87443 B/op	    1264 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-10      	   12481	     97948 ns/op	   90148 B/op	    1299 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-10     	     571	   2220018 ns/op	 1825808 B/op	   26002 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-10    	      70	  14679068 ns/op	14020439 B/op	  198538 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-10    	      55	  18776145 ns/op	18467160 B/op	  259916 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-10        	    1147	   1066386 ns/op	  912826 B/op	   13004 allocs/op
```

After:

```
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-10    	   37986	     32484 ns/op	   25432 B/op	     416 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-10      	   13611	     88131 ns/op	   71820 B/op	    1167 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-10      	   13221	     90941 ns/op	   74053 B/op	    1199 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-10     	     603	   1919072 ns/op	 1483452 B/op	   24000 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-10    	      79	  13570264 ns/op	11297322 B/op	  183258 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-10    	      60	  19903358 ns/op	14860723 B/op	  239911 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-10        	    1239	    979921 ns/op	  740291 B/op	   12002 allocs/op
```