### PR TITLE
fix(awscloudwatchreceiver): emit logs from one stream in one resource

### DIFF
--- a/.chloggen/awscloudwatch-emit-stream-in-one-resource.yaml
+++ b/.chloggen/awscloudwatch-emit-stream-in-one-resource.yaml
@@ -1,0 +1,19 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awscloudwatchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: emit logs from one log stream in the same resource
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22145]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -272,8 +272,7 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 
 		// Now we know resourceLogs is initialized and has one scopeLogs so we don't have to handle any special cases.
 
-		sl := resourceLogs.ScopeLogs()
-		logRecord := sl.At(0).LogRecords().AppendEmpty()
+		logRecord := resourceLogs.ScopeLogs().At(0).LogRecords().AppendEmpty()
 
 		logRecord.SetObservedTimestamp(now)
 		ts := time.UnixMilli(*e.Timestamp)

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	NoStreamName = "THIS IS INVALID STREAM"
+	noStreamName = "THIS IS INVALID STREAM"
 )
 
 type logsReceiver struct {
@@ -263,7 +263,7 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 				resourceMap[logGroupName][*e.LogStreamName] = rl
 				resourceAttributes.PutStr("cloudwatch.log.stream", *e.LogStreamName)
 			} else {
-				resourceMap[logGroupName][NoStreamName] = rl
+				resourceMap[logGroupName][noStreamName] = rl
 			}
 
 			logRecord = rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
@@ -283,7 +283,7 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 func (*logsReceiver) getResourceLogs(m map[string](map[string]plog.ResourceLogs), group string, logStream *string) *plog.ResourceLogs {
 	if streamMap := m[group]; streamMap != nil {
 		if logStream == nil {
-			if resource, ok := streamMap[NoStreamName]; ok {
+			if resource, ok := streamMap[noStreamName]; ok {
 				return &resource
 			}
 		} else if resource, ok := streamMap[*logStream]; ok {

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -225,9 +225,30 @@ func defaultMockClient() client {
 		&cloudwatchlogs.FilterLogEventsOutput{
 			Events: []*cloudwatchlogs.FilteredLogEvent{
 				{
-					EventId:       &testEventID,
+					EventId:       &testEventIDs[0],
 					IngestionTime: aws.Int64(testIngestionTime),
 					LogStreamName: aws.String(testLogStreamName),
+					Message:       aws.String(testLogStreamMessage),
+					Timestamp:     aws.Int64(testTimeStamp),
+				},
+				{
+					EventId:       &testEventIDs[1],
+					IngestionTime: aws.Int64(testIngestionTime),
+					LogStreamName: aws.String(testLogStreamName),
+					Message:       aws.String(testLogStreamMessage),
+					Timestamp:     aws.Int64(testTimeStamp),
+				},
+				{
+					EventId:       &testEventIDs[2],
+					IngestionTime: aws.Int64(testIngestionTime),
+					LogStreamName: aws.String(testLogStreamName2),
+					Message:       aws.String(testLogStreamMessage),
+					Timestamp:     aws.Int64(testTimeStamp),
+				},
+				{
+					EventId:       &testEventIDs[3],
+					IngestionTime: aws.Int64(testIngestionTime),
+					LogStreamName: aws.String(testLogStreamName2),
 					Message:       aws.String(testLogStreamMessage),
 					Timestamp:     aws.Int64(testTimeStamp),
 				},
@@ -238,10 +259,16 @@ func defaultMockClient() client {
 }
 
 var (
-	testLogGroupName     = "test-log-group-name"
-	testLogStreamName    = "test-log-stream-name"
-	testLogStreamPrefix  = "test-log-stream"
-	testEventID          = "37134448277055698880077365577645869800162629528367333379"
+	testLogGroupName    = "test-log-group-name"
+	testLogStreamName   = "test-log-stream-name"
+	testLogStreamName2  = "test-log-stream-name-2"
+	testLogStreamPrefix = "test-log-stream"
+	testEventIDs        = []string{
+		"37134448277055698880077365577645869800162629528367333379",
+		"37134448277055698880077365577645869800162629528367333380",
+		"37134448277055698880077365577645869800162629528367333381",
+		"37134448277055698880077365577645869800162629528367333382",
+	}
 	testIngestionTime    = int64(1665166252124)
 	testTimeStamp        = int64(1665166251014)
 	testLogStreamMessage = `"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""`

--- a/receiver/awscloudwatchreceiver/testdata/processed/prefixed.yaml
+++ b/receiver/awscloudwatchreceiver/testdata/processed/prefixed.yaml
@@ -22,4 +22,48 @@ resourceLogs:
             spanId: ""
             timeUnixNano: "1665166251014000000"
             traceId: ""
+          - attributes:
+              - key: id
+                value:
+                  stringValue: "37134448277055698880077365577645869800162629528367333380"
+            body:
+              stringValue: '"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""'
+            observedTimeUnixNano: "1665166998995360000"
+            spanId: ""
+            timeUnixNano: "1665166251014000000"
+            traceId: ""
+        scope: {}
+  - resource:
+      attributes:
+        - key: aws.region
+          value:
+            stringValue: us-west-1
+        - key: cloudwatch.log.group.name
+          value:
+            stringValue: test-log-group-name
+        - key: cloudwatch.log.stream
+          value:
+            stringValue: test-log-stream-name-2
+    scopeLogs:
+      - logRecords:
+          - attributes:
+              - key: id
+                value:
+                  stringValue: "37134448277055698880077365577645869800162629528367333381"
+            body:
+              stringValue: '"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""'
+            observedTimeUnixNano: "1665166998995360000"
+            spanId: ""
+            timeUnixNano: "1665166251014000000"
+            traceId: ""
+          - attributes:
+              - key: id
+                value:
+                  stringValue: "37134448277055698880077365577645869800162629528367333382"
+            body:
+              stringValue: '"time=\"2022-10-07T18:10:46Z\" level=info msg=\"access granted\" arn=\"arn:aws:iam::892146088969:role/AWSWesleyClusterManagerLambda-NodeManagerRole-16UPVDKA1KBGI\" client=\"127.0.0.1:50252\" groups=\"[]\" method=POST path=/authenticate uid=\"aws-iam-authenticator:892146088969:AROA47OAM7QE2NWPDFDCW\" username=\"eks:node-manager\""'
+            observedTimeUnixNano: "1665166998995360000"
+            spanId: ""
+            timeUnixNano: "1665166251014000000"
+            traceId: ""
         scope: {}


### PR DESCRIPTION
**Description:** 
The receiver treated every event as a separate log. However, it makes a lot sense to group logs into common resource by their group and stream. Logs without a stream are grouped into the same resource.
I'm not sure how should `scope` be treated here, but my intuition tells me that it makes sense to group them also into the same scope.

**Link to tracking Issue:** 
Fixes #22145 

**Testing:** 
The unit test for the receiver has beed updated. Note that the events in `prefixed.yaml` are the same, but differ by their id - I found it simpler to do than creating different events.
