### PR TITLE
[bugfix][jmxreceiver] Cancel rogue subprocess

### DIFF
--- a/.chloggen/bugfix-jmx-receiver-rogue-process.yaml
+++ b/.chloggen/bugfix-jmx-receiver-rogue-process.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: jmxreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed the issue where the JMX receiver's subprocess wasn't canceled upon shutdown, resulting in a rogue java process.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/bugfix-jmx-receiver-rogue-process.yaml
+++ b/.chloggen/bugfix-jmx-receiver-rogue-process.yaml
@@ -8,7 +8,7 @@ component: jmxreceiver
 note: Fixed the issue where the JMX receiver's subprocess wasn't canceled upon shutdown, resulting in a rogue java process.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [23051]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/jmxreceiver/internal/subprocess/subprocess.go
+++ b/receiver/jmxreceiver/internal/subprocess/subprocess.go
@@ -131,6 +131,8 @@ func (subprocess *Subprocess) Shutdown(ctx context.Context) error {
 	}
 	t := time.NewTimer(timeout)
 
+	subprocess.cancel()
+
 	// Wait for the subprocess to exit or the timeout period to elapse
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
**Description:** Fixed the issue where the JMX receiver's subprocess wasn't canceled upon shutdown, resulting in a rogue java process.

**Link to tracking Issue:** Discovered during https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/22751

**Testing:** Ensured rogue process was cleaned up when the JMX integration test was run.