### PR TITLE
[chore] Sort metric datapoint

### DIFF
--- a/internal/coreinternal/golden/sort_attributes_test.go
+++ b/internal/coreinternal/golden/sort_attributes_test.go
@@ -4,8 +4,10 @@
 package golden
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
@@ -41,4 +43,14 @@ func TestSortAttributes(t *testing.T) {
 		}
 	}
 
+}
+
+func TestSortMetricDatapointSlice(t *testing.T) {
+	dir := filepath.Join("testdata", "sort-datapoint-slice")
+	before, err := ReadMetrics(filepath.Join(dir, "before.yaml"))
+	require.NoError(t, err)
+	after, err := ReadMetrics(filepath.Join(dir, "after.yaml"))
+	require.NoError(t, err)
+
+	require.Equal(t, before, after)
 }

--- a/internal/coreinternal/golden/sort_metrics_test.go
+++ b/internal/coreinternal/golden/sort_metrics_test.go
@@ -46,11 +46,13 @@ func TestSortAttributes(t *testing.T) {
 }
 
 func TestSortMetricDatapointSlice(t *testing.T) {
-	dir := filepath.Join("testdata", "sort-datapoint-slice")
-	before, err := ReadMetrics(filepath.Join(dir, "before.yaml"))
+	beforePath := filepath.Join("testdata", "sort-datapoint-slice", "before.yaml")
+	afterPath := filepath.Join("testdata", "sort-datapoint-slice", "after.yaml")
+	before, err := ReadMetrics(beforePath)
 	require.NoError(t, err)
-	after, err := ReadMetrics(filepath.Join(dir, "after.yaml"))
+	after, err := ReadMetrics(afterPath)
 	require.NoError(t, err)
-
+	sortMetricDataPointSlices(before)
 	require.Equal(t, before, after)
+
 }

--- a/internal/coreinternal/golden/testdata/sort-datapoint-slice/after.yaml
+++ b/internal/coreinternal/golden/testdata/sort-datapoint-slice/after.yaml
@@ -1,0 +1,62 @@
+ResourceMetrics:
+  - resource:
+      attributes:
+        - key: device.id
+          value:
+            stringValue: vmnic0
+        - key: nsxt.node.name
+          value:
+            stringValue: esxi-18938.cf5e88ac.australia-southeast1.gve.goog
+        - key: nsxt.node.type
+          value:
+            stringValue: TransportNode
+        - key: nsxt.node.id
+          value:
+            stringValue: 0e7bd3f2-bd49-4fa2-b650-9e9bfcdad827
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes which have flowed through the network interface.
+            name: nsxt.node.network.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4161088074"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: a
+                  startTimeUnixNano: "1111111111111111111"
+                  timeUnixNano: "5555555555555555555"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: b
+                  startTimeUnixNano: "3333333333333333333"
+                  timeUnixNano: "2222222222222222222"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: c
+                  startTimeUnixNano: "1924857624581089658"
+                  timeUnixNano: "1111111111111111111"
+                - asInt: "32"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: c
+                  startTimeUnixNano: "1924857624581089658"
+                  timeUnixNano: "2222222222222222222"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: d
+                  startTimeUnixNano: "1924857624581089658"
+                  timeUnixNano: "5555555555555591029"
+              isMonotonic: true
+            unit: By
+        scope:
+          name: otelcol/nsxtreceiver
+          version: latest

--- a/internal/coreinternal/golden/testdata/sort-datapoint-slice/after.yaml
+++ b/internal/coreinternal/golden/testdata/sort-datapoint-slice/after.yaml
@@ -1,18 +1,5 @@
-ResourceMetrics:
+resourceMetrics:
   - resource:
-      attributes:
-        - key: device.id
-          value:
-            stringValue: vmnic0
-        - key: nsxt.node.name
-          value:
-            stringValue: esxi-18938.cf5e88ac.australia-southeast1.gve.goog
-        - key: nsxt.node.type
-          value:
-            stringValue: TransportNode
-        - key: nsxt.node.id
-          value:
-            stringValue: 0e7bd3f2-bd49-4fa2-b650-9e9bfcdad827
     scopeMetrics:
       - metrics:
           - description: The number of bytes which have flowed through the network interface.
@@ -20,41 +7,41 @@ ResourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4161088074"
+                - asInt: "0"
                   attributes:
-                    - key: direction
+                    - key: a
                       value:
-                        stringValue: a
+                        stringValue: AAAA
                   startTimeUnixNano: "1111111111111111111"
-                  timeUnixNano: "5555555555555555555"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: b
-                  startTimeUnixNano: "3333333333333333333"
-                  timeUnixNano: "2222222222222222222"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: c
-                  startTimeUnixNano: "1924857624581089658"
                   timeUnixNano: "1111111111111111111"
-                - asInt: "32"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: c
-                  startTimeUnixNano: "1924857624581089658"
-                  timeUnixNano: "2222222222222222222"
                 - asInt: "0"
                   attributes:
-                    - key: direction
+                    - key: b
                       value:
-                        stringValue: d
-                  startTimeUnixNano: "1924857624581089658"
-                  timeUnixNano: "5555555555555591029"
+                        stringValue: BBBBFirst
+                  startTimeUnixNano: "1111111111111111111"
+                  timeUnixNano: "1111111111111111111"
+                - asInt: "0"
+                  attributes:
+                    - key: b
+                      value:
+                        stringValue: BBBBSecond
+                  startTimeUnixNano: "1111111111111111111"
+                  timeUnixNano: "1111111111111111111"
+                - asInt: "0"
+                  attributes:
+                    - key: c
+                      value:
+                        stringValue: CCCC
+                  startTimeUnixNano: "1111111111111111111"
+                  timeUnixNano: "1111111111111111111"
+                - asInt: "0"
+                  attributes:
+                    - key: d
+                      value:
+                        stringValue: DDDD
+                  startTimeUnixNano: "1111111111111111111"
+                  timeUnixNano: "1111111111111111111"
               isMonotonic: true
             unit: By
         scope:

--- a/internal/coreinternal/golden/testdata/sort-datapoint-slice/before.yaml
+++ b/internal/coreinternal/golden/testdata/sort-datapoint-slice/before.yaml
@@ -1,0 +1,62 @@
+ResourceMetrics:
+  - resource:
+      attributes:
+        - key: device.id
+          value:
+            stringValue: vmnic0
+        - key: nsxt.node.name
+          value:
+            stringValue: esxi-18938.cf5e88ac.australia-southeast1.gve.goog
+        - key: nsxt.node.type
+          value:
+            stringValue: TransportNode
+        - key: nsxt.node.id
+          value:
+            stringValue: 0e7bd3f2-bd49-4fa2-b650-9e9bfcdad827
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes which have flowed through the network interface.
+            name: nsxt.node.network.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: b
+                  startTimeUnixNano: "3333333333333333333"
+                  timeUnixNano: "2222222222222222222"
+                - asInt: "4161088074"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: a
+                  startTimeUnixNano: "1111111111111111111"
+                  timeUnixNano: "5555555555555555555"
+                - asInt: "32"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: c
+                  startTimeUnixNano: "1924857624581089658"
+                  timeUnixNano: "2222222222222222222"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: c
+                  startTimeUnixNano: "1924857624581089658"
+                  timeUnixNano: "1111111111111111111"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: d
+                  startTimeUnixNano: "1924857624581089658"
+                  timeUnixNano: "5555555555555591029"
+              isMonotonic: true
+            unit: By
+        scope:
+          name: otelcol/nsxtreceiver
+          version: latest

--- a/internal/coreinternal/golden/testdata/sort-datapoint-slice/before.yaml
+++ b/internal/coreinternal/golden/testdata/sort-datapoint-slice/before.yaml
@@ -1,18 +1,5 @@
-ResourceMetrics:
+resourceMetrics:
   - resource:
-      attributes:
-        - key: device.id
-          value:
-            stringValue: vmnic0
-        - key: nsxt.node.name
-          value:
-            stringValue: esxi-18938.cf5e88ac.australia-southeast1.gve.goog
-        - key: nsxt.node.type
-          value:
-            stringValue: TransportNode
-        - key: nsxt.node.id
-          value:
-            stringValue: 0e7bd3f2-bd49-4fa2-b650-9e9bfcdad827
     scopeMetrics:
       - metrics:
           - description: The number of bytes which have flowed through the network interface.
@@ -22,39 +9,39 @@ ResourceMetrics:
               dataPoints:
                 - asInt: "0"
                   attributes:
-                    - key: direction
+                    - key: a
                       value:
-                        stringValue: b
-                  startTimeUnixNano: "3333333333333333333"
-                  timeUnixNano: "2222222222222222222"
-                - asInt: "4161088074"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: a
+                        stringValue: AAAA
                   startTimeUnixNano: "1111111111111111111"
-                  timeUnixNano: "5555555555555555555"
-                - asInt: "32"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: c
-                  startTimeUnixNano: "1924857624581089658"
-                  timeUnixNano: "2222222222222222222"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: c
-                  startTimeUnixNano: "1924857624581089658"
                   timeUnixNano: "1111111111111111111"
                 - asInt: "0"
                   attributes:
-                    - key: direction
+                    - key: d
                       value:
-                        stringValue: d
-                  startTimeUnixNano: "1924857624581089658"
-                  timeUnixNano: "5555555555555591029"
+                        stringValue: DDDD
+                  startTimeUnixNano: "1111111111111111111"
+                  timeUnixNano: "1111111111111111111"
+                - asInt: "0"
+                  attributes:
+                    - key: c
+                      value:
+                        stringValue: CCCC
+                  startTimeUnixNano: "1111111111111111111"
+                  timeUnixNano: "1111111111111111111"
+                - asInt: "0"
+                  attributes:
+                    - key: b
+                      value:
+                        stringValue: BBBBFirst
+                  startTimeUnixNano: "1111111111111111111"
+                  timeUnixNano: "1111111111111111111"
+                - asInt: "0"
+                  attributes:
+                    - key: b
+                      value:
+                        stringValue: BBBBSecond
+                  startTimeUnixNano: "1111111111111111111"
+                  timeUnixNano: "1111111111111111111"
               isMonotonic: true
             unit: By
         scope:

--- a/receiver/bigipreceiver/scraper_test.go
+++ b/receiver/bigipreceiver/scraper_test.go
@@ -262,7 +262,7 @@ func TestScaperScrape(t *testing.T) {
 			expectedMetrics := tc.expectedMetricGen(t)
 
 			err = pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
-				pmetrictest.IgnoreResourceMetricsOrder(), pmetrictest.IgnoreStartTimestamp(),
+				pmetrictest.IgnoreResourceMetricsOrder(), pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(),
 				pmetrictest.IgnoreTimestamp())
 			require.NoError(t, err)
 		})

--- a/receiver/bigipreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/bigipreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -15,6 +15,13 @@ resourceMetrics:
           - description: Availability of the virtual server.
             gauge:
               dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "0"
                   attributes:
                     - key: status
@@ -27,13 +34,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.virtual_server.availability
@@ -137,6 +137,13 @@ resourceMetrics:
           - description: Availability of the virtual server.
             gauge:
               dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "0"
                   attributes:
                     - key: status
@@ -149,13 +156,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.virtual_server.availability
@@ -263,6 +263,13 @@ resourceMetrics:
                   attributes:
                     - key: status
                       value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
                         stringValue: offline
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
@@ -271,13 +278,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.virtual_server.availability
@@ -381,6 +381,13 @@ resourceMetrics:
           - description: Availability of the virtual server.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -393,13 +400,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.virtual_server.availability
@@ -497,6 +497,13 @@ resourceMetrics:
           - description: Availability of the pool.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -509,13 +516,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool.availability
@@ -633,6 +633,13 @@ resourceMetrics:
           - description: Availability of the pool.
             gauge:
               dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "0"
                   attributes:
                     - key: status
@@ -645,13 +652,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool.availability
@@ -775,6 +775,13 @@ resourceMetrics:
           - description: Availability of the pool member.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -787,13 +794,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool_member.availability
@@ -906,6 +906,13 @@ resourceMetrics:
           - description: Availability of the pool member.
             gauge:
               dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "0"
                   attributes:
                     - key: status
@@ -918,13 +925,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool_member.availability
@@ -1037,6 +1037,13 @@ resourceMetrics:
           - description: Availability of the pool member.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -1049,13 +1056,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool_member.availability
@@ -1168,6 +1168,13 @@ resourceMetrics:
           - description: Availability of the pool member.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -1180,13 +1187,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool_member.availability
@@ -1299,6 +1299,13 @@ resourceMetrics:
           - description: Availability of the pool member.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -1311,13 +1318,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool_member.availability
@@ -1431,6 +1431,13 @@ resourceMetrics:
                   attributes:
                     - key: status
                       value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
                         stringValue: offline
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
@@ -1439,13 +1446,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.node.availability
@@ -1559,6 +1559,13 @@ resourceMetrics:
                   attributes:
                     - key: status
                       value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
                         stringValue: offline
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
@@ -1567,13 +1574,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.node.availability
@@ -1687,6 +1687,13 @@ resourceMetrics:
                   attributes:
                     - key: status
                       value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
                         stringValue: offline
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
@@ -1695,13 +1702,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.node.availability
@@ -1815,6 +1815,13 @@ resourceMetrics:
                   attributes:
                     - key: status
                       value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
                         stringValue: offline
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
@@ -1823,13 +1830,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.node.availability
@@ -1939,6 +1939,13 @@ resourceMetrics:
           - description: Availability of the node.
             gauge:
               dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "0"
                   attributes:
                     - key: status
@@ -1951,13 +1958,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.node.availability

--- a/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_golden.yaml
+++ b/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_golden.yaml
@@ -15,6 +15,12 @@ resourceMetrics:
           - description: Availability of the virtual server.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  timeUnixNano: "1651783494931319000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -26,12 +32,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  timeUnixNano: "1651783494931319000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   timeUnixNano: "1651783494931319000"
             name: bigip.virtual_server.availability
             unit: "1"
@@ -126,6 +126,12 @@ resourceMetrics:
           - description: Availability of the virtual server.
             gauge:
               dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  timeUnixNano: "1651783494931319000"
                 - asInt: "0"
                   attributes:
                     - key: status
@@ -137,12 +143,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  timeUnixNano: "1651783494931319000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   timeUnixNano: "1651783494931319000"
             name: bigip.virtual_server.availability
             unit: "1"
@@ -237,6 +237,12 @@ resourceMetrics:
           - description: Availability of the virtual server.
             gauge:
               dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  timeUnixNano: "1651783494931319000"
                 - asInt: "0"
                   attributes:
                     - key: status
