### PR TITLE
[pkg/ottl] Changed replacement string to be a path expression to a string telemetry field or a literal string

### DIFF
--- a/.chloggen/ottl_function_changes.yaml
+++ b/.chloggen/ottl_function_changes.yaml
@@ -9,7 +9,7 @@ change_type: enhancement
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Changed replacement_pattern (replacement) string to be a path expression to a string telemetry field or a literal string
+note: Change replacement functions to accept a path expression as a replacement
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [22787]
@@ -17,4 +17,9 @@ issues: [22787]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  The following replacement functions now accept a path expression as a replacement:
+  - replace_match
+  - replace_pattern
+  - replace_all_matches
+  - replace_all_patterns

--- a/.chloggen/ottl_function_changes.yaml
+++ b/.chloggen/ottl_function_changes.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changed replacement_pattern (replacement) string to be a path expression to a string telemetry field or a literal string
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22787]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -148,7 +148,7 @@ Examples:
 
 The `replace_all_matches` function replaces any matching string value with the replacement string.
 
-`target` is a path expression to a `pdata.Map` type field. `pattern` is a string following [filepath.Match syntax](https://pkg.go.dev/path/filepath#Match). `replacement` is a string.
+`target` is a path expression to a `pdata.Map` type field. `pattern` is a string following [filepath.Match syntax](https://pkg.go.dev/path/filepath#Match). `replacement` is either a path expression to a string telemetry field or a literal string.
 
 Each string value in `target` that matches `pattern` will get replaced with `replacement`. Non-string values are ignored.
 
@@ -162,7 +162,7 @@ Examples:
 
 The `replace_all_patterns` function replaces any segments in a string value or key that match the regex pattern with the replacement string.
 
-`target` is a path expression to a `pdata.Map` type field. `regex` is a regex string indicating a segment to replace. `replacement` is a string.
+`target` is a path expression to a `pdata.Map` type field. `regex` is a regex string indicating a segment to replace. `replacement` is either a path expression to a string telemetry field or a literal string.
 
 `mode` determines whether the match and replace will occur on the map's value or key. Valid values are `key` and `value`.
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -186,7 +186,7 @@ If using OTTL outside of collector configuration, `$` should not be escaped and 
 
 The `replace_match` function allows replacing entire strings if they match a glob pattern.
 
-`target` is a path expression to a telemetry field. `pattern` is a string following [filepath.Match syntax](https://pkg.go.dev/path/filepath#Match). `replacement` is a string.
+`target` is a path expression to a telemetry field. `pattern` is a string following [filepath.Match syntax](https://pkg.go.dev/path/filepath#Match). `replacement` is either a path expression to a string telemetry field or a literal string.
 
 If `target` matches `pattern` it will get replaced with `replacement`.
 
@@ -200,7 +200,7 @@ Examples:
 
 The `replace_pattern` function allows replacing all string sections that match a regex pattern with a new value.
 
-`target` is a path expression to a telemetry field. `regex` is a regex string indicating a segment to replace. `replacement` is a string.
+`target` is a path expression to a telemetry field. `regex` is a regex string indicating a segment to replace. `replacement` is either a path expression to a string telemetry field or a literal string.
 
 If one or more sections of `target` match `regex` they will get replaced with `replacement`.
 

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches.go
@@ -14,9 +14,9 @@ import (
 )
 
 type ReplaceAllMatchesArguments[K any] struct {
-	Target      ottl.PMapGetter[K] `ottlarg:"0"`
-	Pattern     string             `ottlarg:"1"`
-	Replacement string             `ottlarg:"2"`
+	Target      ottl.PMapGetter[K]   `ottlarg:"0"`
+	Pattern     string               `ottlarg:"1"`
+	Replacement ottl.StringGetter[K] `ottlarg:"2"`
 }
 
 func NewReplaceAllMatchesFactory[K any]() ottl.Factory[K] {
@@ -33,7 +33,7 @@ func createReplaceAllMatchesFunction[K any](_ ottl.FunctionContext, oArgs ottl.A
 	return replaceAllMatches(args.Target, args.Pattern, args.Replacement)
 }
 
-func replaceAllMatches[K any](target ottl.PMapGetter[K], pattern string, replacement string) (ottl.ExprFunc[K], error) {
+func replaceAllMatches[K any](target ottl.PMapGetter[K], pattern string, replacement ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
 	glob, err := glob.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to replace_match is not a valid pattern: %w", err)
@@ -43,9 +43,13 @@ func replaceAllMatches[K any](target ottl.PMapGetter[K], pattern string, replace
 		if err != nil {
 			return nil, err
 		}
+		replacementVal, err := replacement.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
 		val.Range(func(key string, value pcommon.Value) bool {
 			if glob.Match(value.Str()) {
-				value.SetStr(replacement)
+				value.SetStr(replacementVal)
 			}
 			return true
 		})

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -34,15 +34,19 @@ func Test_replaceAllPatterns(t *testing.T) {
 		target      ottl.PMapGetter[pcommon.Map]
 		mode        string
 		pattern     string
-		replacement string
+		replacement ottl.StringGetter[pcommon.Map]
 		want        func(pcommon.Map)
 	}{
 		{
-			name:        "replace only matches",
-			target:      target,
-			mode:        modeValue,
-			pattern:     "hello",
-			replacement: "hello {universe}",
+			name:    "replace only matches",
+			target:  target,
+			mode:    modeValue,
+			pattern: "hello",
+			replacement: ottl.StandardStringGetter[pcommon.Map]{
+				Getter: func(context.Context, pcommon.Map) (interface{}, error) {
+					return "hello {universe}", nil
+				},
+			},
 			want: func(expectedMap pcommon.Map) {
 				expectedMap.PutStr("test", "hello {universe} world")
 				expectedMap.PutStr("test2", "hello {universe}")
@@ -53,11 +57,15 @@ func Test_replaceAllPatterns(t *testing.T) {
 			},
 		},
 		{
-			name:        "no matches",
-			target:      target,
-			mode:        modeValue,
-			pattern:     "nothing",
-			replacement: "nothing {matches}",
+			name:    "no matches",
+			target:  target,
+			mode:    modeValue,
+			pattern: "nothing",
+			replacement: ottl.StandardStringGetter[pcommon.Map]{
+				Getter: func(context.Context, pcommon.Map) (interface{}, error) {
+					return "nothing {matches}", nil
+				},
+			},
 			want: func(expectedMap pcommon.Map) {
 				expectedMap.PutStr("test", "hello world")
 				expectedMap.PutStr("test2", "hello")
@@ -68,11 +76,15 @@ func Test_replaceAllPatterns(t *testing.T) {
 			},
 		},
 		{
-			name:        "multiple regex match",
-			target:      target,
-			mode:        modeValue,
-			pattern:     `world[^\s]*(\s?)`,
-			replacement: "**** ",
+			name:    "multiple regex match",
+			target:  target,
+			mode:    modeValue,
+			pattern: `world[^\s]*(\s?)`,
+			replacement: ottl.StandardStringGetter[pcommon.Map]{
+				Getter: func(context.Context, pcommon.Map) (interface{}, error) {
+					return "**** ", nil
+				},
+			},
 			want: func(expectedMap pcommon.Map) {
 				expectedMap.PutStr("test", "hello **** ")
 				expectedMap.PutStr("test2", "hello")
@@ -83,11 +95,15 @@ func Test_replaceAllPatterns(t *testing.T) {
 			},
 		},
 		{
-			name:        "replace only matches",
-			target:      target,
-			mode:        modeKey,
-			pattern:     "test2",
-			replacement: "foo",
+			name:    "replace only matches",
+			target:  target,
+			mode:    modeKey,
+			pattern: "test2",
+			replacement: ottl.StandardStringGetter[pcommon.Map]{
+				Getter: func(context.Context, pcommon.Map) (interface{}, error) {
+					return "foo", nil
+				},
+			},
 			want: func(expectedMap pcommon.Map) {
 				expectedMap.Clear()
 				expectedMap.PutStr("test", "hello world")
@@ -99,11 +115,15 @@ func Test_replaceAllPatterns(t *testing.T) {
 			},
 		},
 		{
-			name:        "no matches",
-			target:      target,
-			mode:        modeKey,
-			pattern:     "nothing",
-			replacement: "nothing {matches}",
+			name:    "no matches",
+			target:  target,
+			mode:    modeKey,
+			pattern: "nothing",
+			replacement: ottl.StandardStringGetter[pcommon.Map]{
+				Getter: func(context.Context, pcommon.Map) (interface{}, error) {
+					return "nothing {matches}", nil
+				},
+			},
 			want: func(expectedMap pcommon.Map) {
 				expectedMap.Clear()
 				expectedMap.PutStr("test", "hello world")
@@ -115,11 +135,15 @@ func Test_replaceAllPatterns(t *testing.T) {
 			},
 		},
 		{
-			name:        "multiple regex match",
-			target:      target,
-			mode:        modeKey,
-			pattern:     `test`,
-			replacement: "test.",
+			name:    "multiple regex match",
+			target:  target,
+			mode:    modeKey,
+			pattern: `test`,
+			replacement: ottl.StandardStringGetter[pcommon.Map]{
+				Getter: func(context.Context, pcommon.Map) (interface{}, error) {
+					return "test.", nil
+				},
+			},
 			want: func(expectedMap pcommon.Map) {
 				expectedMap.Clear()
 				expectedMap.PutStr("test.", "hello world")
@@ -131,11 +155,15 @@ func Test_replaceAllPatterns(t *testing.T) {
 			},
 		},
 		{
-			name:        "expand capturing groups in values",
-			target:      target,
-			mode:        modeValue,
-			pattern:     `world(\d)`,
-			replacement: "world-$1",
+			name:    "expand capturing groups in values",
+			target:  target,
+			mode:    modeValue,
+			pattern: `world(\d)`,
+			replacement: ottl.StandardStringGetter[pcommon.Map]{
+				Getter: func(context.Context, pcommon.Map) (interface{}, error) {
+					return "world-$1", nil
+				},
+			},
 			want: func(expectedMap pcommon.Map) {
 				expectedMap.Clear()
 				expectedMap.PutStr("test", "hello world")
@@ -147,11 +175,15 @@ func Test_replaceAllPatterns(t *testing.T) {
 			},
 		},
 		{
-			name:        "expand capturing groups in keys",
-			target:      target,
-			mode:        modeKey,
-			pattern:     `test(\d)`,
-			replacement: "test-$1",
+			name:    "expand capturing groups in keys",
+			target:  target,
+			mode:    modeKey,
+			pattern: `test(\d)`,
+			replacement: ottl.StandardStringGetter[pcommon.Map]{
+				Getter: func(context.Context, pcommon.Map) (interface{}, error) {
+					return "test-$1", nil
+				},
+			},
 			want: func(expectedMap pcommon.Map) {
 				expectedMap.PutStr("test", "hello world")
 				expectedMap.PutStr("test-2", "hello")
@@ -162,11 +194,15 @@ func Test_replaceAllPatterns(t *testing.T) {
 			},
 		},
 		{
-			name:        "replacement with literal $",
-			target:      target,
-			mode:        modeValue,
-			pattern:     `world(\d)`,
-			replacement: "$$world-$1",
+			name:    "replacement with literal $",
+			target:  target,
+			mode:    modeValue,
+			pattern: `world(\d)`,
+			replacement: ottl.StandardStringGetter[pcommon.Map]{
+				Getter: func(context.Context, pcommon.Map) (interface{}, error) {
+					return "$$world-$1", nil
+				},
+			},
 			want: func(expectedMap pcommon.Map) {
 				expectedMap.Clear()
 				expectedMap.PutStr("test", "hello world")
@@ -205,8 +241,13 @@ func Test_replaceAllPatterns_bad_input(t *testing.T) {
 			return tCtx, nil
 		},
 	}
+	replacement := &ottl.StandardStringGetter[interface{}]{
+		Getter: func(context.Context, interface{}) (interface{}, error) {
+			return "{replacement}", nil
+		},
+	}
 
-	exprFunc, err := replaceAllPatterns[interface{}](target, modeValue, "regexpattern", "{replacement}")
+	exprFunc, err := replaceAllPatterns[interface{}](target, modeValue, "regexpattern", replacement)
 	assert.Nil(t, err)
 
 	_, err = exprFunc(nil, input)
@@ -219,8 +260,13 @@ func Test_replaceAllPatterns_get_nil(t *testing.T) {
 			return tCtx, nil
 		},
 	}
+	replacement := &ottl.StandardStringGetter[interface{}]{
+		Getter: func(context.Context, interface{}) (interface{}, error) {
+			return "{anything}", nil
+		},
+	}
 
-	exprFunc, err := replaceAllPatterns[interface{}](target, modeValue, "regexp", "{anything}")
+	exprFunc, err := replaceAllPatterns[interface{}](target, modeValue, "regexp", replacement)
 	assert.NoError(t, err)
 
 	_, err = exprFunc(nil, nil)
@@ -234,9 +280,14 @@ func Test_replaceAllPatterns_invalid_pattern(t *testing.T) {
 			return nil, nil
 		},
 	}
+	replacement := &ottl.StandardStringGetter[interface{}]{
+		Getter: func(context.Context, interface{}) (interface{}, error) {
+			return "{anything}", nil
+		},
+	}
 
 	invalidRegexPattern := "*"
-	exprFunc, err := replaceAllPatterns[interface{}](target, modeValue, invalidRegexPattern, "{anything}")
+	exprFunc, err := replaceAllPatterns[interface{}](target, modeValue, invalidRegexPattern, replacement)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "error parsing regexp:")
 	assert.Nil(t, exprFunc)
@@ -249,9 +300,14 @@ func Test_replaceAllPatterns_invalid_model(t *testing.T) {
 			return nil, nil
 		},
 	}
+	replacement := &ottl.StandardStringGetter[interface{}]{
+		Getter: func(context.Context, interface{}) (interface{}, error) {
+			return "{anything}", nil
+		},
+	}
 
 	invalidMode := "invalid"
-	exprFunc, err := replaceAllPatterns[interface{}](target, invalidMode, "regex", "{anything}")
+	exprFunc, err := replaceAllPatterns[interface{}](target, invalidMode, "regex", replacement)
 	assert.Nil(t, exprFunc)
 	assert.Contains(t, err.Error(), "invalid mode")
 }

--- a/pkg/ottl/ottlfuncs/func_replace_match.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match.go
@@ -39,12 +39,12 @@ func replaceMatch[K any](target ottl.GetSetter[K], pattern string, replacement o
 	}
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
 		val, err := target.Get(ctx, tCtx)
-		replacementVal, errRepl := replacement.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
-		if errRepl != nil {
-			return nil, errRepl
+		replacementVal, err := replacement.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
 		}
 		if val == nil {
 			return nil, nil

--- a/pkg/ottl/ottlfuncs/func_replace_match.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match.go
@@ -13,9 +13,9 @@ import (
 )
 
 type ReplaceMatchArguments[K any] struct {
-	Target      ottl.GetSetter[K] `ottlarg:"0"`
-	Pattern     string            `ottlarg:"1"`
-	Replacement string            `ottlarg:"2"`
+	Target      ottl.GetSetter[K]    `ottlarg:"0"`
+	Pattern     string               `ottlarg:"1"`
+	Replacement ottl.StringGetter[K] `ottlarg:"2"`
 }
 
 func NewReplaceMatchFactory[K any]() ottl.Factory[K] {
@@ -32,22 +32,26 @@ func createReplaceMatchFunction[K any](_ ottl.FunctionContext, oArgs ottl.Argume
 	return replaceMatch(args.Target, args.Pattern, args.Replacement)
 }
 
-func replaceMatch[K any](target ottl.GetSetter[K], pattern string, replacement string) (ottl.ExprFunc[K], error) {
+func replaceMatch[K any](target ottl.GetSetter[K], pattern string, replacement ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
 	glob, err := glob.Compile(pattern)
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to replace_match is not a valid pattern: %w", err)
 	}
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
 		val, err := target.Get(ctx, tCtx)
+		replacementVal, errRepl := replacement.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
+		}
+		if errRepl != nil {
+			return nil, errRepl
 		}
 		if val == nil {
 			return nil, nil
 		}
 		if valStr, ok := val.(string); ok {
 			if glob.Match(valStr) {
-				err = target.Set(ctx, tCtx, replacement)
+				err = target.Set(ctx, tCtx, replacementVal)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -38,12 +38,12 @@ func replacePattern[K any](target ottl.GetSetter[K], regexPattern string, replac
 	}
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
 		originalVal, err := target.Get(ctx, tCtx)
-		replacementVal, errRepl := replacement.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
-		if errRepl != nil {
-			return nil, errRepl
+		replacementVal, err := replacement.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
 		}
 		if originalVal == nil {
 			return nil, nil

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -12,9 +12,9 @@ import (
 )
 
 type ReplacePatternArguments[K any] struct {
-	Target       ottl.GetSetter[K] `ottlarg:"0"`
-	RegexPattern string            `ottlarg:"1"`
-	Replacement  string            `ottlarg:"2"`
+	Target       ottl.GetSetter[K]    `ottlarg:"0"`
+	RegexPattern string               `ottlarg:"1"`
+	Replacement  ottl.StringGetter[K] `ottlarg:"2"`
 }
 
 func NewReplacePatternFactory[K any]() ottl.Factory[K] {
@@ -31,22 +31,26 @@ func createReplacePatternFunction[K any](_ ottl.FunctionContext, oArgs ottl.Argu
 	return replacePattern(args.Target, args.RegexPattern, args.Replacement)
 }
 
-func replacePattern[K any](target ottl.GetSetter[K], regexPattern string, replacement string) (ottl.ExprFunc[K], error) {
+func replacePattern[K any](target ottl.GetSetter[K], regexPattern string, replacement ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
 	compiledPattern, err := regexp.Compile(regexPattern)
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to replace_pattern is not a valid pattern: %w", err)
 	}
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
 		originalVal, err := target.Get(ctx, tCtx)
+		replacementVal, errRepl := replacement.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
+		}
+		if errRepl != nil {
+			return nil, errRepl
 		}
 		if originalVal == nil {
 			return nil, nil
 		}
 		if originalValStr, ok := originalVal.(string); ok {
 			if compiledPattern.MatchString(originalValStr) {
-				updatedStr := compiledPattern.ReplaceAllString(originalValStr, replacement)
+				updatedStr := compiledPattern.ReplaceAllString(originalValStr, replacementVal)
 				err = target.Set(ctx, tCtx, updatedStr)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION

**Description:** 
- Changed replacement_pattern (replacement) string to be a path expression to a string telemetry field or a literal string
- Added new hash functions to the factory map

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22787
**Testing:** 
- Tested locally using the following processors
```
  attributes/example:
    actions:
      - key: message
        pattern: "^device=(?P<device_name>\\w+)$"
        action: extract
  transform/replace:
    log_statements:
      - context: log
        statements:
          - set(attributes["device_name"], SHA256(attributes["device_name"]))
          - replace_pattern(attributes["message"], "^device=[0-9A-Za-z]+", attributes["device_name"])
```
- Updated unit tests