### PR TITLE
[receiver/kafka] Allow Azure Resource Logs format to be used with the…

### DIFF
--- a/.chloggen/kafka-receiver-add-azureresourcelog-support.yaml
+++ b/.chloggen/kafka-receiver-add-azureresourcelog-support.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the ability to consume logs from Azure Diagnostic Settings streamed through Event Hubs using the Kafka API.
+
+# One or more tracking issues related to the change
+issues: [18210]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -34,6 +34,7 @@ The following settings can be optionally configured:
   - `zipkin_proto`: the payload is deserialized into a list of Zipkin proto spans.
   - `zipkin_json`: the payload is deserialized into a list of Zipkin V2 JSON spans.
   - `zipkin_thrift`: the payload is deserialized into a list of Zipkin Thrift spans.
+  - `azureresourcelogs`: (logs only) the payload is deserialized into a list of Azure Resource Logs (https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/resource-logs-schema).
   - `raw`: (logs only) the payload's bytes are inserted as the body of a log record.
   - `text`: (logs only) the payload are decoded as text and inserted as the body of a log record. By default, it uses UTF-8 to decode. You can use `text_<ENCODING>`, like `text_utf-8`, `text_shift_jis`, etc., to customize this behavior.
 - `group_id` (default = otel-collector):  The consumer group that receiver will be consuming messages from