@@ -248,12 +254,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  timeUnixNano: "1651783494931319000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   timeUnixNano: "1651783494931319000"
             name: bigip.virtual_server.availability
             unit: "1"
@@ -352,6 +352,12 @@ resourceMetrics:
                   attributes:
                     - key: status
                       value:
+                        stringValue: available
+                  timeUnixNano: "1651783494931319000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
                         stringValue: offline
                   timeUnixNano: "1651783494931319000"
                 - asInt: "1"
@@ -359,12 +365,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  timeUnixNano: "1651783494931319000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   timeUnixNano: "1651783494931319000"
             name: bigip.virtual_server.availability
             unit: "1"

--- a/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_with_members_golden.yaml
+++ b/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_with_members_golden.yaml
@@ -15,6 +15,12 @@ resourceMetrics:
           - description: Availability of the virtual server.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  timeUnixNano: "1651783494931319000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -26,12 +32,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  timeUnixNano: "1651783494931319000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   timeUnixNano: "1651783494931319000"
             name: bigip.virtual_server.availability
             unit: "1"
@@ -126,6 +126,12 @@ resourceMetrics:
           - description: Availability of the virtual server.
             gauge:
               dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  timeUnixNano: "1651783494931319000"
                 - asInt: "0"
                   attributes:
                     - key: status
@@ -137,12 +143,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  timeUnixNano: "1651783494931319000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   timeUnixNano: "1651783494931319000"
             name: bigip.virtual_server.availability
             unit: "1"
@@ -237,6 +237,12 @@ resourceMetrics:
           - description: Availability of the virtual server.
             gauge:
               dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  timeUnixNano: "1651783494931319000"
                 - asInt: "0"
                   attributes:
                     - key: status
@@ -248,12 +254,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  timeUnixNano: "1651783494931319000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   timeUnixNano: "1651783494931319000"
             name: bigip.virtual_server.availability
             unit: "1"
@@ -352,6 +352,12 @@ resourceMetrics:
                   attributes:
                     - key: status
                       value:
+                        stringValue: available
+                  timeUnixNano: "1651783494931319000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
                         stringValue: offline
                   timeUnixNano: "1651783494931319000"
                 - asInt: "1"
@@ -359,12 +365,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  timeUnixNano: "1651783494931319000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   timeUnixNano: "1651783494931319000"
             name: bigip.virtual_server.availability
             unit: "1"
@@ -459,6 +459,13 @@ resourceMetrics:
           - description: Availability of the pool member.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -471,13 +478,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool_member.availability
@@ -590,6 +590,13 @@ resourceMetrics:
           - description: Availability of the pool member.
             gauge:
               dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "0"
                   attributes:
                     - key: status
@@ -602,13 +609,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool_member.availability
@@ -721,6 +721,13 @@ resourceMetrics:
           - description: Availability of the pool member.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -733,13 +740,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool_member.availability
@@ -852,6 +852,13 @@ resourceMetrics:
           - description: Availability of the pool member.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -864,13 +871,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool_member.availability
@@ -983,6 +983,13 @@ resourceMetrics:
           - description: Availability of the pool member.
             gauge:
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
                 - asInt: "1"
                   attributes:
                     - key: status
@@ -995,13 +1002,6 @@ resourceMetrics:
                     - key: status
                       value:
                         stringValue: unknown
-                  startTimeUnixNano: "1651783208655196000"
-                  timeUnixNano: "1651783208656862000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: available
                   startTimeUnixNano: "1651783208655196000"
                   timeUnixNano: "1651783208656862000"
             name: bigip.pool_member.availability

--- a/receiver/dockerstatsreceiver/receiver_test.go
+++ b/receiver/dockerstatsreceiver/receiver_test.go
@@ -252,7 +252,7 @@ func TestScrapeV2(t *testing.T) {
 			expectedMetrics, err := golden.ReadMetrics(tc.expectedMetricsFile)
 
 			assert.NoError(t, err)
-			assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+			assert.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricDataPointsOrder(),
 				pmetrictest.IgnoreResourceMetricsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 		})
 	}

--- a/receiver/dockerstatsreceiver/testdata/mock/no_pids_stats/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/no_pids_stats/expected_metrics.yaml
@@ -30,45 +30,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2502656"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1683723817610618000"
-                  timeUnixNano: "1683723817613281000"
-                - asInt: "0"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1683723817610618000"
-                  timeUnixNano: "1683723817613281000"
-                - asInt: "2502656"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1683723817610618000"
-                  timeUnixNano: "1683723817613281000"
                 - asInt: "0"
                   attributes:
                     - key: device_major
@@ -105,7 +66,46 @@ resourceMetrics:
                         stringValue: "0"
                     - key: operation
                       value:
+                        stringValue: read
+                  startTimeUnixNano: "1683723817610618000"
+                  timeUnixNano: "1683723817613281000"
+                - asInt: "2502656"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1683723817610618000"
+                  timeUnixNano: "1683723817613281000"
+                - asInt: "2502656"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
                         stringValue: total
+                  startTimeUnixNano: "1683723817610618000"
+                  timeUnixNano: "1683723817613281000"
+                - asInt: "0"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: write
                   startTimeUnixNano: "1683723817610618000"
                   timeUnixNano: "1683723817613281000"
               isMonotonic: true
@@ -115,45 +115,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "99"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1683723817610618000"
-                  timeUnixNano: "1683723817613281000"
-                - asInt: "0"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1683723817610618000"
-                  timeUnixNano: "1683723817613281000"
-                - asInt: "99"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1683723817610618000"
-                  timeUnixNano: "1683723817613281000"
                 - asInt: "0"
                   attributes:
                     - key: device_major
@@ -190,7 +151,46 @@ resourceMetrics:
                         stringValue: "0"
                     - key: operation
                       value:
+                        stringValue: read
+                  startTimeUnixNano: "1683723817610618000"
+                  timeUnixNano: "1683723817613281000"
+                - asInt: "99"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1683723817610618000"
+                  timeUnixNano: "1683723817613281000"
+                - asInt: "99"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
                         stringValue: total
+                  startTimeUnixNano: "1683723817610618000"
+                  timeUnixNano: "1683723817613281000"
+                - asInt: "0"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: write
                   startTimeUnixNano: "1683723817610618000"
                   timeUnixNano: "1683723817613281000"
               isMonotonic: true

--- a/receiver/dockerstatsreceiver/testdata/mock/pids_stats_max/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/pids_stats_max/expected_metrics.yaml
@@ -28,32 +28,6 @@ resourceMetrics:
                   attributes:
                     - key: device_major
                       value:
-                        stringValue: "7"
-                    - key: device_minor
-                      value:
-                        stringValue: "2"
-                    - key: operation
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1683723781127718000"
-                  timeUnixNano: "1683723781130612000"
-                - asInt: "0"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "7"
-                    - key: device_minor
-                      value:
-                        stringValue: "2"
-                    - key: operation
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1683723781127718000"
-                  timeUnixNano: "1683723781130612000"
-                - asInt: "1998848"
-                  attributes:
-                    - key: device_major
-                      value:
                         stringValue: "253"
                     - key: device_minor
                       value:
@@ -94,6 +68,32 @@ resourceMetrics:
                     - key: device_major
                       value:
                         stringValue: "253"
+                    - key: device_minor
+                      value:
+                        stringValue: "2"
+                    - key: operation
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1683723781127718000"
+                  timeUnixNano: "1683723781130612000"
+                - asInt: "1998848"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "7"
+                    - key: device_minor
+                      value:
+                        stringValue: "2"
+                    - key: operation
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1683723781127718000"
+                  timeUnixNano: "1683723781130612000"
+                - asInt: "0"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "7"
                     - key: device_minor
                       value:
                         stringValue: "2"

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
@@ -36,45 +36,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2502656"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1661128093793004000"
-                  timeUnixNano: "1661128093795620000"
-                - asInt: "0"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1661128093793004000"
-                  timeUnixNano: "1661128093795620000"
-                - asInt: "2502656"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1661128093793004000"
-                  timeUnixNano: "1661128093795620000"
                 - asInt: "0"
                   attributes:
                     - key: device_major
@@ -111,7 +72,46 @@ resourceMetrics:
                         stringValue: "0"
                     - key: operation
                       value:
+                        stringValue: read
+                  startTimeUnixNano: "1661128093793004000"
+                  timeUnixNano: "1661128093795620000"
+                - asInt: "2502656"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1661128093793004000"
+                  timeUnixNano: "1661128093795620000"
+                - asInt: "2502656"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
                         stringValue: total
+                  startTimeUnixNano: "1661128093793004000"
+                  timeUnixNano: "1661128093795620000"
+                - asInt: "0"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: write
                   startTimeUnixNano: "1661128093793004000"
                   timeUnixNano: "1661128093795620000"
               isMonotonic: true
@@ -121,45 +121,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "99"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1661128093793004000"
-                  timeUnixNano: "1661128093795620000"
-                - asInt: "0"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1661128093793004000"
-                  timeUnixNano: "1661128093795620000"
-                - asInt: "99"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "254"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1661128093793004000"
-                  timeUnixNano: "1661128093795620000"
                 - asInt: "0"
                   attributes:
                     - key: device_major
@@ -196,7 +157,46 @@ resourceMetrics:
                         stringValue: "0"
                     - key: operation
                       value:
+                        stringValue: read
+                  startTimeUnixNano: "1661128093793004000"
+                  timeUnixNano: "1661128093795620000"
+                - asInt: "99"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1661128093793004000"
+                  timeUnixNano: "1661128093795620000"
+                - asInt: "99"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
                         stringValue: total
+                  startTimeUnixNano: "1661128093793004000"
+                  timeUnixNano: "1661128093795620000"
+                - asInt: "0"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "254"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: write
                   startTimeUnixNano: "1661128093793004000"
                   timeUnixNano: "1661128093795620000"
               isMonotonic: true

--- a/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.yaml
@@ -30,45 +30,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "73728"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
-                - asInt: "0"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
-                - asInt: "73728"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
                 - asInt: "0"
                   attributes:
                     - key: device_major
@@ -105,7 +66,46 @@ resourceMetrics:
                         stringValue: "0"
                     - key: operation
                       value:
+                        stringValue: read
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "73728"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "73728"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
                         stringValue: total
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "0"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: write
                   startTimeUnixNano: "1661128790156624000"
                   timeUnixNano: "1661128790158163000"
               isMonotonic: true
@@ -115,45 +115,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
-                - asInt: "0"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
-                - asInt: "1"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
                 - asInt: "0"
                   attributes:
                     - key: device_major
@@ -190,7 +151,46 @@ resourceMetrics:
                         stringValue: "0"
                     - key: operation
                       value:
+                        stringValue: read
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "1"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "1"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
                         stringValue: total
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "0"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: write
                   startTimeUnixNano: "1661128790156624000"
                   timeUnixNano: "1661128790158163000"
               isMonotonic: true
@@ -719,45 +719,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1187840"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
-                - asInt: "0"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
-                - asInt: "1187840"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
                 - asInt: "0"
                   attributes:
                     - key: device_major
@@ -794,7 +755,46 @@ resourceMetrics:
                         stringValue: "0"
                     - key: operation
                       value:
+                        stringValue: read
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "1187840"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "1187840"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
                         stringValue: total
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "0"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: write
                   startTimeUnixNano: "1661128790156624000"
                   timeUnixNano: "1661128790158163000"
               isMonotonic: true
@@ -804,45 +804,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "19"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
-                - asInt: "0"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
-                - asInt: "19"
-                  attributes:
-                    - key: device_major
-                      value:
-                        stringValue: "8"
-                    - key: device_minor
-                      value:
-                        stringValue: "0"
-                    - key: operation
-                      value:
-                        stringValue: sync
-                  startTimeUnixNano: "1661128790156624000"
-                  timeUnixNano: "1661128790158163000"
                 - asInt: "0"
                   attributes:
                     - key: device_major
@@ -879,7 +840,46 @@ resourceMetrics:
                         stringValue: "0"
                     - key: operation
                       value:
+                        stringValue: read
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "19"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "19"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
                         stringValue: total
+                  startTimeUnixNano: "1661128790156624000"
+                  timeUnixNano: "1661128790158163000"
+                - asInt: "0"
+                  attributes:
+                    - key: device_major
+                      value:
+                        stringValue: "8"
+                    - key: device_minor
+                      value:
+                        stringValue: "0"
+                    - key: operation
+                      value:
+                        stringValue: write
                   startTimeUnixNano: "1661128790156624000"
                   timeUnixNano: "1661128790158163000"
               isMonotonic: true

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.yaml
@@ -15,18 +15,11 @@ resourceMetrics:
           - description: Estimated memory used for the operation.
             gauge:
               dataPoints:
-                - asInt: "305152000"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: parent
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
-                        stringValue: request
+                        stringValue: accounting
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "0"
@@ -50,11 +43,18 @@ resourceMetrics:
                         stringValue: model_inference
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
+                - asInt: "305152000"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: parent
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
-                        stringValue: accounting
+                        stringValue: request
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
             name: elasticsearch.breaker.memory.estimated
@@ -64,18 +64,11 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "510027366"
+                - asInt: "536870912"
                   attributes:
                     - key: name
                       value:
-                        stringValue: parent
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "322122547"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: request
+                        stringValue: accounting
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "214748364"
@@ -99,11 +92,18 @@ resourceMetrics:
                         stringValue: model_inference
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
-                - asInt: "536870912"
+                - asInt: "510027366"
                   attributes:
                     - key: name
                       value:
-                        stringValue: accounting
+                        stringValue: parent
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "322122547"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: request
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
             unit: By
@@ -116,14 +116,7 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: parent
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: request
+                        stringValue: accounting
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "0"
@@ -151,7 +144,14 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: accounting
+                        stringValue: parent
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: request
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
               isMonotonic: true
@@ -210,11 +210,11 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4"
+                - asInt: "0"
                   attributes:
                     - key: state
                       value:
-                        stringValue: unchanged
+                        stringValue: failure
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "7"
@@ -224,11 +224,11 @@ resourceMetrics:
                         stringValue: success
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
-                - asInt: "0"
+                - asInt: "4"
                   attributes:
                     - key: state
                       value:
-                        stringValue: failure
+                        stringValue: unchanged
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
               isMonotonic: true
@@ -238,54 +238,64 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "7"
+                - asInt: "0"
                   attributes:
                     - key: state
                       value:
-                        stringValue: unchanged
+                        stringValue: failure
+                    - key: type
+                      value:
+                        stringValue: commit
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: failure
+                    - key: type
+                      value:
+                        stringValue: completion
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: failure
                     - key: type
                       value:
                         stringValue: computation
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
-                - asInt: "1"
+                - asInt: "0"
                   attributes:
                     - key: state
                       value:
