### PR TITLE
[chore] mark testreceiver as in development to avoid checks against it

### DIFF
--- a/cmd/mdatagen/internal/metadata/generated_status.go
+++ b/cmd/mdatagen/internal/metadata/generated_status.go
@@ -8,5 +8,5 @@ import (
 
 const (
 	Type             = "test"
-	MetricsStability = component.StabilityLevelAlpha
+	MetricsStability = component.StabilityLevelDevelopment
 )

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -149,7 +149,7 @@ func Test_loadMetadata(t *testing.T) {
 				Status: &Status{
 					Class: "receiver",
 					Stability: map[string][]string{
-						"alpha": {"metrics"},
+						"development": {"metrics"},
 					},
 				},
 			},

--- a/cmd/mdatagen/metadata.yaml
+++ b/cmd/mdatagen/metadata.yaml
@@ -7,7 +7,7 @@ sem_conv_version: 1.9.0
 status:
   class: receiver
   stability:
-    alpha: [metrics]
+    development: [metrics]
 
 resource_attributes:
   string.resource.attr:


### PR DESCRIPTION
See #21275 