### PR TITLE
[pkg/ottl] Added ottl functions for hashing strings

### DIFF
--- a/.chloggen/ottl_hash_functions.yaml
+++ b/.chloggen/ottl_hash_functions.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add hash converters/functions for OTTL"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22725]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -327,12 +327,9 @@ The `FNV` Converter converts the `value` to an FNV hash/digest.
 
 The returned type is int64.
 
-The input `value` types:
-* string. If it fails then nil will be returned.
+`value` is either a path expression to a string telemetry field or a literal string. If `value` is another type an error is returned.
 
-If `value` is another type or parsing failed nil is always returned.
-
-The `value` is either a path expression to a telemetry field to retrieve or a literal.
+If an error occurs during hashing it will be returned.
 
 Examples:
 
@@ -455,14 +452,11 @@ Examples:
 
 The `SHA1` Converter converts the `value` to a sha1 hash/digest.
 
-The returned type is int64.
+The returned type is string.
 
-The input `value` types:
-* string. If it fails then nil will be returned.
+`value` is either a path expression to a string telemetry field or a literal string. If `value` is another type an error is returned.
 
-If `value` is another type or parsing failed nil is always returned.
-
-The `value` is either a path expression to a telemetry field to retrieve or a literal.
+If an error occurs during hashing it will be returned.
 
 Examples:
 
@@ -471,20 +465,19 @@ Examples:
 
 - `SHA1("name")`
 
+**Note:** According to the National Institute of Standards and Technology (NIST), SHA1 is no longer a recommended hash function. It should be avoided except when required for compatibility. New uses should prefer FNV whenever possible.
+
 ### SHA256
 
 `SHA256(value)`
 
 The `SHA256` Converter converts the `value` to a sha256 hash/digest.
 
-The returned type is int64.
+The returned type is string.
 
-The input `value` types:
-* string. If it fails then nil will be returned.
+`value` is either a path expression to a string telemetry field or a literal string. If `value` is another type an error is returned.
 
-If `value` is another type or parsing failed nil is always returned.
-
-The `value` is either a path expression to a telemetry field to retrieve or a literal.
+If an error occurs during hashing it will be returned.
 
 Examples:
 
@@ -492,6 +485,8 @@ Examples:
 
 
 - `SHA256("name")`
