### PR TITLE
fix end to end test

### DIFF
--- a/.chloggen/fix-redis-e2e-test.yaml
+++ b/.chloggen/fix-redis-e2e-test.yaml
@@ -1,4 +1,0 @@
-change_type: "bug_fix"
-component: "redisreceiver"
-note: "Fixes a bug in redis e2e test and test it more comprehensively to prevent recurrence or similar issues in the future"
-issues: [22060]

--- a/.chloggen/fix-redis-e2e-test.yaml
+++ b/.chloggen/fix-redis-e2e-test.yaml
@@ -1,8 +1,4 @@
-# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
 change_type: "bug_fix"
-
-# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: "redisreceiver"
-
-# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Fixes a bug in redis e2e test and test it more comprehensively to prevent recurrence or similar issues in the future"
+issues: [22060]

--- a/.chloggen/fix-redis-e2e-test.yaml
+++ b/.chloggen/fix-redis-e2e-test.yaml
@@ -1,0 +1,8 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "redisreceiver"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes a bug in redis e2e test and test it more comprehensively to prevent recurrence or similar issues in the future"

--- a/receiver/redisreceiver/redis_e2e_test.go
+++ b/receiver/redisreceiver/redis_e2e_test.go
@@ -65,7 +65,7 @@ func TestIntegration(t *testing.T) {
 
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig().(*Config)
-	cfg.Endpoint = fmt.Sprintf("redis://%s:%s", hostIP, mappedPort.Port())
+	cfg.Endpoint = fmt.Sprintf("%s:%s", hostIP, mappedPort.Port())
 
 	consumer := new(consumertest.MetricsSink)
 
@@ -80,4 +80,10 @@ func TestIntegration(t *testing.T) {
 	}, 15*time.Second, 1*time.Second, "failed to receive any metrics")
 
 	assert.NoError(t, rcvr.Shutdown(context.Background()))
+	require.Greater(t, len(consumer.AllMetrics()), 0)
+	require.Greater(t, consumer.AllMetrics()[0].ResourceMetrics().Len(), 0)
+	require.Greater(t, consumer.AllMetrics()[0].ResourceMetrics().At(0).Resource().Attributes().Len(), 0)
+	id, ok := consumer.AllMetrics()[0].ResourceMetrics().At(0).Resource().Attributes().Get("redis.version")
+	require.True(t, ok)
+	require.Equal(t, "6.0.3", id.Str())
 }


### PR DESCRIPTION
**Description:** was getting `nil` for VALUES/members of resource attributes as ingested by `consumertest.MetricsSink`, root cause was due to specifying prefix of protocol `redis://` not playing well with networking in underlying scraper class instance.
Added some tests to prevent similar from occurring in the future

**Testing:**
(ran e2e test in goland)
