### PR TITLE
[chore] addressing lint issues

### DIFF
--- a/cmd/configschema/docsgen/docsgen/cli_test.go
+++ b/cmd/configschema/docsgen/docsgen/cli_test.go
@@ -102,7 +102,7 @@ type fakeFilesystemWriter struct {
 	configFiles, fileContents []string
 }
 
-func (wr *fakeFilesystemWriter) writeFile(filename string, data []byte, perm os.FileMode) error {
+func (wr *fakeFilesystemWriter) writeFile(filename string, data []byte, _ os.FileMode) error {
 	wr.configFiles = append(wr.configFiles, filename)
 	wr.fileContents = append(wr.fileContents, string(data))
 	return nil

--- a/cmd/telemetrygen/internal/metrics/worker_test.go
+++ b/cmd/telemetrygen/internal/metrics/worker_test.go
@@ -22,24 +22,24 @@ type mockExporter struct {
 	rms []*metricdata.ResourceMetrics
 }
 
-func (m *mockExporter) Temporality(kind sdkmetric.InstrumentKind) metricdata.Temporality {
+func (m *mockExporter) Temporality(_ sdkmetric.InstrumentKind) metricdata.Temporality {
 	return metricdata.DeltaTemporality
 }
 
-func (m *mockExporter) Aggregation(kind sdkmetric.InstrumentKind) aggregation.Aggregation {
+func (m *mockExporter) Aggregation(_ sdkmetric.InstrumentKind) aggregation.Aggregation {
 	return aggregation.Default{}
 }
 
-func (m *mockExporter) Export(ctx context.Context, metrics *metricdata.ResourceMetrics) error {
+func (m *mockExporter) Export(_ context.Context, metrics *metricdata.ResourceMetrics) error {
 	m.rms = append(m.rms, metrics)
 	return nil
 }
 
-func (m *mockExporter) ForceFlush(ctx context.Context) error {
+func (m *mockExporter) ForceFlush(_ context.Context) error {
 	return nil
 }
 
-func (m *mockExporter) Shutdown(ctx context.Context) error {
+func (m *mockExporter) Shutdown(_ context.Context) error {
 	return nil
 }
 

--- a/exporter/datadogexporter/zaplogger.go
+++ b/exporter/datadogexporter/zaplogger.go
@@ -13,10 +13,10 @@ import (
 type zaplogger struct{ logger *zap.Logger }
 
 // Trace implements Logger.
-func (z *zaplogger) Trace(v ...interface{}) { /* N/A */ }
+func (z *zaplogger) Trace(_ ...interface{}) { /* N/A */ }
 
 // Tracef implements Logger.
-func (z *zaplogger) Tracef(format string, params ...interface{}) { /* N/A */ }
+func (z *zaplogger) Tracef(_ string, _ ...interface{}) { /* N/A */ }
 
 // Debug implements Logger.
 func (z *zaplogger) Debug(v ...interface{}) {

--- a/exporter/instanaexporter/internal/converter/all_converter.go
+++ b/exporter/instanaexporter/internal/converter/all_converter.go
@@ -20,7 +20,7 @@ type ConvertAllConverter struct {
 	logger     *zap.Logger
 }
 
-func (c *ConvertAllConverter) AcceptsSpans(attributes pcommon.Map, spanSlice ptrace.SpanSlice) bool {
+func (c *ConvertAllConverter) AcceptsSpans(_ pcommon.Map, _ ptrace.SpanSlice) bool {
 	return true
 }
 

--- a/exporter/instanaexporter/internal/converter/span_converter.go
+++ b/exporter/instanaexporter/internal/converter/span_converter.go
@@ -21,8 +21,7 @@ type SpanConverter struct {
 	logger *zap.Logger
 }
 
-func (c *SpanConverter) AcceptsSpans(attributes pcommon.Map, spanSlice ptrace.SpanSlice) bool {
-
+func (c *SpanConverter) AcceptsSpans(_ pcommon.Map, _ ptrace.SpanSlice) bool {
 	return true
 }
 

--- a/exporter/jaegerexporter/exporter_test.go
+++ b/exporter/jaegerexporter/exporter_test.go
@@ -285,7 +285,7 @@ func TestConnectionStateChange(t *testing.T) {
 	assert.Equal(t, connectivity.Ready, state)
 }
 
-func TestConnectionReporterEndsOnStopped(t *testing.T) {
+func TestConnectionReporterEndsOnStopped(_ *testing.T) {
 	sr := &mockStateReporter{
 		state: connectivity.Connecting,
 	}

--- a/exporter/loadbalancingexporter/resolver_dns.go
+++ b/exporter/loadbalancingexporter/resolver_dns.go
@@ -90,7 +90,7 @@ func (r *dnsResolver) start(ctx context.Context) error {
 	return nil
 }
 
-func (r *dnsResolver) shutdown(ctx context.Context) error {
+func (r *dnsResolver) shutdown(_ context.Context) error {
 	r.changeCallbackLock.Lock()
 	r.onChangeCallbacks = nil
 	r.changeCallbackLock.Unlock()

--- a/exporter/loadbalancingexporter/resolver_static.go
+++ b/exporter/loadbalancingexporter/resolver_static.go
@@ -49,7 +49,7 @@ func (r *staticResolver) start(ctx context.Context) error {
 	return err
 }
 
-func (r *staticResolver) shutdown(ctx context.Context) error {
+func (r *staticResolver) shutdown(_ context.Context) error {
 	return nil
 }
 

--- a/exporter/lokiexporter/internal/tenant/context.go
+++ b/exporter/lokiexporter/internal/tenant/context.go
@@ -17,7 +17,7 @@ type ContextTenantSource struct {
 	Key string
 }
 
-func (ts *ContextTenantSource) GetTenant(ctx context.Context, logs plog.Logs) (string, error) {
+func (ts *ContextTenantSource) GetTenant(ctx context.Context, _ plog.Logs) (string, error) {
 	cl := client.FromContext(ctx)
 	ss := cl.Metadata.Get(ts.Key)
 

--- a/exporter/lokiexporter/internal/tenant/static.go
+++ b/exporter/lokiexporter/internal/tenant/static.go
@@ -15,6 +15,6 @@ type StaticTenantSource struct {
 	Value string
 }
 
-func (ts *StaticTenantSource) GetTenant(_ context.Context, logs plog.Logs) (string, error) {
+func (ts *StaticTenantSource) GetTenant(_ context.Context, _ plog.Logs) (string, error) {
 	return ts.Value, nil
 }

--- a/exporter/parquetexporter/exporter.go
+++ b/exporter/parquetexporter/exporter.go
@@ -16,22 +16,22 @@ type parquetExporter struct {
 	path string
 }
 
-func (e parquetExporter) start(ctx context.Context, host component.Host) error {
+func (e parquetExporter) start(_ context.Context, _ component.Host) error {
 	return nil
 }
 
-func (e parquetExporter) shutdown(ctx context.Context) error {
+func (e parquetExporter) shutdown(_ context.Context) error {
 	return nil
 }
 
-func (e parquetExporter) consumeMetrics(ctx context.Context, ld pmetric.Metrics) error {
+func (e parquetExporter) consumeMetrics(_ context.Context, _ pmetric.Metrics) error {
 	return nil
 }
 
-func (e parquetExporter) consumeTraces(ctx context.Context, ld ptrace.Traces) error {
+func (e parquetExporter) consumeTraces(_ context.Context, _ ptrace.Traces) error {
 	return nil
 }
 
-func (e parquetExporter) consumeLogs(ctx context.Context, ld plog.Logs) error {
+func (e parquetExporter) consumeLogs(_ context.Context, _ plog.Logs) error {
 	return nil
 }

--- a/exporter/tanzuobservabilityexporter/trace_exporter_test.go
+++ b/exporter/tanzuobservabilityexporter/trace_exporter_test.go
@@ -301,7 +301,7 @@ func (m *mockSender) SendSpan(
 	name string,
 	startMillis, durationMillis int64,
 	source, traceID, spanID string,
-	parents, followsFrom []string,
+	parents, _ []string,
 	spanTags []senders.SpanTag,
 	spanLogs []senders.SpanLog,
 ) error {

--- a/internal/aws/ecsutil/rest_client_test.go
+++ b/internal/aws/ecsutil/rest_client_test.go
@@ -38,7 +38,7 @@ func TestRestClientFromClient(t *testing.T) {
 
 type fakeErrorClient struct{}
 
-func (f *fakeErrorClient) Get(path string) ([]byte, error) {
+func (f *fakeErrorClient) Get(_ string) ([]byte, error) {
 	return nil, fmt.Errorf("")
 }
 
@@ -52,7 +52,7 @@ func TestRestClientError(t *testing.T) {
 
 type fakeMetadataErrorClient struct{}
 
-func (f *fakeMetadataErrorClient) Get(path string) ([]byte, error) {
+func (f *fakeMetadataErrorClient) Get(_ string) ([]byte, error) {
 	return nil, fmt.Errorf("")
 }
 

--- a/internal/aws/k8s/k8sclient/obj_store.go
+++ b/internal/aws/k8s/k8sclient/obj_store.go
@@ -123,12 +123,12 @@ func (s *ObjStore) ListKeys() []string {
 }
 
 // Get implements the Get method of the store interface.
-func (s *ObjStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
+func (s *ObjStore) Get(_ interface{}) (item interface{}, exists bool, err error) {
 	return nil, false, nil
 }
 
 // GetByKey implements the GetByKey method of the store interface.
-func (s *ObjStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+func (s *ObjStore) GetByKey(_ string) (item interface{}, exists bool, err error) {
 	return nil, false, nil
 }
 

--- a/internal/aws/metrics/metric_calculator.go
+++ b/internal/aws/metrics/metric_calculator.go
@@ -23,7 +23,7 @@ func NewFloat64DeltaCalculator() MetricCalculator {
 	return NewMetricCalculator(calculateDelta)
 }
 
-func calculateDelta(prev *MetricValue, val interface{}, timestamp time.Time) (interface{}, bool) {
+func calculateDelta(prev *MetricValue, val interface{}, _ time.Time) (interface{}, bool) {
 	var deltaValue float64
 	if prev != nil {
 		deltaValue = val.(float64) - prev.RawValue.(float64)

--- a/internal/metadataproviders/consul/metadata.go
+++ b/internal/metadataproviders/consul/metadata.go
@@ -30,7 +30,7 @@ func NewProvider(client *api.Client, allowedLabels map[string]interface{}) Provi
 	return &consulMetadataImpl{consulClient: client, allowedLabels: allowedLabels}
 }
 
-func (d *consulMetadataImpl) Metadata(ctx context.Context) (*Metadata, error) {
+func (d *consulMetadataImpl) Metadata(_ context.Context) (*Metadata, error) {
 	var metadata Metadata
 	self, err := d.consulClient.Agent().Self()
 	if err != nil {

--- a/pkg/experimentalmetricmetadata/metadata_test.go
+++ b/pkg/experimentalmetricmetadata/metadata_test.go
@@ -11,7 +11,7 @@ import (
 
 type mockMetadataExporter struct{}
 
-func (m *mockMetadataExporter) ConsumeMetadata(metadata []*MetadataUpdate) error {
+func (m *mockMetadataExporter) ConsumeMetadata(_ []*MetadataUpdate) error {
 	return nil
 }
 

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -112,7 +112,7 @@ func (r *Reader) ReadToEnd(ctx context.Context) {
 // consumeHeaderLine checks if the given token is a line of the header, and consumes it if it is.
 // The return value dictates whether the given line was a header line or not.
 // If false is returned, the full header can be assumed to be read.
-func (r *Reader) consumeHeaderLine(ctx context.Context, attrs *FileAttributes, token []byte) {
+func (r *Reader) consumeHeaderLine(ctx context.Context, _ *FileAttributes, token []byte) {
 	if !r.headerSettings.matchRegex.Match(token) {
 		// Finalize and cleanup the pipeline
 		r.HeaderFinalized = true

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
@@ -33,20 +33,20 @@ type Decorator interface {
 type Option func(*Cadvisor)
 
 // WithDecorator constructs an option for configuring the metric decorator
-func WithDecorator(d interface{}) Option {
+func WithDecorator(_ interface{}) Option {
 	return func(c *Cadvisor) {
 		// do nothing
 	}
 }
 
-func WithECSInfoCreator(f interface{}) Option {
+func WithECSInfoCreator(_ interface{}) Option {
 	return func(c *Cadvisor) {
 		// do nothing
 	}
 }
 
 // New is a dummy function to construct a dummy Cadvisor struct for windows
-func New(containerOrchestrator string, hostInfo HostInfo, logger *zap.Logger, options ...Option) (*Cadvisor, error) {
+func New(_ string, _ HostInfo, _ *zap.Logger, _ ...Option) (*Cadvisor, error) {
 	return &Cadvisor{}, nil
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecsinfo_test.go
@@ -65,11 +65,11 @@ func (c *MockCgroupScanner) getMemReserved() int64 {
 	return c.memReserved
 }
 
-func (c *MockCgroupScanner) getCPUReservedInTask(taskID string, clusterName string) int64 {
+func (c *MockCgroupScanner) getCPUReservedInTask(_ string, _ string) int64 {
 	return int64(10)
 }
 
-func (c *MockCgroupScanner) getMEMReservedInTask(taskID string, clusterName string, containers []ECSContainer) int64 {
+func (c *MockCgroupScanner) getMEMReservedInTask(_ string, _ string, _ []ECSContainer) int64 {
 	return int64(512)
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils_test.go
@@ -19,7 +19,7 @@ type mockHTTPClient struct {
 	err      error
 }
 
-func (m *mockHTTPClient) Do(reqest *http.Request) (*http.Response, error) {
+func (m *mockHTTPClient) Do(_ *http.Request) (*http.Response, error) {
 	return m.response, m.err
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/host/ec2metadata_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/ec2metadata_test.go
@@ -19,7 +19,7 @@ type mockMetadataClient struct {
 	count int
 }
 
-func (m *mockMetadataClient) GetInstanceIdentityDocumentWithContext(ctx context.Context) (awsec2metadata.EC2InstanceIdentityDocument, error) {
+func (m *mockMetadataClient) GetInstanceIdentityDocumentWithContext(_ context.Context) (awsec2metadata.EC2InstanceIdentityDocument, error) {
 	m.count++
 	if m.count == 1 {
 		return awsec2metadata.EC2InstanceIdentityDocument{}, errors.New("error")

--- a/receiver/awscontainerinsightreceiver/internal/host/ec2tags_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/ec2tags_test.go
@@ -28,8 +28,8 @@ type mockEC2TagsClient struct {
 	containerOrchestrator string
 }
 
-func (m *mockEC2TagsClient) DescribeTagsWithContext(ctx context.Context, input *ec2.DescribeTagsInput,
-	opts ...request.Option) (*ec2.DescribeTagsOutput, error) {
+func (m *mockEC2TagsClient) DescribeTagsWithContext(_ context.Context, _ *ec2.DescribeTagsInput,
+	_ ...request.Option) (*ec2.DescribeTagsOutput, error) {
 	m.count++
 	if m.count == 1 {
 		return &ec2.DescribeTagsOutput{}, errors.New("error")

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
@@ -51,7 +51,7 @@ func (m *mockEC2Metadata) getRegion() string {
 type mockEBSVolume struct {
 }
 
-func (m *mockEBSVolume) getEBSVolumeID(devName string) string {
+func (m *mockEBSVolume) getEBSVolumeID(_ string) string {
 	return "ebs-volume-id"
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -91,15 +91,15 @@ func (client *MockClient) ServiceToPodNum() map[k8sclient.Service]int {
 type mockEventBroadcaster struct {
 }
 
-func (m *mockEventBroadcaster) StartRecordingToSink(sink record.EventSink) watch.Interface {
+func (m *mockEventBroadcaster) StartRecordingToSink(_ record.EventSink) watch.Interface {
 	return watch.NewFake()
 }
 
-func (m *mockEventBroadcaster) StartLogging(logf func(format string, args ...interface{})) watch.Interface {
+func (m *mockEventBroadcaster) StartLogging(_ func(format string, args ...interface{})) watch.Interface {
 	return watch.NewFake()
 }
 
-func (m *mockEventBroadcaster) NewRecorder(scheme *runtime.Scheme, source v1.EventSource) record.EventRecorder {
+func (m *mockEventBroadcaster) NewRecorder(_ *runtime.Scheme, _ v1.EventSource) record.EventRecorder {
 	return record.NewFakeRecorder(100)
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/stores/servicestore.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/servicestore.go
@@ -52,7 +52,7 @@ func (s *ServiceStore) RefreshTick(ctx context.Context) {
 
 // Decorate decorates metrics and update kubernetesBlob
 // service info is not mandatory
-func (s *ServiceStore) Decorate(ctx context.Context, metric CIMetric, _ map[string]interface{}) bool {
+func (s *ServiceStore) Decorate(_ context.Context, metric CIMetric, _ map[string]interface{}) bool {
 	if metric.HasTag(ci.K8sPodNameKey) {
 		podKey := createPodKeyFromMetric(metric)
 		if podKey == "" {

--- a/receiver/awsecscontainermetricsreceiver/factory.go
+++ b/receiver/awsecscontainermetricsreceiver/factory.go
@@ -41,7 +41,7 @@ func createDefaultConfig() component.Config {
 
 // CreateMetricsReceiver creates an AWS ECS Container Metrics receiver.
 func createMetricsReceiver(
-	ctx context.Context,
+	_ context.Context,
 	params receiver.CreateSettings,
 	baseCfg component.Config,
 	consumer consumer.Metrics,

--- a/receiver/awsecscontainermetricsreceiver/receiver.go
+++ b/receiver/awsecscontainermetricsreceiver/receiver.go
@@ -48,7 +48,7 @@ func newAWSECSContainermetrics(
 }
 
 // Start begins collecting metrics from Amazon ECS task metadata endpoint.
-func (aecmr *awsEcsContainerMetricsReceiver) Start(ctx context.Context, host component.Host) error {
+func (aecmr *awsEcsContainerMetricsReceiver) Start(ctx context.Context, _ component.Host) error {
 	ctx, aecmr.cancel = context.WithCancel(ctx)
 	go func() {
 		ticker := time.NewTicker(aecmr.config.CollectionInterval)

--- a/receiver/awsecscontainermetricsreceiver/receiver_test.go
+++ b/receiver/awsecscontainermetricsreceiver/receiver_test.go
@@ -108,7 +108,7 @@ func TestCollectDataFromEndpointWithConsumerError(t *testing.T) {
 type invalidFakeClient struct {
 }
 
-func (f invalidFakeClient) GetResponse(path string) ([]byte, error) {
+func (f invalidFakeClient) GetResponse(_ string) ([]byte, error) {
 	return nil, fmt.Errorf("intentional error")
 }
 

--- a/receiver/awsxrayreceiver/factory.go
+++ b/receiver/awsxrayreceiver/factory.go
@@ -40,7 +40,7 @@ func createDefaultConfig() component.Config {
 }
 
 func createTracesReceiver(
-	ctx context.Context,
+	_ context.Context,
 	params receiver.CreateSettings,
 	cfg component.Config,
 	consumer consumer.Traces) (receiver.Traces, error) {

--- a/receiver/awsxrayreceiver/receiver_test.go
+++ b/receiver/awsxrayreceiver/receiver_test.go
@@ -255,7 +255,7 @@ func (m *mockPoller) SegmentsChan() <-chan udppoller.RawSegment {
 	return make(chan udppoller.RawSegment, 1)
 }
 
-func (m *mockPoller) Start(ctx context.Context) {}
+func (m *mockPoller) Start(_ context.Context) {}
 
 func (m *mockPoller) Close() error {
 	if m.closeErr != nil {
@@ -272,7 +272,7 @@ func (m *mockProxy) ListenAndServe() error {
 	return errors.New("returning from ListenAndServe() always errors out")
 }
 
-func (m *mockProxy) Shutdown(ctx context.Context) error {
+func (m *mockProxy) Shutdown(_ context.Context) error {
 	if m.closeErr != nil {
 		return m.closeErr
 	}

--- a/receiver/azureblobreceiver/factory.go
+++ b/receiver/azureblobreceiver/factory.go
@@ -50,7 +50,7 @@ func (f *blobReceiverFactory) createDefaultConfig() component.Config {
 }
 
 func (f *blobReceiverFactory) createLogsReceiver(
-	ctx context.Context,
+	_ context.Context,
 	set receiver.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Logs,
@@ -69,7 +69,7 @@ func (f *blobReceiverFactory) createLogsReceiver(
 }
 
 func (f *blobReceiverFactory) createTracesReceiver(
-	ctx context.Context,
+	_ context.Context,
 	set receiver.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Traces,

--- a/receiver/azureblobreceiver/receiver.go
+++ b/receiver/azureblobreceiver/receiver.go
@@ -38,7 +38,7 @@ type blobReceiver struct {
 	obsrecv            *obsreport.Receiver
 }
 
-func (b *blobReceiver) Start(ctx context.Context, host component.Host) error {
+func (b *blobReceiver) Start(ctx context.Context, _ component.Host) error {
 	err := b.blobEventHandler.run(ctx)
 
 	return err

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -25,7 +25,7 @@ import (
 type mockHubWrapper struct {
 }
 
-func (m mockHubWrapper) GetRuntimeInformation(ctx context.Context) (*eventhub.HubRuntimeInformation, error) {
+func (m mockHubWrapper) GetRuntimeInformation(_ context.Context) (*eventhub.HubRuntimeInformation, error) {
 	return &eventhub.HubRuntimeInformation{
 		Path:           "foo",
 		CreatedAt:      time.Now(),
@@ -34,9 +34,9 @@ func (m mockHubWrapper) GetRuntimeInformation(ctx context.Context) (*eventhub.Hu
 	}, nil
 }
 
-func (m mockHubWrapper) Receive(ctx context.Context, partitionID string, handler eventhub.Handler, opts ...eventhub.ReceiveOption) (listerHandleWrapper, error) {
+func (m mockHubWrapper) Receive(ctx context.Context, _ string, _ eventhub.Handler, _ ...eventhub.ReceiveOption) (listerHandleWrapper, error) {
 	return &mockListenerHandleWrapper{
-		ctx: context.Background(),
+		ctx: ctx,
 	}, nil
 }
 
@@ -66,8 +66,7 @@ func (m *mockDataConsumer) setNextLogsConsumer(nextLogsConsumer consumer.Logs) {
 	m.nextLogsConsumer = nextLogsConsumer
 }
 
-func (m *mockDataConsumer) setNextMetricsConsumer(nextMetricsConsumer consumer.Metrics) {
-}
+func (m *mockDataConsumer) setNextMetricsConsumer(_ consumer.Metrics) {}
 
 func (m *mockDataConsumer) consume(ctx context.Context, event *eventhub.Event) error {
 

--- a/receiver/azureeventhubreceiver/factory.go
+++ b/receiver/azureeventhubreceiver/factory.go
@@ -46,7 +46,7 @@ func createDefaultConfig() component.Config {
 }
 
 func (f *eventhubReceiverFactory) createLogsReceiver(
-	ctx context.Context,
+	_ context.Context,
 	settings receiver.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Logs,
@@ -63,7 +63,7 @@ func (f *eventhubReceiverFactory) createLogsReceiver(
 }
 
 func (f *eventhubReceiverFactory) createMetricsReceiver(
-	ctx context.Context,
+	_ context.Context,
 	settings receiver.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Metrics,

--- a/receiver/cloudflarereceiver/factory.go
+++ b/receiver/cloudflarereceiver/factory.go
@@ -24,7 +24,7 @@ func NewFactory() receiver.Factory {
 }
 
 func createLogsReceiver(
-	ctx context.Context,
+	_ context.Context,
 	params receiver.CreateSettings,
 	rConf component.Config,
 	consumer consumer.Logs,

--- a/receiver/cloudfoundryreceiver/receiver.go
+++ b/receiver/cloudfoundryreceiver/receiver.go
@@ -81,7 +81,7 @@ func (cfr *cloudFoundryReceiver) Start(ctx context.Context, host component.Host)
 		return fmt.Errorf("creating cloud foundry RLP envelope stream factory: %w", streamErr)
 	}
 
-	innerCtx, cancel := context.WithCancel(context.Background())
+	innerCtx, cancel := context.WithCancel(ctx)
 	cfr.cancel = cancel
 
 	cfr.goroutines.Add(1)

--- a/receiver/datadogreceiver/factory.go
+++ b/receiver/datadogreceiver/factory.go
@@ -34,7 +34,7 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func createTracesReceiver(ctx context.Context, params receiver.CreateSettings, cfg component.Config, consumer consumer.Traces) (r receiver.Traces, err error) {
+func createTracesReceiver(_ context.Context, params receiver.CreateSettings, cfg component.Config, consumer consumer.Traces) (r receiver.Traces, err error) {
 	rcfg := cfg.(*Config)
 	r = receivers.GetOrAdd(cfg, func() component.Component {
 		dd, _ := newDataDogReceiver(rcfg, consumer, params)

--- a/receiver/filereceiver/receiver.go
+++ b/receiver/filereceiver/receiver.go
@@ -23,9 +23,8 @@ type fileReceiver struct {
 	throttle float64
 }
 
-func (r *fileReceiver) Start(_ context.Context, _ component.Host) error {
-	var ctx context.Context
-	ctx, r.cancel = context.WithCancel(context.Background())
+func (r *fileReceiver) Start(ctx context.Context, _ component.Host) error {
+	ctx, r.cancel = context.WithCancel(ctx)
 
 	file, err := os.Open(r.path)
 	if err != nil {

--- a/receiver/filestatsreceiver/filestats_darwin.go
+++ b/receiver/filestatsreceiver/filestats_darwin.go
@@ -16,7 +16,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver/internal/metadata"
 )
 
-func collectStats(now pcommon.Timestamp, fileinfo os.FileInfo, metricsBuilder *metadata.MetricsBuilder, logger *zap.Logger) {
+func collectStats(now pcommon.Timestamp, fileinfo os.FileInfo, metricsBuilder *metadata.MetricsBuilder, _ *zap.Logger) {
 	stat := fileinfo.Sys().(*syscall.Stat_t)
 	atime := stat.Atimespec.Sec
 	ctime := stat.Ctimespec.Sec

--- a/receiver/filestatsreceiver/scraper.go
+++ b/receiver/filestatsreceiver/scraper.go
@@ -25,7 +25,7 @@ type scraper struct {
 	metricsBuilder *metadata.MetricsBuilder
 }
 
-func (s *scraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
+func (s *scraper) scrape(_ context.Context) (pmetric.Metrics, error) {
 	matches, err := doublestar.FilepathGlob(s.include)
 	if err != nil {
 		return pmetric.NewMetrics(), err

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_fallback.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_fallback.go
@@ -13,5 +13,5 @@ import (
 
 const systemSpecificMetricsLen = 0
 
-func (s *scraper) recordSystemSpecificDataPoints(now pcommon.Timestamp, ioCounters map[string]disk.IOCountersStat) {
+func (s *scraper) recordSystemSpecificDataPoints(_ pcommon.Timestamp, _ map[string]disk.IOCountersStat) {
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -465,7 +465,7 @@ func (p *processHandleMock) NumFDs() (int32, error) {
 	return args.Get(0).(int32), args.Error(1)
 }
 
-func (p *processHandleMock) RlimitUsage(gatherUsed bool) ([]process.RlimitStat, error) {
+func (p *processHandleMock) RlimitUsage(_ bool) ([]process.RlimitStat, error) {
 	args := p.MethodCalled("RlimitUsage")
 	return args.Get(0).([]process.RlimitStat), args.Error(1)
 }

--- a/receiver/httpcheckreceiver/factory.go
+++ b/receiver/httpcheckreceiver/factory.go
@@ -42,7 +42,7 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func createMetricsReceiver(ctx context.Context, params receiver.CreateSettings, rConf component.Config, consumer consumer.Metrics) (receiver.Metrics, error) {
+func createMetricsReceiver(_ context.Context, params receiver.CreateSettings, rConf component.Config, consumer consumer.Metrics) (receiver.Metrics, error) {
 	cfg, ok := rConf.(*Config)
 	if !ok {
 		return nil, errConfigNotHTTPCheck

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -30,7 +30,7 @@ type httpcheckScraper struct {
 }
 
 // start starts the scraper by creating a new HTTP Client on the scraper
-func (h *httpcheckScraper) start(ctx context.Context, host component.Host) (err error) {
+func (h *httpcheckScraper) start(_ context.Context, host component.Host) (err error) {
 	h.client, err = h.cfg.ToClient(host, h.settings)
 	return
 }

--- a/receiver/iisreceiver/factory_others.go
+++ b/receiver/iisreceiver/factory_others.go
@@ -17,10 +17,10 @@ import (
 
 // createMetricsReceiver creates a metrics receiver based on provided config.
 func createMetricsReceiver(
-	ctx context.Context,
-	params receiver.CreateSettings,
-	cfg component.Config,
-	consumer consumer.Metrics,
+	_ context.Context,
+	_ receiver.CreateSettings,
+	_ component.Config,
+	_ consumer.Metrics,
 ) (receiver.Metrics, error) {
 	return nil, errors.New("the windows perf counters receiver is only supported on Windows")
 }

--- a/receiver/influxdbreceiver/receiver_test.go
+++ b/receiver/influxdbreceiver/receiver_test.go
@@ -94,7 +94,7 @@ func (m *mockConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
 
-func (m *mockConsumer) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+func (m *mockConsumer) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
 	m.lastMetricsConsumed = pmetric.NewMetrics()
 	md.CopyTo(m.lastMetricsConsumed)
 	return nil

--- a/receiver/jaegerreceiver/trace_receiver.go
+++ b/receiver/jaegerreceiver/trace_receiver.go
@@ -177,11 +177,11 @@ var errNotImplemented = fmt.Errorf("not implemented")
 
 type notImplementedConfigManager struct{}
 
-func (notImplementedConfigManager) GetSamplingStrategy(ctx context.Context, serviceName string) (*sampling.SamplingStrategyResponse, error) {
+func (notImplementedConfigManager) GetSamplingStrategy(_ context.Context, _ string) (*sampling.SamplingStrategyResponse, error) {
 	return nil, errNotImplemented
 }
 
-func (notImplementedConfigManager) GetBaggageRestrictions(ctx context.Context, serviceName string) ([]*baggage.BaggageRestriction, error) {
+func (notImplementedConfigManager) GetBaggageRestrictions(_ context.Context, _ string) ([]*baggage.BaggageRestriction, error) {
 	return nil, errNotImplemented
 }
 

--- a/receiver/journaldreceiver/journald_nonlinux.go
+++ b/receiver/journaldreceiver/journald_nonlinux.go
@@ -41,9 +41,9 @@ func createDefaultConfig() component.Config {
 
 func createLogsReceiver(
 	_ context.Context,
-	params receiver.CreateSettings,
-	cfg component.Config,
-	consumer consumer.Logs,
+	_ receiver.CreateSettings,
+	_ component.Config,
+	_ consumer.Logs,
 ) (receiver.Logs, error) {
 	return nil, fmt.Errorf("journald is only supported on linux")
 }

--- a/receiver/k8sobjectsreceiver/mock_log_consumer_test.go
+++ b/receiver/k8sobjectsreceiver/mock_log_consumer_test.go
@@ -30,7 +30,7 @@ func (m *mockLogConsumer) Capabilities() consumer.Capabilities {
 	}
 }
 
-func (m *mockLogConsumer) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
+func (m *mockLogConsumer) ConsumeLogs(_ context.Context, ld plog.Logs) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	m.logs = append(m.logs, ld)

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -1056,7 +1056,7 @@ func (t *testConsumerGroup) Close() error {
 	return nil
 }
 
-func (t *testConsumerGroup) Pause(partitions map[string][]int32) {
+func (t *testConsumerGroup) Pause(_ map[string][]int32) {
 	panic("implement me")
 }
 
@@ -1064,7 +1064,7 @@ func (t *testConsumerGroup) PauseAll() {
 	panic("implement me")
 }
 
-func (t *testConsumerGroup) Resume(topicPartitions map[string][]int32) {
+func (t *testConsumerGroup) Resume(_ map[string][]int32) {
 	panic("implement me")
 }
 

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -75,7 +75,7 @@ func newTransaction(
 }
 
 // Append always returns 0 to disable label caching.
-func (t *transaction) Append(ref storage.SeriesRef, ls labels.Labels, atMs int64, val float64) (storage.SeriesRef, error) {
+func (t *transaction) Append(_ storage.SeriesRef, ls labels.Labels, atMs int64, val float64) (storage.SeriesRef, error) {
 	select {
 	case <-t.ctx.Done():
 		return 0, errTransactionAborted
@@ -149,7 +149,7 @@ func (t *transaction) getOrCreateMetricFamily(mn string) *metricFamily {
 	return curMf
 }
 
-func (t *transaction) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
+func (t *transaction) AppendExemplar(_ storage.SeriesRef, l labels.Labels, e exemplar.Exemplar) (storage.SeriesRef, error) {
 	select {
 	case <-t.ctx.Done():
 		return 0, errTransactionAborted
@@ -179,7 +179,7 @@ func (t *transaction) AppendExemplar(ref storage.SeriesRef, l labels.Labels, e e
 	return 0, nil
 }
 
-func (t *transaction) AppendHistogram(ref storage.SeriesRef, l labels.Labels, atMs int64, h *histogram.Histogram, fh *histogram.FloatHistogram) (storage.SeriesRef, error) {
+func (t *transaction) AppendHistogram(_ storage.SeriesRef, _ labels.Labels, _ int64, h *histogram.Histogram, _ *histogram.FloatHistogram) (storage.SeriesRef, error) {
 	//TODO: implement this func
 	return 0, nil
 }

--- a/receiver/solacereceiver/messaging_service_test.go
+++ b/receiver/solacereceiver/messaging_service_test.go
@@ -685,13 +685,13 @@ func (c *connMock) LocalAddr() net.Addr {
 func (c *connMock) RemoteAddr() net.Addr {
 	return nil
 }
-func (c *connMock) SetDeadline(t time.Time) error {
+func (c *connMock) SetDeadline(_ time.Time) error {
 	return nil
 }
-func (c *connMock) SetReadDeadline(t time.Time) error {
+func (c *connMock) SetReadDeadline(_ time.Time) error {
 	return nil
 }
-func (c *connMock) SetWriteDeadline(t time.Time) error {
+func (c *connMock) SetWriteDeadline(_ time.Time) error {
 	return nil
 }
 

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -848,7 +848,7 @@ type badReqBody struct{}
 
 var _ io.ReadCloser = (*badReqBody)(nil)
 
-func (b badReqBody) Read(p []byte) (n int, err error) {
+func (b badReqBody) Read(_ []byte) (n int, err error) {
 	return 0, errors.New("badReqBody: can't read it")
 }
 

--- a/receiver/statsdreceiver/transport/mock_reporter.go
+++ b/receiver/statsdreceiver/transport/mock_reporter.go
@@ -27,8 +27,7 @@ func (m *MockReporter) OnDataReceived(ctx context.Context) context.Context {
 	return ctx
 }
 
-func (m *MockReporter) OnTranslationError(ctx context.Context, err error) {
-}
+func (m *MockReporter) OnTranslationError(_ context.Context, _ error) {}
 
 func (m *MockReporter) OnMetricsProcessed(ctx context.Context, numReceivedMessages int, err error) {
 	m.wgMetricsProcessed.Done()

--- a/testbed/mockdatareceivers/mockawsxrayreceiver/factory.go
+++ b/testbed/mockdatareceivers/mockawsxrayreceiver/factory.go
@@ -40,7 +40,7 @@ func createDefaultConfig() component.Config {
 
 // CreateTracesReceiver creates a trace receiver based on provided config.
 func createTracesReceiver(
-	ctx context.Context,
+	_ context.Context,
 	params receiver.CreateSettings,
 	cfg component.Config,
 	nextConsumer consumer.Traces,

--- a/testbed/testbed/in_process_collector.go
+++ b/testbed/testbed/in_process_collector.go
@@ -43,7 +43,7 @@ func (ipp *inProcessCollector) PrepareConfig(configStr string) (configCleanup fu
 	return configCleanup, err
 }
 
-func (ipp *inProcessCollector) Start(args StartParams) error {
+func (ipp *inProcessCollector) Start(_ StartParams) error {
 	var err error
 
 	confFile, err := os.CreateTemp(os.TempDir(), "conf-")


### PR DESCRIPTION
Updating golangci-lint raises many unused-parameter errors, this is addressing some of those. Note in some cases, the context passed into start methods wasn't used, I fixed this.

Linked issue: #20424
