### PR TITLE
[exporter/awsemfexporter] add exponential histogram support

### DIFF
--- a/.chloggen/awsemf-exponential-histogram.yaml
+++ b/.chloggen/awsemf-exponential-histogram.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsemfexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add exponential histogram support.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22626]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -165,7 +165,7 @@ func (dps histogramDataPointSlice) CalculateDeltaDatapoints(i int, instrumentati
 }
 
 // CalculateDeltaDatapoints retrieves the ExponentialHistogramDataPoint at the given index.
-func (dps exponentialHistogramDataPointSlice) CalculateDeltaDatapoints(idx int, instrumentationScopeName string, detailedMetrics bool) ([]dataPoint, bool) {
+func (dps exponentialHistogramDataPointSlice) CalculateDeltaDatapoints(idx int, instrumentationScopeName string, _ bool) ([]dataPoint, bool) {
 	metric := dps.ExponentialHistogramDataPointSlice.At(idx)
 
 	scale := metric.Scale()

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -165,12 +165,11 @@ func (dps histogramDataPointSlice) CalculateDeltaDatapoints(i int, instrumentati
 }
 
 // CalculateDeltaDatapoints retrieves the ExponentialHistogramDataPoint at the given index.
-func (dps exponentialHistogramDataPointSlice) CalculateDeltaDatapoints(i int, instrumentationScopeName string, detailedMetrics bool) ([]dataPoint, bool) {
-	metric := dps.ExponentialHistogramDataPointSlice.At(i)
+func (dps exponentialHistogramDataPointSlice) CalculateDeltaDatapoints(idx int, instrumentationScopeName string, detailedMetrics bool) ([]dataPoint, bool) {
+	metric := dps.ExponentialHistogramDataPointSlice.At(idx)
 
 	scale := metric.Scale()
 	base := math.Pow(2, math.Pow(2, float64(-scale)))
-	datapoints := []dataPoint{}
 	arrayValues := []float64{}
 	arrayCounts := []float64{}
 	var bucketBegin float64
@@ -232,9 +231,8 @@ func (dps exponentialHistogramDataPointSlice) CalculateDeltaDatapoints(i int, in
 		}
 	}
 
-	MetricName := dps.metricName
-	datapoints = append(datapoints, dataPoint{
-		name: MetricName,
+	return []dataPoint{{
+		name: dps.metricName,
 		value: &cWMetricHistogram{
 			Values: arrayValues,
 			Counts: arrayCounts,
@@ -245,9 +243,7 @@ func (dps exponentialHistogramDataPointSlice) CalculateDeltaDatapoints(i int, in
 		},
 		labels:      createLabels(metric.Attributes(), instrumentationScopeName),
 		timestampMs: unixNanoToMilliseconds(metric.Timestamp()),
-	})
-
-	return datapoints, true
+	}}, true
 }
 
 // CalculateDeltaDatapoints retrieves the SummaryDataPoint at the given index and perform calculation with sum and count while retain the quantile value.

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -5,6 +5,7 @@ package awsemfexporter // import "github.com/open-telemetry/opentelemetry-collec
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
@@ -86,6 +87,13 @@ type histogramDataPointSlice struct {
 	pmetric.HistogramDataPointSlice
 }
 
+type exponentialHistogramDataPointSlice struct {
+	// TODO: Calculate delta value for count and sum value with exponential histogram
+	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18245
+	deltaMetricMetadata
+	pmetric.ExponentialHistogramDataPointSlice
+}
+
 // summaryDataPointSlice is a wrapper for pmetric.SummaryDataPointSlice
 type summaryDataPointSlice struct {
 	deltaMetricMetadata
@@ -154,6 +162,79 @@ func (dps histogramDataPointSlice) CalculateDeltaDatapoints(i int, instrumentati
 		labels:      labels,
 		timestampMs: timestamp,
 	}}, true
+}
+
+// CalculateDeltaDatapoints retrieves the ExponentialHistogramDataPoint at the given index.
+func (dps exponentialHistogramDataPointSlice) CalculateDeltaDatapoints(i int, instrumentationScopeName string, detailedMetrics bool) ([]dataPoint, bool) {
+	metric := dps.ExponentialHistogramDataPointSlice.At(i)
+	labels := createLabels(metric.Attributes(), instrumentationScopeName)
+	timestamp := unixNanoToMilliseconds(metric.Timestamp())
+
+	scale := metric.Scale()
+	base := math.Pow(2, math.Pow(2, float64(-scale)))
+	datapoints := []dataPoint{}
+	arrayValues := []float64{}
+	arrayCountes := []float64{}
+
+	// Set mid-point of positive buckets in values/counts array.
+	positiveBuckets := metric.Positive()
+	positiveOffset := positiveBuckets.Offset()
+	positiveBucketCounts := positiveBuckets.BucketCounts()
+	for i := 0; i < positiveBucketCounts.Len(); i++ {
+		index := i + int(positiveOffset)
+		bucketBegin := math.Pow(base, float64(index))
+		bucketEnd := math.Pow(base, float64(index+1))
+		metricVal := (bucketBegin + bucketEnd) / 2
+		count := positiveBucketCounts.At(i)
+		if count > 0 {
+			arrayValues = append(arrayValues, metricVal)
+			arrayCountes = append(arrayCountes, float64(count))
+		}
+	}
+
+	// Set count of zero bucket in values/counts array.
+	if metric.ZeroCount() > 0 {
+		arrayValues = append(arrayValues, 0)
+		arrayCountes = append(arrayCountes, float64(metric.ZeroCount()))
+	}
+
+	// Set mid-point of negative buckets in values/counts array.
+	// According to metrics spec, the value in histogram is expected to be non-negative.
+	// https://opentelemetry.io/docs/specs/otel/metrics/api/#histogram
+	// However, the negative support is defined in metrics data model.
+	// https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram
+	// The negative is also supported but only verified with unit test.
+	negativeBuckets := metric.Negative()
+	negativeOffset := negativeBuckets.Offset()
+	negativeBucketCounts := negativeBuckets.BucketCounts()
+	for i := 0; i < negativeBucketCounts.Len(); i++ {
+		index := i + int(negativeOffset)
+		bucketBegin := -math.Pow(base, float64(index+1))
+		bucketEnd := -math.Pow(base, float64(index))
+		metricVal := (bucketBegin + bucketEnd) / 2
+		count := negativeBucketCounts.At(i)
+		if count > 0 {
+			arrayValues = append(arrayValues, metricVal)
+			arrayCountes = append(arrayCountes, float64(count))
+		}
+	}
+
+	MetricName := dps.metricName
+	datapoints = append(datapoints, dataPoint{
+		name: MetricName,
+		value: &cWMetricHistogram{
+			Values: arrayValues,
+			Counts: arrayCountes,
+			Count:  metric.Count(),
+			Sum:    metric.Sum(),
+			Max:    metric.Max(),
+			Min:    metric.Min(),
+		},
+		labels:      labels,
+		timestampMs: timestamp,
+	})
+
+	return datapoints, true
 }
 
 // CalculateDeltaDatapoints retrieves the SummaryDataPoint at the given index and perform calculation with sum and count while retain the quantile value.
@@ -260,6 +341,12 @@ func getDataPoints(pmd pmetric.Metric, metadata cWMetricMetadata, logger *zap.Lo
 	case pmetric.MetricTypeHistogram:
 		metric := pmd.Histogram()
 		dps = histogramDataPointSlice{
+			metricMetadata,
+			metric.DataPoints(),
+		}
+	case pmetric.MetricTypeExponentialHistogram:
+		metric := pmd.ExponentialHistogram()
+		dps = exponentialHistogramDataPointSlice{
 			metricMetadata,
 			metric.DataPoints(),
 		}

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -56,6 +56,15 @@ type cWMetricStats struct {
 	Sum   float64
 }
 
+type cWMetricHistogram struct {
+	Values []float64
+	Counts []float64
+	Max    float64
+	Min    float64
+	Count  uint64
+	Sum    float64
+}
+
 type groupedMetricMetadata struct {
 	namespace                  string
 	timestampMs                int64

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -56,6 +56,8 @@ type cWMetricStats struct {
 	Sum   float64
 }
 
+// The SampleCount of CloudWatch metrics will be calculated by the sum of the 'Counts' array.
+// The 'Count' field should be same as the sum of the 'Counts' array and will be ignored in CloudWatch.
 type cWMetricHistogram struct {
 	Values []float64
 	Counts []float64


### PR DESCRIPTION
**Description:**

This PR adds [exponential histogram](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram) support in `awsemfexporter`. The exponential histogram metrics are exported in Embedded Metric Format (EMF) log. The Count, Sum, Max and Min are set as Statistical Set. The mid-point values and counts of exponential histogram buckets are translated into Values/Counts array of EMF log entry as well.

**Testing:**

The unit test is added and covers positive, zero and negative values. 

The integration test is performed with following OTEL collector configuration. 
```
extensions:
  health_check:
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:4317
      http:
        endpoint: 0.0.0.0:4318

processors:
  batch/metrics:
    timeout: 60s

exporters:
  logging:
    verbosity: detailed
  awsemf:
    region: 'us-east-1'
    namespace: "Test"
    dimension_rollup_option: "NoDimensionRollup"

service:
  pipelines:
    metrics:
      receivers: [otlp]
      processors: [batch/metrics]
      exporters: [awsemf, logging]
  extensions: [health_check]
  telemetry:
    logs:
      level: "debug"
```
It generated EMF log for histogram metrics in following JSON format. Notes: It doesn't cover negative values since histograms can [only record non-negative values](https://opentelemetry.io/docs/specs/otel/metrics/api/#histogram) and will [drop negative values](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogram.java#L38C7-L44).

```
    "latency": {
        "Values": [
            309.4277237034415,
            323.12725941969757,
            326.64588457862067,
            344.8221530867399,
            520.3933272846809,
            531.7884573308439,
            537.579253961712,
            543.4331082335607,
            549.3507067990806,
            555.3327437881196,
            561.3799208891041,
            567.4929474313465,
            720.1774681373079,
            0
        ],
        "Counts": [
            1,
            1,
            1,
            1,
            1,
            3,
            4,
            2,
            2,
            3,
            1,
            1,
            1,
            22
        ],
        "Max": 720,
        "Min": 0,
        "Count": 44,
        "Sum": 11265
    }
```