--- a/receiver/kafkareceiver/azureresourcelogs_unmarshaler.go
+++ b/receiver/kafkareceiver/azureresourcelogs_unmarshaler.go
@@ -1,0 +1,194 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
+
+import (
+	"bytes"
+	"strconv"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/relvacode/iso8601"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	conventions "go.opentelemetry.io/collector/semconv/v1.13.0"
+	"go.uber.org/zap"
+)
+
+const (
+	// Constants for OpenTelemetry Specs
+	receiverScopeName = "otelcol/" + transport
+
+	// Constants for Azure Log Records
+	azureCategory          = "azure.category"
+	azureCorrelationID     = "azure.correlation.id"
+	azureDuration          = "azure.duration"
+	azureIdentity          = "azure.identity"
+	azureOperationName     = "azure.operation.name"
+	azureOperationVersion  = "azure.operation.version"
+	azureProperties        = "azure.properties"
+	azureResourceID        = "azure.resource.id"
+	azureResultType        = "azure.result.type"
+	azureResultSignature   = "azure.result.signature"
+	azureResultDescription = "azure.result.description"
+	azureTenantID          = "azure.tenant.id"
+)
+
+type azureResourceLogsUnmarshaler struct {
+	version string
+	logger  *zap.Logger
+}
+
+// azureRecords represents an array of Azure log records
+// as exported via an Azure Event Hub
+type azureRecords struct {
+	Records []azureLogRecord `json:"records"`
+}
+
+// azureLogRecord represents a single Azure log following
+// the common schema:
+// https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/resource-logs-schema
+type azureLogRecord struct {
+	Time              string       `json:"time"`
+	ResourceID        string       `json:"resourceId"`
+	TenantID          *string      `json:"tenantId"`
+	OperationName     string       `json:"operationName"`
+	OperationVersion  *string      `json:"operationVersion"`
+	Category          string       `json:"category"`
+	ResultType        *string      `json:"resultType"`
+	ResultSignature   *string      `json:"resultSignature"`
+	ResultDescription *string      `json:"resultDescription"`
+	DurationMs        *string      `json:"durationMs"`
+	CallerIPAddress   *string      `json:"callerIpAddress"`
+	CorrelationID     *string      `json:"correlationId"`
+	Identity          *interface{} `json:"identity"`
+	Level             *string      `json:"Level"`
+	Location          *string      `json:"location"`
+	Properties        *interface{} `json:"properties"`
+}
+
+func newAzureResourceLogsUnmarshaler(version string, logger *zap.Logger) LogsUnmarshaler {
+	return azureResourceLogsUnmarshaler{
+		version: version,
+		logger:  logger,
+	}
+}
+
+func (r azureResourceLogsUnmarshaler) Unmarshal(buf []byte) (plog.Logs, error) {
+	l := plog.NewLogs()
+
+	var azureLogs azureRecords
+	decoder := jsoniter.NewDecoder(bytes.NewReader(buf))
+	if err := decoder.Decode(&azureLogs); err != nil {
+		return l, err
+	}
+
+	resourceLogs := l.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	scopeLogs.Scope().SetName(receiverScopeName)
+	scopeLogs.Scope().SetVersion(r.version)
+	logRecords := scopeLogs.LogRecords()
+
+	resourceID := ""
+	for _, azureLog := range azureLogs.Records {
+		resourceID = azureLog.ResourceID
+		nanos, err := asTimestamp(azureLog.Time)
+		if err != nil {
+			r.logger.Warn("Unable to convert timestamp from log", zap.String("timestamp", azureLog.Time))
+			continue
+		}
+
+		lr := logRecords.AppendEmpty()
+
+		lr.SetTimestamp(nanos)
+
+		if azureLog.Level != nil {
+			severity := asSeverity(*azureLog.Level)
+			lr.SetSeverityNumber(severity)
+			lr.SetSeverityText(*azureLog.Level)
+		}
+
+		if err := lr.Attributes().FromRaw(extractRawAttributes(azureLog)); err != nil {
+			return l, err
+		}
+
+		// The Azure resource ID will be pulled into a common resource attribute.
+		// This implementation assumes that a single log message from Azure will
+		// contain ONLY logs from a single resource.
+		if resourceID != "" {
+			resourceLogs.Resource().Attributes().PutStr(azureResourceID, resourceID)
+		}
+	}
+
+	return l, nil
+}
+
+func (r azureResourceLogsUnmarshaler) Encoding() string {
+	return "azureresourcelogs"
+}
+
+// asTimestamp will parse an ISO8601 string into an OpenTelemetry
+// nanosecond timestamp. If the string cannot be parsed, it will
+// return zero and the error.
+func asTimestamp(s string) (pcommon.Timestamp, error) {
+	t, err := iso8601.ParseString(s)
+	if err != nil {
+		return 0, err
+	}
+	return pcommon.Timestamp(t.UnixNano()), nil
+}
+
+// asSeverity converts the Azure log level to equivalent
+// OpenTelemetry severity numbers. If the log level is not
+// valid, then the 'Unspecified' value is returned.
+func asSeverity(s string) plog.SeverityNumber {
+	switch s {
+	case "Informational":
+		return plog.SeverityNumberInfo
+	case "Warning":
+		return plog.SeverityNumberWarn
+	case "Error":
+		return plog.SeverityNumberError
+	case "Critical":
+		return plog.SeverityNumberFatal
+	default:
+		return plog.SeverityNumberUnspecified
+	}
+}
+
+func extractRawAttributes(log azureLogRecord) map[string]interface{} {
+	var attrs = map[string]interface{}{}
+
+	attrs[azureCategory] = log.Category
+	setIf(attrs, azureCorrelationID, log.CorrelationID)
+	if log.DurationMs != nil {
+		duration, err := strconv.ParseInt(*log.DurationMs, 10, 64)
+		if err == nil {
+			attrs[azureDuration] = duration
+		}
+	}
+	if log.Identity != nil {
+		attrs[azureIdentity] = *log.Identity
+	}
+	attrs[azureOperationName] = log.OperationName
+	setIf(attrs, azureOperationVersion, log.OperationVersion)
+	if log.Properties != nil {
+		attrs[azureProperties] = *log.Properties
+	}
+	setIf(attrs, azureResultDescription, log.ResultDescription)
+	setIf(attrs, azureResultSignature, log.ResultSignature)
+	setIf(attrs, azureResultType, log.ResultType)
+	setIf(attrs, azureTenantID, log.TenantID)
+
+	setIf(attrs, conventions.AttributeCloudRegion, log.Location)
+	attrs[conventions.AttributeCloudProvider] = conventions.AttributeCloudProviderAzure
+
+	setIf(attrs, conventions.AttributeNetSockPeerAddr, log.CallerIPAddress)
+	return attrs
+}
+
+func setIf(attrs map[string]interface{}, key string, value *string) {
+	if value != nil && *value != "" {
+		attrs[key] = *value
+	}
+}

--- a/receiver/kafkareceiver/azureresourcelogs_unmarshaler_test.go
+++ b/receiver/kafkareceiver/azureresourcelogs_unmarshaler_test.go
@@ -1,0 +1,16 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkareceiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func TestNewAzureResourceLogsUnmarshaler(t *testing.T) {
+	um := newAzureResourceLogsUnmarshaler("Test Version", zap.NewNop())
+	assert.Equal(t, "azureresourcelogs", um.Encoding())
+}

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -5,6 +5,7 @@ package kafkareceiver
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -119,7 +121,7 @@ func TestCreateLogsReceiver(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	f := kafkaReceiverFactory{logsUnmarshalers: defaultLogsUnmarshalers()}
+	f := kafkaReceiverFactory{logsUnmarshalers: defaultLogsUnmarshalers("Test Version", zap.NewNop())}
 	r, err := f.createLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, nil)
 	// no available broker
 	require.Error(t, err)
