### PR TITLE
[mdatagen] better formatting for connector READMEs

### DIFF
--- a/cmd/mdatagen/templates/readme.md.tmpl
+++ b/cmd/mdatagen/templates/readme.md.tmpl
@@ -23,7 +23,9 @@
 [{{.}}]: {{ distroURL . }}
 {{- end }}
 {{- if eq $class "connector"}}
+
 ## Supported Pipeline Types
+
 | [Exporter Pipeline Type] | [Receiver Pipeline Type] | [Stability Level] |
 | ------------------------ | ------------------------ | ----------------- |
 {{- range $stability, $pipelines := .Status.Stability }}

--- a/connector/countconnector/README.md
+++ b/connector/countconnector/README.md
@@ -7,7 +7,9 @@
 [development]: https://github.com/open-telemetry/opentelemetry-collector#development
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [sumo]: https://github.com/SumoLogic/sumologic-otel-collector
+
 ## Supported Pipeline Types
+
 | [Exporter Pipeline Type] | [Receiver Pipeline Type] | [Stability Level] |
 | ------------------------ | ------------------------ | ----------------- |
 | traces | metrics | [development] |

--- a/connector/servicegraphconnector/README.md
+++ b/connector/servicegraphconnector/README.md
@@ -8,7 +8,9 @@
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [sumo]: https://github.com/SumoLogic/sumologic-otel-collector
+
 ## Supported Pipeline Types
+
 | [Exporter Pipeline Type] | [Receiver Pipeline Type] | [Stability Level] |
 | ------------------------ | ------------------------ | ----------------- |
 | traces | metrics | [alpha] |

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -8,7 +8,9 @@
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 [sumo]: https://github.com/SumoLogic/sumologic-otel-collector
+
 ## Supported Pipeline Types
+
 | [Exporter Pipeline Type] | [Receiver Pipeline Type] | [Stability Level] |
 | ------------------------ | ------------------------ | ----------------- |
 | traces | metrics | [alpha] |


### PR DESCRIPTION
**Description:** 
mdatagen was recently updated to generate portions of the connector READMEs, but could benefit from some additional line breaks. This PR adds 2. At least one was requested here: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/23017#discussion_r1213788754.

**Testing:**
I've regenerated the relevant readmes in this PR. Take a look and let me know if any additional formatting should be addressed.

cc: @dmitryax 