-                        stringValue: unchanged
-                    - key: type
-                      value:
-                        stringValue: notification
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "40"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
-                    - key: type
-                      value:
-                        stringValue: computation
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "2"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
-                    - key: type
-                      value:
-                        stringValue: notification
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "17"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
+                        stringValue: failure
                     - key: type
                       value:
                         stringValue: context_construction
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: failure
+                    - key: type
+                      value:
+                        stringValue: master_apply
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: failure
+                    - key: type
+                      value:
+                        stringValue: notification
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "113"
@@ -308,6 +318,26 @@ resourceMetrics:
                         stringValue: completion
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
+                - asInt: "40"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: computation
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "17"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: context_construction
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
                 - asInt: "484"
                   attributes:
                     - key: state
@@ -318,64 +348,34 @@ resourceMetrics:
                         stringValue: master_apply
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
-                - asInt: "0"
+                - asInt: "2"
                   attributes:
                     - key: state
                       value:
-                        stringValue: failure
-                    - key: type
-                      value:
-                        stringValue: computation
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: failure
+                        stringValue: success
                     - key: type
                       value:
                         stringValue: notification
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
-                - asInt: "0"
+                - asInt: "7"
                   attributes:
                     - key: state
                       value:
-                        stringValue: failure
+                        stringValue: unchanged
                     - key: type
                       value:
-                        stringValue: context_construction
+                        stringValue: computation
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
-                - asInt: "0"
+                - asInt: "1"
                   attributes:
                     - key: state
                       value:
-                        stringValue: failure
+                        stringValue: unchanged
                     - key: type
                       value:
-                        stringValue: commit
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: failure
-                    - key: type
-                      value:
-                        stringValue: completion
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: failure
-                    - key: type
-                      value:
-                        stringValue: master_apply
+                        stringValue: notification
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
               isMonotonic: true
@@ -417,14 +417,14 @@ resourceMetrics:
                   attributes:
                     - key: stage
                       value:
-                        stringValue: primary
+                        stringValue: coordinating
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "0"
                   attributes:
                     - key: stage
                       value:
-                        stringValue: coordinating
+                        stringValue: primary
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "0"
@@ -643,18 +643,25 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "200"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
                 - asInt: "400"
                   attributes:
                     - key: operation
                       value:
                         stringValue: delete
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "234"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "345"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "600"
@@ -664,6 +671,20 @@ resourceMetrics:
                         stringValue: get
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
+                - asInt: "200"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "5234"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
                 - asInt: "124"
                   attributes:
                     - key: operation
@@ -671,11 +692,11 @@ resourceMetrics:
                         stringValue: query
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
-                - asInt: "234"
+                - asInt: "958"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: fetch
+                        stringValue: refresh
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "235"
@@ -692,27 +713,6 @@ resourceMetrics:
                         stringValue: suggest
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
-                - asInt: "5234"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "958"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "345"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
                 - asInt: "0"
                   attributes:
                     - key: operation
@@ -727,18 +727,25 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "300"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
                 - asInt: "500"
                   attributes:
                     - key: operation
                       value:
                         stringValue: delete
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "256"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "995"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "500"
@@ -748,6 +755,20 @@ resourceMetrics:
                         stringValue: get
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
+                - asInt: "300"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "25345"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
                 - asInt: "2354"
                   attributes:
                     - key: operation
@@ -755,11 +776,11 @@ resourceMetrics:
                         stringValue: query
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
-                - asInt: "256"
+                - asInt: "544"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: fetch
+                        stringValue: refresh
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "5234"
@@ -774,27 +795,6 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "25345"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "544"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
-                - asInt: "995"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "664"
@@ -1052,18 +1052,18 @@ resourceMetrics:
           - description: Amount of physical memory.
             gauge:
               dataPoints:
-                - asInt: "779632640"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
                 - asInt: "294109184"
                   attributes:
                     - key: state
                       value:
                         stringValue: free
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "779632640"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: used
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
             name: elasticsearch.os.memory
@@ -1081,18 +1081,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "20"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
                 - asInt: "10"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "20"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
               isMonotonic: true
@@ -1102,18 +1102,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "930"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1661811026803971000"
-                  timeUnixNano: "1661811026805343000"
                 - asInt: "5"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
+                  startTimeUnixNano: "1661811026803971000"
+                  timeUnixNano: "1661811026805343000"
+                - asInt: "930"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
               isMonotonic: true
@@ -1161,11 +1161,11 @@ resourceMetrics:
           - description: The maximum amount of memory can be used for the memory pool
             gauge:
               dataPoints:
-                - asInt: "636870912"
+                - asInt: "536870912"
                   attributes:
                     - key: name
                       value:
-                        stringValue: young
+                        stringValue: old
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "736870912"
@@ -1175,11 +1175,11 @@ resourceMetrics:
                         stringValue: survivor
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
-                - asInt: "536870912"
+                - asInt: "636870912"
                   attributes:
                     - key: name
                       value:
-                        stringValue: old
+                        stringValue: young
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
             name: jvm.memory.pool.max
@@ -1187,11 +1187,11 @@ resourceMetrics:
           - description: The current memory pool memory usage
             gauge:
               dataPoints:
-                - asInt: "218103808"
+                - asInt: "76562432"
                   attributes:
                     - key: name
                       value:
-                        stringValue: young
+                        stringValue: old
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
                 - asInt: "10485760"
@@ -1201,11 +1201,11 @@ resourceMetrics:
                         stringValue: survivor
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
-                - asInt: "76562432"
+                - asInt: "218103808"
                   attributes:
                     - key: name
                       value:
-                        stringValue: old
+                        stringValue: young
                   startTimeUnixNano: "1661811026803971000"
                   timeUnixNano: "1661811026805343000"
             name: jvm.memory.pool.used
@@ -1236,61 +1236,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -1300,107 +1330,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -1410,47 +1440,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer
@@ -1463,71 +1463,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -1537,107 +1557,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -1647,37 +1667,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer
@@ -1716,61 +1716,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -1780,107 +1810,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -1890,47 +1920,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer
@@ -1943,71 +1943,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -2017,107 +2037,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -2127,37 +2147,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.yaml
@@ -64,13 +64,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "510027366"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: parent
-                  startTimeUnixNano: "1662950372948795000"
-                  timeUnixNano: "1662950372950468000"
                 - asInt: "322122547"
                   attributes:
                     - key: name
@@ -106,6 +99,13 @@ resourceMetrics:
                         stringValue: accounting
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "510027366"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: parent
+                  startTimeUnixNano: "1662950372948795000"
+                  timeUnixNano: "1662950372950468000"
             unit: By
           - description: Total number of times the circuit breaker has been triggered and prevented an out of memory error.
             name: elasticsearch.breaker.tripped

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full.yaml
@@ -19,7 +19,7 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: request
+                        stringValue: accounting
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "0"
@@ -43,18 +43,18 @@ resourceMetrics:
                         stringValue: model_inference
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: accounting
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "305152000"
                   attributes:
                     - key: name
                       value:
                         stringValue: parent
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: request
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             name: elasticsearch.breaker.memory.estimated
@@ -64,11 +64,11 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "322122547"
+                - asInt: "536870912"
                   attributes:
                     - key: name
                       value:
-                        stringValue: request
+                        stringValue: accounting
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "214748364"
@@ -92,13 +92,6 @@ resourceMetrics:
                         stringValue: model_inference
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "536870912"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: accounting
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "510027366"
                   attributes:
                     - key: name
@@ -106,6 +99,13 @@ resourceMetrics:
                         stringValue: parent
                   startTimeUnixNano: "1662950372948795000"
                   timeUnixNano: "1662950372950468000"
+                - asInt: "322122547"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: request
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
             unit: By
           - description: Total number of times the circuit breaker has been triggered and prevented an out of memory error.
             name: elasticsearch.breaker.tripped
@@ -116,7 +116,7 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: request
+                        stringValue: accounting
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "0"
@@ -144,14 +144,14 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: accounting
+                        stringValue: parent
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
-                        stringValue: parent
+                        stringValue: request
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
               isMonotonic: true
@@ -210,11 +210,11 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4"
+                - asInt: "0"
                   attributes:
                     - key: state
                       value:
-                        stringValue: unchanged
+                        stringValue: failure
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "7"
@@ -224,11 +224,11 @@ resourceMetrics:
                         stringValue: success
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "0"
+                - asInt: "4"
                   attributes:
                     - key: state
                       value:
-                        stringValue: failure
+                        stringValue: unchanged
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
               isMonotonic: true
@@ -238,54 +238,64 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "7"
+                - asInt: "0"
                   attributes:
                     - key: state
                       value:
-                        stringValue: unchanged
+                        stringValue: failure
+                    - key: type
+                      value:
+                        stringValue: commit
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: failure
+                    - key: type
+                      value:
+                        stringValue: completion
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: failure
                     - key: type
                       value:
                         stringValue: computation
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "1"
+                - asInt: "0"
                   attributes:
                     - key: state
                       value:
-                        stringValue: unchanged
-                    - key: type
-                      value:
-                        stringValue: notification
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
-                    - key: type
-                      value:
-                        stringValue: computation
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
-                    - key: type
-                      value:
-                        stringValue: notification
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "17"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
+                        stringValue: failure
                     - key: type
                       value:
                         stringValue: context_construction
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: failure
+                    - key: type
+                      value:
+                        stringValue: master_apply
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: failure
+                    - key: type
+                      value:
+                        stringValue: notification
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "113"
@@ -308,6 +318,26 @@ resourceMetrics:
                         stringValue: completion
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: computation
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "17"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: context_construction
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "484"
                   attributes:
                     - key: state
@@ -318,64 +348,34 @@ resourceMetrics:
                         stringValue: master_apply
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "0"
+                - asInt: "2"
                   attributes:
                     - key: state
                       value:
-                        stringValue: failure
-                    - key: type
-                      value:
-                        stringValue: computation
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: failure
+                        stringValue: success
                     - key: type
                       value:
                         stringValue: notification
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "0"
+                - asInt: "7"
                   attributes:
                     - key: state
                       value:
-                        stringValue: failure
+                        stringValue: unchanged
                     - key: type
                       value:
-                        stringValue: context_construction
+                        stringValue: computation
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "0"
+                - asInt: "1"
                   attributes:
                     - key: state
                       value:
-                        stringValue: failure
+                        stringValue: unchanged
                     - key: type
                       value:
-                        stringValue: commit
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: failure
-                    - key: type
-                      value:
-                        stringValue: completion
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: failure
-                    - key: type
-                      value:
-                        stringValue: master_apply
+                        stringValue: notification
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
               isMonotonic: true
@@ -417,14 +417,14 @@ resourceMetrics:
                   attributes:
                     - key: stage
                       value:
-                        stringValue: primary
+                        stringValue: coordinating
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "0"
                   attributes:
                     - key: stage
                       value:
-                        stringValue: coordinating
+                        stringValue: primary
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "0"
@@ -652,18 +652,25 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "200"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "400"
                   attributes:
                     - key: operation
                       value:
                         stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "234"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "345"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "600"
@@ -673,6 +680,20 @@ resourceMetrics:
                         stringValue: get
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "200"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "5234"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "124"
                   attributes:
                     - key: operation
@@ -680,11 +701,11 @@ resourceMetrics:
                         stringValue: query
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "234"
+                - asInt: "958"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: fetch
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "235"
@@ -699,27 +720,6 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "5234"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "958"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "345"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "0"
@@ -790,18 +790,25 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "300"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "500"
                   attributes:
                     - key: operation
                       value:
                         stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "256"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "995"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "500"
@@ -811,6 +818,20 @@ resourceMetrics:
                         stringValue: get
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "300"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "25345"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "2354"
                   attributes:
                     - key: operation
@@ -818,11 +839,11 @@ resourceMetrics:
                         stringValue: query
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "256"
+                - asInt: "544"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: fetch
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "5234"
@@ -837,27 +858,6 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "25345"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "544"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "995"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "664"
@@ -878,14 +878,14 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: xpack_monitoring_7
+                        stringValue: xpack_monitoring_6
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
-                        stringValue: xpack_monitoring_6
+                        stringValue: xpack_monitoring_7
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             unit: '{documents}'
@@ -898,14 +898,14 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: xpack_monitoring_7
+                        stringValue: xpack_monitoring_6
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
-                        stringValue: xpack_monitoring_6
+                        stringValue: xpack_monitoring_7
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             unit: '{documents}'
@@ -918,14 +918,14 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: xpack_monitoring_7
+                        stringValue: xpack_monitoring_6
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
-                        stringValue: xpack_monitoring_6
+                        stringValue: xpack_monitoring_7
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
               isMonotonic: true
@@ -1149,18 +1149,18 @@ resourceMetrics:
           - description: Amount of physical memory.
             gauge:
               dataPoints:
-                - asInt: "779632640"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "294109184"
                   attributes:
                     - key: state
                       value:
                         stringValue: free
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "779632640"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: used
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             name: elasticsearch.os.memory
@@ -1205,18 +1205,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "20"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "10"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "20"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
               isMonotonic: true
@@ -1226,18 +1226,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "930"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "5"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "930"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
               isMonotonic: true
@@ -1293,11 +1293,11 @@ resourceMetrics:
           - description: The maximum amount of memory can be used for the memory pool
             gauge:
               dataPoints:
-                - asInt: "636870912"
+                - asInt: "536870912"
                   attributes:
                     - key: name
                       value:
-                        stringValue: young
+                        stringValue: old
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "736870912"
@@ -1307,11 +1307,11 @@ resourceMetrics:
                         stringValue: survivor
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "536870912"
+                - asInt: "636870912"
                   attributes:
                     - key: name
                       value:
-                        stringValue: old
+                        stringValue: young
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             name: jvm.memory.pool.max
@@ -1319,11 +1319,11 @@ resourceMetrics:
           - description: The current memory pool memory usage
             gauge:
               dataPoints:
-                - asInt: "218103808"
+                - asInt: "76562432"
                   attributes:
                     - key: name
                       value:
-                        stringValue: young
+                        stringValue: old
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "10485760"
@@ -1333,11 +1333,11 @@ resourceMetrics:
                         stringValue: survivor
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "76562432"
+                - asInt: "218103808"
                   attributes:
                     - key: name
                       value:
-                        stringValue: old
+                        stringValue: young
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             name: jvm.memory.pool.used
@@ -1381,18 +1381,18 @@ resourceMetrics:
                         stringValue: green
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: yellow
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "0"
                   attributes:
                     - key: status
                       value:
                         stringValue: red
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: yellow
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             unit: '{status}'
@@ -1456,6 +1456,13 @@ resourceMetrics:
                         stringValue: active
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "23"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active_primary
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "2"
                   attributes:
                     - key: state
