### PR TITLE
[chore] [exporter/splunk_hec] Add max_event_size config option description to README

### DIFF
--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -42,6 +42,7 @@ The following configuration options can also be configured:
 - `max_content_length_traces` (default: 2097152): Maximum trace payload size in bytes. Trace batches of bigger size
   will be broken down into several requests. Default value is 2097152 bytes (2 MiB). Maximum allowed value is 838860800
   (~ 800 MB). When set to 0, it will treat as infinite length and it will create only one request per batch.
+- `max_event_size` (default: 5242880): Maximum raw uncompressed payload size in bytes. Maximum allowed value is 838860800 (~ 800 MB).
 - `splunk_app_name` (default: "OpenTelemetry Collector Contrib") App name is used to track telemetry information for Splunk App's using HEC by App name.
 - `splunk_app_version` (default: Current OpenTelemetry Collector Contrib Build Version): App version is used to track telemetry information for Splunk App's using HEC by App version. 
 - `log_data_enabled` (default: true): Specifies whether the log data is exported. Set it to `false` if you want the log 

--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -42,7 +42,7 @@ The following configuration options can also be configured:
 - `max_content_length_traces` (default: 2097152): Maximum trace payload size in bytes. Trace batches of bigger size
   will be broken down into several requests. Default value is 2097152 bytes (2 MiB). Maximum allowed value is 838860800
   (~ 800 MB). When set to 0, it will treat as infinite length and it will create only one request per batch.
-- `max_event_size` (default: 5242880): Maximum raw uncompressed payload size in bytes. Maximum allowed value is 838860800 (~ 800 MB).
+- `max_event_size` (default: 5242880): Maximum raw uncompressed individual event size in bytes. Maximum allowed value is 838860800 (~ 800 MB).
 - `splunk_app_name` (default: "OpenTelemetry Collector Contrib") App name is used to track telemetry information for Splunk App's using HEC by App name.
 - `splunk_app_version` (default: Current OpenTelemetry Collector Contrib Build Version): App version is used to track telemetry information for Splunk App's using HEC by App version. 
 - `log_data_enabled` (default: true): Specifies whether the log data is exported. Set it to `false` if you want the log 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The max_event_size config option was added to the splunkhec exporter, but it is not documented in the README. This change adds README documentation for this option.

**Link to tracking Issue:** <Issue number if applicable>
#22988