### PR TITLE
Unwrap lumberjack.logger with buffered writer

### DIFF
--- a/.chloggen/fix_fileexporter-brokenlines.yaml
+++ b/.chloggen/fix_fileexporter-brokenlines.yaml
@@ -12,7 +12,7 @@ component: fileexporter
 note: Fixes broken lines when rotation is set.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: ["#22747"]
+issues: [22747]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix_fileexporter-brokenlines.yaml
+++ b/.chloggen/fix_fileexporter-brokenlines.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: fileexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes broken lines when rotation is set.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: ["#22747"]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/fileexporter/README.md
+++ b/exporter/fileexporter/README.md
@@ -45,7 +45,8 @@ The following settings are optional:
 
 - `format`[default: json]: define the data format of encoded telemetry data. The setting can be overridden with `proto`.
 - `compression`[no default]: the compression algorithm used when exporting telemetry data to file. Supported compression algorithms:`zstd`
-- `flush_interval`[default: 1s]: `time.Duration` interval between flushes. See [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for valid formats. NOTE: a value without unit is in nanoseconds.
+- `flush_interval`[default: 1s]: `time.Duration` interval between flushes. See [time.ParseDuration](https://pkg.go.dev/time#ParseDuration) for valid formats. 
+NOTE: a value without unit is in nanoseconds and `flush_interval` is ignored and writes are not buffered if `rotation` is set.
 
 ## File Rotation
 Telemetry data is exported to a single file by default.

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -142,13 +142,13 @@ func buildFileWriter(cfg *Config) (io.WriteCloser, error) {
 		}
 		return newBufferedWriteCloser(f), nil
 	}
-	return newBufferedWriteCloser(&lumberjack.Logger{
+	return &lumberjack.Logger{
 		Filename:   cfg.Path,
 		MaxSize:    cfg.Rotation.MaxMegabytes,
 		MaxAge:     cfg.Rotation.MaxDays,
 		MaxBackups: cfg.Rotation.MaxBackups,
 		LocalTime:  cfg.Rotation.LocalTime,
-	}), nil
+	}, nil
 }
 
 // This is the map of already created File exporters for particular configurations.

--- a/exporter/fileexporter/factory_test.go
+++ b/exporter/fileexporter/factory_test.go
@@ -126,9 +126,7 @@ func TestBuildFileWriter(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, closer io.WriteCloser) {
-				bwc, ok := closer.(*bufferedWriteCloser)
-				assert.Equal(t, true, ok)
-				writer, ok := bwc.wrapped.(*lumberjack.Logger)
+				writer, ok := closer.(*lumberjack.Logger)
 				assert.Equal(t, true, ok)
 				assert.Equal(t, defaultMaxBackups, writer.MaxBackups)
 			},
@@ -147,9 +145,7 @@ func TestBuildFileWriter(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, closer io.WriteCloser) {
-				bwc, ok := closer.(*bufferedWriteCloser)
-				assert.Equal(t, true, ok)
-				writer, ok := bwc.wrapped.(*lumberjack.Logger)
+				writer, ok := closer.(*lumberjack.Logger)
 				assert.Equal(t, true, ok)
 				assert.Equal(t, 3, writer.MaxBackups)
 				assert.Equal(t, 30, writer.MaxSize)


### PR DESCRIPTION
- change the buildFileWriter factory function
- adapt the TestBuildFileWriter in factory_test

**Description:** 
Fixes broken lines when rotation is set. 
Buffering is not possible when the lumberjack.logger is used, so I removed the BufferedWriterCloser when creating the lumberjack.Logger.

**Link to tracking Issue:** 
#22747

**Testing:** 
Reverted to previous tests.

**Documentation:** 
Added to the README that flush_interval has no effect when rotation is set.