@@ -1475,13 +1482,6 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: unassigned
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "23"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: active_primary
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "1"
@@ -1555,16 +1555,6 @@ resourceMetrics:
                         stringValue: fielddata
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: cache_name
-                      value:
-                        stringValue: fielddata
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "12"
                   attributes:
                     - key: aggregation
@@ -1573,6 +1563,16 @@ resourceMetrics:
                     - key: cache_name
                       value:
                         stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "3"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: cache_name
+                      value:
+                        stringValue: fielddata
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "12"
@@ -1615,7 +1615,7 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: state
                       value:
                         stringValue: active
@@ -1625,7 +1625,7 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: state
                       value:
                         stringValue: active
@@ -1637,61 +1637,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -1701,107 +1731,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -1811,47 +1841,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer
@@ -1892,71 +1892,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -1966,107 +1986,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -2076,37 +2096,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer
@@ -2123,14 +2123,14 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "5"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             unit: '{segments}'
@@ -2139,44 +2139,34 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2560"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: object
-                      value:
-                        stringValue: term
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "380"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: object
                       value:
                         stringValue: doc_value
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "37"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: object
-                      value:
-                        stringValue: index_writer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "21"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: object
                       value:
                         stringValue: fixed_bit_set
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "37"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: object
+                      value:
+                        stringValue: index_writer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "2560"
@@ -2193,30 +2183,40 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: object
                       value:
                         stringValue: doc_value
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "37"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: object
-                      value:
-                        stringValue: index_writer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "21"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: object
                       value:
                         stringValue: fixed_bit_set
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "37"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: object
+                      value:
+                        stringValue: index_writer
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "2560"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: object
+                      value:
+                        stringValue: term
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             unit: By
@@ -2229,14 +2229,14 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "5460"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             unit: By
@@ -2335,16 +2335,6 @@ resourceMetrics:
                         stringValue: fielddata
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: cache_name
-                      value:
-                        stringValue: fielddata
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "12"
                   attributes:
                     - key: aggregation
@@ -2353,6 +2343,16 @@ resourceMetrics:
                     - key: cache_name
                       value:
                         stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "3"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: cache_name
+                      value:
+                        stringValue: fielddata
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "12"
@@ -2395,7 +2395,7 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: state
                       value:
                         stringValue: active
@@ -2405,7 +2405,7 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: state
                       value:
                         stringValue: active
@@ -2417,61 +2417,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -2481,107 +2511,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -2591,47 +2621,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer
@@ -2672,71 +2672,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -2746,107 +2766,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -2856,37 +2876,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer
@@ -2903,14 +2903,14 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "5"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             unit: '{segments}'
@@ -2919,44 +2919,34 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2560"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: object
-                      value:
-                        stringValue: term
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "380"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: object
                       value:
                         stringValue: doc_value
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "37"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: object
-                      value:
-                        stringValue: index_writer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "21"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: object
                       value:
                         stringValue: fixed_bit_set
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "37"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: object
+                      value:
+                        stringValue: index_writer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "2560"
@@ -2973,30 +2963,40 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: object
                       value:
                         stringValue: doc_value
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "37"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: object
-                      value:
-                        stringValue: index_writer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "21"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: object
                       value:
                         stringValue: fixed_bit_set
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "37"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: object
+                      value:
+                        stringValue: index_writer
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "2560"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: object
+                      value:
+                        stringValue: term
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             unit: By
@@ -3009,14 +3009,14 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "5460"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
             unit: By

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
@@ -74,6 +74,20 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "23"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active_primary
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: unassigned_delayed
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "45"
                   attributes:
                     - key: state
@@ -102,20 +116,6 @@ resourceMetrics:
                         stringValue: unassigned
                   startTimeUnixNano: "1662458370557980000"
                   timeUnixNano: "1662458370559258000"
-                - asInt: "23"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: active_primary
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "1"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: unassigned_delayed
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
             unit: '{shards}'
         scope:
           name: otelcol/elasticsearchreceiver

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
@@ -27,18 +27,18 @@ resourceMetrics:
                         stringValue: green
                   startTimeUnixNano: "1662458370557980000"
                   timeUnixNano: "1662458370559258000"
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: yellow
-                  startTimeUnixNano: "1662458370557980000"
-                  timeUnixNano: "1662458370559258000"
                 - asInt: "0"
                   attributes:
                     - key: status
                       value:
                         stringValue: red
+                  startTimeUnixNano: "1662458370557980000"
+                  timeUnixNano: "1662458370559258000"
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: yellow
                   startTimeUnixNano: "1662458370557980000"
                   timeUnixNano: "1662458370559258000"
             unit: '{status}'
@@ -74,20 +74,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "23"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: active_primary
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "1"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: unassigned_delayed
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
                 - asInt: "45"
                   attributes:
                     - key: state
@@ -95,6 +81,13 @@ resourceMetrics:
                         stringValue: active
                   startTimeUnixNano: "1662458370557980000"
                   timeUnixNano: "1662458370559258000"
+                - asInt: "23"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active_primary
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "2"
                   attributes:
                     - key: state
@@ -116,6 +109,13 @@ resourceMetrics:
                         stringValue: unassigned
                   startTimeUnixNano: "1662458370557980000"
                   timeUnixNano: "1662458370559258000"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: unassigned_delayed
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
             unit: '{shards}'
         scope:
           name: otelcol/elasticsearchreceiver
@@ -135,61 +135,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -199,107 +229,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -309,47 +339,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer
@@ -362,71 +362,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -436,107 +456,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -546,37 +566,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer
@@ -615,61 +615,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -679,107 +709,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "43"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "43"
+                - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "13"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "8"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "43"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "10"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -789,47 +819,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "6"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer
@@ -842,71 +842,91 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: scroll
@@ -916,107 +936,107 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: total
+                        stringValue: primary_shards
                     - key: operation
                       value:
                         stringValue: warmer
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
+                - asInt: "2"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
                 - asInt: "82"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: fetch
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
-                - asInt: "52"
+                - asInt: "192"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: delete
+                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "3"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: get
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "938"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "12"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "52"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1661811689941624000"
+                  timeUnixNano: "1661811689943245000"
+                - asInt: "169"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "30"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: scroll
@@ -1026,37 +1046,17 @@ resourceMetrics:
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: suggest
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                    - key: operation
-                      value:
-                        stringValue: flush
                   startTimeUnixNano: "1661811689941624000"
                   timeUnixNano: "1661811689943245000"
                 - asInt: "4"
                   attributes:
                     - key: aggregation
                       value:
-                        stringValue: primary_shards
+                        stringValue: total
                     - key: operation
                       value:
                         stringValue: warmer

--- a/receiver/memcachedreceiver/testdata/scraper/expected.yaml
+++ b/receiver/memcachedreceiver/testdata/scraper/expected.yaml
@@ -14,17 +14,17 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1114"
-                  attributes:
-                    - key: command
-                      value:
-                        stringValue: touch
-                  timeUnixNano: "1639770622333015000"
                 - asInt: "1110"
                   attributes:
                     - key: command
                       value:
                         stringValue: flush
+                  timeUnixNano: "1639770622333015000"
+                - asInt: "1111"
+                  attributes:
+                    - key: command
+                      value:
+                        stringValue: get
                   timeUnixNano: "1639770622333015000"
                 - asInt: "1113"
                   attributes:
@@ -32,11 +32,11 @@ resourceMetrics:
                       value:
                         stringValue: set
                   timeUnixNano: "1639770622333015000"
-                - asInt: "1111"
+                - asInt: "1114"
                   attributes:
                     - key: command
                       value:
-                        stringValue: get
+                        stringValue: touch
                   timeUnixNano: "1639770622333015000"
               isMonotonic: true
             unit: '{commands}'
@@ -115,12 +115,6 @@ resourceMetrics:
           - description: Hit ratio for operations, expressed as a percentage value between 0.0 and 100.0.
             gauge:
               dataPoints:
-                - asDouble: 50.0220361392684
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: increment
-                  timeUnixNano: "1639770622333015000"
                 - asDouble: 50.02233139794551
                   attributes:
                     - key: operation
@@ -133,6 +127,12 @@ resourceMetrics:
                       value:
                         stringValue: get
                   timeUnixNano: "1639770622333015000"
+                - asDouble: 50.0220361392684
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: increment
+                  timeUnixNano: "1639770622333015000"
             name: memcached.operation_hit_ratio
             unit: '%'
           - description: Operation counts.
@@ -140,42 +140,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1134"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: increment
-                    - key: type
-                      value:
-                        stringValue: hit
-                  timeUnixNano: "1639770622333015000"
-                - asInt: "1131"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: type
-                      value:
-                        stringValue: miss
-                  timeUnixNano: "1639770622333015000"
-                - asInt: "1135"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: increment
-                    - key: type
-                      value:
-                        stringValue: miss
-                  timeUnixNano: "1639770622333015000"
-                - asInt: "1130"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: type
-                      value:
-                        stringValue: hit
-                  timeUnixNano: "1639770622333015000"
                 - asInt: "1119"
                   attributes:
                     - key: operation
@@ -190,6 +154,42 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: decrement
+                    - key: type
+                      value:
+                        stringValue: miss
+                  timeUnixNano: "1639770622333015000"
+                - asInt: "1130"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: get
+                    - key: type
+                      value:
+                        stringValue: hit
+                  timeUnixNano: "1639770622333015000"
+                - asInt: "1131"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: get
+                    - key: type
+                      value:
+                        stringValue: miss
+                  timeUnixNano: "1639770622333015000"
+                - asInt: "1134"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: increment
+                    - key: type
+                      value:
+                        stringValue: hit
+                  timeUnixNano: "1639770622333015000"
+                - asInt: "1135"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: increment
                     - key: type
                       value:
                         stringValue: miss

--- a/receiver/mongodbreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mongodbreceiver/testdata/scraper/expected.yaml
@@ -7,18 +7,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "14"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: miss
-                  startTimeUnixNano: "1659372940162070000"
-                  timeUnixNano: "1659372940162165000"
                 - asInt: "201"
                   attributes:
                     - key: type
                       value:
                         stringValue: hit
+                  startTimeUnixNano: "1659372940162070000"
+                  timeUnixNano: "1659372940162165000"
+                - asInt: "14"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: miss
                   startTimeUnixNano: "1659372940162070000"
                   timeUnixNano: "1659372940162165000"
               isMonotonic: true
@@ -100,6 +100,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "20"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1659372940162070000"
+                  timeUnixNano: "1659372940162165000"
                 - asInt: "0"
                   attributes:
                     - key: operation
@@ -112,13 +119,6 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: getmore
-                  startTimeUnixNano: "1659372940162070000"
-                  timeUnixNano: "1659372940162165000"
-                - asInt: "20"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: command
                   startTimeUnixNano: "1659372940162070000"
                   timeUnixNano: "1659372940162165000"
                 - asInt: "0"
@@ -147,6 +147,13 @@ resourceMetrics:
           - description: The latency of operations.
             gauge:
               dataPoints:
+                - asInt: "8631"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1670911731284766000"
+                  timeUnixNano: "1670911731288585000"
                 - asInt: "0"
                   attributes:
                     - key: operation
@@ -161,13 +168,6 @@ resourceMetrics:
                         stringValue: write
                   startTimeUnixNano: "1670911731284766000"
                   timeUnixNano: "1670911731288585000"
-                - asInt: "8631"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: command
-                  startTimeUnixNano: "1670911731284766000"
-                  timeUnixNano: "1670911731288585000"
             name: mongodb.operation.latency.time
             unit: us
           - description: The number of replicated operations executed.
@@ -175,6 +175,27 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "27"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1670911805821119000"
+                  timeUnixNano: "1670911805825012000"
+                - asInt: "1"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1670911805821119000"
+                  timeUnixNano: "1670911805825012000"
+                - asInt: "2"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: getmore
+                  startTimeUnixNano: "1670911805821119000"
+                  timeUnixNano: "1670911805825012000"
                 - asInt: "3"
                   attributes:
                     - key: operation
@@ -194,27 +215,6 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1670911805821119000"
-                  timeUnixNano: "1670911805825012000"
-                - asInt: "1"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                  startTimeUnixNano: "1670911805821119000"
-                  timeUnixNano: "1670911805825012000"
-                - asInt: "2"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: getmore
-                  startTimeUnixNano: "1670911805821119000"
-                  timeUnixNano: "1670911805825012000"
-                - asInt: "27"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: command
                   startTimeUnixNano: "1670911805821119000"
                   timeUnixNano: "1670911805825012000"
               isMonotonic: true
@@ -249,6 +249,27 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "49340"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1659372940162070000"
+                  timeUnixNano: "1659372940162165000"
+                - asInt: "3750"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1659372940162070000"
+                  timeUnixNano: "1659372940162165000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: getmore
+                  startTimeUnixNano: "1659372940162070000"
+                  timeUnixNano: "1659372940162165000"
                 - asInt: "12465"
                   attributes:
                     - key: operation
@@ -268,27 +289,6 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1659372940162070000"
-                  timeUnixNano: "1659372940162165000"
-                - asInt: "3750"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                  startTimeUnixNano: "1659372940162070000"
-                  timeUnixNano: "1659372940162165000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: getmore
-                  startTimeUnixNano: "1659372940162070000"
-                  timeUnixNano: "1659372940162165000"
-                - asInt: "49340"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: command
                   startTimeUnixNano: "1659372940162070000"
                   timeUnixNano: "1659372940162165000"
               isMonotonic: true
@@ -370,6 +370,16 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: database
+                      value:
+                        stringValue: fakedatabase
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1659372940162070000"
+                  timeUnixNano: "1659372940162165000"
                 - asInt: "1"
                   attributes:
                     - key: database
@@ -388,16 +398,6 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
-                  startTimeUnixNano: "1659372940162070000"
-                  timeUnixNano: "1659372940162165000"
-                - asInt: "0"
-                  attributes:
-                    - key: database
-                      value:
-                        stringValue: fakedatabase
-                    - key: operation
-                      value:
-                        stringValue: delete
                   startTimeUnixNano: "1659372940162070000"
                   timeUnixNano: "1659372940162165000"
             unit: '{documents}'

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -1666,7 +1666,7 @@ resourceMetrics:
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
               isMonotonic: true
-            unit: "s"
+            unit: s
         scope:
           name: otelcol/mysqlreceiver
           version: latest

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -11,18 +11,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "228"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: dirty
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
                 - asInt: "2"
                   attributes:
                     - key: status
                       value:
                         stringValue: clean
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "228"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: dirty
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
             unit: "1"
@@ -40,6 +40,34 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "237"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: read_ahead
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "238"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: read_ahead_evicted
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "236"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: read_ahead_rnd
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "239"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: read_requests
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
                 - asInt: "240"
                   attributes:
                     - key: operation
