### PR TITLE
[pkg/translator/prw] Use flag to control metrics normalization.

### DIFF
--- a/.chloggen/prw-disable-feature-flag.yaml
+++ b/.chloggen/prw-disable-feature-flag.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/translator/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow control over the metrics names normalization via a flag instead of the feature gate.
+
+# One or more tracking issues related to the change
+issues: [22040]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  It is more convenient to control metrics name normalization via a flag
+  when `pkg/translator/prometheusremotewrite` is used as a third-party dependency.

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -69,10 +69,11 @@ func newPRWExporter(cfg *Config, set exporter.CreateSettings) (*prwExporter, err
 		clientSettings:  &cfg.HTTPClientSettings,
 		settings:        set.TelemetrySettings,
 		exporterSettings: prometheusremotewrite.Settings{
-			Namespace:           cfg.Namespace,
-			ExternalLabels:      sanitizedLabels,
-			DisableTargetInfo:   !cfg.TargetInfo.Enabled,
-			ExportCreatedMetric: cfg.CreatedMetric.Enabled,
+			Namespace:             cfg.Namespace,
+			ExternalLabels:        sanitizedLabels,
+			DisableTargetInfo:     !cfg.TargetInfo.Enabled,
+			DisableNormalizeNames: !prometheustranslator.IsNormalizeNameGateEnabled(),
+			ExportCreatedMetric:   cfg.CreatedMetric.Enabled,
 		},
 	}
 	if cfg.WAL == nil {

--- a/exporter/prometheusremotewriteexporter/go.mod
+++ b/exporter/prometheusremotewriteexporter/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.78.3-0.20230525165144-87dd85a6c034
 	go.opentelemetry.io/collector/consumer v0.78.3-0.20230525165144-87dd85a6c034
 	go.opentelemetry.io/collector/exporter v0.78.3-0.20230525165144-87dd85a6c034
+	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0012.0.20230525165144-87dd85a6c034
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0012.0.20230525165144-87dd85a6c034
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.24.0
@@ -46,7 +47,6 @@ require (
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/tinylru v1.1.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0012.0.20230525165144-87dd85a6c034 // indirect
 	go.opentelemetry.io/collector/receiver v0.78.3-0.20230525165144-87dd85a6c034 // indirect
 	go.opentelemetry.io/collector/semconv v0.78.3-0.20230525165144-87dd85a6c034 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0 // indirect

--- a/pkg/translator/prometheus/normalize_name.go
+++ b/pkg/translator/prometheus/normalize_name.go
@@ -78,11 +78,6 @@ var normalizeNameGate = featuregate.GlobalRegistry().MustRegister(
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8950"),
 )
 
-// IsNormalizeNameGateEnabled returns true if conversion to the Prometheus naming convention enabled
-func IsNormalizeNameGateEnabled() bool {
-	return normalizeNameGate.IsEnabled()
-}
-
 // Build a Prometheus-compliant metric name for the specified metric
 //
 // Metric name is prefixed with specified namespace and underscore (if any).
@@ -92,7 +87,7 @@ func IsNormalizeNameGateEnabled() bool {
 // See rules at https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
 // and https://prometheus.io/docs/practices/naming/#metric-and-label-naming
 func BuildPromCompliantName(metric pmetric.Metric, namespace string) string {
-	return BuildPrometheusMetricName(metric, namespace, IsNormalizeNameGateEnabled())
+	return BuildPrometheusMetricName(metric, namespace, normalizeNameGate.IsEnabled())
 }
 
 // BuildPrometheusMetricName builds a Prometheus metric name for the specified metric.

--- a/pkg/translator/prometheus/normalize_name_test.go
+++ b/pkg/translator/prometheus/normalize_name_test.go
@@ -247,3 +247,8 @@ func TestBuildPromCompliantNameWithoutNormalize(t *testing.T) {
 	require.Equal(t, ":foo::bar", BuildPromCompliantName(createCounter(":foo::bar", ""), ""))
 
 }
+
+func TestBuildPrometheusMetricName(t *testing.T) {
+	require.Equal(t, "foo_bar_total", BuildPrometheusMetricName(createCounter(":foo::bar", ""), "", true))
+	require.Equal(t, ":foo::bar", BuildPrometheusMetricName(createCounter(":foo::bar", ""), "", false))
+}

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -252,7 +252,7 @@ func isValidAggregationTemporality(metric pmetric.Metric) bool {
 func addSingleHistogramDataPoint(pt pmetric.HistogramDataPoint, resource pcommon.Resource, metric pmetric.Metric, settings Settings, tsMap map[string]*prompb.TimeSeries) {
 	timestamp := convertTimeStamp(pt.Timestamp())
 	// sum, count, and buckets of the histogram should append suffix to baseName
-	baseName := prometheustranslator.BuildPromCompliantName(metric, settings.Namespace)
+	baseName := prometheustranslator.BuildPrometheusMetricName(metric, settings.Namespace, !settings.DisableNormalizeNames)
 
 	// If the sum is unset, it indicates the _sum metric point should be
 	// omitted
@@ -442,7 +442,7 @@ func addSingleSummaryDataPoint(pt pmetric.SummaryDataPoint, resource pcommon.Res
 	tsMap map[string]*prompb.TimeSeries) {
 	timestamp := convertTimeStamp(pt.Timestamp())
 	// sum and count of the summary should append suffix to baseName
-	baseName := prometheustranslator.BuildPromCompliantName(metric, settings.Namespace)
+	baseName := prometheustranslator.BuildPrometheusMetricName(metric, settings.Namespace, !settings.DisableNormalizeNames)
 	// treat sum as a sample in an individual TimeSeries
 	sum := &prompb.Sample{
 		Value:     pt.Sum(),

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -16,10 +16,11 @@ import (
 )
 
 type Settings struct {
-	Namespace           string
-	ExternalLabels      map[string]string
-	DisableTargetInfo   bool
-	ExportCreatedMetric bool
+	Namespace             string
+	ExternalLabels        map[string]string
+	DisableNormalizeNames bool
+	DisableTargetInfo     bool
+	ExportCreatedMetric   bool
 }
 
 // FromMetrics converts pmetric.Metrics to prometheus remote write format.
@@ -79,7 +80,7 @@ func FromMetrics(md pmetric.Metrics, settings Settings) (tsMap map[string]*promp
 					if dataPoints.Len() == 0 {
 						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
 					}
-					name := prometheustranslator.BuildPromCompliantName(metric, settings.Namespace)
+					name := prometheustranslator.BuildPrometheusMetricName(metric, settings.Namespace, !settings.DisableNormalizeNames)
 					for x := 0; x < dataPoints.Len(); x++ {
 						errs = multierr.Append(
 							errs,

--- a/pkg/translator/prometheusremotewrite/number_data_points.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points.go
@@ -25,7 +25,7 @@ func addSingleGaugeNumberDataPoint(
 	settings Settings,
 	series map[string]*prompb.TimeSeries,
 ) {
-	name := prometheustranslator.BuildPromCompliantName(metric, settings.Namespace)
+	name := prometheustranslator.BuildPrometheusMetricName(metric, settings.Namespace, !settings.DisableNormalizeNames)
 	labels := createAttributes(
 		resource,
 		pt.Attributes(),
@@ -58,7 +58,7 @@ func addSingleSumNumberDataPoint(
 	settings Settings,
 	series map[string]*prompb.TimeSeries,
 ) {
-	name := prometheustranslator.BuildPromCompliantName(metric, settings.Namespace)
+	name := prometheustranslator.BuildPrometheusMetricName(metric, settings.Namespace, !settings.DisableNormalizeNames)
 	labels := createAttributes(
 		resource,
 		pt.Attributes(),

--- a/pkg/translator/prometheusremotewrite/number_data_points_test.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points_test.go
@@ -58,7 +58,7 @@ func TestAddSingleGaugeNumberDataPoint(t *testing.T) {
 					metric.Gauge().DataPoints().At(x),
 					pcommon.NewResource(),
 					metric,
-					Settings{},
+					Settings{DisableNormalizeNames: false},
 					gotSeries,
 				)
 			}
@@ -70,9 +70,10 @@ func TestAddSingleGaugeNumberDataPoint(t *testing.T) {
 func TestAddSingleSumNumberDataPoint(t *testing.T) {
 	ts := pcommon.Timestamp(time.Now().UnixNano())
 	tests := []struct {
-		name   string
-		metric func() pmetric.Metric
-		want   func() map[string]*prompb.TimeSeries
+		name                 string
+		metric               func() pmetric.Metric
+		disableNormalization bool
+		want                 func() map[string]*prompb.TimeSeries
 	}{
 		{
 			name: "sum",
@@ -145,12 +146,13 @@ func TestAddSingleSumNumberDataPoint(t *testing.T) {
 
 				return metric
 			},
+			disableNormalization: true,
 			want: func() map[string]*prompb.TimeSeries {
 				labels := []prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_sum_total"},
+					{Name: model.MetricNameLabel, Value: "test_sum"},
 				}
 				createdLabels := []prompb.Label{
-					{Name: model.MetricNameLabel, Value: "test_sum_total" + createdSuffix},
+					{Name: model.MetricNameLabel, Value: "test_sum" + createdSuffix},
 				}
 				return map[string]*prompb.TimeSeries{
 					timeSeriesSignature(pmetric.MetricTypeSum.String(), &labels): {
@@ -181,6 +183,7 @@ func TestAddSingleSumNumberDataPoint(t *testing.T) {
 
 				return metric
 			},
+			disableNormalization: false,
 			want: func() map[string]*prompb.TimeSeries {
 				labels := []prompb.Label{
 					{Name: model.MetricNameLabel, Value: "test_sum_total"},
@@ -234,7 +237,7 @@ func TestAddSingleSumNumberDataPoint(t *testing.T) {
 					metric.Sum().DataPoints().At(x),
 					pcommon.NewResource(),
 					metric,
-					Settings{ExportCreatedMetric: true},
+					Settings{ExportCreatedMetric: true, DisableNormalizeNames: tt.disableNormalization},
 					got,
 				)
 			}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Use flag to control metrics normalization.  It is more convenient to control metrics name normalization via a flag
  when `pkg/translator/prometheusremotewrite` is used as a third-party dependency.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/22040

**Testing:** <Describe what testing was performed and which tests were added.>
Exisitng unit tests
