### PR TITLE
Support min/max in histograms

### DIFF
--- a/.chloggen/jjtimmons_support-min-max.yaml
+++ b/.chloggen/jjtimmons_support-min-max.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Added _min/_max timeseries for histograms that have min/max set"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22824]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Histograms can have min/maxes:

> (optional) The min (min) of all values in the histogram.
> (optional) The max (max) of all values in the histogram.

docs: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram

This adds both those as new time series, suffixed by `_min` and `_max`, matching the pattern of adjacent histogram series.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>

There's no additional documentation added for this