@@ -54,39 +82,11 @@ resourceMetrics:
                         stringValue: wait_free
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
-                - asInt: "238"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: read_ahead_evicted
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "239"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: read_requests
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
                 - asInt: "242"
                   attributes:
                     - key: operation
                       value:
                         stringValue: write_requests
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "237"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: read_ahead
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "236"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: read_ahead_rnd
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
               isMonotonic: true
@@ -106,13 +106,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "234"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: misc
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
                 - asInt: "230"
                   attributes:
                     - key: kind
@@ -127,24 +120,31 @@ resourceMetrics:
                         stringValue: free
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
+                - asInt: "234"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: misc
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
             unit: "1"
           - description: The number of bytes in the InnoDB buffer pool.
             name: mysql.buffer_pool.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "229"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: dirty
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
                 - asInt: "2"
                   attributes:
                     - key: status
                       value:
                         stringValue: clean
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "229"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: dirty
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
             unit: By
@@ -289,27 +289,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "211"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: delete
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "213"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: external_lock
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "225"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: savepoint_rollback
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
                 - asInt: "200"
                   attributes:
                     - key: kind
@@ -317,11 +296,11 @@ resourceMetrics:
                         stringValue: commit
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
-                - asInt: "223"
+                - asInt: "211"
                   attributes:
                     - key: kind
                       value:
-                        stringValue: rollback
+                        stringValue: delete
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
                 - asInt: "212"
@@ -331,53 +310,18 @@ resourceMetrics:
                         stringValue: discover
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
+                - asInt: "213"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: external_lock
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
                 - asInt: "214"
                   attributes:
                     - key: kind
                       value:
                         stringValue: mrr_init
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "217"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: read_key
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "222"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: read_rnd_next
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "219"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: read_next
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "226"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: update
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "216"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: read_first
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "224"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: savepoint
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
                 - asInt: "215"
@@ -387,18 +331,18 @@ resourceMetrics:
                         stringValue: prepare
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
-                - asInt: "220"
+                - asInt: "216"
                   attributes:
                     - key: kind
                       value:
-                        stringValue: read_prev
+                        stringValue: read_first
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
-                - asInt: "227"
+                - asInt: "217"
                   attributes:
                     - key: kind
                       value:
-                        stringValue: write
+                        stringValue: read_key
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
                 - asInt: "218"
@@ -408,11 +352,67 @@ resourceMetrics:
                         stringValue: read_last
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
+                - asInt: "219"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: read_next
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "220"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: read_prev
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
                 - asInt: "221"
                   attributes:
                     - key: kind
                       value:
                         stringValue: read_rnd
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "222"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: read_rnd_next
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "223"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: rollback
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "224"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: savepoint
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "225"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: savepoint_rollback
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "226"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: update
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "227"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: write
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
               isMonotonic: true
@@ -616,18 +616,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "441"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: waited
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
                 - asInt: "440"
                   attributes:
                     - key: kind
                       value:
                         stringValue: immediate
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "441"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: waited
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
               isMonotonic: true
@@ -637,11 +637,11 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "255"
+                - asInt: "253"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: writes
+                        stringValue: waits
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
                 - asInt: "254"
@@ -651,11 +651,11 @@ resourceMetrics:
                         stringValue: write_requests
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
-                - asInt: "253"
+                - asInt: "255"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: waits
+                        stringValue: writes
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
               isMonotonic: true
@@ -693,18 +693,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "363"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: available
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
                 - asInt: "364"
                   attributes:
                     - key: kind
                       value:
                         stringValue: active
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "363"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: available
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
             unit: "1"
@@ -720,18 +720,18 @@ resourceMetrics:
                         stringValue: file
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
-                - asInt: "372"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: table_definition
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
                 - asInt: "373"
                   attributes:
                     - key: kind
                       value:
                         stringValue: table
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "372"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: table_definition
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
               isMonotonic: true
@@ -741,18 +741,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "248"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: reads
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
                 - asInt: "243"
                   attributes:
                     - key: operation
                       value:
                         stringValue: fsyncs
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "248"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: reads
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
                 - asInt: "249"
@@ -769,13 +769,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "263"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: written
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
                 - asInt: "261"
                   attributes:
                     - key: operation
@@ -790,6 +783,13 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
+                - asInt: "263"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: written
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
               isMonotonic: true
             unit: "1"
           - description: The number of times each type of prepared statement command has been issued.
@@ -797,32 +797,11 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "165"
-                  attributes:
-                    - key: command
-                      value:
-                        stringValue: prepare
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
                 - asInt: "163"
                   attributes:
                     - key: command
                       value:
                         stringValue: close
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "167"
-                  attributes:
-                    - key: command
-                      value:
-                        stringValue: send_long_data
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "166"
-                  attributes:
-                    - key: command
-                      value:
-                        stringValue: reset
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
                 - asInt: "162"
@@ -837,6 +816,27 @@ resourceMetrics:
                     - key: command
                       value:
                         stringValue: fetch
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "165"
+                  attributes:
+                    - key: command
+                      value:
+                        stringValue: prepare
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "166"
+                  attributes:
+                    - key: command
+                      value:
+                        stringValue: reset
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "167"
+                  attributes:
+                    - key: command
+                      value:
+                        stringValue: send_long_data
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
               isMonotonic: true
@@ -922,11 +922,11 @@ resourceMetrics:
                         stringValue: deleted
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
-                - asInt: "273"
+                - asInt: "271"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: updated
+                        stringValue: inserted
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
                 - asInt: "272"
@@ -936,11 +936,11 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
-                - asInt: "271"
+                - asInt: "273"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: inserted
+                        stringValue: updated
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
               isMonotonic: true
@@ -1288,24 +1288,11 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "0"
+                - asInt: "4"
                   attributes:
                     - key: kind
                       value:
-                        stringValue: normal
-                    - key: schema
-                      value:
-                        stringValue: otel
-                    - key: table
-                      value:
-                        stringValue: otel
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "1"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: with_shared_locks
+                        stringValue: external
                     - key: schema
                       value:
                         stringValue: otel
@@ -1340,11 +1327,24 @@ resourceMetrics:
                         stringValue: otel
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
-                - asInt: "4"
+                - asInt: "0"
                   attributes:
                     - key: kind
                       value:
-                        stringValue: external
+                        stringValue: normal
+                    - key: schema
+                      value:
+                        stringValue: otel
+                    - key: table
+                      value:
+                        stringValue: otel
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "1"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: with_shared_locks
                     - key: schema
                       value:
                         stringValue: otel
@@ -1359,24 +1359,11 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "10"
+                - asInt: "14"
                   attributes:
                     - key: kind
                       value:
-                        stringValue: normal
-                    - key: schema
-                      value:
-                        stringValue: otel
-                    - key: table
-                      value:
-                        stringValue: otel
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "11"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: with_shared_locks
+                        stringValue: external
                     - key: schema
                       value:
                         stringValue: otel
@@ -1411,11 +1398,24 @@ resourceMetrics:
                         stringValue: otel
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
-                - asInt: "14"
+                - asInt: "10"
                   attributes:
                     - key: kind
                       value:
-                        stringValue: external
+                        stringValue: normal
+                    - key: schema
+                      value:
+                        stringValue: otel
+                    - key: table
+                      value:
+                        stringValue: otel
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "11"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: with_shared_locks
                     - key: schema
                       value:
                         stringValue: otel
@@ -1456,6 +1456,19 @@ resourceMetrics:
                         stringValue: otel
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
+                - asInt: "9"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: external
+                    - key: schema
+                      value:
+                        stringValue: otel
+                    - key: table
+                      value:
+                        stringValue: otel
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
                 - asInt: "7"
                   attributes:
                     - key: kind
@@ -1474,19 +1487,6 @@ resourceMetrics:
                     - key: kind
                       value:
                         stringValue: normal
-                    - key: schema
-                      value:
-                        stringValue: otel
-                    - key: table
-                      value:
-                        stringValue: otel
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "9"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: external
                     - key: schema
                       value:
                         stringValue: otel
@@ -1527,6 +1527,19 @@ resourceMetrics:
                         stringValue: otel
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
+                - asInt: "19"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: external
+                    - key: schema
+                      value:
+                        stringValue: otel
+                    - key: table
+                      value:
+                        stringValue: otel
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
                 - asInt: "17"
                   attributes:
                     - key: kind
@@ -1545,19 +1558,6 @@ resourceMetrics:
                     - key: kind
                       value:
                         stringValue: normal
-                    - key: schema
-                      value:
-                        stringValue: otel
-                    - key: table
-                      value:
-                        stringValue: otel
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "19"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: external
                     - key: schema
                       value:
                         stringValue: otel
@@ -1600,6 +1600,20 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "448"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: cached
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "449"
+                  attributes:
+                    - key: kind
+                      value:
+                        stringValue: connected
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
                 - asInt: "450"
                   attributes:
                     - key: kind
@@ -1612,20 +1626,6 @@ resourceMetrics:
                     - key: kind
                       value:
                         stringValue: running
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "449"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: connected
-                  startTimeUnixNano: "1644862687825728000"
-                  timeUnixNano: "1644862687825772000"
-                - asInt: "448"
-                  attributes:
-                    - key: kind
-                      value:
-                        stringValue: cached
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
             unit: "1"

--- a/receiver/nginxreceiver/scraper_test.go
+++ b/receiver/nginxreceiver/scraper_test.go
@@ -41,7 +41,7 @@ func TestScraper(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreStartTimestamp(),
+	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(),
 		pmetrictest.IgnoreTimestamp()))
 }
 
@@ -68,7 +68,7 @@ func TestScraperWithConnectionsAsSum(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(expectedFile)
 	require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreStartTimestamp(),
+	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(),
 		pmetrictest.IgnoreTimestamp(), pmetrictest.IgnoreMetricsOrder()))
 }
 

--- a/receiver/nginxreceiver/testdata/scraper/expected.yaml
+++ b/receiver/nginxreceiver/testdata/scraper/expected.yaml
@@ -26,17 +26,17 @@ resourceMetrics:
                       value:
                         stringValue: reading
                   timeUnixNano: "1638471548185885000"
-                - asInt: "179"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: writing
-                  timeUnixNano: "1638471548185885000"
                 - asInt: "106"
                   attributes:
                     - key: state
                       value:
                         stringValue: waiting
+                  timeUnixNano: "1638471548185885000"
+                - asInt: "179"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: writing
                   timeUnixNano: "1638471548185885000"
             name: nginx.connections_current
             unit: connections

--- a/receiver/nginxreceiver/testdata/scraper/expected_with_connections_as_sum.yaml
+++ b/receiver/nginxreceiver/testdata/scraper/expected_with_connections_as_sum.yaml
@@ -28,17 +28,17 @@ resourceMetrics:
                       value:
                         stringValue: reading
                   timeUnixNano: "1638471548185885000"
-                - asInt: "179"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: writing
-                  timeUnixNano: "1638471548185885000"
                 - asInt: "106"
                   attributes:
                     - key: state
                       value:
                         stringValue: waiting
+                  timeUnixNano: "1638471548185885000"
+                - asInt: "179"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: writing
                   timeUnixNano: "1638471548185885000"
             unit: connections
           - description: The total number of handled connections. Generally, the parameter value is the same as nginx.connections_accepted unless some resource limits have been reached (for example, the worker_connections limit).

--- a/receiver/nsxtreceiver/scraper_test.go
+++ b/receiver/nsxtreceiver/scraper_test.go
@@ -60,7 +60,7 @@ func TestScrape(t *testing.T) {
 	expectedMetrics, err := golden.ReadMetrics(filepath.Join("testdata", "metrics", "expected_metrics.yaml"))
 	require.NoError(t, err)
 
-	err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp())
+	err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp())
 	require.NoError(t, err)
 }
 

--- a/receiver/nsxtreceiver/testdata/metrics/expected_metrics.yaml
+++ b/receiver/nsxtreceiver/testdata/metrics/expected_metrics.yaml
@@ -254,14 +254,14 @@ resourceMetrics:
                   attributes:
                     - key: state
                       value:
-                        stringValue: used
+                        stringValue: available
                   startTimeUnixNano: "1652365826688352000"
                   timeUnixNano: "1652365826697632000"
                 - asInt: "0"
                   attributes:
                     - key: state
                       value:
-                        stringValue: available
+                        stringValue: used
                   startTimeUnixNano: "1652365826688352000"
                   timeUnixNano: "1652365826697632000"
             unit: By
@@ -549,14 +549,14 @@ resourceMetrics:
                   attributes:
                     - key: state
                       value:
-                        stringValue: used
+                        stringValue: available
                   startTimeUnixNano: "1652365826688352000"
                   timeUnixNano: "1652365826697632000"
                 - asInt: "0"
                   attributes:
                     - key: state
                       value:
-                        stringValue: available
+                        stringValue: used
                   startTimeUnixNano: "1652365826688352000"
                   timeUnixNano: "1652365826697632000"
             unit: By
@@ -840,18 +840,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "26168032"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1652365826688352000"
-                  timeUnixNano: "1652365826697632000"
                 - asInt: "237014124"
                   attributes:
                     - key: state
                       value:
                         stringValue: available
+                  startTimeUnixNano: "1652365826688352000"
+                  timeUnixNano: "1652365826697632000"
+                - asInt: "26168032"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: used
                   startTimeUnixNano: "1652365826688352000"
                   timeUnixNano: "1652365826697632000"
             unit: By

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
@@ -14,6 +14,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "20"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
                 - asInt: "19"
                   attributes:
                     - key: source
@@ -21,11 +28,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "20"
+                - asInt: "22"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "21"
@@ -35,11 +42,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "22"
+                - asInt: "26"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "25"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "24"
@@ -56,20 +70,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "25"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
-                - asInt: "26"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -77,13 +77,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "39"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "41"
                   attributes:
                     - key: operation
@@ -91,18 +84,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "39"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "40"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
               isMonotonic: true
@@ -164,6 +164,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "28"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
                 - asInt: "27"
                   attributes:
                     - key: source
@@ -171,11 +178,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "28"
+                - asInt: "30"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "29"
@@ -185,11 +192,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "30"
+                - asInt: "34"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "33"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "32"
@@ -206,20 +220,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "33"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
-                - asInt: "34"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -227,13 +227,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "45"
                   attributes:
                     - key: operation
@@ -241,18 +234,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "44"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "46"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "43"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "44"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
               isMonotonic: true
@@ -438,6 +438,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "21"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
                 - asInt: "20"
                   attributes:
                     - key: source
@@ -445,11 +452,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "21"
+                - asInt: "23"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "22"
@@ -459,11 +466,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "23"
+                - asInt: "27"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "26"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "25"
@@ -480,20 +494,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "26"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
-                - asInt: "27"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -501,13 +501,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "42"
                   attributes:
                     - key: operation