@@ -131,10 +133,32 @@ func TestCreateLogsReceiver_error(t *testing.T) {
 	cfg.ProtocolVersion = "2.0.0"
 	// disable contacting broker at startup
 	cfg.Metadata.Full = false
-	f := kafkaReceiverFactory{logsUnmarshalers: defaultLogsUnmarshalers()}
+	f := kafkaReceiverFactory{logsUnmarshalers: defaultLogsUnmarshalers("Test Version", zap.NewNop())}
 	r, err := f.createLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
+}
+
+func TestGetLogsUnmarshaler_encoding_text_error(t *testing.T) {
+	tests := []struct {
+		name     string
+		encoding string
+	}{
+		{
+			name:     "text encoding has typo",
+			encoding: "text_uft-8",
+		},
+		{
+			name:     "text encoding is a random string",
+			encoding: "text_vnbqgoba156",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := getLogsUnmarshaler(test.encoding, defaultLogsUnmarshalers("Test Version", zap.NewNop()))
+			assert.ErrorContains(t, err, fmt.Sprintf("unsupported encoding '%v'", test.encoding[5:]))
+		})
+	}
 }
 
 func TestWithLogsUnmarshalers(t *testing.T) {

--- a/receiver/kafkareceiver/go.mod
+++ b/receiver/kafkareceiver/go.mod
@@ -7,11 +7,13 @@ require (
 	github.com/apache/thrift v0.18.1
 	github.com/gogo/protobuf v1.3.2
 	github.com/jaegertracing/jaeger v1.41.0
+	github.com/json-iterator/go v1.1.12
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.78.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.78.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.78.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.78.0
 	github.com/openzipkin/zipkin-go v0.4.1
+	github.com/relvacode/iso8601 v1.3.0
 	github.com/stretchr/testify v1.8.3
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector v0.78.3-0.20230525165144-87dd85a6c034
@@ -43,7 +45,6 @@ require (
 	github.com/jcmturner/gokrb5/v8 v8.4.3 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.16.5 // indirect
 	github.com/knadh/koanf v1.5.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/receiver/kafkareceiver/go.sum
+++ b/receiver/kafkareceiver/go.sum
@@ -294,6 +294,8 @@ github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJf
 github.com/prometheus/statsd_exporter v0.22.7 h1:7Pji/i2GuhK6Lu7DHrtTkFmNBCudCPT1pX2CziuyQR0=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/relvacode/iso8601 v1.3.0 h1:HguUjsGpIMh/zsTczGN3DVJFxTU/GX+MMmzcKoMO7ko=
+github.com/relvacode/iso8601 v1.3.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -6,7 +6,6 @@ package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/Shopify/sarama"
@@ -25,7 +24,6 @@ const (
 	transport = "kafka"
 )
 
-var errUnrecognizedEncoding = fmt.Errorf("unrecognized encoding")
 var errInvalidInitialOffset = fmt.Errorf("invalid initial offset")
 
 // kafkaTracesConsumer uses sarama to consume and handle messages from kafka.
@@ -74,8 +72,7 @@ var _ receiver.Traces = (*kafkaTracesConsumer)(nil)
 var _ receiver.Metrics = (*kafkaMetricsConsumer)(nil)
 var _ receiver.Logs = (*kafkaLogsConsumer)(nil)
 
-func newTracesReceiver(config Config, set receiver.CreateSettings, unmarshalers map[string]TracesUnmarshaler, nextConsumer consumer.Traces) (*kafkaTracesConsumer, error) {
-	unmarshaler := unmarshalers[config.Encoding]
+func newTracesReceiver(config Config, set receiver.CreateSettings, unmarshaler TracesUnmarshaler, nextConsumer consumer.Traces) (*kafkaTracesConsumer, error) {
 	if unmarshaler == nil {
 		return nil, errUnrecognizedEncoding
 	}
@@ -167,8 +164,7 @@ func (c *kafkaTracesConsumer) Shutdown(context.Context) error {
 	return c.consumerGroup.Close()
 }
 
-func newMetricsReceiver(config Config, set receiver.CreateSettings, unmarshalers map[string]MetricsUnmarshaler, nextConsumer consumer.Metrics) (*kafkaMetricsConsumer, error) {
-	unmarshaler := unmarshalers[config.Encoding]
+func newMetricsReceiver(config Config, set receiver.CreateSettings, unmarshaler MetricsUnmarshaler, nextConsumer consumer.Metrics) (*kafkaMetricsConsumer, error) {
 	if unmarshaler == nil {
 		return nil, errUnrecognizedEncoding
 	}
@@ -260,7 +256,11 @@ func (c *kafkaMetricsConsumer) Shutdown(context.Context) error {
 	return c.consumerGroup.Close()
 }
 
-func newLogsReceiver(config Config, set receiver.CreateSettings, unmarshalers map[string]LogsUnmarshaler, nextConsumer consumer.Logs) (*kafkaLogsConsumer, error) {
+func newLogsReceiver(config Config, set receiver.CreateSettings, unmarshaler LogsUnmarshaler, nextConsumer consumer.Logs) (*kafkaLogsConsumer, error) {
+	if unmarshaler == nil {
+		return nil, errUnrecognizedEncoding
+	}
+
 	c := sarama.NewConfig()
 	c.ClientID = config.ClientID
 	c.Metadata.Full = config.Metadata.Full
@@ -273,19 +273,16 @@ func newLogsReceiver(config Config, set receiver.CreateSettings, unmarshalers ma
 	} else {
 		return nil, err
 	}
-	unmarshaler, err := getLogsUnmarshaler(config.Encoding, unmarshalers)
-	if err != nil {
-		return nil, err
-	}
+
 	if config.ProtocolVersion != "" {
 		var version sarama.KafkaVersion
-		version, err = sarama.ParseKafkaVersion(config.ProtocolVersion)
+		version, err := sarama.ParseKafkaVersion(config.ProtocolVersion)
 		if err != nil {
 			return nil, err
 		}
 		c.Version = version
 	}
-	if err = kafkaexporter.ConfigureAuthentication(config.Authentication, c); err != nil {
+	if err := kafkaexporter.ConfigureAuthentication(config.Authentication, c); err != nil {
 		return nil, err
 	}
 	client, err := sarama.NewConsumerGroup(config.Brokers, config.GroupID, c)
@@ -301,33 +298,6 @@ func newLogsReceiver(config Config, set receiver.CreateSettings, unmarshalers ma
 		autocommitEnabled: config.AutoCommit.Enable,
 		messageMarking:    config.MessageMarking,
 	}, nil
-}
-
-func getLogsUnmarshaler(encoding string, unmarshalers map[string]LogsUnmarshaler) (LogsUnmarshaler, error) {
-	var enc string
-	unmarshaler, ok := unmarshalers[encoding]
-	if !ok {
-		split := strings.SplitN(encoding, "_", 2)
-		prefix := split[0]
-		if len(split) > 1 {
-			enc = split[1]
-		}
-		unmarshaler, ok = unmarshalers[prefix].(LogsUnmarshalerWithEnc)
-		if !ok {
-			return nil, errUnrecognizedEncoding
-		}
-	}
-
-	if unmarshalerWithEnc, ok := unmarshaler.(LogsUnmarshalerWithEnc); ok {
-		// This should be called even when enc is an empty string to initialize the encoding.
-		unmarshaler, err := unmarshalerWithEnc.WithEnc(enc)
-		if err != nil {
-			return nil, err
-		}
-		return unmarshaler, nil
-	}
-
-	return unmarshaler, nil
 }
 
 func (c *kafkaLogsConsumer) Start(_ context.Context, host component.Host) error {

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -6,7 +6,6 @@ package kafkareceiver
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -37,7 +36,9 @@ func TestNewTracesReceiver_version_err(t *testing.T) {
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	r, err := newTracesReceiver(c, receivertest.NewNopCreateSettings(), defaultTracesUnmarshalers(), consumertest.NewNop())
+
+	unmarshaler := defaultTracesUnmarshalers()[c.Encoding]
+	r, err := newTracesReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	assert.Error(t, err)
 	assert.Nil(t, r)
 }
@@ -46,7 +47,9 @@ func TestNewTracesReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
 	}
-	r, err := newTracesReceiver(c, receivertest.NewNopCreateSettings(), defaultTracesUnmarshalers(), consumertest.NewNop())
+
+	unmarshaler := defaultTracesUnmarshalers()[c.Encoding]
+	r, err := newTracesReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
@@ -67,7 +70,9 @@ func TestNewTracesReceiver_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	r, err := newTracesReceiver(c, receivertest.NewNopCreateSettings(), defaultTracesUnmarshalers(), consumertest.NewNop())
+
+	unmarshaler := defaultTracesUnmarshalers()[c.Encoding]
+	r, err := newTracesReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, r)
@@ -78,7 +83,8 @@ func TestNewTracesReceiver_initial_offset_err(t *testing.T) {
 		InitialOffset: "foo",
 		Encoding:      defaultEncoding,
 	}
-	r, err := newTracesReceiver(c, receivertest.NewNopCreateSettings(), defaultTracesUnmarshalers(), consumertest.NewNop())
+	unmarshaler := defaultTracesUnmarshalers()[c.Encoding]
+	r, err := newTracesReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errInvalidInitialOffset.Error())
@@ -294,7 +300,9 @@ func TestNewMetricsReceiver_version_err(t *testing.T) {
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	r, err := newMetricsReceiver(c, receivertest.NewNopCreateSettings(), defaultMetricsUnmarshalers(), consumertest.NewNop())
+
+	unmarshaler := defaultMetricsUnmarshalers()[c.Encoding]
+	r, err := newMetricsReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	assert.Error(t, err)
 	assert.Nil(t, r)
 }
@@ -303,7 +311,9 @@ func TestNewMetricsReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
 	}
-	r, err := newMetricsReceiver(c, receivertest.NewNopCreateSettings(), defaultMetricsUnmarshalers(), consumertest.NewNop())
+
+	unmarshaler := defaultMetricsUnmarshalers()[c.Encoding]
+	r, err := newMetricsReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
@@ -324,7 +334,9 @@ func TestNewMetricsExporter_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	r, err := newMetricsReceiver(c, receivertest.NewNopCreateSettings(), defaultMetricsUnmarshalers(), consumertest.NewNop())
+
+	unmarshaler := defaultMetricsUnmarshalers()[c.Encoding]
+	r, err := newMetricsReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, r)
@@ -335,7 +347,8 @@ func TestNewMetricsReceiver_initial_offset_err(t *testing.T) {
 		InitialOffset: "foo",
 		Encoding:      defaultEncoding,
 	}
-	r, err := newMetricsReceiver(c, receivertest.NewNopCreateSettings(), defaultMetricsUnmarshalers(), consumertest.NewNop())
+	unmarshaler := defaultMetricsUnmarshalers()[c.Encoding]
+	r, err := newMetricsReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errInvalidInitialOffset.Error())
@@ -549,7 +562,9 @@ func TestNewLogsReceiver_version_err(t *testing.T) {
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	r, err := newLogsReceiver(c, receivertest.NewNopCreateSettings(), defaultLogsUnmarshalers(), consumertest.NewNop())
+
+	unmarshaler := defaultLogsUnmarshalers("Test Version", zap.NewNop())[c.Encoding]
+	r, err := newLogsReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	assert.Error(t, err)
 	assert.Nil(t, r)
 }
@@ -558,7 +573,9 @@ func TestNewLogsReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
 	}
-	r, err := newLogsReceiver(c, receivertest.NewNopCreateSettings(), defaultLogsUnmarshalers(), consumertest.NewNop())
+
+	unmarshaler := defaultLogsUnmarshalers("Test Version", zap.NewNop())[c.Encoding]
+	r, err := newLogsReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
@@ -579,7 +596,9 @@ func TestNewLogsExporter_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	r, err := newLogsReceiver(c, receivertest.NewNopCreateSettings(), defaultLogsUnmarshalers(), consumertest.NewNop())
+
+	unmarshaler := defaultLogsUnmarshalers("Test Version", zap.NewNop())[c.Encoding]
+	r, err := newLogsReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, r)
@@ -590,7 +609,8 @@ func TestNewLogsReceiver_initial_offset_err(t *testing.T) {
 		InitialOffset: "foo",
 		Encoding:      defaultEncoding,
 	}
-	r, err := newLogsReceiver(c, receivertest.NewNopCreateSettings(), defaultLogsUnmarshalers(), consumertest.NewNop())
+	unmarshaler := defaultLogsUnmarshalers("Test Version", zap.NewNop())[c.Encoding]
+	r, err := newLogsReceiver(c, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	require.Error(t, err)
 	assert.Nil(t, r)
 	assert.EqualError(t, err, errInvalidInitialOffset.Error())
@@ -903,30 +923,8 @@ func TestGetLogsUnmarshaler_encoding_text(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := getLogsUnmarshaler(test.encoding, defaultLogsUnmarshalers())
+			_, err := getLogsUnmarshaler(test.encoding, defaultLogsUnmarshalers("Test Version", zap.NewNop()))
 			assert.NoError(t, err)
-		})
-	}
-}
-
-func TestGetLogsUnmarshaler_encoding_text_error(t *testing.T) {
-	tests := []struct {
-		name     string
-		encoding string
-	}{
-		{
-			name:     "text encoding has typo",
-			encoding: "text_uft-8",
-		},
-		{
-			name:     "text encoding is a random string",
-			encoding: "text_vnbqgoba156",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			_, err := getLogsUnmarshaler(test.encoding, defaultLogsUnmarshalers())
-			assert.ErrorContains(t, err, fmt.Sprintf("unsupported encoding '%v'", test.encoding[5:]))
 		})
 	}
 }
