### PR TITLE
[GoogleCloudSpannerReceiver]: Truncate metric label values for query …

### DIFF
--- a/.chloggen/googlecloudspannerreceiver-truncate_query_texte.yaml
+++ b/.chloggen/googlecloudspannerreceiver-truncate_query_texte.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: googlecloudspannerreceiver
+note: Adding a new config option to allow truncation of query text to 1024 characters.
+issues: [22072]
+subtext:

--- a/receiver/googlecloudspannerreceiver/README.md
+++ b/receiver/googlecloudspannerreceiver/README.md
@@ -36,6 +36,7 @@ receivers:
     backfill_enabled: true
     cardinality_total_limit: 200000
     hide_topn_lockstats_rowrangestartkey: false
+    truncate_text: false
     projects:
       - project_id: "spanner project 1"
         service_account_key: "path to spanner project 1 service account json key"
@@ -68,6 +69,7 @@ Brief description of configuration properties:
 - **backfill_enabled** - turn on/off 1-hour data backfill(by default it is turned off)
 - **cardinality_total_limit** - limit of active series per 24 hours period. If specified, turns on cardinality filtering and handling. If zero or not specified, cardinality is not handled. You can read [this document](cardinality.md) for more information about cardinality handling and filtering.
 - **hide_topn_lockstats_rowrangestartkey** - if true, masks PII (key values) in row_range_start_key label for the "top minute lock stats" metric
