### PR TITLE
[chore] Updates to scrape duration

### DIFF
--- a/.chloggen/msg_add-scrape-interval-changelog.yaml
+++ b/.chloggen/msg_add-scrape-interval-changelog.yaml
@@ -1,0 +1,51 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receivers
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adding `initial_delay` to receivers to control when scraping interval starts
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23030]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The updated receivers are:
+  - `active_directory_ds`
+  - `aerospike`
+  - `apache`
+  - `apachespark`
+  - `azuremonitor`
+  - `couchdb`
+  - `docker_stats`
+  - `elasticsearch`
+  - `filestats`
+  - `flinkmetrics`
+  - `googlecloudspanner`
+  - `haproxy`
+  - `httpcheck`
+  - `iis`
+  - `memcached`
+  - `mongodb`
+  - `mysql`
+  - `nginx`
+  - `oracledb`
+  - `podman_stats`
+  - `postgresql`
+  - `rabbitmq`
+  - `riak`
+  - `snowflake`
+  - `sqlquery`
+  - `sqlserver`
+  - `sshcheck`
+  - `vcenter`
+  - `windowsperfcounters`
+  - `zookeeper`

--- a/.chloggen/msg_add-scrape-interval-changelog.yaml
+++ b/.chloggen/msg_add-scrape-interval-changelog.yaml
@@ -25,8 +25,10 @@ subtext: |
   - `apachespark`
   - `azuremonitor`
   - `couchdb`
+  - `chrony`
   - `docker_stats`
   - `elasticsearch`
+  - `expvar`
   - `filestats`
   - `flinkmetrics`
   - `googlecloudspanner`

--- a/.chloggen/msg_revert-default-apache-receiver.yaml
+++ b/.chloggen/msg_revert-default-apache-receiver.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: apache receiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: reverted default collection time back to 10s from 1m
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23030]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/activedirectorydsreceiver/README.md
+++ b/receiver/activedirectorydsreceiver/README.md
@@ -18,6 +18,7 @@ The `active_directory_ds` receiver scrapes metric relating to an Active Director
 The following settings are optional:
 - `metrics` (default: see `DefaultMetricsSettings` [here](./internal/metadata/generated_metrics.go)): Allows enabling and disabling specific metrics from being collected in this receiver.
 - `collection_interval` (default = `10s`): The interval at which metrics are emitted by this receiver.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 Example:
 ```yaml

--- a/receiver/aerospikereceiver/README.md
+++ b/receiver/aerospikereceiver/README.md
@@ -28,6 +28,7 @@ Configuration parameters:
 - `tlsname` Endpoint tls name. Used by the client during TLS connections. See [Aerospike authentication](https://docs.aerospike.com/server/guide/security/tls#standard-authentication) for mor details.
 - `collect_cluster_metrics` (default false): Whether discovered peer nodes should be collected.
 - `collection_interval` (default = 60s): This receiver collects metrics on an interval. Valid time units are ns, us (or µs), ms, s, m, h.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `username` (Enterprise Edition only.)
 - `password` (Enterprise Edition only.)
 - `tls` (default empty/no tls) tls configuration for connection to Aerospike nodes. More information at [OpenTelemetry's tls config page](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md).

--- a/receiver/apachereceiver/README.md
+++ b/receiver/apachereceiver/README.md
@@ -30,6 +30,7 @@ The following settings are required:
 
 The following settings are optional:
 - `collection_interval` (default = `10s`): This receiver collects metrics on an interval. This value must be a string readable by Golang's [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 ### Example Configuration
 

--- a/receiver/apachereceiver/factory.go
+++ b/receiver/apachereceiver/factory.go
@@ -31,8 +31,11 @@ func NewFactory() receiver.Factory {
 }
 
 func createDefaultConfig() component.Config {
+	cfg := scraperhelper.NewDefaultScraperControllerSettings(metadata.Type)
+	cfg.CollectionInterval = 10 * time.Second
+
 	return &Config{
-		ScraperControllerSettings: scraperhelper.NewDefaultScraperControllerSettings(metadata.Type),
+		ScraperControllerSettings: cfg,
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Endpoint: defaultEndpoint,
 			Timeout:  10 * time.Second,

--- a/receiver/apachesparkreceiver/README.md
+++ b/receiver/apachesparkreceiver/README.md
@@ -29,6 +29,7 @@ These configuration options are for connecting to an Apache Spark application.
 The following settings are optional:
 
 - `collection_interval`: (default = `60s`): This receiver collects metrics on an interval. This value must be a string readable by Golang's [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `endpoint`: (default = `http://localhost:4040`): Apache Spark endpoint to connect to in the form of `[http][://]{host}[:{port}]`
 - `application_names`: An array of Spark application names for which metrics should be collected. If no application names are specified, metrics will be collected for all Spark applications running on the cluster at the specified endpoint.
 

