### PR TITLE
[receiver/oracledb] Add a simpler alternative for configuration

### DIFF
--- a/.chloggen/oracledb_config.yaml
+++ b/.chloggen/oracledb_config.yaml
@@ -8,7 +8,7 @@ component: oracledbreceiver
 note: Add a simpler alternative configuration option
 
 # One or more tracking issues related to the change
-issues: []
+issues: [22087]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/oracledb_config.yaml
+++ b/.chloggen/oracledb_config.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: oracledbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a simpler alternative configuration option
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/oracledbreceiver/README.md
+++ b/receiver/oracledbreceiver/README.md
@@ -66,7 +66,7 @@ GRANT SELECT ON DBA_DATA_FILES TO <username>;
 
 ## Enabling metrics.
 
-See [documentation](./documentation).
+See [documentation](./documentation.md).
 
 You can enable or disable selective metrics.
 

--- a/receiver/oracledbreceiver/README.md
+++ b/receiver/oracledbreceiver/README.md
@@ -25,7 +25,7 @@ option will be used.
 ### Primary Configuration Option
 
 Required options:
-- `datasource`: Oracle database connection string. Refer to Oracle Go Driver go_ora documentation for full connection string options.
+- `datasource`: Oracle database connection string. Special characters must be encoded. Refer to Oracle Go Driver go_ora documentation for full connection string options.
 
 Example:
 
@@ -39,16 +39,16 @@ receivers:
 
 Required options:
 - `endpoint`: Endpoint used to connect to the OracleDB server. Must be in the format of `host:port`
-- `password`: Password for the OracleDB connection
+- `password`: Password for the OracleDB connection. Special characters are allowed.
 - `service`: OracleDB Service that the receiver should connect to.
-- `username`: Username for the OracleDB connection
+- `username`: Username for the OracleDB connection.
 
 Example:
 ```yaml
 receivers:
   oracledb:
     endpoint: localhost:51521
-    password: password
+    password: p@sswo%d
     service: XE
     username: otel
 ```

--- a/receiver/oracledbreceiver/README.md
+++ b/receiver/oracledbreceiver/README.md
@@ -17,8 +17,14 @@ The receiver connects to a database host and performs periodically queries.
 
 ## Getting Started
 
