### PR TITLE
[receiver/hostmetrics] Change method to get parent Pid in function parentPid

### DIFF
--- a/.chloggen/fix-parent-error-scrapping.yaml
+++ b/.chloggen/fix-parent-error-scrapping.yaml
@@ -6,10 +6,10 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: processscraper
+component: processor/hostmetrics
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Change method to get parent Pid in function parentPid
+note: Fix issue where receiver fails to read parent-process information for some processes on Windows
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [14679]

--- a/.chloggen/fix-parent-error-scrapping.yaml
+++ b/.chloggen/fix-parent-error-scrapping.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processscraper
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change method to get parent Pid in function parentPid
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [14679]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -86,6 +86,7 @@ type processHandle interface {
 	NumThreads() (int32, error)
 	CreateTime() (int64, error)
 	Parent() (*process.Process, error)
+	Ppid() (int32, error)
 	PageFaults() (*process.PageFaultsStat, error)
 	NumCtxSwitches() (*process.NumCtxSwitchesStat, error)
 	NumFDs() (int32, error)
@@ -123,17 +124,12 @@ func parentPid(handle processHandle, pid int32) (int32, error) {
 	if pid == 0 || (pid == 1 && runtime.GOOS == "darwin") {
 		return 0, nil
 	}
-	parent, err := handle.Parent()
+	pPid, err := handle.Ppid()
 
 	if err != nil {
 		// return pid of -1 along with error for all other problems retrieving parent pid
-		return -1, err
+		return pPid, err
 	}
 
-	// if a process does not have a parent return 0
-	if parent == nil {
-		return 0, nil
-	}
-
-	return parent.Pid, nil
+	return pPid, nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -126,10 +126,5 @@ func parentPid(handle processHandle, pid int32) (int32, error) {
 	}
 	pPid, err := handle.Ppid()
 
-	if err != nil {
-		// return pid of -1 along with error for all other problems retrieving parent pid
-		return pPid, err
-	}
-
-	return pPid, nil
+	return pPid, err
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process.go
@@ -124,7 +124,6 @@ func parentPid(handle processHandle, pid int32) (int32, error) {
 	if pid == 0 || (pid == 1 && runtime.GOOS == "darwin") {
 		return 0, nil
 	}
-	pPid, err := handle.Ppid()
 
-	return pPid, err
+	return handle.Ppid()
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -450,6 +450,11 @@ func (p *processHandleMock) Parent() (*process.Process, error) {
 	return args.Get(0).(*process.Process), args.Error(1)
 }
 
+func (p *processHandleMock) Ppid() (int32, error) {
+	args := p.MethodCalled("Ppid")
+	return args.Get(0).(int32), args.Error(1)
+}
+
 func (p *processHandleMock) PageFaults() (*process.PageFaultsStat, error) {
 	args := p.MethodCalled("PageFaults")
 	return args.Get(0).(*process.PageFaultsStat), args.Error(1)
@@ -480,7 +485,7 @@ func newDefaultHandleMock() *processHandleMock {
 	handleMock.On("MemoryInfo").Return(&process.MemoryInfoStat{}, nil)
 	handleMock.On("MemoryPercent").Return(float32(0), nil)
 	handleMock.On("IOCounters").Return(&process.IOCountersStat{}, nil)
-	handleMock.On("Parent").Return(&process.Process{Pid: 2}, nil)
+	handleMock.On("Ppid").Return(int32(2), nil)
 	handleMock.On("NumThreads").Return(int32(0), nil)
 	handleMock.On("PageFaults").Return(&process.PageFaultsStat{}, nil)
 	handleMock.On("NumCtxSwitches").Return(&process.NumCtxSwitchesStat{}, nil)
@@ -818,7 +823,7 @@ func TestScrapeMetrics_ProcessErrors(t *testing.T) {
 			handleMock.On("MemoryPercent").Return(float32(0), test.memoryPercentError)
 			handleMock.On("IOCounters").Return(&process.IOCountersStat{}, test.ioCountersError)
 			handleMock.On("CreateTime").Return(int64(0), test.createTimeError)
-			handleMock.On("Parent").Return(&process.Process{Pid: 2}, test.parentPidError)
+			handleMock.On("Ppid").Return(int32(2), test.parentPidError)
 			handleMock.On("NumThreads").Return(int32(0), test.numThreadsError)
 			handleMock.On("PageFaults").Return(&process.PageFaultsStat{}, test.pageFaultsError)
 			handleMock.On("NumCtxSwitches").Return(&process.NumCtxSwitchesStat{}, test.numCtxSwitchesError)
@@ -1073,7 +1078,7 @@ func TestScrapeMetrics_DontCheckDisabledMetrics(t *testing.T) {
 		handleMock.On("Name").Return("test", nil)
 		handleMock.On("Exe").Return("test", nil)
 		handleMock.On("CreateTime").Return(time.Now().UnixMilli(), nil)
-		handleMock.On("Parent").Return(&process.Process{Pid: 2}, nil)
+		handleMock.On("Ppid").Return(int32(2), nil)
 
 		scraper.getProcessHandles = func() (processHandles, error) {
 			return &processHandlesMock{handles: []*processHandleMock{handleMock}}, nil


### PR DESCRIPTION
**Description:** 
Change method to get parent Pid in function parentPid.
Fixing the bug with reading parent pid for Windows processes.

**Link to tracking Issue:** [14679](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14679)

**Testing:** Testing was performed manually on Windows 10. The error "error reading parent pid for process" has not occurred in the logs.

**Documentation:** is not needed