### PR TITLE
[chore] Migrate sqlquery receiver integration test to new framework

### DIFF
--- a/receiver/apachereceiver/integration_test.go
+++ b/receiver/apachereceiver/integration_test.go
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+// +build integration
+
 package apachereceiver
 
 import (

--- a/receiver/apachereceiver/integration_test.go
+++ b/receiver/apachereceiver/integration_test.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build integration
-// +build integration
-
 package apachereceiver
 
 import (

--- a/receiver/sqlqueryreceiver/go.mod
+++ b/receiver/sqlqueryreceiver/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/lib/pq v1.10.9
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.77.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.77.0
 	github.com/sijms/go-ora/v2 v2.7.6
 	github.com/snowflakedb/gosnowflake v1.6.18
 	github.com/stretchr/testify v1.8.2
@@ -43,6 +45,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.27.11 // indirect
 	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/containerd v1.6.19 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
@@ -78,6 +81,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.77.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
 	github.com/opencontainers/runc v1.1.5 // indirect
@@ -116,3 +120,9 @@ retract (
 	v0.76.1
 	v0.65.0
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil => ../../pkg/pdatautil

--- a/receiver/sqlqueryreceiver/go.sum
+++ b/receiver/sqlqueryreceiver/go.sum
@@ -117,6 +117,7 @@ github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -2,458 +2,284 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
+// +build integration
 
 package sqlqueryreceiver
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/docker/go-connections/nat"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.opentelemetry.io/collector/component"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/scraperinttest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
+)
+
+const (
+	postgresqlPort = "5432"
+	oraclePort     = "1521"
+	mysqlPort      = "3306"
 )
 
 func TestPostgresIntegration(t *testing.T) {
-	externalPort := "15432"
-	internalPort := "5432"
-	waitStrategy := wait.ForListeningPort(nat.Port(internalPort)).WithStartupTimeout(2 * time.Minute)
-	req := testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context:    filepath.Join("testdata", "integration"),
-			Dockerfile: "Dockerfile.postgresql",
-		},
-		ExposedPorts: []string{externalPort + ":" + internalPort},
-		WaitingFor:   waitStrategy,
-	}
-	ctx := context.Background()
-
-	_, err := testcontainers.GenericContainer(
-		ctx,
-		testcontainers.GenericContainerRequest{
-			ContainerRequest: req,
-			Started:          true,
-		},
-	)
-	require.NoError(t, err)
-
-	factory := NewFactory()
-	config := factory.CreateDefaultConfig().(*Config)
-	config.Driver = "postgres"
-	config.DataSource = fmt.Sprintf("host=localhost port=%s user=otel password=otel sslmode=disable", externalPort)
-	genreKey := "genre"
-	config.Queries = []Query{
-		{
-			SQL: "select genre, count(*), avg(imdb_rating) from movie group by genre",
-			Metrics: []MetricCfg{
-				{
-					MetricName:       "genre.count",
-					ValueColumn:      "count",
-					AttributeColumns: []string{genreKey},
-					ValueType:        MetricValueTypeInt,
-					DataType:         MetricTypeGauge,
+	scraperinttest.NewIntegrationTest(
+		NewFactory(),
+		scraperinttest.WithContainerRequest(
+			testcontainers.ContainerRequest{
+				FromDockerfile: testcontainers.FromDockerfile{
+					Context:    filepath.Join("testdata", "integration"),
+					Dockerfile: "Dockerfile.postgresql",
 				},
-				{
-					MetricName:       "genre.imdb",
-					ValueColumn:      "avg",
-					AttributeColumns: []string{genreKey},
-					ValueType:        MetricValueTypeDouble,
-					DataType:         MetricTypeGauge,
-				},
-			},
-		},
-		{
-			SQL: "select 1::smallint as a, 2::integer as b, 3::bigint as c, 4.1::decimal as d," +
-				" 4.2::numeric as e, 4.3::real as f, 4.4::double precision as g, null as h",
-			Metrics: []MetricCfg{
-				{
-					MetricName:  "a",
-					ValueColumn: "a",
-					ValueType:   MetricValueTypeInt,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "b",
-					ValueColumn: "b",
-					ValueType:   MetricValueTypeInt,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "c",
-					ValueColumn: "c",
-					ValueType:   MetricValueTypeInt,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "d",
-					ValueColumn: "d",
-					ValueType:   MetricValueTypeDouble,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "e",
-					ValueColumn: "e",
-					ValueType:   MetricValueTypeDouble,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "f",
-					ValueColumn: "f",
-					ValueType:   MetricValueTypeDouble,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "g",
-					ValueColumn: "g",
-					ValueType:   MetricValueTypeDouble,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "h",
-					ValueColumn: "h",
-					ValueType:   MetricValueTypeDouble,
-					DataType:    MetricTypeGauge,
-				},
-			},
-		},
-	}
-	consumer := &consumertest.MetricsSink{}
-	receiver, err := factory.CreateMetricsReceiver(
-		ctx,
-		receivertest.NewNopCreateSettings(),
-		config,
-		consumer,
-	)
-	require.NoError(t, err)
-	err = receiver.Start(ctx, componenttest.NewNopHost())
-	require.NoError(t, err)
-	require.Eventuallyf(
-		t,
-		func() bool {
-			ms := consumer.AllMetrics()
-			return len(ms) > 0 && ms[len(ms)-1].ResourceMetrics().Len() >= 2
-		},
-		2*time.Minute,
-		1*time.Second,
-		"failed to receive more than 0 metrics",
-	)
-	allMetrics := consumer.AllMetrics()
-	metrics := allMetrics[len(allMetrics)-1]
-	rms := metrics.ResourceMetrics()
-	testMovieMetrics(t, rms.At(0), genreKey)
-	testPGTypeMetrics(t, rms.At(1))
+				ExposedPorts: []string{postgresqlPort},
+				WaitingFor: wait.ForListeningPort(nat.Port(postgresqlPort)).
+					WithStartupTimeout(2 * time.Minute),
+			}),
+		scraperinttest.WithCustomConfig(
+			func(t *testing.T, cfg component.Config, ci *scraperinttest.ContainerInfo) {
+				rCfg := cfg.(*Config)
+				rCfg.Driver = "postgres"
+				rCfg.DataSource = fmt.Sprintf("host=%s port=%s user=otel password=otel sslmode=disable",
+					ci.Host(t), ci.MappedPort(t, postgresqlPort))
+				rCfg.Queries = []Query{
+					{
+						SQL: "select genre, count(*), avg(imdb_rating) from movie group by genre",
+						Metrics: []MetricCfg{
+							{
+								MetricName:       "genre.count",
+								ValueColumn:      "count",
+								AttributeColumns: []string{"genre"},
+								ValueType:        MetricValueTypeInt,
+								DataType:         MetricTypeGauge,
+							},
+							{
+								MetricName:       "genre.imdb",
+								ValueColumn:      "avg",
+								AttributeColumns: []string{"genre"},
+								ValueType:        MetricValueTypeDouble,
+								DataType:         MetricTypeGauge,
+							},
+						},
+					},
+					{
+						SQL: "select 1::smallint as a, 2::integer as b, 3::bigint as c, 4.1::decimal as d," +
+							" 4.2::numeric as e, 4.3::real as f, 4.4::double precision as g, null as h",
+						Metrics: []MetricCfg{
+							{
+								MetricName:  "a",
+								ValueColumn: "a",
+								ValueType:   MetricValueTypeInt,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "b",
+								ValueColumn: "b",
+								ValueType:   MetricValueTypeInt,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "c",
+								ValueColumn: "c",
+								ValueType:   MetricValueTypeInt,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "d",
+								ValueColumn: "d",
+								ValueType:   MetricValueTypeDouble,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "e",
+								ValueColumn: "e",
+								ValueType:   MetricValueTypeDouble,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "f",
+								ValueColumn: "f",
+								ValueType:   MetricValueTypeDouble,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "g",
+								ValueColumn: "g",
+								ValueType:   MetricValueTypeDouble,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "h",
+								ValueColumn: "h",
+								ValueType:   MetricValueTypeDouble,
+								DataType:    MetricTypeGauge,
+							},
+						},
+					},
+				}
+			}),
+		scraperinttest.WithExpectedFile(
+			filepath.Join("testdata", "integration", "expected_postgresql.yaml"),
+		),
+		scraperinttest.WithCompareOptions(
+			pmetrictest.IgnoreTimestamp(),
+		),
+	).Run(t)
 }
 
 // This test ensures the collector can connect to an Oracle DB, and properly get metrics. It's not intended to
 // test the receiver itself.
 func TestOracleDBIntegration(t *testing.T) {
-	externalPort := "51521"
-	internalPort := "1521"
-
-	// The Oracle DB container takes close to 10 minutes on a local machine to do the default setup, so the best way to
-	// account for startup time is to wait for the container to be healthy before continuing test.
-	waitStrategy := wait.NewHealthStrategy().WithStartupTimeout(15 * time.Minute)
-	req := testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context:    filepath.Join("testdata", "integration"),
-			Dockerfile: "Dockerfile.oracledb",
-		},
-		ExposedPorts: []string{externalPort + ":" + internalPort},
-		WaitingFor:   waitStrategy,
-	}
-	ctx := context.Background()
-
-	container, err := testcontainers.GenericContainer(
-		ctx,
-		testcontainers.GenericContainerRequest{
-			ContainerRequest: req,
-			Started:          true,
-		},
-	)
-	require.NotNil(t, container)
-	require.NoError(t, err)
-
-	genreKey := "GENRE"
-	factory := NewFactory()
-	config := factory.CreateDefaultConfig().(*Config)
-	config.Driver = "oracle"
-	config.DataSource = "oracle://otel:password@localhost:51521/XE"
-	config.Queries = []Query{
-		{
-			SQL: "select genre, count(*) as count, avg(imdb_rating) as avg from sys.movie group by genre",
-			Metrics: []MetricCfg{
-				{
-					MetricName:       "genre.count",
-					ValueColumn:      "COUNT",
-					AttributeColumns: []string{genreKey},
-					ValueType:        MetricValueTypeInt,
-					DataType:         MetricTypeGauge,
+	scraperinttest.NewIntegrationTest(
+		NewFactory(),
+		scraperinttest.WithDumpActualOnFailure(),
+		scraperinttest.WithContainerRequest(
+			testcontainers.ContainerRequest{
+				FromDockerfile: testcontainers.FromDockerfile{
+					Context:    filepath.Join("testdata", "integration"),
+					Dockerfile: "Dockerfile.oracledb",
 				},
-				{
-					MetricName:       "genre.imdb",
-					ValueColumn:      "AVG",
-					AttributeColumns: []string{genreKey},
-					ValueType:        MetricValueTypeDouble,
-					DataType:         MetricTypeGauge,
-				},
-			},
-		},
-	}
-	consumer := &consumertest.MetricsSink{}
-	receiver, err := factory.CreateMetricsReceiver(
-		ctx,
-		receivertest.NewNopCreateSettings(),
-		config,
-		consumer,
-	)
-	require.NoError(t, err)
-	err = receiver.Start(ctx, componenttest.NewNopHost())
-	require.NoError(t, err)
-	require.Eventuallyf(
-		t,
-		func() bool {
-			return consumer.DataPointCount() > 0
-		},
-		15*time.Minute,
-		1*time.Second,
-		"failed to receive more than 0 metrics",
-	)
-	allMetrics := consumer.AllMetrics()
-	metrics := allMetrics[len(allMetrics)-1]
-	rms := metrics.ResourceMetrics()
-	testMovieMetrics(t, rms.At(0), genreKey)
+				ExposedPorts: []string{oraclePort},
+				// The Oracle DB container takes close to 10 minutes on a local machine
+				// to do the default setup, so the best way to account for startup time
+				// is to wait for the container to be healthy before continuing test.
+				WaitingFor: wait.NewHealthStrategy().WithStartupTimeout(15 * time.Minute),
+			}),
+		scraperinttest.WithCreateContainerTimeout(15*time.Minute),
+		scraperinttest.WithCustomConfig(
+			func(t *testing.T, cfg component.Config, ci *scraperinttest.ContainerInfo) {
+				rCfg := cfg.(*Config)
+				rCfg.Driver = "oracle"
+				rCfg.DataSource = fmt.Sprintf("oracle://otel:password@%s:%s/XE",
+					ci.Host(t), ci.MappedPort(t, oraclePort))
+				rCfg.Queries = []Query{
+					{
+						SQL: "select genre, count(*) as count, avg(imdb_rating) as avg from sys.movie group by genre",
+						Metrics: []MetricCfg{
+							{
+								MetricName:       "genre.count",
+								ValueColumn:      "COUNT",
+								AttributeColumns: []string{"GENRE"},
+								ValueType:        MetricValueTypeInt,
+								DataType:         MetricTypeGauge,
+							},
+							{
+								MetricName:       "genre.imdb",
+								ValueColumn:      "AVG",
+								AttributeColumns: []string{"GENRE"},
+								ValueType:        MetricValueTypeDouble,
+								DataType:         MetricTypeGauge,
+							},
+						},
+					},
+				}
+			}),
+		scraperinttest.WithExpectedFile(
+			filepath.Join("testdata", "integration", "expected_oracledb.yaml"),
+		),
+		scraperinttest.WithCompareOptions(
+			pmetrictest.IgnoreTimestamp(),
+		),
+	).Run(t)
 }
 
 func TestMysqlIntegration(t *testing.T) {
-	externalPort := "13306"
-	internalPort := "3306"
-	waitStrategy := wait.ForListeningPort(nat.Port(internalPort)).WithStartupTimeout(2 * time.Minute)
-	req := testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context:    filepath.Join("testdata", "integration"),
-			Dockerfile: "Dockerfile.mysql",
-		},
-		ExposedPorts: []string{externalPort + ":" + internalPort},
-		WaitingFor:   waitStrategy,
-	}
-	ctx := context.Background()
-
-	_, err := testcontainers.GenericContainer(
-		ctx,
-		testcontainers.GenericContainerRequest{
-			ContainerRequest: req,
-			Started:          true,
-		},
-	)
-	require.NoError(t, err)
-
-	factory := NewFactory()
-	config := factory.CreateDefaultConfig().(*Config)
-	config.Driver = "mysql"
-	config.DataSource = fmt.Sprintf("otel:otel@tcp(localhost:%s)/otel", externalPort)
-	genreKey := "genre"
-	config.Queries = []Query{
-		{
-			SQL: "select genre, count(*), avg(imdb_rating) from movie group by genre",
-			Metrics: []MetricCfg{
-				{
-					MetricName:       "genre.count",
-					ValueColumn:      "count(*)",
-					AttributeColumns: []string{genreKey},
-					ValueType:        MetricValueTypeInt,
-					DataType:         MetricTypeGauge,
+	scraperinttest.NewIntegrationTest(
+		NewFactory(),
+		scraperinttest.WithContainerRequest(
+			testcontainers.ContainerRequest{
+				FromDockerfile: testcontainers.FromDockerfile{
+					Context:    filepath.Join("testdata", "integration"),
+					Dockerfile: "Dockerfile.mysql",
 				},
-				{
-					MetricName:       "genre.imdb",
-					ValueColumn:      "avg(imdb_rating)",
-					AttributeColumns: []string{genreKey},
-					ValueType:        MetricValueTypeDouble,
-					DataType:         MetricTypeGauge,
-				},
-			},
-		},
-		{
-			SQL: "select " +
-				"cast(1 as signed) as a, " +
-				"cast(2 as unsigned) as b, " +
-				"cast(3.1 as decimal(10,1)) as c, " +
-				"cast(3.2 as real) as d, " +
-				"cast(3.3 as float) as e, " +
-				"cast(3.4 as double) as f, " +
-				"null as g",
-			Metrics: []MetricCfg{
-				{
-					MetricName:  "a",
-					ValueColumn: "a",
-					ValueType:   MetricValueTypeInt,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "b",
-					ValueColumn: "b",
-					ValueType:   MetricValueTypeInt,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "c",
-					ValueColumn: "c",
-					ValueType:   MetricValueTypeDouble,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "d",
-					ValueColumn: "d",
-					ValueType:   MetricValueTypeDouble,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "e",
-					ValueColumn: "e",
-					ValueType:   MetricValueTypeDouble,
-					DataType:    MetricTypeGauge,
-				},
-				{
-					MetricName:  "f",
-					ValueColumn: "f",
-					ValueType:   MetricValueTypeDouble,
-					DataType:    MetricTypeGauge,
-				},
-			},
-		},
-	}
-	consumer := &consumertest.MetricsSink{}
-	receiver, err := factory.CreateMetricsReceiver(
-		ctx,
-		receivertest.NewNopCreateSettings(),
-		config,
-		consumer,
-	)
-	require.NoError(t, err)
-	err = receiver.Start(ctx, componenttest.NewNopHost())
-	require.NoError(t, err)
-	require.Eventuallyf(
-		t,
-		func() bool {
-			ms := consumer.AllMetrics()
-			return len(ms) > 0 && ms[len(ms)-1].ResourceMetrics().Len() >= 2
-		},
-		2*time.Minute,
-		1*time.Second,
-		"failed to receive more than 0 metrics",
-	)
-	allMetrics := consumer.AllMetrics()
-	metrics := allMetrics[len(allMetrics)-1]
-	rms := metrics.ResourceMetrics()
-	testMovieMetrics(t, rms.At(0), genreKey)
-	testMysqlTypeMetrics(t, rms.At(1))
-}
-
-func testMovieMetrics(t *testing.T, rm pmetric.ResourceMetrics, genreAttrKey string) {
-	sms := rm.ScopeMetrics()
-	assert.Equal(t, 1, sms.Len())
-	sm := sms.At(0)
-	ms := sm.Metrics()
-	assert.Equal(t, 4, ms.Len())
-
-	metricsByName := map[string][]pmetric.Metric{}
-	for i := 0; i < ms.Len(); i++ {
-		metric := ms.At(i)
-		name := metric.Name()
-		metricsByName[name] = append(metricsByName[name], metric)
-	}
-
-	for _, metric := range metricsByName["genre.count"] {
-		pt := metric.Gauge().DataPoints().At(0)
-		genre, _ := pt.Attributes().Get(genreAttrKey)
-		genreStr := genre.AsString()
-		switch genreStr {
-		case "SciFi":
-			assert.EqualValues(t, 3, pt.IntValue())
-		case "Action":
-			assert.EqualValues(t, 2, pt.IntValue())
-		default:
-			assert.Failf(t, "unexpected genre: %s", genreStr)
-		}
-	}
-
-	for _, metric := range metricsByName["genre.imdb"] {
-		pt := metric.Gauge().DataPoints().At(0)
-		genre, _ := pt.Attributes().Get(genreAttrKey)
-		genreStr := genre.AsString()
-		switch genreStr {
-		case "SciFi":
-			assert.InDelta(t, 8.2, pt.DoubleValue(), 0.1)
-		case "Action":
-			assert.InDelta(t, 7.65, pt.DoubleValue(), 0.1)
-		default:
-			assert.Failf(t, "unexpected genre: %s", genreStr)
-		}
-	}
-}
-
-func testPGTypeMetrics(t *testing.T, rm pmetric.ResourceMetrics) {
-	sms := rm.ScopeMetrics()
-	assert.Equal(t, 1, sms.Len())
-	sm := sms.At(0)
-	ms := sm.Metrics()
-	for i := 0; i < ms.Len(); i++ {
-		metric := ms.At(0)
-		switch metric.Name() {
-		case "a":
-			assertIntGaugeEquals(t, 1, metric)
-		case "b":
-			assertIntGaugeEquals(t, 2, metric)
-		case "c":
-			assertIntGaugeEquals(t, 3, metric)
-		case "d":
-			assertDoubleGaugeEquals(t, 4.1, metric)
-		case "e":
-			assertDoubleGaugeEquals(t, 4.2, metric)
-		case "f":
-			assertDoubleGaugeEquals(t, 4.3, metric)
-		case "g":
-			assertDoubleGaugeEquals(t, 4.4, metric)
-		}
-	}
-}
-
-func testMysqlTypeMetrics(t *testing.T, rm pmetric.ResourceMetrics) {
-	sms := rm.ScopeMetrics()
-	assert.Equal(t, 1, sms.Len())
-	sm := sms.At(0)
-	ms := sm.Metrics()
-	for i := 0; i < ms.Len(); i++ {
-		metric := ms.At(0)
-		switch metric.Name() {
-		case "a":
-			assertIntGaugeEquals(t, 1, metric)
-		case "b":
-			assertIntGaugeEquals(t, 2, metric)
-		case "c":
-			assertDoubleGaugeEquals(t, 3.1, metric)
-		case "d":
-			assertDoubleGaugeEquals(t, 3.2, metric)
-		case "e":
-			assertDoubleGaugeEquals(t, 3.3, metric)
-		case "f":
-			assertDoubleGaugeEquals(t, 3.4, metric)
-		}
-	}
-}
-
-func assertIntGaugeEquals(t *testing.T, expected int, metric pmetric.Metric) {
-	assert.EqualValues(t, expected, metric.Gauge().DataPoints().At(0).IntValue())
-}
-
-func assertDoubleGaugeEquals(t *testing.T, expected float64, metric pmetric.Metric) {
-	assert.InDelta(t, expected, metric.Gauge().DataPoints().At(0).DoubleValue(), 0.1)
+				ExposedPorts: []string{mysqlPort},
+				WaitingFor:   wait.ForListeningPort(nat.Port(mysqlPort)).WithStartupTimeout(2 * time.Minute),
+			}),
+		scraperinttest.WithCustomConfig(
+			func(t *testing.T, cfg component.Config, ci *scraperinttest.ContainerInfo) {
+				rCfg := cfg.(*Config)
+				rCfg.Driver = "mysql"
+				rCfg.DataSource = fmt.Sprintf("otel:otel@tcp(%s:%s)/otel",
+					ci.Host(t), ci.MappedPort(t, mysqlPort))
+				rCfg.Queries = []Query{
+					{
+						SQL: "select genre, count(*), avg(imdb_rating) from movie group by genre",
+						Metrics: []MetricCfg{
+							{
+								MetricName:       "genre.count",
+								ValueColumn:      "count(*)",
+								AttributeColumns: []string{"genre"},
+								ValueType:        MetricValueTypeInt,
+								DataType:         MetricTypeGauge,
+							},
+							{
+								MetricName:       "genre.imdb",
+								ValueColumn:      "avg(imdb_rating)",
+								AttributeColumns: []string{"genre"},
+								ValueType:        MetricValueTypeDouble,
+								DataType:         MetricTypeGauge,
+							},
+						},
+					},
+					{
+						SQL: "select " +
+							"cast(1 as signed) as a, " +
+							"cast(2 as unsigned) as b, " +
+							"cast(3.1 as decimal(10,1)) as c, " +
+							"cast(3.2 as real) as d, " +
+							"cast(3.3 as float) as e, " +
+							"cast(3.4 as double) as f, " +
+							"null as g",
+						Metrics: []MetricCfg{
+							{
+								MetricName:  "a",
+								ValueColumn: "a",
+								ValueType:   MetricValueTypeInt,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "b",
+								ValueColumn: "b",
+								ValueType:   MetricValueTypeInt,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "c",
+								ValueColumn: "c",
+								ValueType:   MetricValueTypeDouble,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "d",
+								ValueColumn: "d",
+								ValueType:   MetricValueTypeDouble,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "e",
+								ValueColumn: "e",
+								ValueType:   MetricValueTypeDouble,
+								DataType:    MetricTypeGauge,
+							},
+							{
+								MetricName:  "f",
+								ValueColumn: "f",
+								ValueType:   MetricValueTypeDouble,
+								DataType:    MetricTypeGauge,
+							},
+						},
+					},
+				}
+			}),
+		scraperinttest.WithExpectedFile(
+			filepath.Join("testdata", "integration", "expected_mysql.yaml"),
+		),
+		scraperinttest.WithCompareOptions(
+			pmetrictest.IgnoreTimestamp(),
+		),
+	).Run(t)
 }