@@ -515,18 +508,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "41"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "43"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "40"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "41"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
               isMonotonic: true
@@ -588,6 +588,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "29"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
                 - asInt: "28"
                   attributes:
                     - key: source
@@ -595,11 +602,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "29"
+                - asInt: "31"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "30"
@@ -609,11 +616,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "31"
+                - asInt: "35"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "34"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "33"
@@ -630,20 +644,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "34"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
-                - asInt: "35"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -651,13 +651,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "44"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "46"
                   attributes:
                     - key: operation
@@ -665,18 +658,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "45"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "47"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "44"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "45"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
               isMonotonic: true
@@ -862,6 +862,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "22"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
                 - asInt: "21"
                   attributes:
                     - key: source
@@ -869,11 +876,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "22"
+                - asInt: "24"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "23"
@@ -883,11 +890,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "24"
+                - asInt: "28"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "27"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "26"
@@ -904,20 +918,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "27"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
-                - asInt: "28"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -925,13 +925,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "41"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "43"
                   attributes:
                     - key: operation
@@ -939,18 +932,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "42"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "44"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "41"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "42"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
               isMonotonic: true
@@ -1012,6 +1012,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "30"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
                 - asInt: "29"
                   attributes:
                     - key: source
@@ -1019,11 +1026,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "30"
+                - asInt: "32"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "31"
@@ -1033,11 +1040,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "32"
+                - asInt: "36"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "35"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
                 - asInt: "34"
@@ -1054,20 +1068,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "35"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
-                - asInt: "36"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -1075,13 +1075,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "45"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "47"
                   attributes:
                     - key: operation
@@ -1089,18 +1082,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "46"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "48"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "45"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "46"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
               isMonotonic: true
@@ -1289,13 +1289,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "5"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: bgwriter
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "7"
                   attributes:
                     - key: source
@@ -1303,18 +1296,25 @@ resourceMetrics:
                         stringValue: backend
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "9"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: checkpoints
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
                 - asInt: "8"
                   attributes:
                     - key: source
                       value:
                         stringValue: backend_fsync
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1684786281207476000"
+                  timeUnixNano: "1684786281207521000"
+                - asInt: "9"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
               isMonotonic: true
@@ -1410,11 +1410,11 @@ resourceMetrics:
           - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
             gauge:
               dataPoints:
-                - asInt: "800"
+                - asInt: "600"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: write
+                        stringValue: flush
                     - key: replication_client
                       value:
                         stringValue: unix
@@ -1430,11 +1430,11 @@ resourceMetrics:
                         stringValue: unix
                   startTimeUnixNano: "1684786281207476000"
                   timeUnixNano: "1684786281207521000"
-                - asInt: "600"
+                - asInt: "800"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: flush
+                        stringValue: write
                     - key: replication_client
                       value:
                         stringValue: unix

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.yaml
@@ -14,6 +14,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "20"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
                 - asInt: "19"
                   attributes:
                     - key: source
@@ -21,11 +28,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "20"
+                - asInt: "22"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "21"
@@ -35,11 +42,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "22"
+                - asInt: "26"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "25"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "24"
@@ -56,20 +70,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "25"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
-                - asInt: "26"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -77,13 +77,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "39"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "41"
                   attributes:
                     - key: operation
@@ -91,18 +84,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "39"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "40"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
               isMonotonic: true
@@ -164,6 +164,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "28"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
                 - asInt: "27"
                   attributes:
                     - key: source
@@ -171,11 +178,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "28"
+                - asInt: "30"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "29"
@@ -185,11 +192,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "30"
+                - asInt: "34"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "33"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "32"
@@ -206,20 +220,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "33"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
-                - asInt: "34"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -227,13 +227,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "45"
                   attributes:
                     - key: operation
@@ -241,18 +234,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "44"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "46"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "43"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "44"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
               isMonotonic: true
@@ -438,6 +438,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "21"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
                 - asInt: "20"
                   attributes:
                     - key: source
@@ -445,11 +452,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "21"
+                - asInt: "23"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "22"
@@ -459,11 +466,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "23"
+                - asInt: "27"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "26"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "25"
@@ -480,20 +494,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "26"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
-                - asInt: "27"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -501,13 +501,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "42"
                   attributes:
                     - key: operation
@@ -515,18 +508,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "41"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "43"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "40"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "41"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
               isMonotonic: true
@@ -588,6 +588,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "29"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
                 - asInt: "28"
                   attributes:
                     - key: source
@@ -595,11 +602,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "29"
+                - asInt: "31"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "30"
@@ -609,11 +616,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "31"
+                - asInt: "35"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "34"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "33"
@@ -630,20 +644,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "34"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
-                - asInt: "35"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -651,13 +651,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "44"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "46"
                   attributes:
                     - key: operation
@@ -665,18 +658,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "45"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "47"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "44"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "45"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
               isMonotonic: true
@@ -862,6 +862,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "22"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
                 - asInt: "21"
                   attributes:
                     - key: source
@@ -869,11 +876,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "22"
+                - asInt: "24"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "23"
@@ -883,11 +890,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "24"
+                - asInt: "28"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "27"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "26"
@@ -904,20 +918,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "27"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
-                - asInt: "28"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -925,13 +925,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "41"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "43"
                   attributes:
                     - key: operation
@@ -939,18 +932,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "42"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "44"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "41"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "42"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
               isMonotonic: true
@@ -1012,6 +1012,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "30"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
                 - asInt: "29"
                   attributes:
                     - key: source
@@ -1019,11 +1026,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "30"
+                - asInt: "32"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "31"
@@ -1033,11 +1040,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "32"
+                - asInt: "36"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "35"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
                 - asInt: "34"
@@ -1054,20 +1068,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "35"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
-                - asInt: "36"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -1075,13 +1075,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "45"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "47"
                   attributes:
                     - key: operation
@@ -1089,18 +1082,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "46"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "48"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "45"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "46"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
               isMonotonic: true
@@ -1289,13 +1289,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "5"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: bgwriter
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "7"
                   attributes:
                     - key: source
@@ -1303,18 +1296,25 @@ resourceMetrics:
                         stringValue: backend
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "9"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: checkpoints
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
                 - asInt: "8"
                   attributes:
                     - key: source
                       value:
                         stringValue: backend_fsync
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1660755376404913000"
+                  timeUnixNano: "1660755376405089000"
+                - asInt: "9"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
               isMonotonic: true
@@ -1410,11 +1410,11 @@ resourceMetrics:
           - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
             gauge:
               dataPoints:
-                - asInt: "800"
+                - asInt: "600"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: write
+                        stringValue: flush
                     - key: replication_client
                       value:
                         stringValue: unix
@@ -1430,11 +1430,11 @@ resourceMetrics:
                         stringValue: unix
                   startTimeUnixNano: "1660755376404913000"
                   timeUnixNano: "1660755376405089000"
-                - asInt: "600"
+                - asInt: "800"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: flush
+                        stringValue: write
                     - key: replication_client
                       value:
                         stringValue: unix

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
@@ -14,6 +14,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "20"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1684786281201767000"
+                  timeUnixNano: "1684786281201820000"
                 - asInt: "19"
                   attributes:
                     - key: source
@@ -21,11 +28,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
-                - asInt: "20"
+                - asInt: "22"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
                 - asInt: "21"
@@ -35,11 +42,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
-                - asInt: "22"
+                - asInt: "26"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1684786281201767000"
+                  timeUnixNano: "1684786281201820000"
+                - asInt: "25"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
                 - asInt: "24"
@@ -56,20 +70,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
-                - asInt: "25"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
-                - asInt: "26"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -77,13 +77,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "39"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
                 - asInt: "41"
                   attributes:
                     - key: operation
@@ -91,18 +84,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
                 - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1684786281201767000"
+                  timeUnixNano: "1684786281201820000"
+                - asInt: "39"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1684786281201767000"
+                  timeUnixNano: "1684786281201820000"
+                - asInt: "40"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
               isMonotonic: true
@@ -164,6 +164,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "28"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1684786281201767000"
+                  timeUnixNano: "1684786281201820000"
                 - asInt: "27"
                   attributes:
                     - key: source
@@ -171,11 +178,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
-                - asInt: "28"
+                - asInt: "30"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
                 - asInt: "29"
@@ -185,11 +192,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
-                - asInt: "30"
+                - asInt: "34"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1684786281201767000"
+                  timeUnixNano: "1684786281201820000"
+                - asInt: "33"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
                 - asInt: "32"
@@ -206,20 +220,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
-                - asInt: "33"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
-                - asInt: "34"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -227,13 +227,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
                 - asInt: "45"
                   attributes:
                     - key: operation
@@ -241,18 +234,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
-                - asInt: "44"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
                 - asInt: "46"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1684786281201767000"
+                  timeUnixNano: "1684786281201820000"
+                - asInt: "43"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1684786281201767000"
+                  timeUnixNano: "1684786281201820000"
+                - asInt: "44"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
               isMonotonic: true
@@ -441,13 +441,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "5"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: bgwriter
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
                 - asInt: "7"
                   attributes:
                     - key: source
@@ -455,18 +448,25 @@ resourceMetrics:
                         stringValue: backend
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
-                - asInt: "9"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: checkpoints
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
                 - asInt: "8"
                   attributes:
                     - key: source
                       value:
                         stringValue: backend_fsync
+                  startTimeUnixNano: "1684786281201767000"
+                  timeUnixNano: "1684786281201820000"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1684786281201767000"
+                  timeUnixNano: "1684786281201820000"
+                - asInt: "9"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
               isMonotonic: true
@@ -562,11 +562,11 @@ resourceMetrics:
           - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
             gauge:
               dataPoints:
-                - asInt: "800"
+                - asInt: "600"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: write
+                        stringValue: flush
                     - key: replication_client
                       value:
                         stringValue: unix
@@ -582,11 +582,11 @@ resourceMetrics:
                         stringValue: unix
                   startTimeUnixNano: "1684786281201767000"
                   timeUnixNano: "1684786281201820000"
-                - asInt: "600"
+                - asInt: "800"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: flush
+                        stringValue: write
                     - key: replication_client
                       value:
                         stringValue: unix

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.yaml
@@ -14,6 +14,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "20"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1660755387092164000"
+                  timeUnixNano: "1660755387092521000"
                 - asInt: "19"
                   attributes:
                     - key: source
@@ -21,11 +28,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
-                - asInt: "20"
+                - asInt: "22"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
                 - asInt: "21"
@@ -35,11 +42,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
-                - asInt: "22"
+                - asInt: "26"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1660755387092164000"
+                  timeUnixNano: "1660755387092521000"
+                - asInt: "25"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
                 - asInt: "24"
@@ -56,20 +70,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
-                - asInt: "25"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
-                - asInt: "26"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -77,13 +77,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "39"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
                 - asInt: "41"
                   attributes:
                     - key: operation
@@ -91,18 +84,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
                 - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1660755387092164000"
+                  timeUnixNano: "1660755387092521000"
+                - asInt: "39"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1660755387092164000"
+                  timeUnixNano: "1660755387092521000"
+                - asInt: "40"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
               isMonotonic: true
@@ -164,6 +164,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "28"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1660755387092164000"
+                  timeUnixNano: "1660755387092521000"
                 - asInt: "27"
                   attributes:
                     - key: source
@@ -171,11 +178,11 @@ resourceMetrics:
                         stringValue: heap_read
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
-                - asInt: "28"
+                - asInt: "30"
                   attributes:
                     - key: source
                       value:
-                        stringValue: heap_hit
+                        stringValue: idx_hit
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
                 - asInt: "29"
@@ -185,11 +192,18 @@ resourceMetrics:
                         stringValue: idx_read
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
-                - asInt: "30"
+                - asInt: "34"
                   attributes:
                     - key: source
                       value:
-                        stringValue: idx_hit
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1660755387092164000"
+                  timeUnixNano: "1660755387092521000"
+                - asInt: "33"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
                 - asInt: "32"
@@ -206,20 +220,6 @@ resourceMetrics:
                         stringValue: toast_hit
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
-                - asInt: "33"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
-                - asInt: "34"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -227,13 +227,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
                 - asInt: "45"
                   attributes:
                     - key: operation
@@ -241,18 +234,25 @@ resourceMetrics:
                         stringValue: del
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
-                - asInt: "44"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
                 - asInt: "46"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
+                  startTimeUnixNano: "1660755387092164000"
+                  timeUnixNano: "1660755387092521000"
+                - asInt: "43"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1660755387092164000"
+                  timeUnixNano: "1660755387092521000"
+                - asInt: "44"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
               isMonotonic: true
@@ -441,13 +441,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "5"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: bgwriter
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
                 - asInt: "7"
                   attributes:
                     - key: source
@@ -455,18 +448,25 @@ resourceMetrics:
                         stringValue: backend
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
-                - asInt: "9"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: checkpoints
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
                 - asInt: "8"
                   attributes:
                     - key: source
                       value:
                         stringValue: backend_fsync
+                  startTimeUnixNano: "1660755387092164000"
+                  timeUnixNano: "1660755387092521000"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1660755387092164000"
+                  timeUnixNano: "1660755387092521000"
+                - asInt: "9"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
               isMonotonic: true
@@ -562,11 +562,11 @@ resourceMetrics:
           - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
             gauge:
               dataPoints:
-                - asInt: "800"
+                - asInt: "600"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: write
+                        stringValue: flush
                     - key: replication_client
                       value:
                         stringValue: unix
@@ -582,11 +582,11 @@ resourceMetrics:
                         stringValue: unix
                   startTimeUnixNano: "1660755387092164000"
                   timeUnixNano: "1660755387092521000"
-                - asInt: "600"
+                - asInt: "800"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: flush
+                        stringValue: write
                     - key: replication_client
                       value:
                         stringValue: unix

--- a/receiver/rabbitmqreceiver/scraper_test.go
+++ b/receiver/rabbitmqreceiver/scraper_test.go
@@ -142,7 +142,7 @@ func TestScaperScrape(t *testing.T) {
 
 			expectedMetrics := tc.expectedMetricGen(t)
 
-			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+			require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricDataPointsOrder(),
 				pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 		})
 	}

--- a/receiver/rabbitmqreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/rabbitmqreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -30,14 +30,14 @@ resourceMetrics:
                   attributes:
                     - key: state
                       value:
-                        stringValue: unacknowledged
+                        stringValue: ready
                   startTimeUnixNano: "1656512143898318000"
                   timeUnixNano: "1656512143899572000"
                 - asInt: "0"
                   attributes:
                     - key: state
                       value:
-                        stringValue: ready
+                        stringValue: unacknowledged
                   startTimeUnixNano: "1656512143898318000"
                   timeUnixNano: "1656512143899572000"
             unit: '{messages}'
