### PR TITLE
[pkg/ottl] Allow capture groups in replace_all_patterns when replacing keys

### DIFF
--- a/.chloggen/ottl-issue-22094.yaml
+++ b/.chloggen/ottl-issue-22094.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow using capture groups in `replace_all_patterns` when replacing map keys
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22094]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -66,7 +66,7 @@ func replaceAllPatterns[K any](target ottl.PMapGetter[K], mode string, regexPatt
 				}
 			case modeKey:
 				if compiledPattern.MatchString(key) {
-					updatedKey := compiledPattern.ReplaceAllLiteralString(key, replacement)
+					updatedKey := compiledPattern.ReplaceAllString(key, replacement)
 					originalValue.CopyTo(updated.PutEmpty(updatedKey))
 				} else {
 					originalValue.CopyTo(updated.PutEmpty(key))

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -131,7 +131,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 			},
 		},
 		{
-			name:        "expand capturing groups",
+			name:        "expand capturing groups in values",
 			target:      target,
 			mode:        modeValue,
 			pattern:     `world(\d)`,
@@ -144,6 +144,21 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+			},
+		},
+		{
+			name:        "expand capturing groups in keys",
+			target:      target,
+			mode:        modeKey,
+			pattern:     `test(\d)`,
+			replacement: "test-$1",
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.PutStr("test", "hello world")
+				expectedMap.PutStr("test-2", "hello")
+				expectedMap.PutStr("test-3", "goodbye world1 and world2")
+				expectedMap.PutInt("test-4", 1234)
+				expectedMap.PutDouble("test-5", 1234)
+				expectedMap.PutBool("test-6", true)
 			},
 		},
 		{


### PR DESCRIPTION
**Description:**

Key replacement wasn't switched to allow use of capture groups when the functionality was added to `replace_all_patterns`.

**Link to tracking Issue:**

Fixes #22094 

**Testing:**

Added a unit test to cover this.

**Documentation:**

Using capture groups to replace keys is already in the documentation for `replace_all_patterns`.