--- a/receiver/sqlqueryreceiver/testdata/integration/expected_mysql.yaml
+++ b/receiver/sqlqueryreceiver/testdata/integration/expected_mysql.yaml
@@ -1,0 +1,75 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asInt: "3"
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: SciFi
+                  timeUnixNano: "1684614725494431000"
+            name: genre.count
+          - gauge:
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: Action
+                  timeUnixNano: "1684614725494431000"
+            name: genre.count
+          - gauge:
+              dataPoints:
+                - asDouble: 8.200000286102295
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: SciFi
+                  timeUnixNano: "1684614725494431000"
+            name: genre.imdb
+          - gauge:
+              dataPoints:
+                - asDouble: 7.6499998569488525
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: Action
+                  timeUnixNano: "1684614725494431000"
+            name: genre.imdb
+        scope: {}
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asInt: "1"
+                  timeUnixNano: "1684614725499638000"
+            name: a
+          - gauge:
+              dataPoints:
+                - asInt: "2"
+                  timeUnixNano: "1684614725499638000"
+            name: b
+          - gauge:
+              dataPoints:
+                - asDouble: 3.1
+                  timeUnixNano: "1684614725499638000"
+            name: c
+          - gauge:
+              dataPoints:
+                - asDouble: 3.2
+                  timeUnixNano: "1684614725499638000"
+            name: d
+          - gauge:
+              dataPoints:
+                - asDouble: 3.3
+                  timeUnixNano: "1684614725499638000"
+            name: e
+          - gauge:
+              dataPoints:
+                - asDouble: 3.4
+                  timeUnixNano: "1684614725499638000"
+            name: f
+        scope: {}

