### PR TITLE
[RedisReceiver] Add service.instance.id as an additional resource attribute

### DIFF
--- a/.chloggen/redisreceiver-add-instance-id.yaml
+++ b/.chloggen/redisreceiver-add-instance-id.yaml
@@ -5,7 +5,7 @@ change_type: "enhancement"
 component: "redisreceiver"
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Adds service.instance.id as a resource parameter to redis receiver.
+note: Adds service.instance.id as an additional resource attribute (disabled by default) to redis receiver.
 
 # One or more tracking issues related to the change
 issues: [22044]

--- a/.chloggen/redisreceiver-add-instance-id.yaml
+++ b/.chloggen/redisreceiver-add-instance-id.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "redisreceiver"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds service.instance.id as a resource parameter to redis receiver.
+
+# One or more tracking issues related to the change
+issues: [22044]

--- a/receiver/redisreceiver/documentation.md
+++ b/receiver/redisreceiver/documentation.md
@@ -333,3 +333,4 @@ Redis node's role
 | Name | Description | Values | Enabled |
 | ---- | ----------- | ------ | ------- |
 | redis.version | Redis server's version. | Any Str | true |
+| service.instance.id | Instance identifier of the redis server.  Should be same as endpoint.  Should be enabled by default in the future. | Any Str | false |

--- a/receiver/redisreceiver/internal/metadata/generated_config.go
+++ b/receiver/redisreceiver/internal/metadata/generated_config.go
@@ -171,13 +171,17 @@ type ResourceAttributeConfig struct {
 
 // ResourceAttributesConfig provides config for redis resource attributes.
 type ResourceAttributesConfig struct {
-	RedisVersion ResourceAttributeConfig `mapstructure:"redis.version"`
+	RedisVersion      ResourceAttributeConfig `mapstructure:"redis.version"`
+	ServiceInstanceID ResourceAttributeConfig `mapstructure:"service.instance.id"`
 }
 
 func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 	return ResourceAttributesConfig{
 		RedisVersion: ResourceAttributeConfig{
 			Enabled: true,
+		},
+		ServiceInstanceID: ResourceAttributeConfig{
+			Enabled: false,
 		},
 	}
 }

--- a/receiver/redisreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/redisreceiver/internal/metadata/generated_config_test.go
@@ -61,7 +61,8 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					RedisUptime:                            MetricConfig{Enabled: true},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
-					RedisVersion: ResourceAttributeConfig{Enabled: true},
+					RedisVersion:      ResourceAttributeConfig{Enabled: true},
+					ServiceInstanceID: ResourceAttributeConfig{Enabled: true},
 				},
 			},
 		},
@@ -104,7 +105,8 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					RedisUptime:                            MetricConfig{Enabled: false},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
-					RedisVersion: ResourceAttributeConfig{Enabled: false},
+					RedisVersion:      ResourceAttributeConfig{Enabled: false},
+					ServiceInstanceID: ResourceAttributeConfig{Enabled: false},
 				},
 			},
 		},

--- a/receiver/redisreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/redisreceiver/internal/metadata/generated_metrics.go
@@ -1868,6 +1868,15 @@ func WithRedisVersion(val string) ResourceMetricsOption {
 	}
 }
 
