### PR TITLE
[exporter/splunk_hec] Fix usage of `max_event_size` option

### DIFF
--- a/.chloggen/hecexp-fix-max-event.yaml
+++ b/.chloggen/hecexp-fix-max-event.yaml
@@ -2,7 +2,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: prometheusreceiver
+component: exporter/splunk_hec
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Make sure the `max_event_size` option is used to drop events larger than `max_event_size` instead of using it for batch size.

--- a/.chloggen/hecexp-fix-max-event.yaml
+++ b/.chloggen/hecexp-fix-max-event.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: prometheusreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Make sure the `max_event_size` option is used to drop events larger that that instead of using it for batch size.
+note: Make sure the `max_event_size` option is used to drop events larger than `max_event_size` instead of using it for batch size.
 
 # One or more tracking issues related to the change
 issues: [18066]

--- a/.chloggen/hecexp-fix-max-event.yaml
+++ b/.chloggen/hecexp-fix-max-event.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make sure the `max_event_size` option is used to drop events larger that that instead of using it for batch size.
+
+# One or more tracking issues related to the change
+issues: [18066]

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -723,7 +723,7 @@ func TestReceiveLogs(t *testing.T) {
 			}(),
 			conf: func() *Config {
 				cfg := NewFactory().CreateDefaultConfig().(*Config)
-				cfg.MaxEventSize = 20000 // small so we can reproduce without allocating big logs.
+				cfg.MaxEventSize = 20000 // makes the third event too large to send.
 				cfg.DisableCompression = true
 				return cfg
 			}(),
@@ -747,7 +747,6 @@ func TestReceiveLogs(t *testing.T) {
 			}(),
 			conf: func() *Config {
 				cfg := NewFactory().CreateDefaultConfig().(*Config)
-				cfg.MaxEventSize = 10000 // small so we can reproduce without allocating big logs.
 				cfg.MaxContentLengthLogs = 5000
 				cfg.DisableCompression = true
 				return cfg


### PR DESCRIPTION
Make sure the `max_event_size` option is used to drop events larger that that instead of using it for batch size

Replaces https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/22834

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18066