--- a/receiver/azuremonitorreceiver/README.md
+++ b/receiver/azuremonitorreceiver/README.md
@@ -26,6 +26,7 @@ The following settings are optional:
 - `cache_resources` (default = 86400): List of resources will be cached for the provided amount of time in seconds.
 - `cache_resources_definitions` (default = 86400): List of metrics definitions will be cached for the provided amount of time in seconds.
 - `maximum_number_of_metrics_in_a_call` (default = 20): Maximum number of metrics to fetch in per API call, current limit in Azure is 20 (as of 03/27/2023).
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 ### Example Configuration
 
@@ -43,6 +44,7 @@ receivers:
       - "${service1}"
       - "${service2}"
     collection_interval: 60s
+    initial_delay: 1s
 ```
 
 ## Metrics

--- a/receiver/chronyreceiver/README.md
+++ b/receiver/chronyreceiver/README.md
@@ -43,6 +43,7 @@ The following options can be customised:
 - timeout (optional) - The total amount of time allowed to read and process the data from chronyd
   - Recommendation: This value should be set above 1s to allow `chronyd` time to respond
 - collection_interval (optional) - how frequent this receiver should poll [chrony]
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - metrics (optional) - Which metrics should be exported, read the [documentation] for complete details
 
 ## Example

--- a/receiver/dockerstatsreceiver/README.md
+++ b/receiver/dockerstatsreceiver/README.md
@@ -25,6 +25,7 @@ The following settings are optional:
 
 - `endpoint` (default = `unix:///var/run/docker.sock`): Address to reach the desired Docker daemon.
 - `collection_interval` (default = `10s`): The interval at which to gather container stats.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `container_labels_to_metric_labels` (no default): A map of Docker container label names whose label values to use
 as the specified metric label key.
 - `env_vars_to_metric_labels` (no default): A map of Docker container environment variables whose values to use

--- a/receiver/elasticsearchreceiver/README.md
+++ b/receiver/elasticsearchreceiver/README.md
@@ -33,6 +33,7 @@ The following settings are optional:
 - `username` (no default): Specifies the username used to authenticate with Elasticsearch using basic auth. Must be specified if password is specified.
 - `password` (no default): Specifies the password used to authenticate with Elasticsearch using basic auth. Must be specified if username is specified.
 - `collection_interval` (default = `10s`): This receiver collects metrics on an interval. This value must be a string readable by Golang's [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). On larger clusters, the interval may need to be lengthened, as querying Elasticsearch for metrics will take longer on clusters with more nodes.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 ### Example Configuration
 

--- a/receiver/expvarreceiver/README.md
+++ b/receiver/expvarreceiver/README.md
@@ -39,6 +39,7 @@ The following can be configured:
     - `timeout = 3s`
 - `collection_interval` - Configure how often the metrics are scraped.
   - default: 1m
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `metrics` - Enable or disable metrics by name.
 
 ### Example configuration

--- a/receiver/filestatsreceiver/README.md
+++ b/receiver/filestatsreceiver/README.md
@@ -12,4 +12,9 @@
 
 The File Stats receiver collects metrics from files specified with a glob pattern.
 
+## Configuration
+- `include` (required): The glob path for files to watch
+- `collection_interval` (default = `1m`): The interval at which metrics are emitted by this receiver.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
+
 See [documentation.md] for a list of the metrics collected.

