### PR TITLE
[chore] Bump rate at which we process issues

### DIFF
--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -1,7 +1,8 @@
 name: "Close stale issues and pull requests"
 on:
+  workflow_dispatch:
   schedule:
-    - cron: "12 5 * * *" # arbitrary time not to DDOS GitHub
+    - cron: "12 2-5 * * *" # arbitrary time not to DDOS GitHub
 
 jobs:
   stale:
@@ -20,4 +21,5 @@ jobs:
           days-before-issue-close: 60
           exempt-issue-labels: 'never stale'
           ascending: true
+          operations-per-run: 400
 

--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -7,9 +7,11 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Check rate_limit before
-        run: curl https://api.github.com/rate_limit
+        run: gh api /rate_limit
       - uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -25,5 +27,5 @@ jobs:
           ascending: true
           operations-per-run: 400
       - name: Check rate_limit after
-        run: curl https://api.github.com/rate_limit
+        run: gh api /rate_limit
 

--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -8,6 +8,8 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
+      - name: Check rate_limit before
+        run: curl https://api.github.com/rate_limit
       - uses: actions/stale@v8
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -22,4 +24,6 @@ jobs:
           exempt-issue-labels: 'never stale'
           ascending: true
           operations-per-run: 400
+      - name: Check rate_limit after
+        run: curl https://api.github.com/rate_limit
 


### PR DESCRIPTION
**Description:** 
This PR attempts to increase the amount of issues/PRs the `Close State Issues/PRs` actions can process by:
- increase the number of operations it may perform.  We have [at least 1000 per hour](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions) via actions, so 400 an hour from this job should still leave plenty for the ping-code-owners and other jobs that interact with our PRs/Issues.
- Increase how many times it runs a night.  This is a temporary solution to try and get us caught up.
- Allow manually triggering the job.  I am hoping to use this to test and to manually run the job while we try an catch up.
