### PR TITLE
[pkg/ottl] Replace StandardTypeGetter with type-specific implementations

### DIFF
--- a/.chloggen/ottl-treat-primitive-and-pdata-the-same-2.yaml
+++ b/.chloggen/ottl-treat-primitive-and-pdata-the-same-2.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removes `StandardTypeGetter` in favor of `StandardStringGetter`, `StandardIntGetter`, `StandardFloatGetter`, and `StandardPMapGetter`, which handle converting pcommon.Values of the proper type.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22763]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is only a breaking change for users using OTTL in custom components. For all Contrib components this is an enhancement.

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -612,17 +612,17 @@ func Test_exprGetter_Get_Invalid(t *testing.T) {
 	}
 }
 
-func Test_StandardTypeGetter(t *testing.T) {
+func Test_StandardStringGetter(t *testing.T) {
 	tests := []struct {
 		name             string
-		getter           StandardTypeGetter[interface{}, string]
+		getter           StandardStringGetter[interface{}]
 		want             interface{}
 		valid            bool
 		expectedErrorMsg string
 	}{
 		{
-			name: "Correct type",
-			getter: StandardTypeGetter[interface{}, string]{
+			name: "string type",
+			getter: StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "str", nil
 				},
@@ -631,8 +631,18 @@ func Test_StandardTypeGetter(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "ValueTypeString type",
+			getter: StandardStringGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return pcommon.NewValueStr("str"), nil
+				},
+			},
+			want:  "str",
+			valid: true,
+		},
+		{
 			name: "Incorrect type",
-			getter: StandardTypeGetter[interface{}, string]{
+			getter: StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return true, nil
 				},
@@ -642,7 +652,7 @@ func Test_StandardTypeGetter(t *testing.T) {
 		},
 		{
 			name: "nil",
-			getter: StandardTypeGetter[interface{}, string]{
+			getter: StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return nil, nil
 				},
@@ -791,6 +801,69 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 				} else {
 					assert.Equal(t, tt.want, *val)
 				}
+			} else {
+				assert.EqualError(t, err, tt.expectedErrorMsg)
+			}
+		})
+	}
+}
+
+func Test_StandardFloatGetter(t *testing.T) {
+	tests := []struct {
+		name             string
+		getter           StandardFloatGetter[interface{}]
+		want             interface{}
+		valid            bool
+		expectedErrorMsg string
+	}{
+		{
+			name: "float64 type",
+			getter: StandardFloatGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return 1.1, nil
+				},
+			},
+			want:  1.1,
+			valid: true,
+		},
+		{
+			name: "ValueTypeFloat type",
+			getter: StandardFloatGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return pcommon.NewValueDouble(1.1), nil
+				},
+			},
+			want:  1.1,
+			valid: true,
+		},
+		{
+			name: "Incorrect type",
+			getter: StandardFloatGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return true, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected float64 but got bool",
+		},
+		{
+			name: "nil",
+			getter: StandardFloatGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return nil, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected float64 but got nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := tt.getter.Get(context.Background(), nil)
+			if tt.valid {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, val)
 			} else {
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}
@@ -961,6 +1034,69 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 	}
 }
 
+func Test_StandardIntGetter(t *testing.T) {
+	tests := []struct {
+		name             string
+		getter           StandardIntGetter[interface{}]
+		want             interface{}
+		valid            bool
+		expectedErrorMsg string
+	}{
+		{
+			name: "int64 type",
+			getter: StandardIntGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return int64(1), nil
+				},
+			},
+			want:  int64(1),
+			valid: true,
+		},
+		{
+			name: "ValueTypeInt type",
+			getter: StandardIntGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return pcommon.NewValueInt(1), nil
+				},
+			},
+			want:  int64(1),
+			valid: true,
+		},
+		{
+			name: "Incorrect type",
+			getter: StandardIntGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return true, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected int64 but got bool",
+		},
+		{
+			name: "nil",
+			getter: StandardIntGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return nil, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected int64 but got nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := tt.getter.Get(context.Background(), nil)
+			if tt.valid {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, val)
+			} else {
+				assert.EqualError(t, err, tt.expectedErrorMsg)
+			}
+		})
+	}
+}
+
 func Test_StandardIntLikeGetter(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -1117,6 +1253,79 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 				} else {
 					assert.Equal(t, tt.want, *val)
 				}
