### PR TITLE
[chore] skip flink metrics in lifecycle checks.

### DIFF
--- a/cmd/otelcontribcol/receivers_test.go
+++ b/cmd/otelcontribcol/receivers_test.go
@@ -187,7 +187,8 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "filestats",
 		},
 		{
-			receiver: "flinkmetrics",
+			receiver:      "flinkmetrics",
+			skipLifecycle: true, // Requires connecting to a running flink cluster
 		},
 		{
 			receiver: "fluentforward",


### PR DESCRIPTION
**Description:** 

So this check previously worked since it the test would finish before the `component.Start` was called.

**Link to tracking Issue:**
NA

**Testing:**
NA

**Documentation:**
NA