### PR TITLE
[chore] disable gomod in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
       },
       {
         "matchManagers": ["gomod"],
-        "matchUpdateTypes": ["minor", "major"]
+        "enabled": false
       }
     ],
     "ignoreDeps": [


### PR DESCRIPTION
The tidy job isn't working because of branch protection. I'm testing forking-renovate instead. For now this configuration is just creating noise.