@@ -85,14 +85,14 @@ resourceMetrics:
                   attributes:
                     - key: state
                       value:
-                        stringValue: unacknowledged
+                        stringValue: ready
                   startTimeUnixNano: "1656512143898318000"
                   timeUnixNano: "1656512143899572000"
                 - asInt: "1"
                   attributes:
                     - key: state
                       value:
-                        stringValue: ready
+                        stringValue: unacknowledged
                   startTimeUnixNano: "1656512143898318000"
                   timeUnixNano: "1656512143899572000"
             unit: '{messages}'

--- a/receiver/riakreceiver/scraper_test.go
+++ b/receiver/riakreceiver/scraper_test.go
@@ -197,7 +197,7 @@ func TestScaperScrape(t *testing.T) {
 
 			expectedMetrics := tc.expectedMetricGen(t)
 
-			err = pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreStartTimestamp(),
+			err = pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(),
 				pmetrictest.IgnoreTimestamp())
 			require.NoError(t, err)
 		})

--- a/receiver/riakreceiver/testdata/scraper/expected.yaml
+++ b/receiver/riakreceiver/testdata/scraper/expected.yaml
@@ -70,6 +70,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1648220661611816000"
+                  timeUnixNano: "1648220661612587000"
                 - asInt: "10"
                   attributes:
                     - key: operation
@@ -82,13 +89,6 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: write
-                  startTimeUnixNano: "1648220661611816000"
-                  timeUnixNano: "1648220661612587000"
-                - asInt: "9"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
                   startTimeUnixNano: "1648220661611816000"
                   timeUnixNano: "1648220661612587000"
             unit: '{operation}'

--- a/receiver/riakreceiver/testdata/scraper/expected_disabled.yaml
+++ b/receiver/riakreceiver/testdata/scraper/expected_disabled.yaml
@@ -40,6 +40,13 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1648220661611816000"
+                  timeUnixNano: "1648220661612587000"
                 - asInt: "10"
                   attributes:
                     - key: operation
@@ -52,13 +59,6 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: write
-                  startTimeUnixNano: "1648220661611816000"
-                  timeUnixNano: "1648220661612587000"
-                - asInt: "9"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
                   startTimeUnixNano: "1648220661611816000"
                   timeUnixNano: "1648220661612587000"
             unit: '{operation}'

--- a/receiver/saphanareceiver/scraper_test.go
+++ b/receiver/saphanareceiver/scraper_test.go
@@ -36,7 +36,7 @@ func TestScraper(t *testing.T) {
 	actualMetrics, err := sc.Scrape(context.Background())
 	require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics,
+	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricDataPointsOrder(),
 		pmetrictest.IgnoreResourceMetricsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 }
 

--- a/receiver/saphanareceiver/testdata/expected_metrics/full.yaml
+++ b/receiver/saphanareceiver/testdata/expected_metrics/full.yaml
@@ -14,46 +14,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "12"
-                  attributes:
-                    - key: subtype
-                      value:
-                        stringValue: data
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
-                - asInt: "13"
-                  attributes:
-                    - key: subtype
-                      value:
-                        stringValue: dict
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
-                - asInt: "14"
-                  attributes:
-                    - key: subtype
-                      value:
-                        stringValue: index
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
-                - asInt: "15"
-                  attributes:
-                    - key: subtype
-                      value:
-                        stringValue: misc
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "16"
                   attributes:
                     - key: subtype
@@ -62,6 +22,16 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: delta
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "12"
+                  attributes:
+                    - key: subtype
+                      value:
+                        stringValue: data
+                    - key: type
+                      value:
+                        stringValue: main
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
                 - asInt: "17"
@@ -74,6 +44,16 @@ resourceMetrics:
                         stringValue: delta
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
+                - asInt: "13"
+                  attributes:
+                    - key: subtype
+                      value:
+                        stringValue: dict
+                    - key: type
+                      value:
+                        stringValue: main
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
                 - asInt: "18"
                   attributes:
                     - key: subtype
@@ -84,6 +64,16 @@ resourceMetrics:
                         stringValue: delta
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
+                - asInt: "14"
+                  attributes:
+                    - key: subtype
+                      value:
+                        stringValue: index
+                    - key: type
+                      value:
+                        stringValue: main
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
                 - asInt: "19"
                   attributes:
                     - key: subtype
@@ -92,6 +82,16 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: delta
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "15"
+                  attributes:
+                    - key: subtype
+                      value:
+                        stringValue: misc
+                    - key: type
+                      value:
+                        stringValue: main
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
             unit: By
@@ -113,18 +113,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "15"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: running
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "4"
                   attributes:
                     - key: status
                       value:
                         stringValue: idle
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "15"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: running
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
             unit: '{connections}'
@@ -133,18 +133,11 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "82"
+                - asInt: "23"
                   attributes:
                     - key: type
                       value:
-                        stringValue: user
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
-                - asInt: "82828"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: system
+                        stringValue: idle
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
                 - asInt: "8674"
@@ -154,11 +147,18 @@ resourceMetrics:
                         stringValue: io_wait
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
-                - asInt: "23"
+                - asInt: "82828"
                   attributes:
                     - key: type
                       value:
-                        stringValue: idle
+                        stringValue: system
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "82"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: user
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
               isMonotonic: true
@@ -168,32 +168,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "123"
-                  attributes:
-                    - key: path
-                      value:
-                        stringValue: /a/b/c
-                    - key: state
-                      value:
-                        stringValue: free
-                    - key: usage_type
-                      value:
-                        stringValue: LOG
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
-                - asInt: "456"
-                  attributes:
-                    - key: path
-                      value:
-                        stringValue: /a/b/c
-                    - key: state
-                      value:
-                        stringValue: used
-                    - key: usage_type
-                      value:
-                        stringValue: LOG
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "2233"
                   attributes:
                     - key: path
@@ -207,6 +181,19 @@ resourceMetrics:
                         stringValue: DATA
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
+                - asInt: "123"
+                  attributes:
+                    - key: path
+                      value:
+                        stringValue: /a/b/c
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: usage_type
+                      value:
+                        stringValue: LOG
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
                 - asInt: "33"
                   attributes:
                     - key: path
@@ -218,6 +205,19 @@ resourceMetrics:
                     - key: usage_type
                       value:
                         stringValue: DATA
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "456"
+                  attributes:
+                    - key: path
+                      value:
+                        stringValue: /a/b/c
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: usage_type
+                      value:
+                        stringValue: LOG
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
             unit: By
@@ -275,18 +275,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "62727"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "5"
                   attributes:
                     - key: state
                       value:
                         stringValue: free
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "62727"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: used
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
             unit: By
@@ -382,16 +382,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "123123"
-                  attributes:
-                    - key: schema
-                      value:
-                        stringValue: SYS
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "23"
                   attributes:
                     - key: schema
@@ -400,6 +390,16 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: delta
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "7777"
+                  attributes:
+                    - key: schema
+                      value:
+                        stringValue: SYS
+                    - key: type
+                      value:
+                        stringValue: history_delta
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
                 - asInt: "43434"
@@ -412,14 +412,14 @@ resourceMetrics:
                         stringValue: history_main
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
-                - asInt: "7777"
+                - asInt: "123123"
                   attributes:
                     - key: schema
                       value:
                         stringValue: SYS
                     - key: type
                       value:
-                        stringValue: history_delta
+                        stringValue: main
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
             unit: By
@@ -441,6 +441,16 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "4444"
+                  attributes:
+                    - key: schema
+                      value:
+                        stringValue: SYS
+                    - key: type
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
                 - asInt: "123"
                   attributes:
                     - key: schema
@@ -459,16 +469,6 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: write
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
-                - asInt: "4444"
-                  attributes:
-                    - key: schema
-                      value:
-                        stringValue: SYS
-                    - key: type
-                      value:
-                        stringValue: merge
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
               isMonotonic: true
@@ -491,16 +491,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1234"
-                  attributes:
-                    - key: schema
-                      value:
-                        stringValue: SYS
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "30000"
                   attributes:
                     - key: schema
@@ -509,6 +499,16 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: delta
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "878743"
+                  attributes:
+                    - key: schema
+                      value:
+                        stringValue: SYS
+                    - key: type
+                      value:
+                        stringValue: history_delta
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
                 - asInt: "34843"
@@ -521,14 +521,14 @@ resourceMetrics:
                         stringValue: history_main
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
-                - asInt: "878743"
+                - asInt: "1234"
                   attributes:
                     - key: schema
                       value:
                         stringValue: SYS
                     - key: type
                       value:
-                        stringValue: history_delta
+                        stringValue: main
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
             unit: '{records}'
@@ -742,13 +742,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "100"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: update
-                  startTimeUnixNano: "1655998954206841000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "0"
                   attributes:
                     - key: type
@@ -761,6 +754,13 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: rollback
+                  startTimeUnixNano: "1655998954206841000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "100"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: update
                   startTimeUnixNano: "1655998954206841000"
                   timeUnixNano: "1655998954206724000"
               isMonotonic: true
@@ -898,46 +898,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "100"
-                  attributes:
-                    - key: subtype
-                      value:
-                        stringValue: data
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206896000"
-                  timeUnixNano: "1655998954206724000"
-                - asInt: "99"
-                  attributes:
-                    - key: subtype
-                      value:
-                        stringValue: dict
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206896000"
-                  timeUnixNano: "1655998954206724000"
-                - asInt: "98"
-                  attributes:
-                    - key: subtype
-                      value:
-                        stringValue: index
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206896000"
-                  timeUnixNano: "1655998954206724000"
-                - asInt: "97"
-                  attributes:
-                    - key: subtype
-                      value:
-                        stringValue: misc
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206896000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "96"
                   attributes:
                     - key: subtype
@@ -946,6 +906,16 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: delta
+                  startTimeUnixNano: "1655998954206896000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "100"
+                  attributes:
+                    - key: subtype
+                      value:
+                        stringValue: data
+                    - key: type
+                      value:
+                        stringValue: main
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
                 - asInt: "95"
@@ -958,6 +928,16 @@ resourceMetrics:
                         stringValue: delta
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
+                - asInt: "99"
+                  attributes:
+                    - key: subtype
+                      value:
+                        stringValue: dict
+                    - key: type
+                      value:
+                        stringValue: main
+                  startTimeUnixNano: "1655998954206896000"
+                  timeUnixNano: "1655998954206724000"
                 - asInt: "94"
                   attributes:
                     - key: subtype
@@ -968,6 +948,16 @@ resourceMetrics:
                         stringValue: delta
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
+                - asInt: "98"
+                  attributes:
+                    - key: subtype
+                      value:
+                        stringValue: index
+                    - key: type
+                      value:
+                        stringValue: main
+                  startTimeUnixNano: "1655998954206896000"
+                  timeUnixNano: "1655998954206724000"
                 - asInt: "93"
                   attributes:
                     - key: subtype
@@ -976,6 +966,16 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: delta
+                  startTimeUnixNano: "1655998954206896000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "97"
+                  attributes:
+                    - key: subtype
+                      value:
+                        stringValue: misc
+                    - key: type
+                      value:
+                        stringValue: main
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
             unit: By
@@ -1010,18 +1010,11 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "412"
+                - asInt: "7456"
                   attributes:
                     - key: type
                       value:
-                        stringValue: user
-                  startTimeUnixNano: "1655998954206896000"
-                  timeUnixNano: "1655998954206724000"
-                - asInt: "774"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: system
+                        stringValue: idle
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
                 - asInt: "884"
@@ -1031,11 +1024,18 @@ resourceMetrics:
                         stringValue: io_wait
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
-                - asInt: "7456"
+                - asInt: "774"
                   attributes:
                     - key: type
                       value:
-                        stringValue: idle
+                        stringValue: system
+                  startTimeUnixNano: "1655998954206896000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "412"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: user
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
               isMonotonic: true
@@ -1126,18 +1126,18 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "451"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1655998954206896000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "34"
                   attributes:
                     - key: state
                       value:
                         stringValue: free
+                  startTimeUnixNano: "1655998954206896000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "451"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: used
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
             unit: By
@@ -1233,16 +1233,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2"
-                  attributes:
-                    - key: schema
-                      value:
-                        stringValue: MON
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206896000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "7888888"
                   attributes:
                     - key: schema
@@ -1251,6 +1241,16 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: delta
+                  startTimeUnixNano: "1655998954206896000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "8265"
+                  attributes:
+                    - key: schema
+                      value:
+                        stringValue: MON
+                    - key: type
+                      value:
+                        stringValue: history_delta
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
                 - asInt: "2456"
@@ -1263,14 +1263,14 @@ resourceMetrics:
                         stringValue: history_main
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
-                - asInt: "8265"
+                - asInt: "2"
                   attributes:
                     - key: schema
                       value:
                         stringValue: MON
                     - key: type
                       value:
-                        stringValue: history_delta
+                        stringValue: main
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
             unit: By
@@ -1292,6 +1292,16 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
+                - asInt: "62"
+                  attributes:
+                    - key: schema
+                      value:
+                        stringValue: MON
+                    - key: type
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1655998954206896000"
+                  timeUnixNano: "1655998954206724000"
                 - asInt: "76578"
                   attributes:
                     - key: schema
@@ -1310,16 +1320,6 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: write
-                  startTimeUnixNano: "1655998954206896000"
-                  timeUnixNano: "1655998954206724000"
-                - asInt: "62"
-                  attributes:
-                    - key: schema
-                      value:
-                        stringValue: MON
-                    - key: type
-                      value:
-                        stringValue: merge
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
               isMonotonic: true
@@ -1342,16 +1342,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "654"
-                  attributes:
-                    - key: schema
-                      value:
-                        stringValue: MON
-                    - key: type
-                      value:
-                        stringValue: main
-                  startTimeUnixNano: "1655998954206896000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "625662"
                   attributes:
                     - key: schema
@@ -1360,6 +1350,16 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: delta
+                  startTimeUnixNano: "1655998954206896000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "85"
+                  attributes:
+                    - key: schema
+                      value:
+                        stringValue: MON
+                    - key: type
+                      value:
+                        stringValue: history_delta
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
                 - asInt: "8888"
@@ -1372,14 +1372,14 @@ resourceMetrics:
                         stringValue: history_main
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
-                - asInt: "85"
+                - asInt: "654"
                   attributes:
                     - key: schema
                       value:
                         stringValue: MON
                     - key: type
                       value:
-                        stringValue: history_delta
+                        stringValue: main
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
             unit: '{records}'
@@ -1593,13 +1593,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: update
-                  startTimeUnixNano: "1655998954206896000"
-                  timeUnixNano: "1655998954206724000"
                 - asInt: "123"
                   attributes:
                     - key: type
