### PR TITLE
Honor enabled resource attributes

### DIFF
--- a/.chloggen/redisreceiver-honor-enabled-resource-attrs.yaml
+++ b/.chloggen/redisreceiver-honor-enabled-resource-attrs.yaml
@@ -1,0 +1,10 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "redisreceiver"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Honor the enabled flag for resource attributes (flag was introduced after creation of this receiver)"
+
+issues: [22044]

--- a/receiver/redisreceiver/redis_scraper_test.go
+++ b/receiver/redisreceiver/redis_scraper_test.go
@@ -33,6 +33,8 @@ func TestRedisRunnable(t *testing.T) {
 	ilm := rm.ScopeMetrics().At(0)
 	il := ilm.Scope()
 	assert.Equal(t, "otelcol/redisreceiver", il.Name())
+	// Only version should be enabled by default at this moment
+	assert.Equal(t, 1, rm.Resource().Attributes().Len())
 }
 
 func TestNewReceiver_invalid_auth_error(t *testing.T) {


### PR DESCRIPTION
**Description:** 
Enables the resource_attribute flag in redis

**Link to tracking Issue:** Enables [22044](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22044)

**Testing:** integration test in goland