### PR TITLE
[chore] Run integration tests without coverage

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -315,7 +315,7 @@ jobs:
             ~/go/pkg/mod
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Run Integration Tests
-        run: make integration-tests-with-cover
+        run: make integration-test
 
   correctness-traces:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,13 @@ all-common:
 e2e-test: otelcontribcol oteltestbedcol
 	$(MAKE) -C testbed run-tests
 
-TARGET="do-integration-tests-with-cover"
+.PHONY: integration-test
+integration-test:
+	@$(MAKE) for-integration-target TARGET="mod-integration-test"
+
 .PHONY: integration-tests-with-cover
-integration-tests-with-cover: $(INTEGRATION_MODS)
+integration-tests-with-cover:
+	@$(MAKE) for-integration-target TARGET="do-integration-tests-with-cover"
 
 # Long-running e2e tests
 .PHONY: stability-tests
@@ -204,6 +208,9 @@ for-pkg-target: $(PKG_MODS)
 
 .PHONY: for-other-target
 for-other-target: $(OTHER_MODS)
+
+.PHONY: for-integration-target
+for-integration-target: $(INTEGRATION_MODS)
 
 # Debugging target, which helps to quickly determine whether for-all-target is working or not.
 .PHONY: all-pwd

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -1,11 +1,11 @@
 # In order to ensure make instructions fail if there is command that fails a pipe (ie: `go test ... | tee -a ./test_results.txt`)
 # the value `-o pipefail` (or `set -o pipefail`) is added to each shell command that make runs
-# otherwise in the example command pipe, only the exit code of `tee` is recorded instead of `go test` which can cause 
+# otherwise in the example command pipe, only the exit code of `tee` is recorded instead of `go test` which can cause
 # test to pass in CI when they should not.
 SHELL = /bin/bash
 ifeq ($(shell uname -s),Windows)
 	.SHELLFLAGS = /o pipefile /c
-else 
+else
 	.SHELLFLAGS = -o pipefail -c
 endif
 
@@ -17,7 +17,8 @@ GO_BUILD_TAGS=""
 GOTEST_OPT?= -race -timeout 300s -parallel 4 --tags=$(GO_BUILD_TAGS)
 GOTEST_INTEGRATION_OPT?= -race -timeout 360s -parallel 4
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
-GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
+GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -tags=integration,$(GO_BUILD_TAGS) -run=Integration
+GOTEST_OPT_WITH_INTEGRATION_COVERAGE=$(GOTEST_OPT_WITH_INTEGRATION) -coverprofile=integration-coverage.txt -covermode=atomic
 GOCMD?= go
 GOTEST=$(GOCMD) test
 GOOS=$(shell $(GOCMD) env GOOS)
@@ -108,10 +109,18 @@ do-unit-tests-with-cover:
 	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) ./...
 	$(GOCMD) tool cover -html=coverage.txt -o coverage.html
 
+.PHONY: mod-integration-test
+mod-integration-test:
+	@echo "running $(GOCMD) integration test ./... in `pwd`"
+	$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION) ./...
+	@if [ -e integration-coverage.txt ]; then \
+  		$(GOCMD) tool cover -html=integration-coverage.txt -o integration-coverage.html; \
+  	fi
+
 .PHONY: do-integration-tests-with-cover
 do-integration-tests-with-cover:
 	@echo "running $(GOCMD) integration test ./... + coverage in `pwd`"
-	$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION) ./...
+	$(GOTEST) $(GOTEST_OPT_WITH_INTEGRATION_COVERAGE) ./...
 	@if [ -e integration-coverage.txt ]; then \
   		$(GOCMD) tool cover -html=integration-coverage.txt -o integration-coverage.html; \
   	fi

--- a/internal/coreinternal/scraperinttest/scraperint.go
+++ b/internal/coreinternal/scraperinttest/scraperint.go
@@ -261,7 +261,7 @@ func (ci *ContainerInfo) Host(t *testing.T) string {
 func (ci *ContainerInfo) HostForNamedContainer(t *testing.T, containerName string) string {
 	c := ci.container(t, containerName)
 	h, err := c.Host(context.Background())
-	require.NoErrorf(t, err, "get host for container %q: %w", containerName, err)
+	require.NoErrorf(t, err, "get host for container %q: %v", containerName, err)
 	return h
 }
 
@@ -272,7 +272,7 @@ func (ci *ContainerInfo) MappedPort(t *testing.T, port string) string {
 func (ci *ContainerInfo) MappedPortForNamedContainer(t *testing.T, containerName string, port string) string {
 	c := ci.container(t, containerName)
 	p, err := c.MappedPort(context.Background(), nat.Port(port))
-	require.NoErrorf(t, err, "get port %q for container %q: %w", port, containerName, err)
+	require.NoErrorf(t, err, "get port %q for container %q: %v", port, containerName, err)
 	return p.Port()
 }
 

--- a/internal/coreinternal/scraperinttest/scraperint.go
+++ b/internal/coreinternal/scraperinttest/scraperint.go
@@ -261,7 +261,7 @@ func (ci *ContainerInfo) Host(t *testing.T) string {
 func (ci *ContainerInfo) HostForNamedContainer(t *testing.T, containerName string) string {
 	c := ci.container(t, containerName)
 	h, err := c.Host(context.Background())
-	require.NoErrorf(t, err, "get host for container %q: %v", containerName, err)
+	require.NoErrorf(t, err, "get host for container %q: %w", containerName, err)
 	return h
 }
 
@@ -272,7 +272,7 @@ func (ci *ContainerInfo) MappedPort(t *testing.T, port string) string {
 func (ci *ContainerInfo) MappedPortForNamedContainer(t *testing.T, containerName string, port string) string {
 	c := ci.container(t, containerName)
 	p, err := c.MappedPort(context.Background(), nat.Port(port))
-	require.NoErrorf(t, err, "get port %q for container %q: %v", port, containerName, err)
+	require.NoErrorf(t, err, "get port %q for container %q: %w", port, containerName, err)
 	return p.Port()
 }
 


### PR DESCRIPTION
The previous target still exists, but a more intuitive target is added and used by CI. Also switches integration targets to the same iteration pattern used for other groups of modules.