### PR TITLE
[receiver/httpcheck] remove default endpoint

### DIFF
--- a/.chloggen/httpcheck-endpoint.yaml
+++ b/.chloggen/httpcheck-endpoint.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'breaking'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/httpcheck
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removed the default `endpoint` value of `http://localhost:80`. The `endpoint` property is now required.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22995]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/httpcheckreceiver/config.go
+++ b/receiver/httpcheckreceiver/config.go
@@ -17,10 +17,9 @@ import (
 
 // Predefined error responses for configuration validation failures
 var (
+	errMissingEndpoint = errors.New(`"endpoint" must be specified`)
 	errInvalidEndpoint = errors.New(`"endpoint" must be in the form of <scheme>://<hostname>:<port>`)
 )
-
-const defaultEndpoint = "http://localhost:80"
 
 // Config defines the configuration for the various elements of the receiver agent.
 type Config struct {
@@ -34,6 +33,9 @@ type Config struct {
 func (cfg *Config) Validate() error {
 	var err error
 
+	if cfg.Endpoint == "" {
+		err = multierr.Append(err, errMissingEndpoint)
+	}
 	_, parseErr := url.Parse(cfg.Endpoint)
 	if parseErr != nil {
 		wrappedErr := fmt.Errorf("%s: %w", errInvalidEndpoint.Error(), parseErr)

--- a/receiver/httpcheckreceiver/config_test.go
+++ b/receiver/httpcheckreceiver/config_test.go
@@ -20,6 +20,15 @@ func TestValidate(t *testing.T) {
 		expectedErr error
 	}{
 		{
+			desc: "missing endpoint",
+			cfg: &Config{
+				HTTPClientSettings: confighttp.HTTPClientSettings{},
+			},
+			expectedErr: multierr.Combine(
+				errMissingEndpoint,
+			),
+		},
+		{
 			desc: "invalid endpoint",
 			cfg: &Config{
 				HTTPClientSettings: confighttp.HTTPClientSettings{
@@ -34,7 +43,7 @@ func TestValidate(t *testing.T) {
 			desc: "valid config",
 			cfg: &Config{
 				HTTPClientSettings: confighttp.HTTPClientSettings{
-					Endpoint: defaultEndpoint,
+					Endpoint: "https://opentelemetry.io",
 				},
 			},
 			expectedErr: nil,

--- a/receiver/httpcheckreceiver/factory.go
+++ b/receiver/httpcheckreceiver/factory.go
@@ -35,14 +35,14 @@ func createDefaultConfig() component.Config {
 	cfg := scraperhelper.NewDefaultScraperControllerSettings(metadata.Type)
 	cfg.CollectionInterval = 10 * time.Second
 
+	httpSettings := confighttp.NewDefaultHTTPClientSettings()
+	httpSettings.Timeout = 10 * time.Second
+
 	return &Config{
 		ScraperControllerSettings: cfg,
-		HTTPClientSettings: confighttp.HTTPClientSettings{
-			Endpoint: defaultEndpoint,
-			Timeout:  10 * time.Second,
-		},
-		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
-		Method:               "GET",
+		HTTPClientSettings:        httpSettings,
+		MetricsBuilderConfig:      metadata.DefaultMetricsBuilderConfig(),
+		Method:                    "GET",
 	}
 }
 

--- a/receiver/httpcheckreceiver/factory_test.go
+++ b/receiver/httpcheckreceiver/factory_test.go
@@ -31,18 +31,18 @@ func TestNewFactory(t *testing.T) {
 			},
 		},
 		{
-			desc: "creates a new factory with valid default config",
+			desc: "creates a new factory with default config",
 			testFunc: func(t *testing.T) {
 				factory := NewFactory()
+
+				httpSettings := confighttp.NewDefaultHTTPClientSettings()
+				httpSettings.Timeout = 10 * time.Second
 
 				var expectedCfg component.Config = &Config{
 					ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
 						CollectionInterval: 10 * time.Second,
 					},
-					HTTPClientSettings: confighttp.HTTPClientSettings{
-						Endpoint: defaultEndpoint,
-						Timeout:  10 * time.Second,
-					},
+					HTTPClientSettings:   httpSettings,
 					MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 					Method:               "GET",
 				}

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -42,7 +42,7 @@ func TestScraperStart(t *testing.T) {
 			scraper: &httpcheckScraper{
 				cfg: &Config{
 					HTTPClientSettings: confighttp.HTTPClientSettings{
-						Endpoint: defaultEndpoint,
+						Endpoint: "http://example.com",
 						TLSSetting: configtls.TLSClientSetting{
 							TLSSetting: configtls.TLSSetting{
 								CAFile: "/non/existent",
@@ -60,7 +60,7 @@ func TestScraperStart(t *testing.T) {
 				cfg: &Config{
 					HTTPClientSettings: confighttp.HTTPClientSettings{
 						TLSSetting: configtls.TLSClientSetting{},
-						Endpoint:   defaultEndpoint,
+						Endpoint:   "http://example.com",
 					},
 				},
 				settings: componenttest.NewNopTelemetrySettings(),


### PR DESCRIPTION
Fixes #22995

This removes the default endpoint `http://localhost:80` and makes the `endpoint` setting required, as described in the README.

I also used the function `confighttp.NewDefaultHTTPClientSettings()` instead of the struct literal `confighttp.HTTPClientSettings{}`, as it is [recommended](https://github.com/open-telemetry/opentelemetry-collector/blob/v0.78.2/config/confighttp/confighttp.go#L81).