+- **truncate_text** - if true, the query text is truncated to 1024 characters.
 - **projects** - list of GCP projects
     - **project_id** - identifier of GCP project
     - **service_account_key** - path to service account JSON key It is highly recommended to set this property to the correct value. In case it is empty, the [Application Default Credentials](https://google.aip.dev/auth/4110) will be used for the database connection.

--- a/receiver/googlecloudspannerreceiver/config.go
+++ b/receiver/googlecloudspannerreceiver/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	CardinalityTotalLimit             int       `mapstructure:"cardinality_total_limit"`
 	Projects                          []Project `mapstructure:"projects"`
 	HideTopnLockstatsRowrangestartkey bool      `mapstructure:"hide_topn_lockstats_rowrangestartkey"`
+	TruncateText                      bool      `mapstructure:"truncate_text"`
 }
 
 type Project struct {

--- a/receiver/googlecloudspannerreceiver/config_test.go
+++ b/receiver/googlecloudspannerreceiver/config_test.go
@@ -40,6 +40,7 @@ func TestLoadConfig(t *testing.T) {
 			BackfillEnabled:                   true,
 			CardinalityTotalLimit:             200000,
 			HideTopnLockstatsRowrangestartkey: true,
+			TruncateText:                      true,
 			Projects: []Project{
 				{
 					ID:                "spanner project 1",

--- a/receiver/googlecloudspannerreceiver/factory.go
+++ b/receiver/googlecloudspannerreceiver/factory.go
@@ -20,6 +20,7 @@ const (
 	defaultTopMetricsQueryMaxRows            = 100
 	defaultBackfillEnabled                   = false
 	defaultHideTopnLockstatsRowrangestartkey = false
+	defaultTruncateText                      = false
 )
 
 func NewFactory() receiver.Factory {
@@ -37,6 +38,7 @@ func createDefaultConfig() component.Config {
 		TopMetricsQueryMaxRows:            defaultTopMetricsQueryMaxRows,
 		BackfillEnabled:                   defaultBackfillEnabled,
 		HideTopnLockstatsRowrangestartkey: defaultHideTopnLockstatsRowrangestartkey,
+		TruncateText:                      defaultTruncateText,
 	}
 }
 

--- a/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/labelvalue.go
@@ -181,6 +181,14 @@ func (v *byteSliceLabelValue) ModifyValue(s string) {
 	v.value = s
 }
 
+func (v *stringSliceLabelValue) ModifyValue(s string) {
+	v.value = s
+}
+
+func (v *stringLabelValue) ModifyValue(s string) {
+	v.value = s
+}
+
 func newByteSliceLabelValue(metadata LabelValueMetadata, valueHolder interface{}) LabelValue {
 	return byteSliceLabelValue{
 		metadata: metadata,

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint.go
@@ -8,13 +8,14 @@ import (
 	"hash/fnv"
 	"strings"
 	"time"
+	"unicode/utf8"
+
 	"github.com/mitchellh/hashstructure"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/datasource"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/filter"
-	"unicode/utf8"
 )
 
 const (
@@ -151,15 +152,15 @@ func (mdp *MetricsDataPoint) HideLockStatsRowrangestartkeyPII() {
 }
 
 func TruncateString(str string, length int) string {
-    if length <= 0 {
-        return ""
-    }
+	if length <= 0 {
+		return ""
+	}
 
-    if utf8.RuneCountInString(str) < length {
-        return str
-    }
+	if utf8.RuneCountInString(str) < length {
+		return str
+	}
 
-    return string([]rune(str)[:length])
+	return string([]rune(str)[:length])
 }
 
 func (mdp *MetricsDataPoint) TruncateQueryText(length int) {
@@ -174,7 +175,6 @@ func (mdp *MetricsDataPoint) TruncateQueryText(length int) {
 		}
 	}
 }
-
 
 func (mdp *MetricsDataPoint) hash() (string, error) {
 	hashedData, err := hashstructure.Hash(mdp.toDataForHashing(), nil)

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
@@ -153,8 +153,8 @@ func TestMetricsDataPoint_HideLockStatsRowrangestartkeyPIIWithInvalidLabelValue(
 }
 
 func TestMetricsDataPoint_TruncateQueryText(t *testing.T) {
-	strSliceLabelValueMetadata, _ := NewLabelValueMetadata("query_text", "stringLabelColumnName", StringValueType)
-	labelValue1 := stringSliceLabelValue{metadata: strSliceLabelValueMetadata, value: "SELECT 1"}
+	strLabelValueMetadata, _ := NewLabelValueMetadata("query_text", "stringLabelColumnName", StringValueType)
+	labelValue1 := stringLabelValue{metadata: strLabelValueMetadata, value: "SELECT 1"}
 	metricValues := allPossibleMetricValues(metricDataType)
 	labelValues := []LabelValue{labelValue1}
 	timestamp := time.Now().UTC()

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
@@ -152,6 +152,26 @@ func TestMetricsDataPoint_HideLockStatsRowrangestartkeyPIIWithInvalidLabelValue(
 	assert.Equal(t, len(metricsDataPoint.labelValues), 4)
 }
 
+func TestMetricsDataPoint_TruncateQueryText(t *testing.T) {
+	strSliceLabelValueMetadata, _ := NewLabelValueMetadata("query_text", "stringLabelColumnName", StringValueType)
+	labelValue1 := stringSliceLabelValue{metadata: strSliceLabelValueMetadata, value: "SELECT 1"}
+	metricValues := allPossibleMetricValues(metricDataType)
+	labelValues := []LabelValue{labelValue1}
+	timestamp := time.Now().UTC()
+	metricsDataPoint := &MetricsDataPoint{
+		metricName:  metricName,
+		timestamp:   timestamp,
+		databaseID:  databaseID(),
+		labelValues: labelValues,
+		metricValue: metricValues[0],
+	}
+
+	metricsDataPoint.TruncateQueryText(6)
+
+	assert.Equal(t, len(metricsDataPoint.labelValues), 1)
+	assert.Equal(t, metricsDataPoint.labelValues[0].Value(), "SELECT")
+}
+
 func allPossibleLabelValues() []LabelValue {
 	strLabelValueMetadata, _ := NewLabelValueMetadata("stringLabelName", "stringLabelColumnName", StringValueType)
 	strLabelValue := stringLabelValue{

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader.go
@@ -20,8 +20,8 @@ const (
 	// this constant was set to 1 hour - max allowed interval by Prometheus.
 	backfillIntervalDuration = time.Hour
 	topLockStatsMetricName   = "top minute lock stats"
-	topQueryStatsMetricName = "top minute query stats"
-	maxLengthTruncateText = 1024
+	topQueryStatsMetricName  = "top minute query stats"
+	maxLengthTruncateText    = 1024
 )
 
 type intervalStatsReader struct {
@@ -29,7 +29,7 @@ type intervalStatsReader struct {
 	timestampsGenerator               *timestampsGenerator
 	lastPullTimestamp                 time.Time
 	hideTopnLockstatsRowrangestartkey bool
-	truncateText                 bool
+	truncateText                      bool
 }
 
 func newIntervalStatsReader(
@@ -54,7 +54,7 @@ func newIntervalStatsReader(
 		currentStatsReader:                reader,
 		timestampsGenerator:               tsGenerator,
 		hideTopnLockstatsRowrangestartkey: config.HideTopnLockstatsRowrangestartkey,
-		truncateText: config.TruncateText,
+		truncateText:                      config.TruncateText,
 	}
 }
 

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader.go
@@ -20,6 +20,8 @@ const (
 	// this constant was set to 1 hour - max allowed interval by Prometheus.
 	backfillIntervalDuration = time.Hour
 	topLockStatsMetricName   = "top minute lock stats"
+	topQueryStatsMetricName = "top minute query stats"
+	maxLengthTruncateText = 1024
 )
 
 type intervalStatsReader struct {
@@ -27,6 +29,7 @@ type intervalStatsReader struct {
 	timestampsGenerator               *timestampsGenerator
 	lastPullTimestamp                 time.Time
 	hideTopnLockstatsRowrangestartkey bool
+	truncateText                 bool
 }
 
 func newIntervalStatsReader(
@@ -51,6 +54,7 @@ func newIntervalStatsReader(
 		currentStatsReader:                reader,
 		timestampsGenerator:               tsGenerator,
 		hideTopnLockstatsRowrangestartkey: config.HideTopnLockstatsRowrangestartkey,
+		truncateText: config.TruncateText,
 	}
 }
 
@@ -78,6 +82,11 @@ func (reader *intervalStatsReader) Read(ctx context.Context) ([]*metadata.Metric
 		if reader.hideTopnLockstatsRowrangestartkey && metricMetadata != nil && metricMetadata.Name == topLockStatsMetricName {
 			for _, dataPoint := range dataPoints {
 				dataPoint.HideLockStatsRowrangestartkeyPII()
+			}
+		}
+		if reader.truncateText && metricMetadata != nil && metricMetadata.Name == topQueryStatsMetricName {
+			for _, dataPoint := range dataPoints {
+				dataPoint.TruncateQueryText(maxLengthTruncateText)
 			}
 		}
 

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/intervalstatsreader_test.go
@@ -49,6 +49,7 @@ func TestNewIntervalStatsReader(t *testing.T) {
 		TopMetricsQueryMaxRows:            topMetricsQueryMaxRows,
 		BackfillEnabled:                   true,
 		HideTopnLockstatsRowrangestartkey: true,
+		TruncateText:                      true,
 	}
 
 	reader := newIntervalStatsReader(logger, database, metricsMetadata, config)
@@ -60,6 +61,7 @@ func TestNewIntervalStatsReader(t *testing.T) {
 	assert.NotNil(t, reader.timestampsGenerator)
 	assert.True(t, reader.timestampsGenerator.backfillEnabled)
 	assert.True(t, reader.hideTopnLockstatsRowrangestartkey)
+	assert.True(t, reader.truncateText)
 }
 
 func TestIntervalStatsReader_NewPullStatement(t *testing.T) {
@@ -70,6 +72,7 @@ func TestIntervalStatsReader_NewPullStatement(t *testing.T) {
 		TopMetricsQueryMaxRows:            topMetricsQueryMaxRows,
 		BackfillEnabled:                   false,
 		HideTopnLockstatsRowrangestartkey: true,
+		TruncateText:                      true,
 	}
 	ctx := context.Background()
 	client, _ := spanner.NewClient(ctx, "")

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/reader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/reader.go
@@ -13,6 +13,7 @@ type ReaderConfig struct {
 	TopMetricsQueryMaxRows            int
 	BackfillEnabled                   bool
 	HideTopnLockstatsRowrangestartkey bool
+	TruncateText                      bool
 }
 
 type Reader interface {

--- a/receiver/googlecloudspannerreceiver/receiver.go
+++ b/receiver/googlecloudspannerreceiver/receiver.go
@@ -104,6 +104,7 @@ func (r *googleCloudSpannerReceiver) initializeProjectReaders(ctx context.Contex
 		BackfillEnabled:                   r.config.BackfillEnabled,
 		TopMetricsQueryMaxRows:            r.config.TopMetricsQueryMaxRows,
 		HideTopnLockstatsRowrangestartkey: r.config.HideTopnLockstatsRowrangestartkey,
+		TruncateText:                      r.config.TruncateText,
 	}
 
 	for _, project := range r.config.Projects {

--- a/receiver/googlecloudspannerreceiver/testdata/config.yaml
+++ b/receiver/googlecloudspannerreceiver/testdata/config.yaml
@@ -4,7 +4,7 @@ googlecloudspanner:
   backfill_enabled: true
   cardinality_total_limit: 200000
   hide_topn_lockstats_rowrangestartkey: true
-  truncate_query_text: true
+  truncate_text: true
   projects:
     - project_id: "spanner project 1"
       service_account_key: "path to spanner project 1 service account json key"

--- a/receiver/googlecloudspannerreceiver/testdata/config.yaml
+++ b/receiver/googlecloudspannerreceiver/testdata/config.yaml
@@ -4,6 +4,7 @@ googlecloudspanner:
   backfill_enabled: true
   cardinality_total_limit: 200000
   hide_topn_lockstats_rowrangestartkey: true
+  truncate_query_text: true
   projects:
     - project_id: "spanner project 1"
       service_account_key: "path to spanner project 1 service account json key"


### PR DESCRIPTION
…text to 1024 characters

Introduced a new config truncate_text, which when set to true will truncate the query text to 1024 characters.

**Description:**
For Google Managed Prometheus(GMP) the limit for the metric label value is 1024 characters. The fields from the SPANNER_SYS.* tables of spanner can have some field values greater that 1024 characters. For example query text can be 64 KB. In order to support the spanner receiver for GMP we will perform the truncation of the metric label value before exporting the value.

**Link to tracking Issue:**
Closes #22075

**Testing:** 
Manual testing with local docker setup done. Unit tests were added for the new config change.
**Documentation:** <Describe the documentation added.>