--- a/receiver/flinkmetricsreceiver/README.md
+++ b/receiver/flinkmetricsreceiver/README.md
@@ -29,6 +29,7 @@ The following settings are optional:
 - `endpoint` (default: `http://localhost:15672`): The URL of the node to be monitored.
 - `collection_interval` (default = `10s`): This receiver collects metrics on an interval. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
 - `tls` (defaults defined [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)): TLS control. By default insecure settings are rejected and certificate verification is on.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 ### Example Configuration
 

--- a/receiver/googlecloudspannerreceiver/README.md
+++ b/receiver/googlecloudspannerreceiver/README.md
@@ -33,6 +33,7 @@ The following configuration example is:
 receivers:
   googlecloudspanner:
     collection_interval: 60s
+    initial_delay: 1s
     top_metrics_query_max_rows: 100
     backfill_enabled: true
     cardinality_total_limit: 200000
@@ -66,6 +67,7 @@ receivers:
 Brief description of configuration properties:
 - **googlecloudspanner** - name of the Cloud Spanner Receiver related section in OpenTelemetry collector configuration file
 - **collection_interval** - this receiver runs periodically. Each time it runs, it queries Google Cloud Spanner, creates metrics, and sends them to the next consumer (default: 1 minute). **It is not recommended to change the default value of collection interval, since new values for metrics in the Spanner database appear only once a minute.**
+- **initial_delay**  defines how long this receiver waits before starting.
 - **top_metrics_query_max_rows** - max number of rows to fetch from Top N built-in table(100 by default)
 - **backfill_enabled** - turn on/off 1-hour data backfill(by default it is turned off)
 - **cardinality_total_limit** - limit of active series per 24 hours period. If specified, turns on cardinality filtering and handling. If zero or not specified, cardinality is not handled. You can read [this document](cardinality.md) for more information about cardinality handling and filtering.

--- a/receiver/haproxyreceiver/README.md
+++ b/receiver/haproxyreceiver/README.md
@@ -25,6 +25,11 @@ The scraping collection interval can be configured.
 
 Default: 1 minute
 
+### Initial delay settings (optional)
+defines how long this receiver waits before starting.
+
+Default: `1s` 
+
 ### Example configuration
 
 ```yaml

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -26,6 +26,7 @@ configured:
 ```yaml
 hostmetrics:
   collection_interval: <duration> # default = 1m
+  initial_delay: <duration> # default = 1s
   root_path: <string>
   scrapers:
     <scraper1>:

--- a/receiver/httpcheckreceiver/README.md
+++ b/receiver/httpcheckreceiver/README.md
@@ -33,6 +33,7 @@ The following configuration settings are optional:
 
 - `method` (default: `GET`): The method used to call the endpoint.
 - `collection_interval` (default = `60s`): This receiver collects metrics on an interval. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 ### Example Configuration
 

--- a/receiver/iisreceiver/README.md
+++ b/receiver/iisreceiver/README.md
@@ -20,6 +20,7 @@ Because of this, it is a Windows only receiver.
 The following settings are optional:
 
 - `collection_interval` (default = `10s`): The interval at which metrics should be emitted by this receiver.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 Example:
 
@@ -27,6 +28,7 @@ Example:
     receivers:
       iis:
         collection_interval: 10s
