### PR TITLE
[chore] Fix Makefile's INTEGRATION_MODS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS
 
 # find -exec dirname cannot be used to process multiple matching patterns
 FIND_INTEGRATION_TEST_MODS={ find . -type f -name "*integration_test.go" & find . -type f -name "*e2e_test.go" -not -path "./testbed/*"; }
-INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | uniq | xargs $(TO_MOD_DIR) )
+INTEGRATION_MODS := $(shell $(FIND_INTEGRATION_TEST_MODS) | xargs $(TO_MOD_DIR) | uniq)
 
 ifeq ($(GOOS),windows)
 	EXTENSION := .exe


### PR DESCRIPTION
This properly deduplicates integration test modules.

Can be manually validated by adding a simple make target:
```make
int-modules:
	@echo $(INTEGRATION_MODS) | tr ' ' '\n' | sort
```

```diff
./exporter/azuredataexplorerexporter
./extension/observer/dockerobserver
./pkg/stanza/adapter
./processor/k8sattributesprocessor
./receiver/activedirectorydsreceiver
./receiver/aerospikereceiver
./receiver/apachereceiver
./receiver/awscloudwatchreceiver
./receiver/bigipreceiver
./receiver/cloudflarereceiver
./receiver/dockerstatsreceiver
./receiver/elasticsearchreceiver
./receiver/flinkmetricsreceiver
./receiver/iisreceiver
./receiver/jmxreceiver
./receiver/jmxreceiver/internal/subprocess
./receiver/kafkametricsreceiver
./receiver/memcachedreceiver
./receiver/mongodbatlasreceiver
- ./receiver/mongodbatlasreceiver
./receiver/mongodbreceiver
./receiver/mysqlreceiver
./receiver/nginxreceiver
./receiver/postgresqlreceiver
./receiver/rabbitmqreceiver
./receiver/redisreceiver
./receiver/riakreceiver
./receiver/snmpreceiver
./receiver/sqlqueryreceiver
./receiver/vcenterreceiver
./receiver/zookeeperreceiver
```