### PR TITLE
[pkg/ottl] Allow StandardTypeGetter to handle converting to an from pdata values.

### DIFF
--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -612,7 +612,7 @@ func Test_exprGetter_Get_Invalid(t *testing.T) {
 	}
 }
 
-func Test_StandardTypeGetter(t *testing.T) {
+func Test_StandardTypeGetter_String(t *testing.T) {
 	tests := []struct {
 		name             string
 		getter           StandardTypeGetter[interface{}, string]
@@ -650,6 +650,36 @@ func Test_StandardTypeGetter(t *testing.T) {
 			valid:            false,
 			expectedErrorMsg: "expected string but got nil",
 		},
+		{
+			name: "ValueTypeStr",
+			getter: StandardTypeGetter[interface{}, string]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return pcommon.NewValueStr("test"), nil
+				},
+			},
+			want:  "test",
+			valid: true,
+		},
+		{
+			name: "ValueTypeInt",
+			getter: StandardTypeGetter[interface{}, string]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return pcommon.NewValueInt(1), nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected string but got pcommon.Value",
+		},
+		{
+			name: "ValueTypeEmpty",
+			getter: StandardTypeGetter[interface{}, string]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return pcommon.NewValueEmpty(), nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected string but got pcommon.Value",
+		},
 	}
 
 	for _, tt := range tests {
@@ -661,6 +691,93 @@ func Test_StandardTypeGetter(t *testing.T) {
 			} else {
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
+		})
+	}
+}
+
+func Test_StandardTypeGetter_Int(t *testing.T) {
+	tests := []struct {
+		name   string
+		getter StandardTypeGetter[interface{}, int64]
+		want   int64
+	}{
+		{
+			name: "ValueTypeInt",
+			getter: StandardTypeGetter[interface{}, int64]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return pcommon.NewValueInt(1), nil
+				},
+			},
+			want: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := tt.getter.Get(context.Background(), nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, val)
+		})
+	}
+}
+
+func Test_StandardTypeGetter_Double(t *testing.T) {
+	tests := []struct {
+		name   string
+		getter StandardTypeGetter[interface{}, float64]
+		want   float64
+	}{
+		{
+			name: "ValueTypeDouble",
+			getter: StandardTypeGetter[interface{}, float64]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return pcommon.NewValueDouble(1.1), nil
+				},
+			},
+			want: 1.1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := tt.getter.Get(context.Background(), nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, val)
+		})
+	}
+}
+
+func Test_StandardTypeGetter_PMap(t *testing.T) {
+	tests := []struct {
+		name   string
+		getter StandardTypeGetter[interface{}, pcommon.Map]
+		want   pcommon.Map
+	}{
+		{
+			name: "ValueTypeMap",
+			getter: StandardTypeGetter[interface{}, pcommon.Map]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return pcommon.NewValueMap(), nil
+				},
+			},
+			want: pcommon.NewMap(),
+		},
+		{
+			name: "map",
+			getter: StandardTypeGetter[interface{}, pcommon.Map]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return make(map[string]any), nil
+				},
+			},
+			want: pcommon.NewMap(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := tt.getter.Get(context.Background(), nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, val)
 		})
 	}
 }


### PR DESCRIPTION
**Description:** 
Updates `StandardTypeGetter` to try to convert to and from `pcommon.Value` when checking the type. Also restricts `StandardTypeGetter` to only work with types for which we have an existing Getter.

I feel like there are some crimes against generics happening in here. It is probably better for each type getter to implement their own standard struct instead of using `StandardTypeGetter`, but I'm interested in opinions with this approach.  

**Link to tracking Issue:**
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22161

**Testing:** 
Added new tests