### PR TITLE
[chore][scraperinttest] Add ability to run multiple containers

### DIFF
--- a/internal/coreinternal/go.mod
+++ b/internal/coreinternal/go.mod
@@ -17,6 +17,7 @@ require (
 	go.opentelemetry.io/collector/semconv v0.78.2
 	go.opentelemetry.io/otel v1.15.1
 	go.opentelemetry.io/otel/trace v1.15.1
+	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/text v0.9.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -59,7 +60,6 @@ require (
 	go.opentelemetry.io/collector/confmap v0.78.2 // indirect
 	go.opentelemetry.io/otel/metric v0.38.1 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect


### PR DESCRIPTION
This capability is necessary for the `flinkmetrics` and `kafkametrics` integration tests.
- When providing multiple `ContainerRequest`s, each must have a unique `Name`.
- Extracts a `validate` function to pre-validate much of the integration test setup.
- Extracts a `createContainers` function to spin up containers in parallel.
- Capture all errors during container creation, while still printing only if it never succeeds.
- Reworks the `ContainerInfo` struct to manage multiple containers.
  - This struct can be used the same as before.
  - New exported functions allow requesting a host or port for a specific named container.
  - New unexported functions facilitate easier management of the containers within the package.