### PR TITLE
[chore][scraperinttest] Always print errors on failure

### DIFF
--- a/internal/coreinternal/golden/golden.go
+++ b/internal/coreinternal/golden/golden.go
@@ -47,24 +47,33 @@ func WriteMetrics(t *testing.T, filePath string, metrics pmetric.Metrics) error 
 	return nil
 }
 
-// writeMetrics writes a pmetric.Metrics to the specified file in YAML format.
-func writeMetrics(filePath string, metrics pmetric.Metrics) error {
+// MarshalMetricsYAML marshals a pmetric.Metrics to YAML format.
+func MarshalMetricsYAML(metrics pmetric.Metrics) ([]byte, error) {
 	unmarshaler := &pmetric.JSONMarshaler{}
 	fileBytes, err := unmarshaler.MarshalMetrics(metrics)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var jsonVal map[string]interface{}
 	if err = json.Unmarshal(fileBytes, &jsonVal); err != nil {
-		return err
+		return nil, err
 	}
 	b := &bytes.Buffer{}
 	enc := yaml.NewEncoder(b)
 	enc.SetIndent(2)
 	if err := enc.Encode(jsonVal); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+// writeMetrics writes a pmetric.Metrics to the specified file in YAML format.
+func writeMetrics(filePath string, metrics pmetric.Metrics) error {
+	b, err := MarshalMetricsYAML(metrics)
+	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(filePath, b.Bytes(), 0600); err != nil {
+	if err := os.WriteFile(filePath, b, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/receiver/elasticsearchreceiver/integration_test.go
+++ b/receiver/elasticsearchreceiver/integration_test.go
@@ -57,7 +57,5 @@ func integrationTest(name string) func(*testing.T) {
 			pmetrictest.IgnoreScopeMetricsOrder(),
 			pmetrictest.IgnoreResourceMetricsOrder(),
 		),
-		// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19755
-		scraperinttest.WithDumpActualOnFailure(),
 	).Run
 }

--- a/receiver/mongodbreceiver/integration_test.go
+++ b/receiver/mongodbreceiver/integration_test.go
@@ -71,7 +71,5 @@ func integrationTest(name string, script []string, cfgMod func(*Config)) func(*t
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreTimestamp(),
 		),
-		// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16273
-		scraperinttest.WithDumpActualOnFailure(),
 	).Run
 }

--- a/receiver/mysqlreceiver/integration_test.go
+++ b/receiver/mysqlreceiver/integration_test.go
@@ -55,7 +55,5 @@ func TestMySQLIntegration(t *testing.T) {
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreTimestamp(),
 		),
-		// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18286
-		scraperinttest.WithDumpActualOnFailure(),
 	).Run(t)
 }

--- a/receiver/rabbitmqreceiver/integration_test.go
+++ b/receiver/rabbitmqreceiver/integration_test.go
@@ -52,7 +52,5 @@ func TestRabbitmqIntegration(t *testing.T) {
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreMetricValues(),
 		),
-		// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17201
-		scraperinttest.WithDumpActualOnFailure(),
 	).Run(t)
 }

--- a/receiver/riakreceiver/integration_test.go
+++ b/receiver/riakreceiver/integration_test.go
@@ -46,7 +46,5 @@ func TestRiakIntegration(t *testing.T) {
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreTimestamp(),
 		),
-		// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17556
-		scraperinttest.WithDumpActualOnFailure(),
 	).Run(t)
 }

--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -136,7 +136,6 @@ func TestPostgresIntegration(t *testing.T) {
 func TestOracleDBIntegration(t *testing.T) {
 	scraperinttest.NewIntegrationTest(
 		NewFactory(),
-		scraperinttest.WithDumpActualOnFailure(),
 		scraperinttest.WithContainerRequest(
 			testcontainers.ContainerRequest{
 				FromDockerfile: testcontainers.FromDockerfile{


### PR DESCRIPTION
- Extracts a `MarshalMetricsYAML` from `golden.writeMetrics`, and uses this to print actual result upon failure. This allows failure results to be diffed directly against "expected" files.
- Removes conditional setting for dumping actual result. Now just always does on failure.
- Prints failure reason when container creation fails.