### PR TITLE
[chore][receiver/zookeeper] Refactor to separate connection/request from metric processing

### DIFF
--- a/receiver/zookeeperreceiver/scraper.go
+++ b/receiver/zookeeperreceiver/scraper.go
@@ -77,13 +77,22 @@ func (z *zookeeperMetricsScraper) scrape(ctx context.Context) (pmetric.Metrics, 
 	var ctxWithTimeout context.Context
 	ctxWithTimeout, z.cancel = context.WithTimeout(ctx, z.config.Timeout)
 
+	response, err := z.runCommand(ctxWithTimeout, "mntr")
+	if err != nil {
+		return pmetric.NewMetrics(), err
+	}
+
+	return z.processMntr(response)
+}
+
+func (z *zookeeperMetricsScraper) runCommand(ctx context.Context, command string) ([]string, error) {
 	conn, err := z.config.Dial()
 	if err != nil {
 		z.logger.Error("failed to establish connection",
 			zap.String("endpoint", z.config.Endpoint),
 			zap.Error(err),
 		)
-		return pmetric.NewMetrics(), err
+		return nil, err
 	}
 	defer func() {
 		if closeErr := z.closeConnection(conn); closeErr != nil {
@@ -91,31 +100,34 @@ func (z *zookeeperMetricsScraper) scrape(ctx context.Context) (pmetric.Metrics, 
 		}
 	}()
 
-	deadline, ok := ctxWithTimeout.Deadline()
+	deadline, ok := ctx.Deadline()
 	if ok {
-		if err := z.setConnectionDeadline(conn, deadline); err != nil {
+		if err = z.setConnectionDeadline(conn, deadline); err != nil {
 			z.logger.Warn("failed to set deadline on connection", zap.Error(err))
 		}
 	}
 
-	return z.getResourceMetrics(conn)
-}
-
-func (z *zookeeperMetricsScraper) getResourceMetrics(conn net.Conn) (pmetric.Metrics, error) {
-	scanner, err := z.sendCmd(conn, mntrCommand)
+	scanner, err := z.sendCmd(conn, command)
 	if err != nil {
 		z.logger.Error("failed to send command",
 			zap.Error(err),
-			zap.String("command", mntrCommand),
+			zap.String("command", command),
 		)
-		return pmetric.NewMetrics(), err
+		return nil, err
 	}
 
+	var response []string
+	for scanner.Scan() {
+		response = append(response, scanner.Text())
+	}
+	return response, nil
+}
+
+func (z *zookeeperMetricsScraper) processMntr(response []string) (pmetric.Metrics, error) {
 	creator := newMetricCreator(z.mb)
 	now := pcommon.NewTimestampFromTime(time.Now())
 	resourceOpts := make([]metadata.ResourceMetricsOption, 0, 2)
-	for scanner.Scan() {
-		line := scanner.Text()
+	for _, line := range response {
 		parts := zookeeperFormatRE.FindStringSubmatch(line)
 		if len(parts) != 3 {
 			z.logger.Warn("unexpected line in response",
@@ -155,7 +167,6 @@ func (z *zookeeperMetricsScraper) getResourceMetrics(conn net.Conn) (pmetric.Met
 
 	// Generate computed metrics
 	creator.generateComputedMetrics(z.logger, now)
-
 	return z.mb.Emit(resourceOpts...), nil
 }
 

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -147,12 +147,12 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			mockedZKOutputSourceFilename: "mntr-3.4.14",
 			expectedLogs: []logMsg{
 				{
-					msg:   "metric computation failed",
-					level: zapcore.DebugLevel,
-				},
-				{
 					msg:   "failed to shutdown connection",
 					level: zapcore.WarnLevel,
+				},
+				{
+					msg:   "metric computation failed",
+					level: zapcore.DebugLevel,
 				},
 			},
 			expectedMetricsFilename: "error-closing-connection",


### PR DESCRIPTION
Motivated by #22726, which can benefit from a cleaner separation of these concerns.