+        initial_delay: 1s
 
 ```
 

--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -39,6 +39,7 @@ receivers:
     endpoint: my_jmx_host:12345
     target_system: jvm
     collection_interval: 10s
+    initial_delay: 1s
     # optional: the same as specifying OTLP receiver endpoint.
     otlp:
       endpoint: mycollectorotlpreceiver:4317
@@ -92,6 +93,10 @@ Corresponds to the `otel.jmx.target.system` property.
 The interval time for the Groovy script to be run and metrics to be exported by the JMX Metric Gatherer within the persistent JRE process.
 
 Corresponds to the `otel.jmx.interval.milliseconds` property.
+
+### initial_delay (default: `1s`)
+
+Defines how long this receiver waits before starting.
 
 ### username
 

--- a/receiver/kafkametricsreceiver/README.md
+++ b/receiver/kafkametricsreceiver/README.md
@@ -34,6 +34,7 @@ Optional Settings (with defaults):
 - `group_match` (default = .*): regex pattern of consumer groups to filter on for metrics.
 - `client_id` (default = otel-metrics-receiver): consumer client id
 - `collection_interval` (default = 1m): frequency of metric collection/scraping.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `auth` (default none)
     - `plain_text`
         - `username`: The username to use.

--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -33,6 +33,7 @@ endpoint will be used if `auth_type` set to any of the following values:
 to authenticate to the kubelet API.
 - `kubeConfig` tells this receiver to use the kubeconfig file (KUBECONFIG env variable or ~/.kube/config)
 to authenticate and use API server proxy to access the kubelet API.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 ### TLS Example
 
@@ -40,6 +41,7 @@ to authenticate and use API server proxy to access the kubelet API.
 receivers:
   kubeletstats:
     collection_interval: 20s
+    initial_delay: 1s
     auth_type: "tls"
     ca_file: "/path/to/ca.crt"
     key_file: "/path/to/apiserver.key"

--- a/receiver/memcachedreceiver/README.md
+++ b/receiver/memcachedreceiver/README.md
@@ -35,6 +35,7 @@ next consumer. The `collection_interval` configuration option tells this
 receiver the duration between runs. This value must be a string readable by
 Golang's `ParseDuration` function (example: `1h30m`). Valid time units are
 `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 Example:
 

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -40,6 +40,7 @@ The following settings are optional:
 - `username`: If authentication is required, the user can with `clusterMonitor` permissions can be provided here.
 - `password`: If authentication is required, the password can be provided here.
 - `collection_interval`: (default = `1m`): This receiver collects metrics on an interval. This value must be a string readable by Golang's [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `replica_set`: If the deployment of MongoDB is a replica set then this allows users to specify the replica set name which allows for autodiscovery of other nodes in the replica set.
 - `timeout`: (default = `1m`) The timeout of running commands against mongo.
 - `tls`: (defaults defined [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)): TLS control. By default insecure settings are rejected and certificate verification is on.
@@ -54,6 +55,7 @@ receivers:
     username: otel
     password: ${env:MONGODB_PASSWORD}
     collection_interval: 60s
+    initial_delay: 1s
     tls:
       insecure: true
       insecure_skip_verify: true

--- a/receiver/mysqlreceiver/README.md
+++ b/receiver/mysqlreceiver/README.md
@@ -31,6 +31,7 @@ The following settings are optional:
 - `database`: The database name. If not specified, metrics will be collected for all databases.
 
 - `collection_interval` (default = `10s`): This receiver collects metrics on an interval. This value must be a string readable by Golang's [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 - `transport`: (default = `tcp`): Defines the network to use for connecting to the server.
 - `statement_events`: Additional configuration for query to build `mysql.statement_events.count` and `mysql.statement_events.wait.time` metrics:
@@ -48,6 +49,7 @@ receivers:
     password: ${env:MYSQL_PASSWORD}
     database: otel
     collection_interval: 10s
+    initial_delay: 1s
     statement_events:
       digest_text_limit: 120
       time_limit: 24h

--- a/receiver/nginxreceiver/README.md
+++ b/receiver/nginxreceiver/README.md
@@ -40,6 +40,7 @@ next consumer. The `collection_interval` configuration option tells this
 receiver the duration between runs. This value must be a string readable by
 Golang's `ParseDuration` function (example: `1h30m`). Valid time units are
 `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 Example:
 

--- a/receiver/nsxtreceiver/README.md
+++ b/receiver/nsxtreceiver/README.md
@@ -41,6 +41,8 @@ This receiver supports NSX-T Datacenter versions:
 
 - `collection_interval`: (default = `1m`): This receiver collects metrics on an interval. This value must be a string readable by Golang's [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
 
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
+
 - `timeout`: (default = `1m`) The timeout of running commands against the NSX REST API.
 
 - `metrics` (default: see DefaultMetricsSettings [here])(./internal/metadata/generated_metrics.go): Allows enabling and disabling specific metrics from being collected in this receiver.

--- a/receiver/podmanreceiver/README.md
+++ b/receiver/podmanreceiver/README.md
@@ -29,6 +29,7 @@ The following settings are required:
 The following settings are optional:
 
 - `collection_interval` (default = `10s`): The interval at which to gather container stats.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `timeout` (default = `5s`): The maximum amount of time to wait for Podman API responses.
 
 Example:
@@ -39,6 +40,7 @@ receivers:
     endpoint: unix://run/podman/podman.sock
     timeout: 10s
     collection_interval: 10s
+    initial_delay: 1s
 ```
 
 The full list of settings exposed for this receiver are documented [here](./config.go)

