### PR TITLE
[pkg/stanza] return raw Windows events as strings

### DIFF
--- a/.chloggen/feat_stanza_windowsinput_raweventbody.yaml
+++ b/.chloggen/feat_stanza_windowsinput_raweventbody.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: windowseventlogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Emit raw Windows events as strings instead of byte arrays
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22704]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/operator/input/windows/buffer.go
+++ b/pkg/stanza/operator/input/windows/buffer.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 
 import (

--- a/pkg/stanza/operator/input/windows/buffer_test.go
+++ b/pkg/stanza/operator/input/windows/buffer_test.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package windows
 
 import (
@@ -17,9 +14,7 @@ func TestBufferReadBytes(t *testing.T) {
 	buffer := NewBuffer()
 	utf8 := []byte("test")
 	utf16, _ := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewEncoder().Bytes(utf8)
-	for i, b := range utf16 {
-		buffer.buffer[i] = b
-	}
+	copy(buffer.buffer, utf16)
 	offset := uint32(len(utf16))
 	bytes, err := buffer.ReadBytes(offset)
 	require.NoError(t, err)
@@ -30,9 +25,7 @@ func TestBufferReadWideBytes(t *testing.T) {
 	buffer := NewBuffer()
 	utf8 := []byte("test")
 	utf16, _ := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewEncoder().Bytes(utf8)
-	for i, b := range utf16 {
-		buffer.buffer[i] = b
-	}
+	copy(buffer.buffer, utf16)
 	offset := uint32(len(utf16) / 2)
 	bytes, err := buffer.ReadWideChars(offset)
 	require.NoError(t, err)
@@ -43,9 +36,7 @@ func TestBufferReadString(t *testing.T) {
 	buffer := NewBuffer()
 	utf8 := []byte("test")
 	utf16, _ := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewEncoder().Bytes(utf8)
-	for i, b := range utf16 {
-		buffer.buffer[i] = b
-	}
+	copy(buffer.buffer, utf16)
 	offset := uint32(len(utf16))
 	result, err := buffer.ReadString(offset)
 	require.NoError(t, err)

--- a/pkg/stanza/operator/input/windows/raw.go
+++ b/pkg/stanza/operator/input/windows/raw.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 
 import (
@@ -19,7 +16,7 @@ type EventRaw struct {
 	TimeCreated   TimeCreated `xml:"System>TimeCreated"`
 	RenderedLevel string      `xml:"RenderingInfo>Level"`
 	Level         string      `xml:"System>Level"`
-	bytes         []byte
+	Body          string      `xml:"-"`
 }
 
 // parseTimestamp will parse the timestamp of the event.
@@ -65,8 +62,8 @@ func (e *EventRaw) parseSeverity() entry.Severity {
 }
 
 // parseBody will parse a body from the event.
-func (e *EventRaw) parseBody() []byte {
-	return e.bytes
+func (e *EventRaw) parseBody() string {
+	return e.Body
 }
 
 // unmarshalEventRaw will unmarshal EventRaw from xml bytes.
@@ -75,6 +72,6 @@ func unmarshalEventRaw(bytes []byte) (EventRaw, error) {
 	if err := xml.Unmarshal(bytes, &eventRaw); err != nil {
 		return EventRaw{}, fmt.Errorf("failed to unmarshal xml bytes into event: %w (%s)", err, string(bytes))
 	}
-	eventRaw.bytes = bytes
+	eventRaw.Body = string(bytes)
 	return eventRaw, nil
 }

--- a/pkg/stanza/operator/input/windows/raw_test.go
+++ b/pkg/stanza/operator/input/windows/raw_test.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package windows
 
 import (
@@ -65,10 +62,10 @@ func TestParseSeverityRaw(t *testing.T) {
 
 func TestParseBodyRaw(t *testing.T) {
 	raw := EventRaw{
-		bytes: []byte("foo"),
+		Body: "foo",
 	}
 
-	require.Equal(t, []byte("foo"), raw.parseBody())
+	require.Equal(t, "foo", raw.parseBody())
 }
 
 func TestInvalidUnmarshalRaw(t *testing.T) {
@@ -89,7 +86,7 @@ func TestUnmarshalRaw(t *testing.T) {
 			SystemTime: "2022-04-22T10:20:52.3778625Z",
 		},
 		Level: "4",
-		bytes: data,
+		Body:  string(data),
 	}
 
 	require.Equal(t, raw, event)

--- a/pkg/stanza/operator/input/windows/xml.go
+++ b/pkg/stanza/operator/input/windows/xml.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 
 import (

--- a/pkg/stanza/operator/input/windows/xml_test.go
+++ b/pkg/stanza/operator/input/windows/xml_test.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build windows
-// +build windows
-
 package windows
 
 import (


### PR DESCRIPTION
**Description:**
Return raw Windows events as strings instead of byte slices. This is just generally nicer and easier to use, and there's no reason not to, as we know they're valid strings.

I've also removed some windows build tags from files that didn't need them. This just makes it easier to work with the package in non-Windows dev environments.

**Link to tracking Issue:** #22704 

**Testing:**
Modified existing unit test. Also did a manual e2e test using the contrib distro.