@@ -935,7 +933,8 @@ func TestCreateLogsReceiver_encoding_text_error(t *testing.T) {
 	cfg := Config{
 		Encoding: "text_uft-8",
 	}
-	_, err := newLogsReceiver(cfg, receivertest.NewNopCreateSettings(), defaultLogsUnmarshalers(), consumertest.NewNop())
+	unmarshaler := defaultLogsUnmarshalers("Test Version", zap.NewNop())[cfg.Encoding]
+	_, err := newLogsReceiver(cfg, receivertest.NewNopCreateSettings(), unmarshaler, consumertest.NewNop())
 	// encoding error comes first
 	assert.Error(t, err, "unsupported encoding")
 }

--- a/receiver/kafkareceiver/unmarshaler.go
+++ b/receiver/kafkareceiver/unmarshaler.go
@@ -7,6 +7,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinv1"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinv2"
@@ -71,13 +72,15 @@ func defaultMetricsUnmarshalers() map[string]MetricsUnmarshaler {
 	}
 }
 
-func defaultLogsUnmarshalers() map[string]LogsUnmarshaler {
+func defaultLogsUnmarshalers(version string, logger *zap.Logger) map[string]LogsUnmarshaler {
 	otlpPb := newPdataLogsUnmarshaler(&plog.ProtoUnmarshaler{}, defaultEncoding)
 	raw := newRawLogsUnmarshaler()
 	text := newTextLogsUnmarshaler()
+	azureresourcelogs := newAzureResourceLogsUnmarshaler(version, logger)
 	return map[string]LogsUnmarshaler{
-		otlpPb.Encoding(): otlpPb,
-		raw.Encoding():    raw,
-		text.Encoding():   text,
+		otlpPb.Encoding():            otlpPb,
+		raw.Encoding():               raw,
+		text.Encoding():              text,
+		azureresourcelogs.Encoding(): azureresourcelogs,
 	}
 }

--- a/receiver/kafkareceiver/unmarshaler_test.go
+++ b/receiver/kafkareceiver/unmarshaler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestDefaultTracesUnMarshaler(t *testing.T) {
@@ -50,8 +51,9 @@ func TestDefaultLogsUnMarshaler(t *testing.T) {
 		"otlp_proto",
 		"raw",
 		"text",
+		"azureresourcelogs",
 	}
-	marshalers := defaultLogsUnmarshalers()
+	marshalers := defaultLogsUnmarshalers("Test Version", zap.NewNop())
 	assert.Equal(t, len(expectedEncodings), len(marshalers))
 	for _, e := range expectedEncodings {
 		t.Run(e, func(t *testing.T) {


### PR DESCRIPTION
… receiver as Azure Event Hubs supports the Kafka API.

**Description:** <Describe what has changed.>
Add the ability to consume logs from Azure Diagnostic Settings streamed through Kafka.

**Link to tracking Issue:** <Issue number if applicable>
#18210 

**Testing:** <Describe what testing was performed and which tests were added.>
Manual testing connecting Azure Diagnostic Setting Logs to Local Collector and confirming data is as expected.

**Documentation:** <Describe the documentation added.>
Documentation for new Encoding protocol for Logs only.