### PR TITLE
[chore][receiver/awscloudwatch] addressing lint issues

### DIFF
--- a/receiver/awscloudwatchreceiver/factory.go
+++ b/receiver/awscloudwatchreceiver/factory.go
@@ -23,7 +23,7 @@ func NewFactory() receiver.Factory {
 }
 
 func createLogsReceiver(
-	ctx context.Context,
+	_ context.Context,
 	params receiver.CreateSettings,
 	rConf component.Config,
 	consumer consumer.Logs,

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -130,14 +130,14 @@ func newLogsReceiver(cfg *Config, logger *zap.Logger, consumer consumer.Logs) *l
 	}
 }
 
-func (l *logsReceiver) Start(ctx context.Context, host component.Host) error {
+func (l *logsReceiver) Start(ctx context.Context, _ component.Host) error {
 	l.logger.Debug("starting to poll for Cloudwatch logs")
 	l.wg.Add(1)
 	go l.startPolling(ctx)
 	return nil
 }
 
-func (l *logsReceiver) Shutdown(ctx context.Context) error {
+func (l *logsReceiver) Shutdown(_ context.Context) error {
 	l.logger.Debug("shutting down logs receiver")
 	close(l.doneChan)
 	l.wg.Wait()


### PR DESCRIPTION
Updating golangci-lint raises the following warnings:

```
factory.go:26:2: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
        ctx context.Context,
        ^
logs.go:133:51: unused-parameter: parameter 'host' seems to be unused, consider removing or renaming it as _ (revive)
func (l *logsReceiver) Start(ctx context.Context, host component.Host) error {
                                                  ^
logs.go:140:33: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (l *logsReceiver) Shutdown(ctx context.Context) error {
```

Linked issue: #20424
