### PR TITLE
[chore] add more info to the changelog template

### DIFF
--- a/.chloggen/TEMPLATE.yaml
+++ b/.chloggen/TEMPLATE.yaml
@@ -1,3 +1,7 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
 change_type:
 
@@ -7,7 +11,7 @@ component:
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note:
 
-# One or more tracking issues related to the change
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: []
 
 # (Optional) One or more lines of additional information to render under the primary note.


### PR DESCRIPTION
Adds a bit more info to the changelog template to explain when to use it and what to do if the change is not end user facing.