### PR TITLE
[fix] [pkg/stanza/fileconsumer] do not update fingerprint size when less data has been read

### DIFF
--- a/.chloggen/kk-fix-stanza-fileconsumer.yaml
+++ b/.chloggen/kk-fix-stanza-fileconsumer.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza/fileconsumer
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: increase scanner buffer to fingerprint size to enable reading the whole fingerprint in single iteration
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22936]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -178,8 +178,8 @@ func (r *Reader) Read(dst []byte) (int, error) {
 	}
 	n, err := r.file.Read(dst)
 	appendCount := min0(n, r.fingerprintSize-int(r.Offset))
-	// return for n == 0 or r.Offset >= r.fileInput.fingerprintSize
-	if appendCount == 0 {
+	if appendCount == 0 || int(r.Offset)+appendCount < len(r.Fingerprint.FirstBytes) {
+		r.Debugw("Fingerprint does not need to be updated")
 		return n, err
 	}
 

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -129,7 +129,7 @@ func TestReadingWithLargeFingerPrintSizeAndFileLargerThanScannerBuf(t *testing.T
 		encodingConfig:  splitterConfig.EncodingConfig,
 	}
 
-	r, err := f.newReaderBuilder().withFile(temp).build()
+	r, err := f.newReaderBuilder().withFile(temp).withBufferSize().build()
 	require.NoError(t, err)
 
 	initialFingerPrintSize := len(r.Fingerprint.FirstBytes)

--- a/pkg/stanza/fileconsumer/scanner.go
+++ b/pkg/stanza/fileconsumer/scanner.go
@@ -20,13 +20,13 @@ type PositionalScanner struct {
 }
 
 // NewPositionalScanner creates a new positional scanner
-func NewPositionalScanner(r io.Reader, maxLogSize int, startOffset int64, splitFunc bufio.SplitFunc) *PositionalScanner {
+func NewPositionalScanner(r io.Reader, maxLogSize int, startOffset int64, bufferSize int, splitFunc bufio.SplitFunc) *PositionalScanner {
 	ps := &PositionalScanner{
 		pos:     startOffset,
 		Scanner: bufio.NewScanner(r),
 	}
 
-	buf := make([]byte, 0, defaultBufSize)
+	buf := make([]byte, 0, bufferSize)
 	ps.Scanner.Buffer(buf, maxLogSize*2)
 
 	scanFunc := func(data []byte, atEOF bool) (advance int, token []byte, err error) {

--- a/pkg/stanza/fileconsumer/scanner_test.go
+++ b/pkg/stanza/fileconsumer/scanner_test.go
@@ -72,7 +72,7 @@ func TestScanner(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			reader := bytes.NewReader(tc.stream)
 			splitter := simpleSplit(tc.delimiter)
-			scanner := NewPositionalScanner(reader, tc.maxSize, tc.startOffset, splitter)
+			scanner := NewPositionalScanner(reader, tc.maxSize, tc.startOffset, defaultBufSize, splitter)
 
 			for i, p := 0, 0; scanner.Scan(); i++ {
 				require.NoError(t, scanner.getError())


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Do not update fingerprint bytes when less data has been read than it was read during initialisation of fingerprint bytes 

**Link to tracking Issue:** <Issue number if applicable>

 #22936 

**Testing:** <Describe what testing was performed and which tests were added.>

Manual tests - done
Unit test - in progress

**Documentation:** <Describe the documentation added.>