### PR TITLE
[chore] Increase operations-per-run to 40% limit

### DIFF
--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -25,7 +25,7 @@ jobs:
           days-before-issue-close: 60
           exempt-issue-labels: 'never stale'
           ascending: true
-          operations-per-run: 400
+          operations-per-run: 6000
       - name: Check rate_limit after
         run: gh api /rate_limit
 


### PR DESCRIPTION
**Description:** 
As seen here, https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/5094448289/jobs/9158270592, we have 15000 actions per hour, so bumping this number to a true 40% of limit.  If people are comfortable we can increase it even further.
 