### PR TITLE
[chore][receiver/aerospike] addressing lint issues

### DIFF
--- a/receiver/aerospikereceiver/config.go
+++ b/receiver/aerospikereceiver/config.go
@@ -51,7 +51,7 @@ func (c *Config) Validate() error {
 
 	host, portStr, err := net.SplitHostPort(c.Endpoint)
 	if err != nil {
-		return multierr.Append(allErrs, fmt.Errorf("%w: %s", errBadEndpoint, err))
+		return multierr.Append(allErrs, fmt.Errorf("%w: %s", errBadEndpoint, err.Error()))
 	}
 
 	if host == "" {
@@ -60,7 +60,7 @@ func (c *Config) Validate() error {
 
 	port, err := strconv.ParseInt(portStr, 10, 32)
 	if err != nil {
-		allErrs = multierr.Append(allErrs, fmt.Errorf("%w: %s", errBadPort, err))
+		allErrs = multierr.Append(allErrs, fmt.Errorf("%w: %s", errBadPort, err.Error()))
 	}
 
 	if port < 0 || port > 65535 {
@@ -81,7 +81,7 @@ func (c *Config) Validate() error {
 	if c.TLS != nil {
 		_, err := c.TLS.LoadTLSConfig()
 		if err != nil {
-			allErrs = multierr.Append(allErrs, fmt.Errorf("%w: %s", errFailedTLSLoad, err))
+			allErrs = multierr.Append(allErrs, fmt.Errorf("%w: %s", errFailedTLSLoad, err.Error()))
 		}
 	}
 

--- a/receiver/aerospikereceiver/integration_test.go
+++ b/receiver/aerospikereceiver/integration_test.go
@@ -142,8 +142,7 @@ func recordsWaitAndCheck(f aeroRecordsFunc) error {
 	}
 
 	// consume all records
-	for range chk.Results() {
-	}
+	chk.Results()
 	return nil
 }
 
@@ -382,10 +381,7 @@ func populateMetrics(host *as.Host) error {
 	if sferr := geoStm1.SetFilter(geoFilt1); sferr != nil {
 		return errSetFilter
 	}
-	if err := recordsWaitAndCheck(func() (recordsCheckable, as.Error) {
+	return recordsWaitAndCheck(func() (recordsCheckable, as.Error) {
 		return c.Query(queryPolicy, geoStm1)
-	}); err != nil {
-		return err
-	}
-	return nil
+	})
 }

--- a/receiver/aerospikereceiver/scraper.go
+++ b/receiver/aerospikereceiver/scraper.go
@@ -45,18 +45,18 @@ func newAerospikeReceiver(params receiver.CreateSettings, cfg *Config, consumer 
 	if cfg.TLS != nil {
 		tlsCfg, err = cfg.TLS.LoadTLSConfig()
 		if err != nil {
-			return nil, fmt.Errorf("%w: %s", errFailedTLSLoad, err)
+			return nil, fmt.Errorf("%w: %s", errFailedTLSLoad, err.Error())
 		}
 	}
 
 	host, portStr, err := net.SplitHostPort(cfg.Endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", errBadEndpoint, err)
+		return nil, fmt.Errorf("%w: %s", errBadEndpoint, err.Error())
 	}
 
 	port, err := strconv.ParseInt(portStr, 10, 32)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", errBadPort, err)
+		return nil, fmt.Errorf("%w: %s", errBadPort, err.Error())
 	}
 
 	ashost := as.NewHost(host, int(port))
@@ -109,7 +109,7 @@ func (r *aerospikeReceiver) shutdown(_ context.Context) error {
 
 // scrape scrapes both Node and Namespace metrics from the provided Aerospike node.
 // If CollectClusterMetrics is true, it then scrapes every discovered node
-func (r *aerospikeReceiver) scrape(ctx context.Context) (pmetric.Metrics, error) {
+func (r *aerospikeReceiver) scrape(_ context.Context) (pmetric.Metrics, error) {
 	r.logger.Debug("beginning scrape")
 	errs := &scrapererror.ScrapeErrors{}
 


### PR DESCRIPTION
Updating golangci-lint raises the following warnings:

```
integration_test.go:385:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
        if err := recordsWaitAndCheck(func() (recordsCheckable, as.Error) {
                return c.Query(queryPolicy, geoStm1)
        }); err != nil {
                return err
        }
integration_test.go:145:2: empty-block: this block is empty, you can remove it (revive)
        for range chk.Results() {
        }
scraper.go:112:36: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (r *aerospikeReceiver) scrape(ctx context.Context) (pmetric.Metrics, error) {
                                   ^
config.go:54:72: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                return multierr.Append(allErrs, fmt.Errorf("%w: %s", errBadEndpoint, err))
                                                                                     ^
config.go:63:71: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                allErrs = multierr.Append(allErrs, fmt.Errorf("%w: %s", errBadPort, err))
                                                                                    ^
config.go:84:78: non-wrapping format verb for fmt.Errorf. Use `%w` to format errors (errorlint)
                        allErrs = multierr.Append(allErrs, fmt.Errorf("%w: %s", errFailedTLSLoad, err))
```

Linked issue: #20424
