### PR TITLE
[receiver/datadog] add datadog span and trace id

### DIFF
--- a/.chloggen/dd-receiver-span-id.yaml
+++ b/.chloggen/dd-receiver-span-id.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "add datadog trace and span id"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23057]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/datadogreceiver/translator_test.go
+++ b/receiver/datadogreceiver/translator_test.go
@@ -74,10 +74,10 @@ func TestTracePayloadV05Unmarshalling(t *testing.T) {
 	assert.Equal(t, 1, translated.SpanCount(), "Span Count wrong")
 	span := translated.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	assert.NotNil(t, span)
-	assert.Equal(t, 5, span.Attributes().Len(), "missing tags")
+	assert.Equal(t, 7, span.Attributes().Len(), "missing attributes")
 	value, exists := span.Attributes().Get("service.name")
 	assert.True(t, exists, "service.name missing")
-	assert.Equal(t, "my-service", value.AsString(), "service.name tag value incorrect")
+	assert.Equal(t, "my-service", value.AsString(), "service.name attribute value incorrect")
 	assert.Equal(t, "my-name", span.Name())
 	spanResource, _ := span.Attributes().Get("dd.span.Resource")
 	assert.Equal(t, "my-resource", spanResource.Str())
@@ -103,10 +103,10 @@ func TestTracePayloadV07Unmarshalling(t *testing.T) {
 	translated, _ := handlePayload(req)
 	span := translated.GetChunks()[0].GetSpans()[0]
 	assert.NotNil(t, span)
-	assert.Equal(t, 4, len(span.GetMeta()), "missing tags")
+	assert.Equal(t, 4, len(span.GetMeta()), "missing attributes")
 	value, exists := span.GetMeta()["service.name"]
 	assert.True(t, exists, "service.name missing")
-	assert.Equal(t, "my-service", value, "service.name tag value incorrect")
+	assert.Equal(t, "my-service", value, "service.name attribute value incorrect")
 	assert.Equal(t, "my-name", span.GetName())
 	assert.Equal(t, "my-resource", span.GetResource())
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Add datadog trace id and span id so we cancorrelate traces received by datadogreceiver with logs.

Datadog libraries automatically provide datadog span ids and trace ids with the logs for various languages:

- https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/python/
-https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/java?tab=log4j2

Example log for python:
```
2023-06-05 06:01:30,459 INFO [__main__] [test-enhanced.py:44] [dd.service= dd.env= dd.version= dd.trace_id=6249785623524942554 dd.span_id=2
28114450199004348] - Starting a new Game!
```

**Link to tracking Issue:**  https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23057
**Testing:** <Describe what testing was performed and which tests were added.>
- local testing with python app
- updated unit tests
- 
**Documentation:** <Describe the documentation added.>