### PR TITLE
[exporter/splunk_hec] Apply compression if it's enabled in the config

### DIFF
--- a/.chloggen/splunk-hec-apply-compression.yaml
+++ b/.chloggen/splunk-hec-apply-compression.yaml
@@ -1,0 +1,25 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/splunk_hec
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Apply compression to Splunk HEC payload unconditionally if it's enabled in the config.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22969, 22018]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The compression used to be enabled only if the payload size was greater than 1.5KB which significantly
+  complicated the logic and made it hard to test. This change makes the compression unconditionally applied to 
+  the payload if it's enabled in the config. The benchmarking shows improvements in the throughput and CPU usage for 
+  large payloads and expected degradation for small payloads which is acceptable given that it's not a common case.
+

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -219,7 +219,7 @@ func (c *client) fillLogsBuffer(logs plog.Logs, bs *bufferState, is iterState) (
 					}
 					permanentErrors = append(permanentErrors, consumererror.NewPermanent(
 						fmt.Errorf("dropped log event: error: event size %d bytes larger than configured max"+
-							" content length %d bytes", len(b), bs.bufferMaxLen)))
+							" content length %d bytes", len(b), c.config.MaxContentLengthLogs)))
 					return iterState{i, j, k + 1, false}, permanentErrors
 				}
 			}
@@ -277,7 +277,7 @@ func (c *client) fillMetricsBuffer(metrics pmetric.Metrics, bs *bufferState, is 
 					}
 					permanentErrors = append(permanentErrors, consumererror.NewPermanent(
 						fmt.Errorf("dropped metric event: error: event size %d bytes larger than configured max"+
-							" content length %d bytes", len(b), bs.bufferMaxLen)))
+							" content length %d bytes", len(b), c.config.MaxContentLengthMetrics)))
 					return iterState{i, j, k + 1, false}, permanentErrors
 				}
 			}
@@ -322,7 +322,7 @@ func (c *client) fillTracesBuffer(traces ptrace.Traces, bs *bufferState, is iter
 					}
 					permanentErrors = append(permanentErrors, consumererror.NewPermanent(
 						fmt.Errorf("dropped span event: error: event size %d bytes larger than configured max"+
-							" content length %d bytes", len(b), bs.bufferMaxLen)))
+							" content length %d bytes", len(b), c.config.MaxContentLengthTraces)))
 					return iterState{i, j, k + 1, false}, permanentErrors
 				}
 			}
@@ -381,7 +381,7 @@ func (c *client) pushTracesDataInBatches(ctx context.Context, td ptrace.Traces, 
 }
 
 func (c *client) postEvents(ctx context.Context, bufState *bufferState, headers map[string]string) error {
-	if err := bufState.Close(); err != nil {
+	if err := bufState.buf.Close(); err != nil {
 		return err
 	}
 	return c.hecWorker.send(ctx, bufState, headers)


### PR DESCRIPTION
The compression used to be enabled only if the payload size was greater than 1.5KB which significantly complicated the logic and made it hard to test. This change makes the compression unconditionally applied to the payload if it's enabled in the config. The benchmarking shows improvements in the throughput and CPU usage for large payloads and expected degradation for small payloads, which is acceptable given that it's not a common case.

Before:

```
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-10    	   10000	    105616 ns/op	   84893 B/op	    1285 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-10      	    4635	    260261 ns/op	  899893 B/op	    1130 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-10      	    3620	    334618 ns/op	 2993165 B/op	    1131 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-10     	     308	   3884943 ns/op	 4376605 B/op	   22031 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-10    	      32	  35486009 ns/op	17481330 B/op	  220032 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-10    	      31	  35574226 ns/op	20626891 B/op	  220032 allocs/op
```

After:

```
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-10    	    1850	    650097 ns/op	 3106085 B/op	    1192 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-10      	    7755	    158985 ns/op	   74715 B/op	    1109 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-10      	    7790	    152750 ns/op	   74079 B/op	    1109 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-10     	     332	   3607309 ns/op	 1459565 B/op	   22010 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-10    	      32	  34716503 ns/op	14595388 B/op	  220012 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-10    	      31	  34683440 ns/op	14596493 B/op	  220012 allocs/op
```
 