### PR TITLE
[receiver/splunkhec] support different splitting strategies

### DIFF
--- a/.chloggen/splitting-hec-receiver.yaml
+++ b/.chloggen/splitting-hec-receiver.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support different strategies for splitting payloads when receiving a request with the Splunk HEC receiver.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22788]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/splunkhecreceiver/README.md
+++ b/receiver/splunkhecreceiver/README.md
@@ -43,6 +43,7 @@ The following settings are optional:
     * `key_file`: Specifies the key file to use for TLS connection. Note: Both
       `key_file` and `cert_file` are required for TLS connection.
 * `raw_path` (default = '/services/collector/raw'): The path accepting [raw HEC events](https://docs.splunk.com/Documentation/Splunk/8.2.2/Data/HECExamples#Example_3:_Send_raw_text_to_HEC). Only applies when the receiver is used for logs.
+* `splitting` defines the splitting strategy used by the receiver when ingesting raw events. Can be set to "line" or "none". Default is "line".
 * `health_path` (default = '/services/collector/health'): The path reporting [health checks](https://docs.splunk.com/Documentation/Splunk/9.0.1/RESTREF/RESTinput#services.2Fcollector.2Fhealth).
 * `hec_metadata_to_otel_attrs/source` (default = 'com.splunk.source'): Specifies the mapping of the source field to a specific unified model attribute.
 * `hec_metadata_to_otel_attrs/sourcetype` (default = 'com.splunk.sourcetype'): Specifies the mapping of the sourcetype field to a specific unified model attribute.

--- a/receiver/splunkhecreceiver/config.go
+++ b/receiver/splunkhecreceiver/config.go
@@ -9,6 +9,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
 
+type SplittingStrategy string
+
+const (
+	Line SplittingStrategy = "line"
+	None SplittingStrategy = "none"
+)
+
 // Config defines configuration for the Splunk HEC receiver.
 type Config struct {
 	confighttp.HTTPServerSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
@@ -16,6 +23,8 @@ type Config struct {
 	splunk.AccessTokenPassthroughConfig `mapstructure:",squash"`
 	// RawPath for raw data collection, default is '/services/collector/raw'
 	RawPath string `mapstructure:"raw_path"`
+	// Splitting defines the splitting strategy used by the receiver when ingesting raw events. Can be set to "line" or "none". Default is "line".
+	Splitting SplittingStrategy `mapstructure:"splitting"`
 	// HealthPath for health API, default is '/services/collector/health'
 	HealthPath string `mapstructure:"health_path"`
 	// HecToOtelAttrs creates a mapping from HEC metadata to attributes.

--- a/receiver/splunkhecreceiver/config.go
+++ b/receiver/splunkhecreceiver/config.go
@@ -12,8 +12,8 @@ import (
 type SplittingStrategy string
 
 const (
-	Line SplittingStrategy = "line"
-	None SplittingStrategy = "none"
+	SplittingStrategyLine SplittingStrategy = "line"
+	SplittingStrategyNone SplittingStrategy = "none"
 )
 
 // Config defines configuration for the Splunk HEC receiver.

--- a/receiver/splunkhecreceiver/config_test.go
+++ b/receiver/splunkhecreceiver/config_test.go
@@ -42,7 +42,7 @@ func TestLoadConfig(t *testing.T) {
 					AccessTokenPassthrough: true,
 				},
 				RawPath:    "/foo",
-				Splitting:  Line,
+				Splitting:  SplittingStrategyLine,
 				HealthPath: "/bar",
 				HecToOtelAttrs: splunk.HecToOtelAttrs{
 					Source:     "file.name",
@@ -68,7 +68,7 @@ func TestLoadConfig(t *testing.T) {
 					AccessTokenPassthrough: false,
 				},
 				RawPath:    "/services/collector/raw",
-				Splitting:  Line,
+				Splitting:  SplittingStrategyLine,
 				HealthPath: "/services/collector/health",
 				HecToOtelAttrs: splunk.HecToOtelAttrs{
 					Source:     "com.splunk.source",

--- a/receiver/splunkhecreceiver/config_test.go
+++ b/receiver/splunkhecreceiver/config_test.go
@@ -42,6 +42,7 @@ func TestLoadConfig(t *testing.T) {
 					AccessTokenPassthrough: true,
 				},
 				RawPath:    "/foo",
+				Splitting:  Line,
 				HealthPath: "/bar",
 				HecToOtelAttrs: splunk.HecToOtelAttrs{
 					Source:     "file.name",
@@ -67,6 +68,7 @@ func TestLoadConfig(t *testing.T) {
 					AccessTokenPassthrough: false,
 				},
 				RawPath:    "/services/collector/raw",
+				Splitting:  Line,
 				HealthPath: "/services/collector/health",
 				HecToOtelAttrs: splunk.HecToOtelAttrs{
 					Source:     "com.splunk.source",

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -48,7 +48,7 @@ func createDefaultConfig() component.Config {
 		},
 		RawPath:    splunk.DefaultRawPath,
 		HealthPath: splunk.DefaultHealthPath,
-		Splitting:  Line,
+		Splitting:  SplittingStrategyLine,
 	}
 }
 

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -48,6 +48,7 @@ func createDefaultConfig() component.Config {
 		},
 		RawPath:    splunk.DefaultRawPath,
 		HealthPath: splunk.DefaultHealthPath,
+		Splitting:  Line,
 	}
 }
 

--- a/receiver/splunkhecreceiver/splunk_to_logdata.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata.go
@@ -84,7 +84,7 @@ func splunkHecRawToLogData(bodyReader io.Reader, query url.Values, resourceCusto
 		resourceCustomizer(rl.Resource())
 	}
 	sl := rl.ScopeLogs().AppendEmpty()
-	if config.Splitting == None {
+	if config.Splitting == SplittingStrategyNone {
 		b, err := io.ReadAll(bodyReader)
 		if err != nil {
 			return ld, 0, err

--- a/receiver/splunkhecreceiver/splunk_to_logdata_test.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata_test.go
@@ -4,7 +4,6 @@
 package splunkhecreceiver
 
 import (
-	"bufio"
 	"bytes"
 	"io"
 	"testing"
@@ -352,15 +351,16 @@ func Test_SplunkHecRawToLogData(t *testing.T) {
 	}
 	tests := []struct {
 		name           string
-		sc             *bufio.Scanner
+		sc             io.Reader
 		query          map[string][]string
 		assertResource func(t *testing.T, got plog.Logs, slLen int)
+		config         *Config
 	}{
 		{
 			name: "all_mapping",
-			sc: func() *bufio.Scanner {
+			sc: func() io.Reader {
 				reader := io.NopCloser(bytes.NewReader([]byte("test")))
-				return bufio.NewScanner(reader)
+				return reader
 			}(),
 			query: func() map[string][]string {
 				m := make(map[string][]string)
@@ -396,12 +396,13 @@ func Test_SplunkHecRawToLogData(t *testing.T) {
 					assert.Fail(t, "index is not added to attributes")
 				}
 			},
+			config: hecConfig,
 		},
 		{
 			name: "some_mapping",
-			sc: func() *bufio.Scanner {
+			sc: func() io.Reader {
 				reader := io.NopCloser(bytes.NewReader([]byte("test")))
-				return bufio.NewScanner(reader)
+				return reader
 			}(),
 			query: func() map[string][]string {
 				m := make(map[string][]string)
@@ -425,12 +426,48 @@ func Test_SplunkHecRawToLogData(t *testing.T) {
 					assert.Fail(t, "sourcetype is not added to attributes")
 				}
 			},
+			config: hecConfig,
+		},
+		{
+			name: "no splitting",
+			sc: func() io.Reader {
+				reader := io.NopCloser(bytes.NewReader([]byte("test\nfoo\r\nbar")))
+				return reader
+			}(),
+			query: func() map[string][]string {
+				return map[string][]string{}
+			}(),
+			assertResource: func(t *testing.T, got plog.Logs, slLen int) {
+				assert.Equal(t, 1, got.LogRecordCount())
+			},
+			config: func() *Config {
+				return &Config{
+					Splitting: None,
+				}
+			}(),
+		},
+		{
+			name: "line splitting",
+			sc: func() io.Reader {
+				reader := io.NopCloser(bytes.NewReader([]byte("test\nfoo\r\nbar")))
+				return reader
+			}(),
+			query: func() map[string][]string {
+				return map[string][]string{}
+			}(),
+			assertResource: func(t *testing.T, got plog.Logs, slLen int) {
+				assert.Equal(t, 3, got.LogRecordCount())
+			},
+			config: func() *Config {
+				return &Config{}
+			}(),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, slLen := splunkHecRawToLogData(tt.sc, tt.query, func(resource pcommon.Resource) {}, hecConfig)
+			result, slLen, err := splunkHecRawToLogData(tt.sc, tt.query, func(resource pcommon.Resource) {}, tt.config)
+			require.NoError(t, err)
 			tt.assertResource(t, result, slLen)
 		})
 	}

--- a/receiver/splunkhecreceiver/splunk_to_logdata_test.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata_test.go
@@ -442,7 +442,7 @@ func Test_SplunkHecRawToLogData(t *testing.T) {
 			},
 			config: func() *Config {
 				return &Config{
-					Splitting: None,
+					Splitting: SplittingStrategyNone,
 				}
 			}(),
 		},

--- a/receiver/splunkhecreceiver/testdata/config.yaml
+++ b/receiver/splunkhecreceiver/testdata/config.yaml
@@ -5,6 +5,7 @@ splunk_hec/allsettings:
   endpoint: localhost:8088
   access_token_passthrough: true
   raw_path: "/foo"
+  splitting: "line"
   health_path: "/bar"
   hec_metadata_to_otel_attrs:
     source: "file.name"


### PR DESCRIPTION
**Description:**
Support different strategies for splitting payloads when receiving a request with the Splunk HEC receiver.

**Link to tracking Issue:**
Fixes #22788

**Testing:**
Added tests for the functionality

**Documentation:**
Added to README.