### PR TITLE
[receiver/statsdreceiver] Handle StatsD server not running on Shutdown

### DIFF
--- a/.chloggen/cj-handle-no-statsd-server.yaml
+++ b/.chloggen/cj-handle-no-statsd-server.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: statsdreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Handles StatsD server not running when shutting down to avoid NPE
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22004]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -122,7 +122,7 @@ func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 
 // Shutdown stops the StatsD receiver.
 func (r *statsdReceiver) Shutdown(context.Context) error {
-	if r.cancel == nil {
+	if r.cancel == nil || r.server == nil {
 		return nil
 	}
 	err := r.server.Close()

--- a/receiver/statsdreceiver/receiver_test.go
+++ b/receiver/statsdreceiver/receiver_test.go
@@ -83,8 +83,20 @@ func Test_statsdreceiver_Start(t *testing.T) {
 			require.NoError(t, err)
 			err = receiver.Start(context.Background(), componenttest.NewNopHost())
 			assert.Equal(t, tt.wantErr, err)
+
+			assert.NoError(t, receiver.Shutdown(context.Background()))
 		})
 	}
+}
+
+func TestStatsdReceiver_ShutdownBeforeStart(t *testing.T) {
+	ctx := context.Background()
+	cfg := createDefaultConfig().(*Config)
+	nextConsumer := consumertest.NewNop()
+	rcv, err := New(receivertest.NewNopCreateSettings(), *cfg, nextConsumer)
+	assert.NoError(t, err)
+	r := rcv.(*statsdReceiver)
+	assert.NoError(t, r.Shutdown(ctx))
 }
 
 func TestStatsdReceiver_Flush(t *testing.T) {


### PR DESCRIPTION

**Description:** <Describe what has changed.>
There are cases where the receiver's server cannot start (e.g. inuse port, invalid config) which will leave a nil server. As the collector begins the shutdown process (since statsd cannot start) this ends up causing a NPE and a panic. This guards against the case.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22004

**Testing:** <Describe what testing was performed and which tests were added.>
Added Unit tests

**Documentation:** <Describe the documentation added.>
N/A