+// WithServiceInstanceID sets provided value as "service.instance.id" attribute for current resource.
+func WithServiceInstanceID(val string) ResourceMetricsOption {
+	return func(rac ResourceAttributesConfig, rm pmetric.ResourceMetrics) {
+		if rac.ServiceInstanceID.Enabled {
+			rm.Resource().Attributes().PutStr("service.instance.id", val)
+		}
+	}
+}
+
 // WithStartTimeOverride overrides start time for all the resource metrics data points.
 // This option should be only used if different start time has to be set on metrics coming from different resources.
 func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {

--- a/receiver/redisreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/redisreceiver/internal/metadata/generated_metrics_test.go
@@ -182,7 +182,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordRedisUptimeDataPoint(ts, 1)
 
-			metrics := mb.Emit(WithRedisVersion("attr-val"))
+			metrics := mb.Emit(WithRedisVersion("attr-val"), WithServiceInstanceID("attr-val"))
 
 			if test.configSet == testSetNone {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -200,8 +200,15 @@ func TestMetricsBuilder(t *testing.T) {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
+			attrVal, ok = rm.Resource().Attributes().Get("service.instance.id")
+			attrCount++
+			assert.Equal(t, mb.resourceAttributesConfig.ServiceInstanceID.Enabled, ok)
+			if mb.resourceAttributesConfig.ServiceInstanceID.Enabled {
+				enabledAttrCount++
+				assert.EqualValues(t, "attr-val", attrVal.Str())
+			}
 			assert.Equal(t, enabledAttrCount, rm.Resource().Attributes().Len())
-			assert.Equal(t, attrCount, 1)
+			assert.Equal(t, attrCount, 2)
 
 			assert.Equal(t, 1, rm.ScopeMetrics().Len())
 			ms := rm.ScopeMetrics().At(0).Metrics()

--- a/receiver/redisreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/redisreceiver/internal/metadata/testdata/config.yaml
@@ -70,6 +70,8 @@ all_set:
   resource_attributes:
     redis.version:
       enabled: true
+    service.instance.id:
+      enabled: true
 none_set:
   metrics:
     redis.clients.blocked:
@@ -140,4 +142,6 @@ none_set:
       enabled: false
   resource_attributes:
     redis.version:
+      enabled: false
+    service.instance.id:
       enabled: false

--- a/receiver/redisreceiver/metadata.yaml
+++ b/receiver/redisreceiver/metadata.yaml
@@ -11,6 +11,10 @@ resource_attributes:
     description: Redis server's version.
     enabled: true
     type: string
+  service.instance.id:
+    description: Instance identifier of the redis server.  Should be same as endpoint.  Should be enabled by default in the future.
+    enabled: false
+    type: string
 
 attributes:
   state:

--- a/receiver/redisreceiver/redis_scraper.go
+++ b/receiver/redisreceiver/redis_scraper.go
@@ -28,6 +28,7 @@ type redisScraper struct {
 	settings component.TelemetrySettings
 	mb       *metadata.MetricsBuilder
 	uptime   time.Duration
+	cfg      *Config
 }
 
 const redisMaxDbs = 16 // Maximum possible number of redis databases
@@ -52,6 +53,7 @@ func newRedisScraperWithClient(client client, settings receiver.CreateSettings, 
 		redisSvc: newRedisSvc(client),
 		settings: settings.TelemetrySettings,
 		mb:       metadata.NewMetricsBuilder(cfg.MetricsBuilderConfig, settings),
+		cfg:      cfg,
 	}
 	return scraperhelper.NewScraper(
 		metadata.Type,
@@ -93,7 +95,7 @@ func (rs *redisScraper) Scrape(context.Context) (pmetric.Metrics, error) {
 	rs.recordKeyspaceMetrics(now, inf)
 	rs.recordRoleMetrics(now, inf)
 	rs.recordCmdStatsMetrics(now, inf)
-	return rs.mb.Emit(metadata.WithRedisVersion(rs.getRedisVersion(inf))), nil
+	return rs.mb.Emit(metadata.WithRedisVersion(rs.getRedisVersion(inf)), metadata.WithServiceInstanceID(rs.cfg.Endpoint)), nil
 }
 
 // recordCommonMetrics records metrics from Redis info key-value pairs.

--- a/receiver/redisreceiver/redis_scraper_test.go
+++ b/receiver/redisreceiver/redis_scraper_test.go
@@ -33,6 +33,8 @@ func TestRedisRunnable(t *testing.T) {
 	ilm := rm.ScopeMetrics().At(0)
 	il := ilm.Scope()
 	assert.Equal(t, "otelcol/redisreceiver", il.Name())
+	// Only version should be enabled by default at this moment
+	assert.Equal(t, 1, rm.Resource().Attributes().Len())
 }
 
 func TestNewReceiver_invalid_auth_error(t *testing.T) {

--- a/receiver/redisreceiver/testdata/integration/expected.yaml
+++ b/receiver/redisreceiver/testdata/integration/expected.yaml
@@ -4,6 +4,9 @@ resourceMetrics:
         - key: redis.version
           value:
             stringValue: 6.0.3
+        - key: service.instance.id
+          value:
+            stringValue: localhost:6379
     scopeMetrics:
       - metrics:
           - description: Number of clients pending on a blocking call


### PR DESCRIPTION
**Description:**
Add a resource_attribute to track `service.instance.id` and set the value of such to be the configuration's endpoint

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22044

**Testing:**
Ran test in intellij

**Documentation:**
I believe mdatagen takes care of this but can add to README too.  LMK if you think I should.