### PR TITLE
Fix typo in s3 confmap provider validation regex

### DIFF
--- a/.chloggen/rapphil-fix-s3-provider-regex-pattern.yaml
+++ b/.chloggen/rapphil-fix-s3-provider-regex-pattern.yaml
@@ -1,0 +1,18 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: confmap/provider/s3provider
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix typo in s3 confmap provider regex pattern
+
+# One or more tracking issues related to the change
+issues: [22146]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Fix regex pattern for s3 confmap provider. This typo allows for using different domains
+  from what is expected.

--- a/confmap/provider/s3provider/provider.go
+++ b/confmap/provider/s3provider/provider.go
@@ -20,7 +20,7 @@ import (
 const (
 	schemeName = "s3"
 	// Pattern for a s3 uri
-	s3Pattern = `^s3:\/\/([a-z0-9\.\-]{3,63})\.s3\.([a-z0-9\-]+).amazonaws\.com\/.`
+	s3Pattern = `^s3:\/\/([a-z0-9\.\-]{3,63})\.s3\.([a-z0-9\-]+)\.amazonaws\.com\/.`
 )
 
 var s3Regexp = regexp.MustCompile(s3Pattern)

--- a/confmap/provider/s3provider/provider_test.go
+++ b/confmap/provider/s3provider/provider_test.go
@@ -73,6 +73,7 @@ func TestURIs(t *testing.T) {
 		{"Invalid region", "s3://bucket.s3.region.aws.amazonaws.com/key", false, "", "", ""},
 		{"Invalid bucket", "s3://b.s3.region.amazonaws.com/key", false, "", "", ""},
 		{"No key", "s3://bucket.s3.region.amazonaws.com/", false, "", "", ""},
+		{"Merged region domain", "s3://bucket.name-here.s3.us-west-2aamazonaws.com/key", false, "", "", ""},
 		{"No bucket", "s3://s3.region.amazonaws.com/key", false, "", "", ""},
 		{"No region", "s3://some-bucket.s3..amazonaws.com/key", false, "", "", ""},
 		{"Test malformed uri", "s3://some-bucket.s3.us-west-2.amazonaws.com/key%", false, "", "", ""},


### PR DESCRIPTION
**Description:** Fix typo in regex pattern for s3 confmap provider

**Testing:** Added unit test for the specific bug.

