### PR TITLE
[receiver/datadog] add client info to datadogreceiver

### DIFF
--- a/.chloggen/dd-receiver-listener.yaml
+++ b/.chloggen/dd-receiver-listener.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "add client context to the traces received by datadogreceiver"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22991]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Fix add client context and use other http settings defined in config.

I've used ToServer() and ToListener(), which is similiar to otlp http receiver. They add a bunch of common logic, such as handling client context.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22991

**Testing:** <Describe what testing was performed and which tests w
ere added.>

- Tested with python app that sends dd traces
- 
**Documentation:** <Describe the documentation added.>