### PR TITLE
[chore] [exporter/splunk_hec] Remove redundant bufState struct

### DIFF
--- a/exporter/splunkhecexporter/hec_worker_test.go
+++ b/exporter/splunkhecexporter/hec_worker_test.go
@@ -14,7 +14,7 @@ type mockHecWorker struct {
 	failSend bool
 }
 
-func (m *mockHecWorker) send(_ context.Context, _ *bufferState, _ map[string]string) error {
+func (m *mockHecWorker) send(_ context.Context, _ buffer, _ map[string]string) error {
 	if m.failSend {
 		return errHecSendFailed
 	}


### PR DESCRIPTION
Most of the stuff was moved out from this struct, so it's not needed anymore.

Before:

```
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-10               	   10000	    107221 ns/op	   84895 B/op	    1285 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-10                 	   13437	     90507 ns/op	   73997 B/op	    1120 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-10                 	   13738	     88993 ns/op	   73353 B/op	    1109 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-10                	     648	   1894437 ns/op	 1458670 B/op	   22010 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-10               	      64	  17309091 ns/op	14628003 B/op	  220022 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-10               	      61	  17405197 ns/op	14699228 B/op	  220011 allocs/op
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-10    	    1788	    693214 ns/op	 3083792 B/op	    1191 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-10      	    7432	    158729 ns/op	   74559 B/op	    1109 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-10      	    7195	    158115 ns/op	   75396 B/op	    1109 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-10     	     326	   3711475 ns/op	 1459604 B/op	   22010 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-10    	      31	  36415599 ns/op	14596465 B/op	  220012 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-10    	      31	  35341629 ns/op	14596468 B/op	  220012 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-10                   	    1262	    944553 ns/op	  730226 B/op	   11012 allocs/op
```

After:

```
Benchmark_pushLogData_10_10_1024
Benchmark_pushLogData_10_10_1024-10               	   11834	     99971 ns/op	   84935 B/op	    1285 allocs/op
Benchmark_pushLogData_10_10_8K
Benchmark_pushLogData_10_10_8K-10                 	   13904	     86312 ns/op	   74047 B/op	    1120 allocs/op
Benchmark_pushLogData_10_10_2M
Benchmark_pushLogData_10_10_2M-10                 	   13968	     86110 ns/op	   73364 B/op	    1109 allocs/op
Benchmark_pushLogData_10_200_2M
Benchmark_pushLogData_10_200_2M-10                	     654	   1831256 ns/op	 1460156 B/op	   22011 allocs/op
Benchmark_pushLogData_100_200_2M
Benchmark_pushLogData_100_200_2M-10               	      66	  16905388 ns/op	14659144 B/op	  220024 allocs/op
Benchmark_pushLogData_100_200_5M
Benchmark_pushLogData_100_200_5M-10               	      70	  16717557 ns/op	14742392 B/op	  220013 allocs/op
Benchmark_pushLogData_compressed_10_10_1024
Benchmark_pushLogData_compressed_10_10_1024-10    	    1810	    652715 ns/op	 3098670 B/op	    1193 allocs/op
Benchmark_pushLogData_compressed_10_10_8K
Benchmark_pushLogData_compressed_10_10_8K-10      	    7550	    154149 ns/op	   74909 B/op	    1109 allocs/op
Benchmark_pushLogData_compressed_10_10_2M
Benchmark_pushLogData_compressed_10_10_2M-10      	    7508	    155652 ns/op	   74373 B/op	    1109 allocs/op
Benchmark_pushLogData_compressed_10_200_2M
Benchmark_pushLogData_compressed_10_200_2M-10     	     333	   3595814 ns/op	 1462712 B/op	   22011 allocs/op
Benchmark_pushLogData_compressed_100_200_2M
Benchmark_pushLogData_compressed_100_200_2M-10    	      31	  34835004 ns/op	14597835 B/op	  220014 allocs/op
Benchmark_pushLogData_compressed_100_200_5M
Benchmark_pushLogData_compressed_100_200_5M-10    	      31	  34560606 ns/op	14597822 B/op	  220014 allocs/op
BenchmarkConsumeLogsRejected
BenchmarkConsumeLogsRejected-10                   	    1242	    932774 ns/op	  730061 B/op	   11013 allocs/op
```