### PR TITLE
[processor/k8sattribute] fix occasionaly missing attributes bugs of e2e test

### DIFF
--- a/processor/k8sattributesprocessor/e2e_test.go
+++ b/processor/k8sattributesprocessor/e2e_test.go
@@ -75,12 +75,16 @@ func TestE2E(t *testing.T) {
 
 	testID := uuid.NewString()[:8]
 	collectorObjs := createCollectorObjects(t, dynamicClient, testID)
-	telemetryGenObjs := createTelemetryGenObjects(t, dynamicClient, testID)
+	telemetryGenObjs, telemetryGenObjInfos := createTelemetryGenObjects(t, dynamicClient, testID)
 	defer func() {
 		for _, obj := range append(collectorObjs, telemetryGenObjs...) {
 			require.NoErrorf(t, deleteObject(dynamicClient, obj), "failed to delete object %s", obj.GetName())
 		}
 	}()
+
+	for _, info := range telemetryGenObjInfos {
+		waitForTelemetryGenToStart(t, dynamicClient, info.namespace, info.podLabelSelectors, info.workload, info.dataType)
+	}
 
 	metricsConsumer := new(consumertest.MetricsSink)
 	tracesConsumer := new(consumertest.TracesSink)
@@ -526,7 +530,15 @@ func selectorFromMap(labelMap map[string]any) labels.Selector {
 	return labelSet.AsSelector()
 }
 
-func createTelemetryGenObjects(t *testing.T, client *dynamic.DynamicClient, testID string) []*unstructured.Unstructured {
+type telemetrygenObjInfo struct {
+	namespace         string
+	podLabelSelectors map[string]any
+	dataType          string
+	workload          string
+}
+
+func createTelemetryGenObjects(t *testing.T, client *dynamic.DynamicClient, testID string) ([]*unstructured.Unstructured, []*telemetrygenObjInfo) {
+	telemetrygenObjInfos := make([]*telemetrygenObjInfo, 0)
 	manifestsDir := filepath.Join(".", "testdata", "e2e", "telemetrygen")
 	manifestFiles, err := os.ReadDir(manifestsDir)
 	require.NoErrorf(t, err, "failed to read telemetrygen manifests directory %s", manifestsDir)
@@ -542,10 +554,17 @@ func createTelemetryGenObjects(t *testing.T, client *dynamic.DynamicClient, test
 			}))
 			obj, err := createObject(client, manifest.Bytes())
 			require.NoErrorf(t, err, "failed to create telemetrygen object from manifest %s", manifestFile.Name())
+			selector := obj.Object["spec"].(map[string]any)["selector"]
+			telemetrygenObjInfos = append(telemetrygenObjInfos, &telemetrygenObjInfo{
+				namespace:         "default",
+				podLabelSelectors: selector.(map[string]any)["matchLabels"].(map[string]any),
+				dataType:          dataType,
+				workload:          obj.GetKind(),
+			})
 			createdObjs = append(createdObjs, obj)
 		}
 	}
-	return createdObjs
+	return createdObjs, telemetrygenObjInfos
 }
 
 func createObject(client *dynamic.DynamicClient, manifest []byte) (*unstructured.Unstructured, error) {
@@ -571,6 +590,23 @@ func deleteObject(client *dynamic.DynamicClient, obj *unstructured.Unstructured)
 		Resource: strings.ToLower(gvk.Kind + "s"),
 	}
 	return client.Resource(gvr).Namespace(obj.GetNamespace()).Delete(context.Background(), obj.GetName(), metav1.DeleteOptions{})
+}
+
+func waitForTelemetryGenToStart(t *testing.T, client *dynamic.DynamicClient, podNamespace string, podLabels map[string]any, workload, dataType string) {
+	podGVR := schema.GroupVersionResource{Version: "v1", Resource: "pods"}
+	listOptions := metav1.ListOptions{LabelSelector: selectorFromMap(podLabels).String()}
+	podTimeoutMinutes := 3
+	var podPhase string
+	require.Eventually(t, func() bool {
+		list, err := client.Resource(podGVR).Namespace(podNamespace).List(context.Background(), listOptions)
+		require.NoError(t, err, "failed to list collector pods")
+		if len(list.Items) == 0 {
+			return false
+		}
+		podPhase = list.Items[0].Object["status"].(map[string]interface{})["phase"].(string)
+		return podPhase == "Running"
+	}, time.Duration(podTimeoutMinutes)*time.Minute, 50*time.Millisecond,
+		"telemetrygen pod of workload [%s] in datatype [%s] haven't started within %d minutes, latest pod phase is %s", workload, dataType, podTimeoutMinutes, podPhase)
 }
 
 func waitForData(t *testing.T, entriesNum int, mc *consumertest.MetricsSink, tc *consumertest.TracesSink, lc *consumertest.LogsSink) {

--- a/processor/k8sattributesprocessor/testdata/e2e/telemetrygen/job.yaml
+++ b/processor/k8sattributesprocessor/testdata/e2e/telemetrygen/job.yaml
@@ -17,8 +17,8 @@ spec:
         - {{ .DataType }}
         - --otlp-insecure
         - --otlp-endpoint={{ .OTLPEndpoint }}
-        - --{{ .DataType }}=60
         - --rate=1
+        - --duration=36000s
         - --otlp-attributes=service.name="test-{{ .DataType }}-job"
         - --otlp-attributes=k8s.container.name="telemetrygen"
         image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:latest


### PR DESCRIPTION
**Description:** <Describe what has changed.>
fix #18892

      I don't think the order matter that much. We can keep the existing order, just need to wait for the telemetrygen pods to start before listening for collector's output. Not sure about the k8s job tho, can we make it run longer to make sure it doesn't end until we wait for all telemetrygen pods to start?

_Originally posted by @dmitryax in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18892#issuecomment-1502011034_

Fix the k8sattribute processor e2e test bugs, here are two enhancements
- start the otlp receiver after all telemetrygen pods are running
- change the telemetrygen job to keep running for a long time

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>