### PR TITLE
[receiver/httpcheck] Update default collection interval

### DIFF
--- a/.chloggen/httpcheck-default-collection-interval.yaml
+++ b/.chloggen/httpcheck-default-collection-interval.yaml
@@ -9,7 +9,7 @@ change_type: bug_fix
 component: httpcheckreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Update default collection interval to make documented value
+note: Update default collection interval to match documented value
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [23019]

--- a/.chloggen/httpcheck-default-collection-interval.yaml
+++ b/.chloggen/httpcheck-default-collection-interval.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: httpcheckreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update default collection interval to make documented value
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23019]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/httpcheckreceiver/factory.go
+++ b/receiver/httpcheckreceiver/factory.go
@@ -29,7 +29,7 @@ func NewFactory() receiver.Factory {
 
 func createDefaultConfig() component.Config {
 	cfg := scraperhelper.NewDefaultScraperControllerSettings(metadata.Type)
-	cfg.CollectionInterval = 10 * time.Second
+	cfg.CollectionInterval = 60 * time.Second
 
 	httpSettings := confighttp.NewDefaultHTTPClientSettings()
 	httpSettings.Timeout = 10 * time.Second

--- a/receiver/httpcheckreceiver/factory_test.go
+++ b/receiver/httpcheckreceiver/factory_test.go
@@ -40,7 +40,7 @@ func TestNewFactory(t *testing.T) {
 
 				var expectedCfg component.Config = &Config{
 					ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
-						CollectionInterval: 10 * time.Second,
+						CollectionInterval: 60 * time.Second,
 					},
 					HTTPClientSettings:   httpSettings,
 					MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The default collection interval was documented in the receiver's README as 60s, but in the code it was being set to 10s by default. This change updates the code to set the default interval to 60s.

**Link to tracking Issue:** <Issue number if applicable>
Fixes #23019

**Testing:** <Describe what testing was performed and which tests were added.>
Updated test to match correct default value