### PR TITLE
[chore] Skip non-arm compatible integration tests

### DIFF
--- a/receiver/riakreceiver/integration_test.go
+++ b/receiver/riakreceiver/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -24,6 +25,9 @@ import (
 const riakPort = "8098"
 
 func TestIntegration(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("Incompatible with arm64")
+	}
 	scraperinttest.NewIntegrationTest(
 		NewFactory(),
 		scraperinttest.WithContainerRequest(

--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -9,6 +9,7 @@ package sqlqueryreceiver
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -134,6 +135,9 @@ func TestPostgresqlIntegration(t *testing.T) {
 // This test ensures the collector can connect to an Oracle DB, and properly get metrics. It's not intended to
 // test the receiver itself.
 func TestOracleDBIntegration(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("Incompatible with arm64")
+	}
 	scraperinttest.NewIntegrationTest(
 		NewFactory(),
 		scraperinttest.WithContainerRequest(


### PR DESCRIPTION
Nearly all integration tests in this repo are now compatible with arm processors. There are two remaining tests that are not, and these do not appear to have a clear path forward. Skipping these tests allows those of us with arm processors to locally run `make integration-tests-with-cover`. 

Skipped tests:
- Riak does not appear to publish an arm compatible binary
- Oracle does not publish an arm compatible image

