### PR TITLE
[fileexporter] refactor to use compressed writer in fileexporter

### DIFF
--- a/.chloggen/use-compressed-writer-in-fileexporter.yaml
+++ b/.chloggen/use-compressed-writer-in-fileexporter.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: fileexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: refactor fileexporter to use a compressed writer
+
+# One or more tracking issues related to the change
+issues: [13626]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+

--- a/exporter/fileexporter/buffered_writer.go
+++ b/exporter/fileexporter/buffered_writer.go
@@ -21,7 +21,7 @@ var (
 	_ io.WriteCloser = (*bufferedWriteCloser)(nil)
 )
 
-func newBufferedWriteCloser(f io.WriteCloser) io.WriteCloser {
+func newBufferedWriteCloser(f io.WriteCloser) WriteCloseFlusher {
 	return &bufferedWriteCloser{
 		wrapped:  f,
 		buffered: bufio.NewWriter(f),
@@ -39,6 +39,10 @@ func (bwc *bufferedWriteCloser) Close() error {
 	)
 }
 
-func (bwc *bufferedWriteCloser) flush() error {
+func (bwc *bufferedWriteCloser) getWrapped() io.Closer {
+	return bwc.wrapped
+}
+
+func (bwc *bufferedWriteCloser) Flush() error {
 	return bwc.buffered.Flush()
 }

--- a/exporter/fileexporter/config_test.go
+++ b/exporter/fileexporter/config_test.go
@@ -8,12 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter/internal/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter/internal/metadata"
 )
 
 func TestLoadConfig(t *testing.T) {

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -8,15 +8,14 @@ import (
 	"io"
 	"os"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"gopkg.in/natefinch/lumberjack.v2"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter/internal/metadata"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 const (

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -120,18 +120,19 @@ func createLogsExporter(
 }
 
 func newFileExporter(conf *Config, writer io.WriteCloser) *fileExporter {
-	return &fileExporter{
+	fe := &fileExporter{
 		path:             conf.Path,
 		formatType:       conf.FormatType,
 		file:             writer,
 		tracesMarshaler:  tracesMarshalers[conf.FormatType],
 		metricsMarshaler: metricsMarshalers[conf.FormatType],
 		logsMarshaler:    logsMarshalers[conf.FormatType],
-		exporter:         buildExportFunc(conf),
 		compression:      conf.Compression,
 		compressor:       buildCompressor(conf.Compression),
 		flushInterval:    conf.FlushInterval,
 	}
+	fe.exporter = fe.createExporterWriter(conf)
+	return fe
 }
 
 func buildFileWriter(cfg *Config) (io.WriteCloser, error) {

--- a/exporter/fileexporter/factory_test.go
+++ b/exporter/fileexporter/factory_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	"gopkg.in/natefinch/lumberjack.v2"
 	"go.uber.org/zap"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -157,6 +157,7 @@ func TestBuildFileWriter(t *testing.T) {
 				bc, ok := fl.getFile().(interface{ getWrapped() io.Closer })
 				assert.True(t, ok)
 				writer, ok := bc.getWrapped().(*lumberjack.Logger)
+				assert.True(t, ok)
 
 				assert.Equal(t, 3, writer.MaxBackups)
 				assert.Equal(t, 30, writer.MaxSize)

--- a/exporter/fileexporter/file_exporter.go
+++ b/exporter/fileexporter/file_exporter.go
@@ -39,10 +39,9 @@ type WriteCloseFlusher interface {
 
 // fileExporter is the implementation of file exporter that writes telemetry data to a file
 type fileExporter struct {
-	path     string
-	file     WriteCloseFlusher
-	mutex    sync.Mutex
-	logger   *zap.Logger
+	path  string
+	file  WriteCloseFlusher
+	mutex sync.Mutex
 
 	tracesMarshaler  ptrace.Marshaler
 	metricsMarshaler pmetric.Marshaler
@@ -96,9 +95,8 @@ func NewLineWriter(cfg *Config, logger *zap.Logger, file io.WriteCloser) WriteCl
 		if cw, err := zstd.NewWriter(file); err == nil {
 			lw.file = cw
 			return lw
-		} else {
-			logger.Debug("Unable to create compressed writer", zap.Error(err))
 		}
+		logger.Debug("Unable to create compressed writer", zap.Error(err))
 	}
 
 	lw.file = newBufferedWriteCloser(file)
@@ -143,9 +141,8 @@ func NewFileWriter(cfg *Config, logger *zap.Logger, file io.WriteCloser) WriteCl
 		if cw, err := zstd.NewWriter(file); err == nil {
 			fw.file = cw
 			return fw
-		} else {
-			logger.Debug("Unable to create compressed writer", zap.Error(err))
 		}
+		logger.Debug("Unable to create compressed writer", zap.Error(err))
 	}
 
 	fw.file = newBufferedWriteCloser(file)

--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -16,16 +16,15 @@ import (
 	"time"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"gopkg.in/natefinch/lumberjack.v2"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 func TestFileTracesExporter(t *testing.T) {
@@ -170,8 +169,8 @@ func TestFileTracesExporter(t *testing.T) {
 func TestFileTracesExporterError(t *testing.T) {
 	mf := &errorWriter{}
 	fe := &fileExporter{
-		file:       mf,
-		formatType: formatTypeJSON,
+		file:            mf,
+		formatType:      formatTypeJSON,
 		tracesMarshaler: tracesMarshalers[formatTypeJSON],
 		compressor:      noneCompress,
 	}
@@ -286,7 +285,7 @@ func TestFileMetricsExporter(t *testing.T) {
 			}
 			for {
 				buf, isEnd, err := func() ([]byte, bool, error) {
-					if fe.formatType == formatTypeJSON {	
+					if fe.formatType == formatTypeJSON {
 						return readJSONMessage(br)
 					}
 					return readMessageFromStream(br)
@@ -308,8 +307,8 @@ func TestFileMetricsExporter(t *testing.T) {
 func TestFileMetricsExporterError(t *testing.T) {
 	mf := &errorWriter{}
 	fe := &fileExporter{
-		file:       mf,
-		formatType: formatTypeJSON,
+		file:             mf,
+		formatType:       formatTypeJSON,
 		metricsMarshaler: metricsMarshalers[formatTypeJSON],
 		compressor:       noneCompress,
 	}
@@ -449,7 +448,7 @@ func TestFileLogsExporterErrors(t *testing.T) {
 		file:          mf,
 		formatType:    formatTypeJSON,
 		logsMarshaler: logsMarshalers[formatTypeJSON],
-		compressor: noneCompress,
+		compressor:    noneCompress,
 	}
 	require.NotNil(t, fe)
 
@@ -482,9 +481,9 @@ func TestExportMessageAsBuffer(t *testing.T) {
 		MaxSize:  1,
 	}
 	fe := &fileExporter{
-		path:       path,
-		formatType: formatTypeProto,
-		file: &testWriter{writer: fw},
+		path:          path,
+		formatType:    formatTypeProto,
+		file:          &testWriter{writer: fw},
 		logsMarshaler: logsMarshalers[formatTypeProto],
 	}
 	require.NotNil(t, fe)

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/exporter v0.80.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0013
 	go.uber.org/multierr v1.11.0
+	go.uber.org/zap v1.24.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 


### PR DESCRIPTION
**Description:** 
[PART 1] Breaking https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/22021 into 2 PRs
This PR is refactoring of the fileexporter to use a compressed writer.  The goal of this change is to make it easier to read compressed data in the filereceiver by using a corresponding compressed reader. 

This also makes it clearer to distinguish between the two types of writes. 1. writing line by line used for json and compressed json 2. writing a chunk at a time prefixed with the chunk size

For more context see part 2: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/22080

**Link to tracking Issue:**
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13626
Supports ongoing effort to record and replay telemetry data for experimental/research purposes

**Testing:** 
Locally running otelcontribcol and writing to a file using all supported formats (json, json+compression, proto, proto+compression) and recovering original metrics using filereceiver

**Documentation:** <Describe the documentation added.>