--- a/receiver/sqlqueryreceiver/testdata/integration/expected_oracledb.yaml
+++ b/receiver/sqlqueryreceiver/testdata/integration/expected_oracledb.yaml
@@ -1,0 +1,41 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asInt: "3"
+                  attributes:
+                    - key: GENRE
+                      value:
+                        stringValue: SciFi
+                  timeUnixNano: "1684632870521947236"
+            name: genre.count
+          - gauge:
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: GENRE
+                      value:
+                        stringValue: Action
+                  timeUnixNano: "1684632870521947236"
+            name: genre.count
+          - gauge:
+              dataPoints:
+                - asDouble: 8.2
+                  attributes:
+                    - key: GENRE
+                      value:
+                        stringValue: SciFi
+                  timeUnixNano: "1684632870521947236"
+            name: genre.imdb
+          - gauge:
+              dataPoints:
+                - asDouble: 7.65
+                  attributes:
+                    - key: GENRE
+                      value:
+                        stringValue: Action
+                  timeUnixNano: "1684632870521947236"
+            name: genre.imdb
+        scope: {}

--- a/receiver/sqlqueryreceiver/testdata/integration/expected_postgresql.yaml
+++ b/receiver/sqlqueryreceiver/testdata/integration/expected_postgresql.yaml
@@ -1,0 +1,84 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: Action
+                  timeUnixNano: "1684613308016320000"
+            name: genre.count
+          - gauge:
+              dataPoints:
+                - asInt: "3"
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: SciFi
+                  timeUnixNano: "1684613308016320000"
+            name: genre.count
+          - gauge:
+              dataPoints:
+                - asDouble: 7.6499999999999995
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: Action
+                  timeUnixNano: "1684613308016320000"
+            name: genre.imdb
+          - gauge:
+              dataPoints:
+                - asDouble: 8.200000000000001
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: SciFi
+                  timeUnixNano: "1684613308016320000"
+            name: genre.imdb
+        scope: {}
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asInt: "1"
+                  timeUnixNano: "1684613308030553000"
+            name: a
+          - gauge:
+              dataPoints:
+                - asInt: "2"
+                  timeUnixNano: "1684613308030553000"
+            name: b
+          - gauge:
+              dataPoints:
+                - asInt: "3"
+                  timeUnixNano: "1684613308030553000"
+            name: c
+          - gauge:
+              dataPoints:
+                - asDouble: 4.1
+                  timeUnixNano: "1684613308030553000"
+            name: d
+          - gauge:
+              dataPoints:
+                - asDouble: 4.2
+                  timeUnixNano: "1684613308030553000"
+            name: e
+          - gauge:
+              dataPoints:
+                - asDouble: 4.3000002
+                  timeUnixNano: "1684613308030553000"
+            name: f
+          - gauge:
+              dataPoints:
+                - asDouble: 4.4
+                  timeUnixNano: "1684613308030553000"
+            name: g
+          - gauge:
+              dataPoints:
+                - timeUnixNano: "1684613308030553000"
+            name: h
+        scope: {}


### PR DESCRIPTION
Follows #22104

This also effectively migrates these tests from manual validation of results to using the `golden` package for defining expected results.