+			} else {
+				assert.EqualError(t, err, tt.expectedErrorMsg)
+			}
+		})
+	}
+}
+
+func Test_StandardPMapGetter(t *testing.T) {
+	tests := []struct {
+		name             string
+		getter           StandardPMapGetter[interface{}]
+		want             interface{}
+		valid            bool
+		expectedErrorMsg string
+	}{
+		{
+			name: "pcommon.map type",
+			getter: StandardPMapGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return pcommon.NewMap(), nil
+				},
+			},
+			want:  pcommon.NewMap(),
+			valid: true,
+		},
+		{
+			name: "map[string]any type",
+			getter: StandardPMapGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return make(map[string]any), nil
+				},
+			},
+			want:  pcommon.NewMap(),
+			valid: true,
+		},
+		{
+			name: "ValueTypeMap type",
+			getter: StandardPMapGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return pcommon.NewValueMap(), nil
+				},
+			},
+			want:  pcommon.NewMap(),
+			valid: true,
+		},
+		{
+			name: "Incorrect type",
+			getter: StandardPMapGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return true, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected pcommon.Map but got bool",
+		},
+		{
+			name: "nil",
+			getter: StandardPMapGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return nil, nil
+				},
+			},
+			valid:            false,
+			expectedErrorMsg: "expected pcommon.Map but got nil",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := tt.getter.Get(context.Background(), nil)
+			if tt.valid {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, val)
 			} else {
 				assert.EqualError(t, err, tt.expectedErrorMsg)
 			}

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -9,8 +9,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-
-	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
 type PathExpressionParser[K any] func(*Path) (GetSetter[K], error)