@@ -1612,6 +1605,13 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: rollback
+                  startTimeUnixNano: "1655998954206896000"
+                  timeUnixNano: "1655998954206724000"
+                - asInt: "0"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: update
                   startTimeUnixNano: "1655998954206896000"
                   timeUnixNano: "1655998954206724000"
               isMonotonic: true

--- a/receiver/vcenterreceiver/scraper_test.go
+++ b/receiver/vcenterreceiver/scraper_test.go
@@ -62,7 +62,7 @@ func testScrape(ctx context.Context, t *testing.T, cfg *Config) {
 	expectedMetrics, err := golden.ReadMetrics(goldenPath)
 	require.NoError(t, err)
 
-	err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp())
+	err = pmetrictest.CompareMetrics(expectedMetrics, metrics, pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp())
 	require.NoError(t, err)
 	require.NoError(t, scraper.Shutdown(ctx))
 }

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -36,6 +36,34 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
+                - asInt: "789"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "645"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "781"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
                 - asInt: "781"
                   attributes:
                     - key: direction
@@ -47,23 +75,9 @@ resourceMetrics:
                   attributes:
                     - key: direction
                       value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
                         stringValue: write
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808300000000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
                 - asInt: "645"
                   attributes:
                     - key: direction
@@ -75,23 +89,9 @@ resourceMetrics:
                   attributes:
                     - key: direction
                       value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
                         stringValue: write
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
-                - asInt: "782"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -133,6 +133,34 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
                 - asInt: "7"
                   attributes:
                     - key: direction
@@ -140,6 +168,34 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "4"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
                 - asInt: "28"
                   attributes:
                     - key: direction
@@ -147,76 +203,6 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
                 - asInt: "45"
                   attributes:
                     - key: direction
@@ -224,76 +210,6 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "25"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "10"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
                 - asInt: "88"
                   attributes:
                     - key: direction
@@ -301,76 +217,6 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808320000000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "76"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "92"
                   attributes:
                     - key: direction
@@ -378,76 +224,6 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "8"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "63"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "7"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
                 - asInt: "31"
                   attributes:
                     - key: direction
@@ -455,6 +231,34 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "4"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -462,6 +266,34 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "6"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "6"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "4"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "8"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "19"
                   attributes:
                     - key: direction
@@ -475,7 +307,63 @@ resourceMetrics:
                       value:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "4"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "25"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "76"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "63"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -489,7 +377,63 @@ resourceMetrics:
                       value:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "5"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "10"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "5"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "7"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "6"
                   attributes:
                     - key: direction
@@ -503,7 +447,63 @@ resourceMetrics:
                       value:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "781"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "789"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "645"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "781"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -541,133 +541,7 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
-                - asInt: "42110"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "11182"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "13316"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "116"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "55647"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "51992"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "105"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
                 - asInt: "41703"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "42686"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "13009"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "14473"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "114"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "57376"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "54712"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "103"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
                   attributes:
                     - key: direction
                       value:
@@ -681,133 +555,7 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808320000000000"
-                - asInt: "44277"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "16489"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "19662"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "113"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "64156"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "59449"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "104"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
                 - asInt: "42206"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "43122"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "12398"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "15478"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "112"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "58814"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "54604"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "102"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
                   attributes:
                     - key: direction
                       value:
@@ -821,6 +569,34 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "42110"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "42686"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "44277"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "43122"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "42703"
                   attributes:
                     - key: direction
@@ -828,6 +604,34 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "11182"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "13009"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "16489"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "12398"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "12984"
                   attributes:
                     - key: direction
@@ -835,6 +639,34 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "13316"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "14473"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "19662"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "15478"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "14458"
                   attributes:
                     - key: direction
@@ -842,6 +674,34 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "116"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "114"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "113"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "120"
                   attributes:
                     - key: direction
@@ -849,6 +709,34 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "55647"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "57376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "64156"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "58814"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "57390"
                   attributes:
                     - key: direction
@@ -856,6 +744,34 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "51992"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "54712"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "59449"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "54604"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "54464"
                   attributes:
                     - key: direction
@@ -869,7 +785,63 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "105"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "103"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "104"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "102"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "109"
                   attributes:
                     - key: direction
@@ -877,6 +849,34 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -903,132 +903,6 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808300000000000"
                 - asInt: "0"
                   attributes:
@@ -1037,132 +911,6 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1183,7 +931,63 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1197,7 +1001,63 @@ resourceMetrics:
                       value:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1211,7 +1071,63 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1225,7 +1141,28 @@ resourceMetrics:
                       value:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1233,6 +1170,69 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1253,137 +1253,11 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "928"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "3064"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "570"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "357"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "3475"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
                 - asInt: "422"
                   attributes:
                     - key: direction
                       value:
                         stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "1120"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "2537"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "768"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "351"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "2959"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808300000000000"
                 - asInt: "551"
@@ -1393,137 +1267,11 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "1646"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "4373"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "1269"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "376"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "4924"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
                 - asInt: "617"
                   attributes:
                     - key: direction
                       value:
                         stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "1291"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "3746"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "927"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "363"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "4364"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
                 - asInt: "488"
@@ -1539,7 +1287,63 @@ resourceMetrics:
                       value:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "928"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "1120"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "1646"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "1291"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "1058"
                   attributes:
                     - key: direction
@@ -1547,6 +1351,34 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "3064"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "2537"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "4373"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "3746"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "2569"
                   attributes:
                     - key: direction
@@ -1560,7 +1392,63 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "570"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "768"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "1269"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "927"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "681"
                   attributes:
                     - key: direction
@@ -1568,6 +1456,34 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "357"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "351"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "363"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "376"
                   attributes:
                     - key: direction
@@ -1575,6 +1491,34 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "3475"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "2959"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "4924"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "4364"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "3058"
                   attributes:
                     - key: direction
@@ -1588,7 +1532,63 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1605,61 +1605,13 @@ resourceMetrics:
                 - asInt: "769"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "3634"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "4404"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
                 - asInt: "773"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "3305"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "4079"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808300000000000"
                 - asInt: "927"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "5642"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "6570"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
                 - asInt: "980"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "4674"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "5655"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
                 - asInt: "864"
@@ -1667,13 +1619,61 @@ resourceMetrics:
                   timeUnixNano: "1652808360000000000"
                 - asInt: "0"
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "3634"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "3305"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "5642"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "4674"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "3251"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
+                - asInt: "4404"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "4079"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "6570"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "5655"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "4117"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -36,34 +36,6 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "782"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
                 - asInt: "781"
                   attributes:
                     - key: direction
@@ -75,9 +47,23 @@ resourceMetrics:
                   attributes:
                     - key: direction
                       value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "789"
+                  attributes:
+                    - key: direction
+                      value:
                         stringValue: write
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808300000000000"
+                - asInt: "645"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
                 - asInt: "645"
                   attributes:
                     - key: direction
@@ -89,9 +75,23 @@ resourceMetrics:
                   attributes:
                     - key: direction
                       value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "781"
+                  attributes:
+                    - key: direction
+                      value:
                         stringValue: write
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -133,34 +133,6 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
                 - asInt: "7"
                   attributes:
                     - key: direction
@@ -168,34 +140,6 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
                 - asInt: "28"
                   attributes:
                     - key: direction
@@ -203,34 +147,27 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
-                - asInt: "45"
+                - asInt: "4"
                   attributes:
                     - key: direction
                       value:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "88"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "6"
                   attributes:
                     - key: direction
                       value:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "92"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
                   attributes:
                     - key: direction
                       value:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "31"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
+                  timeUnixNano: "1652808280000000000"
                 - asInt: "4"
                   attributes:
                     - key: direction
@@ -244,12 +181,180 @@ resourceMetrics:
                       value:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "5"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "781"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "45"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "6"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "25"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "10"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "789"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "88"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
                 - asInt: "1"
                   attributes:
                     - key: direction
                       value:
                         stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "4"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "76"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "5"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "645"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808320000000000"
                 - asInt: "2"
@@ -259,34 +364,27 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
                 - asInt: "4"
                   attributes:
                     - key: direction
                       value:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "92"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "8"
                   attributes:
                     - key: direction
@@ -294,34 +392,6 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
-                - asInt: "19"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
                 - asInt: "1"
                   attributes:
                     - key: direction
@@ -329,34 +399,6 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "25"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "76"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
                 - asInt: "63"
                   attributes:
                     - key: direction
@@ -370,63 +412,7 @@ resourceMetrics:
                       value:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "10"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
                 - asInt: "7"
                   attributes:
                     - key: direction
@@ -434,6 +420,76 @@ resourceMetrics:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "781"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "31"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "19"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
                 - asInt: "6"
                   attributes:
                     - key: direction
@@ -447,63 +503,7 @@ resourceMetrics:
                       value:
                         stringValue: read
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -541,7 +541,133 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
+                - asInt: "42110"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "11182"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "13316"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "116"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "55647"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "51992"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "105"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
                 - asInt: "41703"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "42686"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "13009"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "14473"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "114"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "57376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "54712"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "103"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
                   attributes:
                     - key: direction
                       value:
@@ -555,7 +681,133 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808320000000000"
+                - asInt: "44277"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "16489"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "19662"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "113"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "64156"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "59449"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "104"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
                 - asInt: "42206"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "43122"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "12398"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "15478"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "58814"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "54604"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "102"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
                   attributes:
                     - key: direction
                       value:
@@ -569,34 +821,6 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "42110"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "42686"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "44277"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "43122"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "42703"
                   attributes:
                     - key: direction
@@ -604,34 +828,6 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "11182"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "13009"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "16489"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "12398"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "12984"
                   attributes:
                     - key: direction
@@ -639,34 +835,6 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "13316"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "14473"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "19662"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "15478"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "14458"
                   attributes:
                     - key: direction
@@ -674,34 +842,6 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "116"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "114"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "113"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "112"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "120"
                   attributes:
                     - key: direction
@@ -709,34 +849,6 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "55647"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "57376"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "64156"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "58814"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "57390"
                   attributes:
                     - key: direction
@@ -744,34 +856,6 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "51992"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "54712"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "59449"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "54604"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "54464"
                   attributes:
                     - key: direction
@@ -785,63 +869,7 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "105"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "103"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "104"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "102"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "109"
                   attributes:
                     - key: direction
@@ -849,34 +877,6 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -903,28 +903,56 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
+                  timeUnixNano: "1652808280000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
+                  timeUnixNano: "1652808280000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
-                        stringValue: transmitted
+                        stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -945,28 +973,56 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
+                  timeUnixNano: "1652808300000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
+                  timeUnixNano: "1652808300000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
-                        stringValue: transmitted
+                        stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -987,28 +1043,14 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
+                  timeUnixNano: "1652808320000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
+                  timeUnixNano: "1652808320000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1022,28 +1064,14 @@ resourceMetrics:
                       value:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
+                  timeUnixNano: "1652808320000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
-                        stringValue: received
+                        stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
+                  timeUnixNano: "1652808320000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1057,28 +1085,14 @@ resourceMetrics:
                       value:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
+                  timeUnixNano: "1652808320000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
+                  timeUnixNano: "1652808320000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1099,28 +1113,14 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
-                        stringValue: received
+                        stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1134,28 +1134,14 @@ resourceMetrics:
                       value:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
-                        stringValue: received
+                        stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1169,28 +1155,7 @@ resourceMetrics:
                       value:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808360000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
+                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1202,6 +1167,41 @@ resourceMetrics:
                   attributes:
                     - key: direction
                       value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808360000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
@@ -1211,28 +1211,28 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
+                  timeUnixNano: "1652808360000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
-                        stringValue: transmitted
+                        stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
+                  timeUnixNano: "1652808360000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
-                        stringValue: transmitted
+                        stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
+                  timeUnixNano: "1652808360000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
-                        stringValue: transmitted
+                        stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
+                  timeUnixNano: "1652808360000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1253,11 +1253,137 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "928"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "3064"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "570"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "357"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "3475"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
                 - asInt: "422"
                   attributes:
                     - key: direction
                       value:
                         stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "1120"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "2537"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "768"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "351"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "2959"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808300000000000"
                 - asInt: "551"
@@ -1267,11 +1393,137 @@ resourceMetrics:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "1646"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "4373"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "1269"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "4924"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
                 - asInt: "617"
                   attributes:
                     - key: direction
                       value:
                         stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "1291"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "3746"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "927"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "363"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "4364"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
                 - asInt: "488"
@@ -1287,63 +1539,7 @@ resourceMetrics:
                       value:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "928"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "1120"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "1646"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "1291"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "1058"
                   attributes:
                     - key: direction
@@ -1351,34 +1547,6 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "3064"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "2537"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "4373"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "3746"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "2569"
                   attributes:
                     - key: direction
@@ -1392,63 +1560,7 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "570"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "768"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "1269"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "927"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "681"
                   attributes:
                     - key: direction
@@ -1456,34 +1568,6 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "357"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "351"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "376"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "363"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "376"
                   attributes:
                     - key: direction
@@ -1491,34 +1575,6 @@ resourceMetrics:
                         stringValue: received
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "3475"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "2959"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "4924"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "4364"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "3058"
                   attributes:
                     - key: direction
@@ -1532,63 +1588,7 @@ resourceMetrics:
                       value:
                         stringValue: transmitted
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1605,13 +1605,61 @@ resourceMetrics:
                 - asInt: "769"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "3634"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
+                - asInt: "4404"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808280000000000"
                 - asInt: "773"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "3305"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808300000000000"
+                - asInt: "4079"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808300000000000"
                 - asInt: "927"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "5642"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
+                - asInt: "6570"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808320000000000"
                 - asInt: "980"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "4674"
+                  startTimeUnixNano: "1685461512690128453"
+                  timeUnixNano: "1652808340000000000"
+                - asInt: "5655"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808340000000000"
                 - asInt: "864"
@@ -1619,61 +1667,13 @@ resourceMetrics:
                   timeUnixNano: "1652808360000000000"
                 - asInt: "0"
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
                 - asInt: "0"
                   startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "3634"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "3305"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "5642"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "4674"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "3251"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"
-                - asInt: "4404"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808280000000000"
-                - asInt: "4079"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808300000000000"
-                - asInt: "6570"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808320000000000"
-                - asInt: "5655"
-                  startTimeUnixNano: "1685461512690128453"
-                  timeUnixNano: "1652808340000000000"
                 - asInt: "4117"
                   startTimeUnixNano: "1685461512690128453"
                   timeUnixNano: "1652808360000000000"


### PR DESCRIPTION
Metrics Datapoint slices of Golden files are now sorted by their respective attribute key.
This is in the efforts to bring Golden files 1 step closer to being more deterministic.

There is a test folder (sort-datapoint-slice) in golden/testdata that shows an example of what this accomplishes.