### PR TITLE
[processor/servicegraph] consume traces even metric count is equal to 0

### DIFF
--- a/.chloggen/fix-trace-data-loss.yaml
+++ b/.chloggen/fix-trace-data-loss.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: servicegraphprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: consume traces even metric count is equal to 0
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23028]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/servicegraphprocessor/processor.go
+++ b/processor/servicegraphprocessor/processor.go
@@ -166,7 +166,10 @@ func (p *serviceGraphProcessor) ConsumeTraces(ctx context.Context, td ptrace.Tra
 
 	// Skip empty metrics.
 	if md.MetricCount() == 0 {
-		return p.tracesConsumer.ConsumeTraces(ctx, td)
+		if p.tracesConsumer != nil {
+			return p.tracesConsumer.ConsumeTraces(ctx, td)
+		}
+		return nil
 	}
 
 	// true when p is a connector

--- a/processor/servicegraphprocessor/processor.go
+++ b/processor/servicegraphprocessor/processor.go
@@ -166,7 +166,7 @@ func (p *serviceGraphProcessor) ConsumeTraces(ctx context.Context, td ptrace.Tra
 
 	// Skip empty metrics.
 	if md.MetricCount() == 0 {
-		return nil
+		return p.tracesConsumer.ConsumeTraces(ctx, td)
 	}
 
 	// true when p is a connector


### PR DESCRIPTION
**Description:** 
consume traces even metric count is equal to 0

**Link to tracking Issue:** 
#23028 
