### PR TITLE
[exporter/awsxray] Fix panic with string-valued DDB attrs

### DIFF
--- a/.chloggen/fix_xrayddbattr.yaml
+++ b/.chloggen/fix_xrayddbattr.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a panic that can occur with string-valued DynamoDB attributes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22707]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -157,14 +157,19 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 		queueURL = value.Str()
 	}
 	if value, ok := attributes[conventions.AttributeAWSDynamoDBTableNames]; ok {
-		if value.Slice().Len() == 1 {
-			tableName = value.Slice().At(0).Str()
-		} else if value.Slice().Len() > 1 {
-			tableName = ""
-			tableNames = []string{}
-			for i := 0; i < value.Slice().Len(); i++ {
-				tableNames = append(tableNames, value.Slice().At(i).Str())
+		switch value.Type() {
+		case pcommon.ValueTypeSlice:
+			if value.Slice().Len() == 1 {
+				tableName = value.Slice().At(0).Str()
+			} else if value.Slice().Len() > 1 {
+				tableName = ""
+				tableNames = []string{}
+				for i := 0; i < value.Slice().Len(); i++ {
+					tableNames = append(tableNames, value.Slice().At(i).Str())
+				}
 			}
+		case pcommon.ValueTypeStr:
+			tableName = value.Str()
 		}
 	}
 

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -304,6 +304,18 @@ func TestAwsWithDynamoDbSemConvAttributes(t *testing.T) {
 	assert.Equal(t, tableName, *awsData.TableName)
 }
 
+func TestAwsWithDynamoDbSemConvAttributesString(t *testing.T) {
+	tableName := "MyTable"
+	attributes := make(map[string]pcommon.Value)
+	attributes[conventions.AttributeAWSDynamoDBTableNames] = pcommon.NewValueStr(tableName)
+
+	filtered, awsData := makeAws(attributes, pcommon.NewResource(), nil)
+
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, awsData)
+	assert.Equal(t, tableName, *awsData.TableName)
+}
+
 func TestAwsWithRequestIdAlternateAttribute(t *testing.T) {
 	requestid := "12345-request"
 	attributes := make(map[string]pcommon.Value)


### PR DESCRIPTION
**Description:** Fixes a panic caused by assuming an attribute is slice-valued.
**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/2079

**Testing:** A new unit test was added with a string-valued attribute.