+
+**Note:** According to the National Institute of Standards and Technology (NIST), SHA256 is no longer a recommended hash function. It should be avoided except when required for compatibility. New uses should prefer FNV whenever possible.
 
 ### SpanID
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -263,10 +263,13 @@ Unlike functions, they do not modify any input telemetry and always return a val
 Available Converters:
 - [Concat](#concat)
 - [ConvertCase](#convertcase)
+- [FNV](#fnv)
 - [Int](#int)
 - [IsMatch](#ismatch)
 - [Log](#log)
 - [ParseJSON](#parsejson)
+- [SHA1](#sha1)
+- [SHA256](#sha256)
 - [SpanID](#spanid)
 - [Split](#split)
 - [TraceID](#traceid)
@@ -315,6 +318,28 @@ If `toCase` is any value other than the options above, the `ConvertCase` Convert
 Examples:
 
 - `ConvertCase(metric.name, "snake")`
+
+### FNV
+
+`FNV(value)`
+
+The `FNV` Converter converts the `value` to an FNV hash/digest.
+
+The returned type is int64.
+
+The input `value` types:
+* string. If it fails then nil will be returned.
+
+If `value` is another type or parsing failed nil is always returned.
+
+The `value` is either a path expression to a telemetry field to retrieve or a literal.
+
+Examples:
+
+- `FNV(attributes["device.name"])`
+
+
+- `FNV("name")`
 
 ### Int
 
@@ -423,6 +448,50 @@ Examples:
 
 
 - `ParseJSON(body)`
+
+### SHA1
+
+`SHA1(value)`
+
+The `SHA1` Converter converts the `value` to a sha1 hash/digest.
+
+The returned type is int64.
+
+The input `value` types:
+* string. If it fails then nil will be returned.
+
+If `value` is another type or parsing failed nil is always returned.
+
+The `value` is either a path expression to a telemetry field to retrieve or a literal.
+
+Examples:
+
+- `SHA1(attributes["device.name"])`
+
+
+- `SHA1("name")`
+
+### SHA256
+
+`SHA256(value)`
+
+The `SHA256` Converter converts the `value` to a sha256 hash/digest.
+
+The returned type is int64.
+
+The input `value` types:
+* string. If it fails then nil will be returned.
+
+If `value` is another type or parsing failed nil is always returned.
+
+The `value` is either a path expression to a telemetry field to retrieve or a literal.
+
+Examples:
+
+- `SHA256(attributes["device.name"])`
+
+
+- `SHA256("name")`
 
 ### SpanID
 

--- a/pkg/ottl/ottlfuncs/func_fnv.go
+++ b/pkg/ottl/ottlfuncs/func_fnv.go
@@ -44,9 +44,9 @@ func FNVHashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error)
 		hash := fnv.New64a()
 		_, err1 := hash.Write([]byte(val))
 		if err1 != nil {
-			return val, err1
+			return nil, err1
 		}
 		hashValue := hash.Sum64()
-		return hashValue, nil
+		return int64(hashValue), nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_fnv.go
+++ b/pkg/ottl/ottlfuncs/func_fnv.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type FnvArguments[K any] struct {
+	Target ottl.StringGetter[K] `ottlarg:"0"`
+}
+
+func NewFnvFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("FNV", &FnvArguments[K]{}, createFnvFunction[K])
+}
+
+func createFnvFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*FnvArguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("FNVFactory args must be of type *FnvArguments[K]")
+	}
+
+	return FNVHashString(args.Target)
+}
+
+func FNVHashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
+
+	return func(ctx context.Context, tCtx K) (interface{}, error) {
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		if val == "" {
+			return val, nil
+		}
+
+		hash := fnv.New64a()
+		_, err1 := hash.Write([]byte(val))
+		if err1 != nil {
+			return val, err1
+		}
+		hashValue := hash.Sum64()
+		return hashValue, nil
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_fnv.go
+++ b/pkg/ottl/ottlfuncs/func_fnv.go
@@ -36,15 +36,10 @@ func FNVHashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error)
 		if err != nil {
 			return nil, err
 		}
-
-		if val == "" {
-			return val, nil
-		}
-
 		hash := fnv.New64a()
-		_, err1 := hash.Write([]byte(val))
-		if err1 != nil {
-			return nil, err1
+		_, err = hash.Write([]byte(val))
+		if err != nil {
+			return nil, err
 		}
 		hashValue := hash.Sum64()
 		return int64(hashValue), nil

--- a/pkg/ottl/ottlfuncs/func_fnv_test.go
+++ b/pkg/ottl/ottlfuncs/func_fnv_test.go
@@ -27,7 +27,7 @@ func Test_FNV(t *testing.T) {
 		{
 			name:     "empty string",
 			value:    "",
-			expected: "",
+			expected: int64(-3750763034362895579),
 		},
 	}
 	for _, tt := range tests {
@@ -45,6 +45,38 @@ func Test_FNV(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_FNVError(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         interface{}
+		err           bool
+		expectedError string
+	}{
+		{
+			name:          "non-string",
+			value:         10,
+			expectedError: "expected string but got int",
+		},
+		{
+			name:          "nil",
+			value:         nil,
+			expectedError: "expected string but got nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := FNVHashString[interface{}](&ottl.StandardStringGetter[interface{}]{
+				Getter: func(context.Context, interface{}) (interface{}, error) {
+					return tt.value, nil
+				},
+			})
+			assert.NoError(t, err)
+			_, err = exprFunc(nil, nil)
+			assert.ErrorContains(t, err, tt.expectedError)
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_fnv_test.go
+++ b/pkg/ottl/ottlfuncs/func_fnv_test.go
@@ -22,7 +22,7 @@ func Test_FNV(t *testing.T) {
 		{
 			name:     "string",
 			value:    "hello world",
-			expected: uint64(8618312879776256743),
+			expected: int64(8618312879776256743),
 		},
 		{
 			name:     "empty string",

--- a/pkg/ottl/ottlfuncs/func_fnv_test.go
+++ b/pkg/ottl/ottlfuncs/func_fnv_test.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_FNV(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected interface{}
+		err      bool
+	}{
+		{
+			name:     "string",
+			value:    "hello world",
+			expected: uint64(8618312879776256743),
+		},
+		{
+			name:     "empty string",
+			value:    "",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := FNVHashString[interface{}](&ottl.StandardStringGetter[interface{}]{
+				Getter: func(context.Context, interface{}) (interface{}, error) {
+					return tt.value, nil
+				},
+			})
+			assert.NoError(t, err)
+			result, err := exprFunc(nil, nil)
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_sha1.go
+++ b/pkg/ottl/ottlfuncs/func_sha1.go
@@ -8,7 +8,6 @@ import (
 	"crypto/sha1" // #nosec
 	"encoding/hex"
 	"fmt"
-	"io"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
@@ -44,8 +43,9 @@ func SHA1HashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error
 		}
 
 		hash := sha1.New() // #nosec
-		if _, err := io.WriteString(hash, val); err != nil {
-			return val, err
+		_, err1 := hash.Write([]byte(val))
+		if err1 != nil {
+			return nil, err1
 		}
 		hashValue := hex.EncodeToString(hash.Sum(nil))
 		return hashValue, nil

--- a/pkg/ottl/ottlfuncs/func_sha1.go
+++ b/pkg/ottl/ottlfuncs/func_sha1.go
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"crypto/sha1" // #nosec
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type SHA1Arguments[K any] struct {
+	Target ottl.StringGetter[K] `ottlarg:"0"`
+}
+
+func NewSHA1Factory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("SHA1", &SHA1Arguments[K]{}, createSHA1Function[K])
+}
+
+func createSHA1Function[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*SHA1Arguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("SHA1Factory args must be of type *SHA1Arguments[K]")
+	}
+
+	return SHA1HashString(args.Target)
+}
+
+func SHA1HashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
+
+	return func(ctx context.Context, tCtx K) (interface{}, error) {
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		if val == "" {
+			return val, nil
+		}
+
+		hash := sha1.New() // #nosec
+		if _, err := io.WriteString(hash, val); err != nil {
+			return val, err
+		}
+		hashValue := hex.EncodeToString(hash.Sum(nil))
+		return hashValue, nil
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_sha1.go
+++ b/pkg/ottl/ottlfuncs/func_sha1.go
@@ -37,15 +37,10 @@ func SHA1HashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error
 		if err != nil {
 			return nil, err
 		}
-
-		if val == "" {
-			return val, nil
-		}
-
 		hash := sha1.New() // #nosec
-		_, err1 := hash.Write([]byte(val))
-		if err1 != nil {
-			return nil, err1
+		_, err = hash.Write([]byte(val))
+		if err != nil {
+			return nil, err
 		}
 		hashValue := hex.EncodeToString(hash.Sum(nil))
 		return hashValue, nil

--- a/pkg/ottl/ottlfuncs/func_sha1_test.go
+++ b/pkg/ottl/ottlfuncs/func_sha1_test.go
@@ -27,7 +27,7 @@ func Test_SHA1(t *testing.T) {
 		{
 			name:     "empty string",
 			value:    "",
-			expected: "",
+			expected: "da39a3ee5e6b4b0d3255bfef95601890afd80709",
 		},
 	}
 	for _, tt := range tests {
@@ -45,6 +45,38 @@ func Test_SHA1(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_SHA1Error(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         interface{}
+		err           bool
+		expectedError string
+	}{
+		{
+			name:          "non-string",
+			value:         10,
+			expectedError: "expected string but got int",
+		},
+		{
+			name:          "nil",
+			value:         nil,
+			expectedError: "expected string but got nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := SHA1HashString[interface{}](&ottl.StandardStringGetter[interface{}]{
+				Getter: func(context.Context, interface{}) (interface{}, error) {
+					return tt.value, nil
+				},
+			})
+			assert.NoError(t, err)
+			_, err = exprFunc(nil, nil)
+			assert.ErrorContains(t, err, tt.expectedError)
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_sha1_test.go
+++ b/pkg/ottl/ottlfuncs/func_sha1_test.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_SHA1(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected interface{}
+		err      bool
+	}{
+		{
+			name:     "string",
+			value:    "hello world",
+			expected: "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+		},
+		{
+			name:     "empty string",
+			value:    "",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := SHA1HashString[interface{}](&ottl.StandardStringGetter[interface{}]{
+				Getter: func(context.Context, interface{}) (interface{}, error) {
+					return tt.value, nil
+				},
+			})
+			assert.NoError(t, err)
+			result, err := exprFunc(nil, nil)
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_sha256.go
+++ b/pkg/ottl/ottlfuncs/func_sha256.go
@@ -45,10 +45,9 @@ func SHA256HashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], err
 		hash := sha256.New()
 		_, err1 := hash.Write([]byte(val))
 		if err1 != nil {
-			return val, err1
+			return nil, err1
 		}
 		hashValue := hex.EncodeToString(hash.Sum(nil))
-		fmt.Print(hashValue)
 		return hashValue, nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_sha256.go
+++ b/pkg/ottl/ottlfuncs/func_sha256.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type SHA256Arguments[K any] struct {
+	Target ottl.StringGetter[K] `ottlarg:"0"`
+}
+
+func NewSHA256Factory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("SHA256", &SHA256Arguments[K]{}, createSHA256Function[K])
+}
+
+func createSHA256Function[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*SHA256Arguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("SHA256Factory args must be of type *SHA256Arguments[K]")
+	}
+
+	return SHA256HashString(args.Target)
+}
+
+func SHA256HashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
+
+	return func(ctx context.Context, tCtx K) (interface{}, error) {
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		if val == "" {
+			return val, nil
+		}
+
+		hash := sha256.New()
+		_, err1 := hash.Write([]byte(val))
+		if err1 != nil {
+			return val, err1
+		}
+		hashValue := hex.EncodeToString(hash.Sum(nil))
+		fmt.Print(hashValue)
+		return hashValue, nil
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_sha256.go
+++ b/pkg/ottl/ottlfuncs/func_sha256.go
@@ -37,15 +37,10 @@ func SHA256HashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], err
 		if err != nil {
 			return nil, err
 		}
-
-		if val == "" {
-			return val, nil
-		}
-
 		hash := sha256.New()
-		_, err1 := hash.Write([]byte(val))
-		if err1 != nil {
-			return nil, err1
+		_, err = hash.Write([]byte(val))
+		if err != nil {
+			return nil, err
 		}
 		hashValue := hex.EncodeToString(hash.Sum(nil))
 		return hashValue, nil

--- a/pkg/ottl/ottlfuncs/func_sha256_test.go
+++ b/pkg/ottl/ottlfuncs/func_sha256_test.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_SHA256(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected interface{}
+		err      bool
+	}{
+		{
+			name:     "string",
+			value:    "hello world",
+			expected: "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+		},
+		{
+			name:     "empty string",
+			value:    "",
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := SHA256HashString[interface{}](&ottl.StandardStringGetter[interface{}]{
+				Getter: func(context.Context, interface{}) (interface{}, error) {
+					return tt.value, nil
+				},
+			})
+			assert.NoError(t, err)
+			result, err := exprFunc(nil, nil)
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_sha256_test.go
+++ b/pkg/ottl/ottlfuncs/func_sha256_test.go
@@ -27,7 +27,7 @@ func Test_SHA256(t *testing.T) {
 		{
 			name:     "empty string",
 			value:    "",
-			expected: "",
+			expected: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 		},
 	}
 	for _, tt := range tests {
@@ -45,6 +45,38 @@ func Test_SHA256(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_SHA256Error(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         interface{}
+		err           bool
+		expectedError string
+	}{
+		{
+			name:          "non-string",
+			value:         10,
+			expectedError: "expected string but got int",
+		},
+		{
+			name:          "nil",
+			value:         nil,
+			expectedError: "expected string but got nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := SHA256HashString[interface{}](&ottl.StandardStringGetter[interface{}]{
+				Getter: func(context.Context, interface{}) (interface{}, error) {
+					return tt.value, nil
+				},
+			})
+			assert.NoError(t, err)
+			_, err = exprFunc(nil, nil)
+			assert.ErrorContains(t, err, tt.expectedError)
 		})
 	}
 }


### PR DESCRIPTION
**Description:** 
Added 3 ottl functions for hashing strings
- FNV
- SHA1
- SHA256

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22725

**Testing:** 
Added the following unit tests
- [FNV](https://github.com/rnishtala-sumo/opentelemetry-collector-contrib/blob/ottl_hash_functions/pkg/ottl/ottlfuncs/func_fnv_test.go)
- [SHA1](https://github.com/rnishtala-sumo/opentelemetry-collector-contrib/blob/ottl_hash_functions/pkg/ottl/ottlfuncs/func_sha1_test.go)
- [SHA256](https://github.com/rnishtala-sumo/opentelemetry-collector-contrib/blob/ottl_hash_functions/pkg/ottl/ottlfuncs/func_sha256_test.go)

**Documentation:**
- https://github.com/rnishtala-sumo/opentelemetry-collector-contrib/tree/ottl_hash_functions/pkg/ottl/ottlfuncs#converters