### PR TITLE
[receiver/snmpreceiver] Updates integration test Dockerfile to use older 3.7 base image

### DIFF
--- a/receiver/snmpreceiver/go.mod
+++ b/receiver/snmpreceiver/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpre
 go 1.19
 
 require (
+	github.com/docker/docker v24.0.2+incompatible
 	github.com/gosnmp/gosnmp v1.35.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.78.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.78.0
@@ -29,7 +30,6 @@ require (
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
-	github.com/docker/docker v24.0.2+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect

--- a/receiver/snmpreceiver/integration_test.go
+++ b/receiver/snmpreceiver/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"go.opentelemetry.io/collector/component"
@@ -88,7 +89,8 @@ var (
 			Context:    filepath.Join("testdata", "integration", "docker"),
 			Dockerfile: "snmp_agent.Dockerfile",
 		},
-		ExposedPorts: []string{"1024:1024/udp"},
+		ExposedPorts:       []string{"1024:1024/udp"},
+		HostConfigModifier: addExtraHost,
 	}
 )
 
@@ -102,4 +104,8 @@ func getContainer(t *testing.T, req testcontainers.ContainerRequest) testcontain
 		})
 	require.NoError(t, err)
 	return container
+}
+
+func addExtraHost(conf *container.HostConfig) {
+	conf.ExtraHosts = []string{"host.docker.internal:host-gateway"}
 }

--- a/receiver/snmpreceiver/integration_test.go
+++ b/receiver/snmpreceiver/integration_test.go
@@ -54,7 +54,6 @@ func TestIntegration(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.desc, func(t *testing.T) {
-			t.Skip("Flaky test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21086")
 			factory := NewFactory()
 			factories.Receivers[metadata.Type] = factory
 			configFile := filepath.Join("testdata", "integration", testCase.configFilename)

--- a/receiver/snmpreceiver/testdata/integration/docker/snmp_agent.Dockerfile
+++ b/receiver/snmpreceiver/testdata/integration/docker/snmp_agent.Dockerfile
@@ -1,6 +1,6 @@
 # https://github.com/maxgio92/docker-snmpsim
-# WARNING: This can't be updated beyond 3.7 as snmpsim seems to have issues!
-FROM python:3.7-slim
+# WARNING: This can't be updated beyond 3.5 as snmpsim seems to have issues running on linux!
+FROM python:3.5-slim
 
 RUN pip install snmpsim
 

--- a/receiver/snmpreceiver/testdata/integration/docker/snmp_agent.Dockerfile
+++ b/receiver/snmpreceiver/testdata/integration/docker/snmp_agent.Dockerfile
@@ -1,5 +1,6 @@
 # https://github.com/maxgio92/docker-snmpsim
-FROM python:3.11-slim
+# WARNING: This can't be updated beyond 3.7 as snmpsim seems to have issues!
+FROM python:3.7-slim
 
 RUN pip install snmpsim
 

--- a/receiver/snmpreceiver/testdata/integration/integration_test_v2c_config.yaml
+++ b/receiver/snmpreceiver/testdata/integration/integration_test_v2c_config.yaml
@@ -2,7 +2,7 @@ receivers:
   snmp:
     community: "1.3.6.1.6.1.1.0"
     collection_interval: 10s
-    endpoint: udp://localhost:1024
+    endpoint: udp://host.docker.internal:1024
     version: v2c
     resource_attributes:
       ra1:

--- a/receiver/snmpreceiver/testdata/integration/integration_test_v3_config.yaml
+++ b/receiver/snmpreceiver/testdata/integration/integration_test_v3_config.yaml
@@ -2,7 +2,7 @@ receivers:
   snmp:
     collection_interval: 10s
     community: "1.3.6.1.6.1.1.0"
-    endpoint: udp://localhost:1024
+    endpoint: udp://host.docker.internal:1024
     version: v3
     security_level: auth_priv
     user: simulator


### PR DESCRIPTION
*DO NOT MERGE*
Not meant to be merged in this state. Playing with some things to see what happens with CI runs as I can't get the same failures locally.

**Description:** 
The integration test was acting erratically (often failing). I wasn't able to reproduce this completely, but I was consistently seeing failures locally once the integration test's Dockerfile was updated to use a 3.11 base image vs the original 3.7. 

This switches back to 3.7 along with a comment to not update this as snmpsim seems to not do well with anything newer.

**Link to tracking Issue:** #21086 

**Testing:** Ran `make -C receiver/snmpreceiver "do-integration-tests-with-cover"` locally to verify that tests were successful

**Documentation:** Add note in SNMP integration test Dockerfile to not upgrade base docker image.