### PR TITLE
[chore][receiver/awscloudwatchmetrics] addressing lint issues

### DIFF
--- a/receiver/awscloudwatchmetricsreceiver/receiver.go
+++ b/receiver/awscloudwatchmetricsreceiver/receiver.go
@@ -39,14 +39,14 @@ func newMetricReceiver(cfg *Config, logger *zap.Logger, consumer consumer.Metric
 	}
 }
 
-func (m *metricReceiver) Start(ctx context.Context, host component.Host) error {
+func (m *metricReceiver) Start(ctx context.Context, _ component.Host) error {
 	m.logger.Debug("starting to poll for CloudWatch metrics")
 	m.wg.Add(1)
 	go m.startPolling(ctx)
 	return nil
 }
 
-func (m *metricReceiver) Shutdown(ctx context.Context) error {
+func (m *metricReceiver) Shutdown(_ context.Context) error {
 	m.logger.Debug("shutting down awscloudwatchmetrics receiver")
 	close(m.doneChan)
 	m.wg.Wait()


### PR DESCRIPTION
Updating golangci-lint raises the following warnings:

```
receiver.go:42:53: unused-parameter: parameter 'host' seems to be unused, consider removing or renaming it as _ (revive)
func (m *metricReceiver) Start(ctx context.Context, host component.Host) error {
                                                    ^
receiver.go:49:35: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func (m *metricReceiver) Shutdown(ctx context.Context) error {
```

Linked issue: #20424