--- a/receiver/postgresqlreceiver/README.md
+++ b/receiver/postgresqlreceiver/README.md
@@ -46,6 +46,7 @@ The following settings are also optional and nested under `tls` to help configur
 - `ca_file` (default = ""): A set of certificate authorities used to validate the database server's SSL certificate.
 
 - `collection_interval` (default = `10s`): This receiver collects metrics on an interval. This value must be a string readable by Golang's [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 ### Example Configuration
 

--- a/receiver/riakreceiver/README.md
+++ b/receiver/riakreceiver/README.md
@@ -29,6 +29,7 @@ The following configuration settings are optional:
 
 - `endpoint` (default: `http://localhost:8098`): The URL of the node to be monitored.
 - `collection_interval` (default = `60s`): This receiver collects metrics on an interval. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `tls` (defaults defined [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)): TLS control. By default insecure settings are rejected and certificate verification is on.
 
 ### Example Configuration

--- a/receiver/saphanareceiver/README.md
+++ b/receiver/saphanareceiver/README.md
@@ -74,6 +74,7 @@ next consumer. The `collection_interval` configuration option tells this
 receiver the duration between runs. This value must be a string readable by
 Golang's `ParseDuration` function (example: `1h30m`). Valid time units are
 `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 - `tls`:
   - `insecure` (default = true): whether to disable client transport security for the exporter's connection.
   - `ca_file`: path to the CA cert. For a client this verifies the server certificate. Should only be used if `insecure` is set to false.

--- a/receiver/vcenterreceiver/README.md
+++ b/receiver/vcenterreceiver/README.md
@@ -34,6 +34,7 @@ A “Read Only” user assigned to a vSphere with permissions to the vCenter ser
 | password            |         | String           | Required                                                                                                                                                                                                                                        |
 | tls                 |         | TLSClientSetting | Not Required. Will use defaults for [configtls.TLSClientSetting](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md). By default insecure settings are rejected and certificate verification is on. |
 | collection_interval | 2m      | Duration         | This receiver collects metrics on an interval. If the vCenter is fairly large, this value may need to be increased. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, `h`                                                              |
+| initial_delay       | 1s      | Duration         | Defines how long this receiver waits before starting.                                                                                                                                                                                           |
 
 ### Example Configuration
 
@@ -44,6 +45,7 @@ receivers:
     username: otelu
     password: ${env:VCENTER_PASSWORD}
     collection_interval: 5m
+    initial_delay: 1s
     metrics: []
 ```
 

--- a/receiver/windowsperfcountersreceiver/README.md
+++ b/receiver/windowsperfcountersreceiver/README.md
@@ -35,6 +35,7 @@ be configured:
 ```yaml
 windowsperfcounters:
   collection_interval: <duration> # default = "1m"
+  initial_delay: <duration> # default = "1s"
   metrics:
     <metric name>:
       description: <description>

--- a/receiver/zookeeperreceiver/README.md
+++ b/receiver/zookeeperreceiver/README.md
@@ -19,6 +19,7 @@ to be enabled for the receiver to be able to collect metrics.
 
 - `endpoint`: (default = `:2181`) Endpoint to connect to collect metrics. Takes the form `host:port`.
 - `timeout`: (default = `10s`) Timeout within which requests should be completed.
+- `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
 Example configuration.
 
@@ -27,6 +28,7 @@ receivers:
   zookeeper:
     endpoint: "localhost:2181"
     collection_interval: 20s
+    initial_delay: 1s
 ```
 
 ## Metrics


### PR DESCRIPTION
**Description:** 

- This is to prepare for the future release of core that includes scraping from collector start.
- Fixes accidental change to apache receiver's default collection interval.

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector/pull/7635

**Testing:**
NA

**Documentation:**
NA