### PR TITLE
[processor/filter] Fix HasAttributeKeyOnDatapointFactory arg type

### DIFF
--- a/.chloggen/fp-fix-HasAttributeKeyOnDatapointFactory.yaml
+++ b/.chloggen/fp-fix-HasAttributeKeyOnDatapointFactory.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/filter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix issue where the OTTL function `HasAttributeKeyOnDatapoint` was not usable.
+
+# One or more tracking issues related to the change
+issues: [22057]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/filterprocessor/internal/common/functions.go
+++ b/processor/filterprocessor/internal/common/functions.go
@@ -27,11 +27,11 @@ import (
 
 func MetricFunctions() map[string]ottl.Factory[ottlmetric.TransformContext] {
 	funcs := filterottl.StandardMetricFuncs()
-	hasAttributeKeyOnDatapoint := newHasAttributeKeyOnDatapointFactory()
-	funcs[hasAttributeKeyOnDatapoint.Name()] = hasAttributeKeyOnDatapoint
+	hasAttributeKeyOnDatapointFactory := newHasAttributeKeyOnDatapointFactory()
+	funcs[hasAttributeKeyOnDatapointFactory.Name()] = hasAttributeKeyOnDatapointFactory
 
-	hasAttributeOnDatapoint := newHasAttributeOnDatapointFactory()
-	funcs[hasAttributeOnDatapoint.Name()] = hasAttributeOnDatapoint
+	hasAttributeOnDatapointFactory := newHasAttributeOnDatapointFactory()
+	funcs[hasAttributeOnDatapointFactory.Name()] = hasAttributeOnDatapointFactory
 	return funcs
 }
 
@@ -69,7 +69,7 @@ func newHasAttributeKeyOnDatapointFactory() ottl.Factory[ottlmetric.TransformCon
 }
 
 func createHasAttributeKeyOnDatapointFunction(fCtx ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	args, ok := oArgs.(*hasAttributeOnDatapointArguments)
+	args, ok := oArgs.(*hasAttributeKeyOnDatapointArguments)
 
 	if !ok {
 		return nil, fmt.Errorf("hasAttributeKeyOnDatapointFactory args must be of type *hasAttributeOnDatapointArguments")

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -714,6 +714,26 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 			want:      func(md pmetric.Metrics) {},
 			errorMode: ottl.IgnoreError,
 		},
+		{
+			name: "HasAttrOnDatapoint",
+			conditions: MetricFilters{
+				MetricConditions: []string{
+					`HasAttrOnDatapoint("attr1", "test1")`,
+				},
+			},
+			filterEverything: true,
+			errorMode:        ottl.IgnoreError,
+		},
+		{
+			name: "HasAttrOnDatapoint",
+			conditions: MetricFilters{
+				MetricConditions: []string{
+					`HasAttrKeyOnDatapoint("attr1")`,
+				},
+			},
+			filterEverything: true,
+			errorMode:        ottl.IgnoreError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -725,7 +725,7 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 			errorMode:        ottl.IgnoreError,
 		},
 		{
-			name: "HasAttrOnDatapoint",
+			name: "HasAttrKeyOnDatapoint",
 			conditions: MetricFilters{
 				MetricConditions: []string{
 					`HasAttrKeyOnDatapoint("attr1")`,


### PR DESCRIPTION
**Description:** 
Fixes bug where `HasAttributeKeyOnDatapoint` was not useable because it asserted the incorrect argument type in the factory.

**Testing:**
Added new unit tests