### PR TITLE
[chore][exporter/clickhouse] align success path logging to other exporters

### DIFF
--- a/exporter/clickhouseexporter/exporter_logs.go
+++ b/exporter/clickhouseexporter/exporter_logs.go
@@ -101,7 +101,7 @@ func (e *logsExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
 		return nil
 	})
 	duration := time.Since(start)
-	e.logger.Info("insert logs", zap.Int("records", ld.LogRecordCount()),
+	e.logger.Debug("insert logs", zap.Int("records", ld.LogRecordCount()),
 		zap.String("cost", duration.String()))
 	return err
 }

--- a/exporter/clickhouseexporter/exporter_traces.go
+++ b/exporter/clickhouseexporter/exporter_traces.go
@@ -120,7 +120,7 @@ func (e *tracesExporter) pushTraceData(ctx context.Context, td ptrace.Traces) er
 		return nil
 	})
 	duration := time.Since(start)
-	e.logger.Info("insert traces", zap.Int("records", td.SpanCount()),
+	e.logger.Debug("insert traces", zap.Int("records", td.SpanCount()),
 		zap.String("cost", duration.String()))
 	return err
 }


### PR DESCRIPTION
**Description:**

The ClickHouse exporter currently logs success messages on `info` level whenever it inserts traces or logs (but not metrics). Other exporters aren't behaving this way.

Reduce the log level to `debug` to align with the metric insertion logging behavior and with the logging behavior of other exporters.

**Link to tracking Issue:** None

**Testing:** None, just the logger call was changed which can be validated at compile time.

**Documentation:** None