### PR TITLE
[receiver/awscloudwatch] Fix issue with log stream filtering in the cloudwatch receiver

### DIFF
--- a/.chloggen/rnishtala_cw_receiver.yaml
+++ b/.chloggen/rnishtala_cw_receiver.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receivers/awscloudwatch
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes a bug where the AWS CloudWatch receiver does the log stream filtering (using prefix) incorrectly."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22123]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  An additional request was being made with a single log stream prefix definition.
+  This request was made with the stream name set to "".
+  This results in logs collection from all log streams in the log group.

--- a/.chloggen/rnishtala_cw_receiver.yaml
+++ b/.chloggen/rnishtala_cw_receiver.yaml
@@ -6,7 +6,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: receivers/awscloudwatch
+component: awscloudwatchreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Fixes a bug where the AWS CloudWatch receiver does the log stream filtering (using prefix) incorrectly."

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -103,7 +103,9 @@ func newLogsReceiver(cfg *Config, logger *zap.Logger, consumer consumer.Logs) *l
 		for _, prefix := range sc.Prefixes {
 			groups = append(groups, &streamPrefix{group: logGroupName, prefix: prefix})
 		}
-		groups = append(groups, &streamNames{group: logGroupName, names: sc.Names})
+		if len(sc.Names) > 0 {
+			groups = append(groups, &streamNames{group: logGroupName, names: sc.Names})
+		}
 	}
 
 	// safeguard from using both

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -93,6 +93,10 @@ func TestPrefixedNamedStreamsConfig(t *testing.T) {
 		return sink.LogRecordCount() > 0
 	}, 2*time.Second, 10*time.Millisecond)
 
+	groupRequests := alertRcvr.groupRequests
+	require.Len(t, groupRequests, 1)
+	require.Equal(t, groupRequests[0].groupName(), "test-log-group-name")
+
 	err = alertRcvr.Shutdown(context.Background())
 	require.NoError(t, err)
 


### PR DESCRIPTION
**Description:** 
Fix issue with log stream filtering in the cloudwatch receiver

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22123

**Testing:**
Modified a unit test case that asserts on the number of requests being made for a single log stream prefix configured.
