### PR TITLE
[chore][scraperinttest] Retry container creation and setup.

### DIFF
--- a/internal/coreinternal/scraperinttest/scraperint.go
+++ b/internal/coreinternal/scraperinttest/scraperint.go
@@ -62,16 +62,20 @@ type IntegrationTest struct {
 
 func (it *IntegrationTest) Run(t *testing.T) {
 	ctx := context.Background()
-
 	require.NoError(t, it.containerRequest.Validate())
-	container, err := testcontainers.GenericContainer(ctx,
-		testcontainers.GenericContainerRequest{
-			ContainerRequest: it.containerRequest,
-			Started:          true,
-		})
-	require.NoError(t, err)
+
+	var container testcontainers.Container
+	var err error
+	require.Eventually(t, func() bool {
+		container, err = testcontainers.GenericContainer(ctx,
+			testcontainers.GenericContainerRequest{
+				ContainerRequest: it.containerRequest,
+				Started:          true,
+			})
+		return err == nil
+	}, 5*time.Minute, time.Second)
 	defer func() {
-		require.NoError(t, container.Terminate(context.Background()))
+		require.NoError(t, container.Terminate(ctx))
 	}()
 
 	cfg := it.factory.CreateDefaultConfig()


### PR DESCRIPTION
#22134 and #17201 appear to result from running the setup script before the rabbit service is available. In an effort to rapidly reduce the overall rate of failure, I think the framework should retry container creation from the start whenever it fails.