-The following settings are required:
+To use the OracleDB receiver you must define how to connect to your DB. This can be done in two ways,
+defined in the [Primary](#primary-configuration-option) and [Secondary](#secondary-configuration-option) configuration
+option sections. Defining one of the two configurations is required. If both are defined, the primary
+option will be used.
 
+### Primary Configuration Option
+
+Required options:
 - `datasource`: Oracle database connection string. Refer to Oracle Go Driver go_ora documentation for full connection string options.
 
 Example:
@@ -27,6 +33,24 @@ Example:
 receivers:
   oracledb:
     datasource: "oracle://otel:password@localhost:51521/XE"
+```
+
+### Secondary Configuration Option
+
+Required options:
+- `endpoint`: Endpoint used to connect to the OracleDB server. Must be in the format of `host:port`
+- `password`: Password for the OracleDB connection
+- `service`: OracleDB Service that the receiver should connect to.
+- `username`: Username for the OracleDB connection
+
+Example:
+```yaml
+receivers:
+  oracledb:
+    endpoint: localhost:51521
+    password: password
+    service: XE
+    username: otel
 ```
 
 ## Permissions
@@ -42,7 +66,7 @@ GRANT SELECT ON DBA_DATA_FILES TO <username>;
 
 ## Enabling metrics.
 
-See [documentation.md].
+See [documentation](./documentation).
 
 You can enable or disable selective metrics.
 

--- a/receiver/oracledbreceiver/config.go
+++ b/receiver/oracledbreceiver/config.go
@@ -6,25 +6,79 @@ package oracledbreceiver // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"errors"
 	"fmt"
+	"go.uber.org/multierr"
+	"net"
 	"net/url"
+	"strconv"
 
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver/internal/metadata"
 )
 
+var (
+	errBadDataSource = errors.New("datasource is invalid")
+	errBadEndpoint   = errors.New("endpoint must be specified as host:port")
+	errBadPort       = errors.New("invalid port in endpoint")
+	errEmptyEndpoint = errors.New("endpoint must be specified")
+	errEmptyPassword = errors.New("password must be set")
+	errEmptyService  = errors.New("service must be specified")
+	errEmptyUsername = errors.New("username must be set")
+)
+
 type Config struct {
 	DataSource                              string `mapstructure:"datasource"`
+	Endpoint                                string `mapstructure:"endpoint"`
+	Password                                string `mapstructure:"password"`
+	Service                                 string `mapstructure:"service"`
+	Username                                string `mapstructure:"username"`
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 	metadata.MetricsBuilderConfig           `mapstructure:",squash"`
 }
 
 func (c Config) Validate() error {
+	var allErrs error
+
+	// If DataSource is defined it takes precedence over the rest of the connection options.
 	if c.DataSource == "" {
-		return errors.New("'datasource' cannot be empty")
+
+		if c.Endpoint == "" {
+			allErrs = multierr.Append(allErrs, errEmptyEndpoint)
+		}
+
+		host, portStr, err := net.SplitHostPort(c.Endpoint)
+		if err != nil {
+			return multierr.Append(allErrs, fmt.Errorf("%w: %s", errBadEndpoint, err))
+		}
+
+		if host == "" {
+			allErrs = multierr.Append(allErrs, errBadEndpoint)
+		}
+
+		port, err := strconv.ParseInt(portStr, 10, 32)
+		if err != nil {
+			allErrs = multierr.Append(allErrs, fmt.Errorf("%w: %s", errBadPort, err))
+		}
+
+		if port < 0 || port > 65535 {
+			allErrs = multierr.Append(allErrs, fmt.Errorf("%w: %d", errBadPort, port))
+		}
+
+		if c.Username == "" {
+			allErrs = multierr.Append(allErrs, errEmptyUsername)
+		}
+
+		if c.Password == "" {
+			allErrs = multierr.Append(allErrs, errEmptyPassword)
+		}
+
+		if c.Service == "" {
+			allErrs = multierr.Append(allErrs, errEmptyService)
+		}
+	} else {
+		if _, err := url.Parse(c.DataSource); err != nil {
+			allErrs = multierr.Append(allErrs, fmt.Errorf("%w: %s", errBadDataSource, err))
+		}
 	}
-	if _, err := url.Parse(c.DataSource); err != nil {
-		return fmt.Errorf("'datasource' is invalid: %w", err)
-	}
-	return nil
+	return allErrs
 }

--- a/receiver/oracledbreceiver/config.go
+++ b/receiver/oracledbreceiver/config.go
@@ -6,12 +6,12 @@ package oracledbreceiver // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/multierr"
 	"net"
 	"net/url"
 	"strconv"
 
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
+	"go.uber.org/multierr"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver/internal/metadata"
 )

--- a/receiver/oracledbreceiver/config_test.go
+++ b/receiver/oracledbreceiver/config_test.go
@@ -14,6 +14,97 @@ import (
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
 
+func TestValidateInvalidConfigs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   *Config
+		expected error
+	}{
+		{
+			name: "Empty endpoint",
+			config: &Config{
+				Endpoint: "",
+			},
+			expected: errEmptyEndpoint,
+		},
+		{
+			name: "Missing port in endpoint",
+			config: &Config{
+				Endpoint: "localhost",
+			},
+			expected: errBadEndpoint,
+		},
+		{
+			name: "Invalid endpoint format",
+			config: &Config{
+				Endpoint: "x;;ef;s;d:::ss:23423423423423423",
+			},
+			expected: errBadEndpoint,
+		},
+		{
+			name: "Missing host in endpoint",
+			config: &Config{
+				Endpoint: ":3001",
+			},
+			expected: errBadEndpoint,
+		},
+		{
+			name: "Negative port",
+			config: &Config{
+				Endpoint: "localhost:-2",
+			},
+			expected: errBadPort,
+		},
+		{
+			name: "Bad port",
+			config: &Config{
+				Endpoint: "localhost:9999999999999999999",
+			},
+			expected: errBadPort,
+		},
+		{
+			name: "Empty username",
+			config: &Config{
+				Endpoint: "localhost:3000",
+				Username: "",
+				Password: "secret",
+			},
+			expected: errEmptyUsername,
+		},
+		{
+			name: "Empty password",
+			config: &Config{
+				Endpoint: "localhost:3000",
+				Username: "ro_user",
+			},
+			expected: errEmptyPassword,
+		},
+		{
+			name: "Empty service",
+			config: &Config{
+				Endpoint: "localhost:3000",
+				Password: "password",
+				Username: "ro_user",
+			},
+			expected: errEmptyService,
+		},
+		{
+			name: "Invalid data source",
+			config: &Config{
+				DataSource: "%%%",
+			},
+			expected: errBadDataSource,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.Validate()
+			require.ErrorIs(t, err, tc.expected)
+		})
+	}
+}
+
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	assert.Equal(t, 10*time.Second, cfg.ScraperControllerSettings.CollectionInterval)
@@ -29,6 +120,10 @@ func TestParseConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 	assert.Equal(t, "oracle://otel:password@localhost:51521/XE", cfg.DataSource)
+	assert.Equal(t, "otel", cfg.Username)
+	assert.Equal(t, "password", cfg.Password)
+	assert.Equal(t, "localhost:51521", cfg.Endpoint)
+	assert.Equal(t, "XE", cfg.Service)
 	settings := cfg.MetricsBuilderConfig.Metrics
 	assert.False(t, settings.OracledbTablespaceSizeUsage.Enabled)
 	assert.False(t, settings.OracledbExchangeDeadlocks.Enabled)

--- a/receiver/oracledbreceiver/factory.go
+++ b/receiver/oracledbreceiver/factory.go
@@ -16,9 +16,8 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 
-	go_ora "github.com/sijms/go-ora/v2"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver/internal/metadata"
+	"github.com/sijms/go-ora/v2"
 )
 
 // NewFactory creates a new Oracle receiver factory.

--- a/receiver/oracledbreceiver/factory.go
+++ b/receiver/oracledbreceiver/factory.go
@@ -16,8 +16,9 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 
+	go_ora "github.com/sijms/go-ora/v2"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver/internal/metadata"
-	"github.com/sijms/go-ora/v2"
 )
 
 // NewFactory creates a new Oracle receiver factory.

--- a/receiver/oracledbreceiver/factory.go
+++ b/receiver/oracledbreceiver/factory.go
@@ -50,16 +50,15 @@ func createReceiverFunc(sqlOpenerFunc sqlOpenerFunc, clientProviderFunc clientPr
 		consumer consumer.Metrics,
 	) (receiver.Metrics, error) {
 		sqlCfg := cfg.(*Config)
-		sqlCfg.DataSource = getDataSource(*sqlCfg)
 		metricsBuilder := metadata.NewMetricsBuilder(sqlCfg.MetricsBuilderConfig, settings)
 
-		instanceName, err := getInstanceName(sqlCfg.DataSource)
+		instanceName, err := getInstanceName(getDataSource(*sqlCfg))
 		if err != nil {
 			return nil, err
 		}
 
 		mp, err := newScraper(settings.ID, metricsBuilder, sqlCfg.MetricsBuilderConfig, sqlCfg.ScraperControllerSettings, settings.TelemetrySettings.Logger, func() (*sql.DB, error) {
-			return sqlOpenerFunc(sqlCfg.DataSource)
+			return sqlOpenerFunc(getDataSource(*sqlCfg))
 		}, clientProviderFunc, instanceName)
 		if err != nil {
 			return nil, err

--- a/receiver/oracledbreceiver/factory.go
+++ b/receiver/oracledbreceiver/factory.go
@@ -6,6 +6,7 @@ package oracledbreceiver // import "github.com/open-telemetry/opentelemetry-coll
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"net/url"
 	"time"
 
@@ -47,6 +48,7 @@ func createReceiverFunc(sqlOpenerFunc sqlOpenerFunc, clientProviderFunc clientPr
 		consumer consumer.Metrics,
 	) (receiver.Metrics, error) {
 		sqlCfg := cfg.(*Config)
+		sqlCfg.DataSource = getDataSource(*sqlCfg)
 		metricsBuilder := metadata.NewMetricsBuilder(sqlCfg.MetricsBuilderConfig, settings)
 
 		mp, err := newScraper(settings.ID, metricsBuilder, sqlCfg.MetricsBuilderConfig, sqlCfg.ScraperControllerSettings, settings.TelemetrySettings.Logger, func() (*sql.DB, error) {
@@ -64,6 +66,16 @@ func createReceiverFunc(sqlOpenerFunc sqlOpenerFunc, clientProviderFunc clientPr
 			opt,
 		)
 	}
+}
+
+func getDataSource(cfg Config) string {
+	if cfg.DataSource != "" {
+		return cfg.DataSource
+	}
+
+	// Data source string is format of:
+	// oracle://username:password@endpoint/OracleDBService
+	return fmt.Sprintf("oracle://%s:%s@%s/%s", cfg.Username, cfg.Password, cfg.Endpoint, cfg.Service)
 }
 
 func getInstanceName(datasource string) string {

--- a/receiver/oracledbreceiver/factory.go
+++ b/receiver/oracledbreceiver/factory.go
@@ -11,12 +11,11 @@ import (
 	"strconv"
 	"time"
 
+	go_ora "github.com/sijms/go-ora/v2"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
-
-	go_ora "github.com/sijms/go-ora/v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver/internal/metadata"
 )

--- a/receiver/oracledbreceiver/factory_test.go
+++ b/receiver/oracledbreceiver/factory_test.go
@@ -39,7 +39,7 @@ func TestGetInstanceName(t *testing.T) {
 	assert.Equal(t, "example.com:1521/mydb", instanceName)
 
 	// Should fail on non-encoded special characters
-	instanceName, err = getInstanceName("oracle://username1:p@ssw%rd@example1.com:1521/mydb")
+	_, err = getInstanceName("oracle://username1:p@ssw%rd@example1.com:1521/mydb")
 	assert.ErrorContains(t, err, "invalid URL escape")
 
 	// Should succeed when special characters are encoded

--- a/receiver/oracledbreceiver/factory_test.go
+++ b/receiver/oracledbreceiver/factory_test.go
@@ -5,6 +5,7 @@ package oracledbreceiver
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +32,59 @@ func TestNewFactory(t *testing.T) {
 	)
 	require.NoError(t, err)
 }
+
 func TestGetInstanceName(t *testing.T) {
 	instanceName := getInstanceName("oracle://example.com:1521/mydb")
 	assert.Equal(t, "example.com:1521/mydb", instanceName)
+}
+
+func TestGetDataSource(t *testing.T) {
+	endpoint := "example1.com:1521"
+	password := "password1"
+	service := "mydb1"
+	username := "username1"
+	nonDefaultDataSource := fmt.Sprintf("oracle://%s:%s@%s/%s", username, password, endpoint, service)
+	defaultDataSource := "oracle://username:password@example.com:1521/mydb"
+
+	testCases := []struct {
+		name     string
+		config   *Config
+		expected string
+	}{
+		{
+			name: "Default data source",
+			config: &Config{
+				DataSource: defaultDataSource,
+			},
+			expected: defaultDataSource,
+		},
+		{
+			name: "Default data source takes priority over other config options",
+			config: &Config{
+				DataSource: defaultDataSource,
+				Endpoint:   endpoint,
+				Password:   password,
+				Service:    service,
+				Username:   username,
+			},
+			expected: defaultDataSource,
+		},
+		{
+			name: "Individual config options properly render data source",
+			config: &Config{
+				Endpoint: endpoint,
+				Password: password,
+				Service:  service,
+				Username: username,
+			},
+			expected: nonDefaultDataSource,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dataSource := getDataSource(*tc.config)
+			require.Equal(t, dataSource, tc.expected)
+		})
+	}
 }

--- a/receiver/oracledbreceiver/testdata/config.yaml
+++ b/receiver/oracledbreceiver/testdata/config.yaml
@@ -1,10 +1,9 @@
 oracledb:
   # driver name: oracle
-  # username: otel
-  # password: password
-  # host: localhost
-  # container exposed port: 51521
-  # Oracle DB service name: XE
+  endpoint: localhost:51521
+  password: password
+  service: XE
+  username: otel
   # Refer to Oracle Go Driver go_ora documentation for full connection string options
   datasource: "oracle://otel:password@localhost:51521/XE"
   metrics:

--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -153,7 +153,7 @@ func TestOracleDBIntegration(t *testing.T) {
 			func(t *testing.T, cfg component.Config, ci *scraperinttest.ContainerInfo) {
 				rCfg := cfg.(*Config)
 				rCfg.Driver = "oracle"
-				rCfg.DataSource = fmt.Sprintf("oracle://otel:password@%s:%s/XE",
+				rCfg.DataSource = fmt.Sprintf("oracle://otel:p@ssw%%25rd@%s:%s/XE",
 					ci.Host(t), ci.MappedPort(t, oraclePort))
 				rCfg.Queries = []Query{
 					{

--- a/receiver/sqlqueryreceiver/testdata/integration/initOracleDB.sql
+++ b/receiver/sqlqueryreceiver/testdata/integration/initOracleDB.sql
@@ -19,6 +19,6 @@ values ('Mission Impossible', 'Action', 7.1);
 /* The alter session command is required to enable user creation in an Oracle docker container
    This command shouldn't be used outside of test environments. */
 alter session set "_ORACLE_SCRIPT"=true;
-CREATE USER OTEL IDENTIFIED BY password;
+CREATE USER OTEL IDENTIFIED BY "p@ssw%rd";
 GRANT CREATE SESSION TO OTEL;
 GRANT ALL ON movie TO OTEL;


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Currently the only way to configure the OracleDB receiver is to manually define a custom datasource string. This string must have a specific format with specific pieces of information. It's easier for a user to identify information in smaller sizes, and leave the formatting of the connection string to the receiver itself. This change allows the user to define their connection information in whichever format they prefer.

**Link to tracking Issue:** 
#22087 

**Testing:** <Describe what testing was performed and which tests were added.>
Added unit tests for making sure invalid configurations were detected, as well as making sure defined precedence is followed if both options are defined in the config. Manually did functional testing as well to make sure new formatting works as expected.

Testing logic heavily inspired by the `aerospike` receiver, as configuration options are very similar.

**Documentation:** <Describe the documentation added.>
Updated README with new configuration information.