### PR TITLE
[receiver/splunk_hec] Fix reusing the shared splunkhecreiver

### DIFF
--- a/.chloggen/splunkhecreiver_shared_component.yaml
+++ b/.chloggen/splunkhecreiver_shared_component.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix reusing the same splunkhecreiver between logs and metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22848]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -89,7 +89,7 @@ func createLogsReceiver(
 	if err != nil {
 		return nil, err
 	}
-	r.Component.(*splunkReceiver).logsConsumer = consumer
+	r.Unwrap().(*splunkReceiver).logsConsumer = consumer
 	return r, nil
 }
 

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -68,7 +68,7 @@ func createMetricsReceiver(
 	if err != nil {
 		return nil, err
 	}
-	r.Component.(*splunkReceiver).metricsConsumer = consumer
+	r.Unwrap().(*splunkReceiver).metricsConsumer = consumer
 	return r, nil
 }
 

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -68,6 +68,7 @@ func createMetricsReceiver(
 	if err != nil {
 		return nil, err
 	}
+	r.Component.(*splunkReceiver).metricsConsumer = consumer
 	return r, nil
 }
 
@@ -88,6 +89,7 @@ func createLogsReceiver(
 	if err != nil {
 		return nil, err
 	}
+	r.Component.(*splunkReceiver).logsConsumer = consumer
 	return r, nil
 }
 

--- a/receiver/splunkhecreceiver/factory_test.go
+++ b/receiver/splunkhecreceiver/factory_test.go
@@ -5,6 +5,7 @@ package splunkhecreceiver
 
 import (
 	"context"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,4 +74,15 @@ func TestMultipleMetricsReceivers(t *testing.T) {
 	mReceiver, _ := createLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, mockMetricsConsumer)
 	mReceiver2, _ := createLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, mockMetricsConsumer)
 	assert.Equal(t, mReceiver, mReceiver2)
+}
+
+func TestReuseLogsAndMetricsReceivers(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Endpoint = "localhost:1"
+	mockMetricsConsumer := consumertest.NewNop()
+	mReceiver, _ := createLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, mockMetricsConsumer)
+	mReceiver2, _ := createMetricsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, mockMetricsConsumer)
+	assert.Equal(t, mReceiver, mReceiver2)
+	assert.NotNil(t, mReceiver.(*sharedcomponent.SharedComponent).Component.(*splunkReceiver).metricsConsumer)
+	assert.NotNil(t, mReceiver.(*sharedcomponent.SharedComponent).Component.(*splunkReceiver).logsConsumer)
 }

--- a/receiver/splunkhecreceiver/factory_test.go
+++ b/receiver/splunkhecreceiver/factory_test.go
@@ -5,7 +5,6 @@ package splunkhecreceiver
 
 import (
 	"context"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +12,8 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {


### PR DESCRIPTION
**Description:**
Reuse the shared splunkhec receiver between logs and metrics.

**Testing:**
Unit test.