@@ -199,7 +197,7 @@ func (p *Parser[K]) buildArg(argVal value, argType reflect.Type) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		return StandardTypeGetter[K, string]{Getter: arg.Get}, nil
+		return StandardStringGetter[K]{Getter: arg.Get}, nil
 	case strings.HasPrefix(name, "StringLikeGetter"):
 		arg, err := p.newGetter(argVal)
 		if err != nil {
@@ -211,7 +209,7 @@ func (p *Parser[K]) buildArg(argVal value, argType reflect.Type) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		return StandardTypeGetter[K, float64]{Getter: arg.Get}, nil
+		return StandardFloatGetter[K]{Getter: arg.Get}, nil
 	case strings.HasPrefix(name, "FloatLikeGetter"):
 		arg, err := p.newGetter(argVal)
 		if err != nil {
@@ -223,7 +221,7 @@ func (p *Parser[K]) buildArg(argVal value, argType reflect.Type) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		return StandardTypeGetter[K, int64]{Getter: arg.Get}, nil
+		return StandardIntGetter[K]{Getter: arg.Get}, nil
 	case strings.HasPrefix(name, "IntLikeGetter"):
 		arg, err := p.newGetter(argVal)
 		if err != nil {
@@ -235,7 +233,7 @@ func (p *Parser[K]) buildArg(argVal value, argType reflect.Type) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		return StandardTypeGetter[K, pcommon.Map]{Getter: arg.Get}, nil
+		return StandardPMapGetter[K]{Getter: arg.Get}, nil
 	case name == "Enum":
 		arg, err := p.enumParser(argVal.Enum)
 		if err != nil {

--- a/pkg/ottl/ottlfuncs/func_convert_case_test.go
+++ b/pkg/ottl/ottlfuncs/func_convert_case_test.go
@@ -23,7 +23,7 @@ func Test_convertCase(t *testing.T) {
 		// snake case
 		{
 			name: "snake simple convert",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "simpleString", nil
 				},
@@ -33,7 +33,7 @@ func Test_convertCase(t *testing.T) {
 		},
 		{
 			name: "snake noop already snake case",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "simple_string", nil
 				},
@@ -43,7 +43,7 @@ func Test_convertCase(t *testing.T) {
 		},
 		{
 			name: "snake multiple uppercase",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "CPUUtilizationMetric", nil
 				},
@@ -53,7 +53,7 @@ func Test_convertCase(t *testing.T) {
 		},
 		{
 			name: "snake hyphens",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "simple-string", nil
 				},
@@ -63,7 +63,7 @@ func Test_convertCase(t *testing.T) {
 		},
 		{
 			name: "snake empty string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "", nil
 				},
@@ -74,7 +74,7 @@ func Test_convertCase(t *testing.T) {
 		// camel case
 		{
 			name: "camel simple convert",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "simple_string", nil
 				},
@@ -84,7 +84,7 @@ func Test_convertCase(t *testing.T) {
 		},
 		{
 			name: "snake noop already snake case",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "SimpleString", nil
 				},
@@ -94,7 +94,7 @@ func Test_convertCase(t *testing.T) {
 		},
 		{
 			name: "snake hyphens",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "simple-string", nil
 				},
@@ -104,7 +104,7 @@ func Test_convertCase(t *testing.T) {
 		},
 		{
 			name: "snake empty string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "", nil
 				},
@@ -115,7 +115,7 @@ func Test_convertCase(t *testing.T) {
 		// upper case
 		{
 			name: "upper simple",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "simple", nil
 				},
@@ -125,7 +125,7 @@ func Test_convertCase(t *testing.T) {
 		},
 		{
 			name: "upper complex",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "complex_SET-of.WORDS1234", nil
 				},
@@ -135,7 +135,7 @@ func Test_convertCase(t *testing.T) {
 		},
 		{
 			name: "upper empty string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "", nil
 				},
@@ -146,7 +146,7 @@ func Test_convertCase(t *testing.T) {
 		// lower case
 		{
 			name: "lower simple",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "SIMPLE", nil
 				},
@@ -156,7 +156,7 @@ func Test_convertCase(t *testing.T) {
 		},
 		{
 			name: "lower complex",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "complex_SET-of.WORDS1234", nil
 				},
@@ -166,7 +166,7 @@ func Test_convertCase(t *testing.T) {
 		},
 		{
 			name: "lower empty string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "", nil
 				},
@@ -194,7 +194,7 @@ func Test_convertCaseError(t *testing.T) {
 	}{
 		{
 			name: "error bad case",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "simpleString", nil
 				},
@@ -220,7 +220,7 @@ func Test_convertCaseRuntimeError(t *testing.T) {
 	}{
 		{
 			name: "non-string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return 10, nil
 				},
@@ -230,7 +230,7 @@ func Test_convertCaseRuntimeError(t *testing.T) {
 		},
 		{
 			name: "nil",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return nil, nil
 				},

--- a/pkg/ottl/ottlfuncs/func_delete_key_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key_test.go
@@ -19,7 +19,7 @@ func Test_deleteKey(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -80,7 +80,7 @@ func Test_deleteKey(t *testing.T) {
 
 func Test_deleteKey_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -94,7 +94,7 @@ func Test_deleteKey_bad_input(t *testing.T) {
 }
 
 func Test_deleteKey_get_nil(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
@@ -20,7 +20,7 @@ func Test_deleteMatchingKeys(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -80,7 +80,7 @@ func Test_deleteMatchingKeys(t *testing.T) {
 
 func Test_deleteMatchingKeys_bad_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -94,7 +94,7 @@ func Test_deleteMatchingKeys_bad_input(t *testing.T) {
 }
 
 func Test_deleteMatchingKeys_get_nil(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -107,7 +107,7 @@ func Test_deleteMatchingKeys_get_nil(t *testing.T) {
 }
 
 func Test_deleteMatchingKeys_invalid_pattern(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return nil, nil

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -19,7 +19,7 @@ func Test_keepKeys(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -81,7 +81,7 @@ func Test_keepKeys(t *testing.T) {
 
 func Test_keepKeys_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -96,7 +96,7 @@ func Test_keepKeys_bad_input(t *testing.T) {
 }
 
 func Test_keepKeys_get_nil(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},

--- a/pkg/ottl/ottlfuncs/func_limit_test.go
+++ b/pkg/ottl/ottlfuncs/func_limit_test.go
@@ -19,7 +19,7 @@ func Test_limit(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -137,12 +137,12 @@ func Test_limit_validation(t *testing.T) {
 	}{
 		{
 			name:   "limit less than zero",
-			target: &ottl.StandardTypeGetter[interface{}, pcommon.Map]{},
+			target: &ottl.StandardPMapGetter[interface{}]{},
 			limit:  int64(-1),
 		},
 		{
 			name:   "limit less than # of keep attrs",
-			target: &ottl.StandardTypeGetter[interface{}, pcommon.Map]{},
+			target: &ottl.StandardPMapGetter[interface{}]{},
 			keep:   []string{"test", "test"},
 			limit:  int64(1),
 		},
@@ -157,7 +157,7 @@ func Test_limit_validation(t *testing.T) {
 
 func Test_limit_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -170,7 +170,7 @@ func Test_limit_bad_input(t *testing.T) {
 }
 
 func Test_limit_get_nil(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},

--- a/pkg/ottl/ottlfuncs/func_merge_maps_test.go
+++ b/pkg/ottl/ottlfuncs/func_merge_maps_test.go
@@ -18,7 +18,7 @@ func Test_MergeMaps(t *testing.T) {
 	input := pcommon.NewMap()
 	input.PutStr("attr1", "value1")
 
-	targetGetter := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+	targetGetter := &ottl.StandardPMapGetter[pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -32,7 +32,7 @@ func Test_MergeMaps(t *testing.T) {
 	}{
 		{
 			name: "Upsert no conflicting keys",
-			source: ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+			source: ottl.StandardPMapGetter[pcommon.Map]{
 				Getter: func(ctx context.Context, _ pcommon.Map) (interface{}, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr2", "value2")
@@ -47,7 +47,7 @@ func Test_MergeMaps(t *testing.T) {
 		},
 		{
 			name: "Upsert conflicting key",
-			source: ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+			source: ottl.StandardPMapGetter[pcommon.Map]{
 				Getter: func(ctx context.Context, _ pcommon.Map) (interface{}, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr1", "value3")
@@ -63,7 +63,7 @@ func Test_MergeMaps(t *testing.T) {
 		},
 		{
 			name: "Insert no conflicting keys",
-			source: ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+			source: ottl.StandardPMapGetter[pcommon.Map]{
 				Getter: func(ctx context.Context, _ pcommon.Map) (interface{}, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr2", "value2")
@@ -78,7 +78,7 @@ func Test_MergeMaps(t *testing.T) {
 		},
 		{
 			name: "Insert conflicting key",
-			source: ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+			source: ottl.StandardPMapGetter[pcommon.Map]{
 				Getter: func(ctx context.Context, _ pcommon.Map) (interface{}, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr1", "value3")
@@ -94,7 +94,7 @@ func Test_MergeMaps(t *testing.T) {
 		},
 		{
 			name: "Update no conflicting keys",
-			source: ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+			source: ottl.StandardPMapGetter[pcommon.Map]{
 				Getter: func(ctx context.Context, _ pcommon.Map) (interface{}, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr2", "value2")
@@ -108,7 +108,7 @@ func Test_MergeMaps(t *testing.T) {
 		},
 		{
 			name: "Update conflicting key",
-			source: ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+			source: ottl.StandardPMapGetter[pcommon.Map]{
 				Getter: func(ctx context.Context, _ pcommon.Map) (interface{}, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr1", "value3")
@@ -142,12 +142,12 @@ func Test_MergeMaps(t *testing.T) {
 }
 
 func Test_MergeMaps_bad_target(t *testing.T) {
-	input := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	input := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
 	}
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return 1, nil
 		},
@@ -160,12 +160,12 @@ func Test_MergeMaps_bad_target(t *testing.T) {
 }
 
 func Test_MergeMaps_bad_input(t *testing.T) {
-	input := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	input := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return 1, nil
 		},
 	}
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},

--- a/pkg/ottl/ottlfuncs/func_parse_json_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_json_test.go
@@ -22,7 +22,7 @@ func Test_ParseJSON(t *testing.T) {
 	}{
 		{
 			name: "handle string",
-			target: ottl.StandardTypeGetter[any, string]{
+			target: ottl.StandardStringGetter[any]{
 				Getter: func(ctx context.Context, tCtx any) (interface{}, error) {
 					return `{"test":"string value"}`, nil
 				},
@@ -33,7 +33,7 @@ func Test_ParseJSON(t *testing.T) {
 		},
 		{
 			name: "handle bool",
-			target: ottl.StandardTypeGetter[any, string]{
+			target: ottl.StandardStringGetter[any]{
 				Getter: func(ctx context.Context, tCtx any) (interface{}, error) {
 					return `{"test":true}`, nil
 				},
@@ -44,7 +44,7 @@ func Test_ParseJSON(t *testing.T) {
 		},
 		{
 			name: "handle int",
-			target: ottl.StandardTypeGetter[any, string]{
+			target: ottl.StandardStringGetter[any]{
 				Getter: func(ctx context.Context, tCtx any) (interface{}, error) {
 					return `{"test":1}`, nil
 				},
@@ -55,7 +55,7 @@ func Test_ParseJSON(t *testing.T) {
 		},
 		{
 			name: "handle float",
-			target: ottl.StandardTypeGetter[any, string]{
+			target: ottl.StandardStringGetter[any]{
 				Getter: func(ctx context.Context, tCtx any) (interface{}, error) {
 					return `{"test":1.1}`, nil
 				},
@@ -66,7 +66,7 @@ func Test_ParseJSON(t *testing.T) {
 		},
 		{
 			name: "handle nil",
-			target: ottl.StandardTypeGetter[any, string]{
+			target: ottl.StandardStringGetter[any]{
 				Getter: func(ctx context.Context, tCtx any) (interface{}, error) {
 					return `{"test":null}`, nil
 				},
@@ -77,7 +77,7 @@ func Test_ParseJSON(t *testing.T) {
 		},
 		{
 			name: "handle array",
-			target: ottl.StandardTypeGetter[any, string]{
+			target: ottl.StandardStringGetter[any]{
 				Getter: func(ctx context.Context, tCtx any) (interface{}, error) {
 					return `{"test":["string","value"]}`, nil
 				},
@@ -90,7 +90,7 @@ func Test_ParseJSON(t *testing.T) {
 		},
 		{
 			name: "handle nested object",
-			target: ottl.StandardTypeGetter[any, string]{
+			target: ottl.StandardStringGetter[any]{
 				Getter: func(ctx context.Context, tCtx any) (interface{}, error) {
 					return `{"test":{"nested":"true"}}`, nil
 				},
@@ -102,7 +102,7 @@ func Test_ParseJSON(t *testing.T) {
 		},
 		{
 			name: "updates existing",
-			target: ottl.StandardTypeGetter[any, string]{
+			target: ottl.StandardStringGetter[any]{
 				Getter: func(ctx context.Context, tCtx any) (interface{}, error) {
 					return `{"existing":"pass"}`, nil
 				},
@@ -113,7 +113,7 @@ func Test_ParseJSON(t *testing.T) {
 		},
 		{
 			name: "complex",
-			target: ottl.StandardTypeGetter[any, string]{
+			target: ottl.StandardStringGetter[any]{
 				Getter: func(ctx context.Context, tCtx any) (interface{}, error) {
 					return `{"test1":{"nested":"true"},"test2":"string","test3":1,"test4":1.1,"test5":[[1], [2, 3],[]],"test6":null}`, nil
 				},
@@ -159,7 +159,7 @@ func Test_ParseJSON(t *testing.T) {
 }
 
 func Test_ParseJSON_Error(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, string]{
+	target := &ottl.StandardStringGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return 1, nil
 		},

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
@@ -19,7 +19,7 @@ func Test_replaceAllMatches(t *testing.T) {
 	input.PutStr("test2", "hello")
 	input.PutStr("test3", "goodbye")
 
-	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -77,7 +77,7 @@ func Test_replaceAllMatches(t *testing.T) {
 
 func Test_replaceAllMatches_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -90,7 +90,7 @@ func Test_replaceAllMatches_bad_input(t *testing.T) {
 }
 
 func Test_replaceAllMatches_get_nil(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -23,7 +23,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 	input.PutDouble("test5", 1234)
 	input.PutBool("test6", true)
 
-	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -200,7 +200,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 func Test_replaceAllPatterns_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -214,7 +214,7 @@ func Test_replaceAllPatterns_bad_input(t *testing.T) {
 }
 
 func Test_replaceAllPatterns_get_nil(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -228,7 +228,7 @@ func Test_replaceAllPatterns_get_nil(t *testing.T) {
 }
 
 func Test_replaceAllPatterns_invalid_pattern(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return nil, nil
@@ -243,7 +243,7 @@ func Test_replaceAllPatterns_invalid_pattern(t *testing.T) {
 }
 
 func Test_replaceAllPatterns_invalid_model(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return nil, nil

--- a/pkg/ottl/ottlfuncs/func_split_test.go
+++ b/pkg/ottl/ottlfuncs/func_split_test.go
@@ -21,7 +21,7 @@ func Test_split(t *testing.T) {
 	}{
 		{
 			name: "split string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "A|B|C", nil
 				},
@@ -31,7 +31,7 @@ func Test_split(t *testing.T) {
 		},
 		{
 			name: "split empty string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "", nil
 				},
@@ -41,7 +41,7 @@ func Test_split(t *testing.T) {
 		},
 		{
 			name: "split empty delimiter",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "A|B|C", nil
 				},
@@ -51,7 +51,7 @@ func Test_split(t *testing.T) {
 		},
 		{
 			name: "split empty string and empty delimiter",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "", nil
 				},
@@ -71,7 +71,7 @@ func Test_split(t *testing.T) {
 }
 
 func Test_Split_Error(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, string]{
+	target := &ottl.StandardStringGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return 1, nil
 		},

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -22,7 +22,7 @@ func Test_substring(t *testing.T) {
 	}{
 		{
 			name: "substring",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "123456789", nil
 				},
@@ -33,7 +33,7 @@ func Test_substring(t *testing.T) {
 		},
 		{
 			name: "substring with result of total string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "123456789", nil
 				},
@@ -63,7 +63,7 @@ func Test_substring_validation(t *testing.T) {
 	}{
 		{
 			name: "substring with result of empty string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "123456789", nil
 				},
@@ -73,7 +73,7 @@ func Test_substring_validation(t *testing.T) {
 		},
 		{
 			name: "substring with invalid start index",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "123456789", nil
 				},
@@ -99,7 +99,7 @@ func Test_substring_error(t *testing.T) {
 	}{
 		{
 			name: "substring empty string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "", nil
 				},
@@ -109,7 +109,7 @@ func Test_substring_error(t *testing.T) {
 		},
 		{
 			name: "substring with invalid length index",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return "123456789", nil
 				},
@@ -119,7 +119,7 @@ func Test_substring_error(t *testing.T) {
 		},
 		{
 			name: "substring non-string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return 123456789, nil
 				},
@@ -129,7 +129,7 @@ func Test_substring_error(t *testing.T) {
 		},
 		{
 			name: "substring nil string",
-			target: &ottl.StandardTypeGetter[interface{}, string]{
+			target: &ottl.StandardStringGetter[interface{}]{
 				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 					return nil, nil
 				},

--- a/pkg/ottl/ottlfuncs/func_truncate_all_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all_test.go
@@ -20,7 +20,7 @@ func Test_truncateAll(t *testing.T) {
 	input.PutInt("test2", 3)
 	input.PutBool("test3", true)
 
-	target := &ottl.StandardTypeGetter[pcommon.Map, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[pcommon.Map]{
 		Getter: func(ctx context.Context, tCtx pcommon.Map) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -94,14 +94,14 @@ func Test_truncateAll(t *testing.T) {
 }
 
 func Test_truncateAll_validation(t *testing.T) {
-	_, err := TruncateAll[interface{}](&ottl.StandardTypeGetter[interface{}, pcommon.Map]{}, -1)
+	_, err := TruncateAll[interface{}](&ottl.StandardPMapGetter[interface{}]{}, -1)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "invalid limit for truncate_all function, -1 cannot be negative")
 }
 
 func Test_truncateAll_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},
@@ -115,7 +115,7 @@ func Test_truncateAll_bad_input(t *testing.T) {
 }
 
 func Test_truncateAll_get_nil(t *testing.T) {
-	target := &ottl.StandardTypeGetter[interface{}, pcommon.Map]{
+	target := &ottl.StandardPMapGetter[interface{}]{
 		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
 			return tCtx, nil
 		},


### PR DESCRIPTION
**Description:** 
Replaces `StandardTypeGetter` with type-specific implementations to facilitate converting from pcommon.Value types when able.  This capability is an important abstraction for users who may not know when a field is a string or a pcommon.ValueTypeStr for example.

**Link to tracking Issue:**
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22161

**Testing:**
Added new tests