### PR TITLE
[mysqlreceiver]: add `aborted`, `aborted_clients` and `locked` values to `error` property for `mysql.connection.errors` metric

### DIFF
--- a/.chloggen/drosiek-mysql-aborted.yaml
+++ b/.chloggen/drosiek-mysql-aborted.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "add `aborted`, `aborted_clients` and `locked` values to `error` property for `mysql.connection.errors` metric"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [14138]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -422,7 +422,7 @@ Errors that occur during the client connection process.
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| error | The connection error type. | Str: ``accept``, ``internal``, ``max_connections``, ``peer_address``, ``select``, ``tcpwrap`` |
+| error | The connection error type. | Str: ``accept``, ``internal``, ``max_connections``, ``peer_address``, ``select``, ``tcpwrap``, ``aborted``, ``aborted_clients``, ``locked`` |
 
 ### mysql.joins
 

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -190,6 +190,9 @@ const (
 	AttributeConnectionErrorPeerAddress
 	AttributeConnectionErrorSelect
 	AttributeConnectionErrorTcpwrap
+	AttributeConnectionErrorAborted
+	AttributeConnectionErrorAbortedClients
+	AttributeConnectionErrorLocked
 )
 
 // String returns the string representation of the AttributeConnectionError.
@@ -207,6 +210,12 @@ func (av AttributeConnectionError) String() string {
 		return "select"
 	case AttributeConnectionErrorTcpwrap:
 		return "tcpwrap"
+	case AttributeConnectionErrorAborted:
+		return "aborted"
+	case AttributeConnectionErrorAbortedClients:
+		return "aborted_clients"
+	case AttributeConnectionErrorLocked:
+		return "locked"
 	}
 	return ""
 }
@@ -219,6 +228,9 @@ var MapAttributeConnectionError = map[string]AttributeConnectionError{
 	"peer_address":    AttributeConnectionErrorPeerAddress,
 	"select":          AttributeConnectionErrorSelect,
 	"tcpwrap":         AttributeConnectionErrorTcpwrap,
+	"aborted":         AttributeConnectionErrorAborted,
+	"aborted_clients": AttributeConnectionErrorAbortedClients,
+	"locked":          AttributeConnectionErrorLocked,
 }
 
 // AttributeConnectionStatus specifies the a value connection_status attribute.

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -41,7 +41,7 @@ attributes:
     name_override: error
     description: The connection error type.
     type: string
-    enum: [accept, internal, max_connections, peer_address, select, tcpwrap]
+    enum: [accept, internal, max_connections, peer_address, select, tcpwrap, aborted, aborted_clients, locked]
   handler:
     name_override: kind
     description: The handler types.

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -122,7 +122,6 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 
 	for k, v := range globalStats {
 		switch k {
-
 		// bytes transmission
 		case "Bytes_received":
 			addPartialIfError(errs, m.mb.RecordMysqlClientNetworkIoDataPoint(now, v, metadata.AttributeDirectionReceived))
@@ -186,6 +185,17 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 		case "Connection_errors_tcpwrap":
 			addPartialIfError(errs, m.mb.RecordMysqlConnectionErrorsDataPoint(now, v,
 				metadata.AttributeConnectionErrorTcpwrap))
+		case "Aborted_clients":
+			addPartialIfError(errs, m.mb.RecordMysqlConnectionErrorsDataPoint(now, v,
+				metadata.AttributeConnectionErrorAbortedClients))
+		case "Aborted_connects":
+			addPartialIfError(errs, m.mb.RecordMysqlConnectionErrorsDataPoint(now, v,
+				metadata.AttributeConnectionErrorAborted))
+		case "Locked_connects":
+			addPartialIfError(errs, m.mb.RecordMysqlLockedConnectsDataPoint(now, v))
+			addPartialIfError(errs, m.mb.RecordMysqlConnectionErrorsDataPoint(now, v,
+				metadata.AttributeConnectionErrorLocked))
+
 		// connection
 		case "Connections":
 			addPartialIfError(errs, m.mb.RecordMysqlConnectionCountDataPoint(now, v))
@@ -321,10 +331,6 @@ func (m *mySQLScraper) scrapeGlobalStats(now pcommon.Timestamp, errs *scrapererr
 			addPartialIfError(errs, m.mb.RecordMysqlLocksDataPoint(now, v, metadata.AttributeLocksImmediate))
 		case "Table_locks_waited":
 			addPartialIfError(errs, m.mb.RecordMysqlLocksDataPoint(now, v, metadata.AttributeLocksWaited))
-
-		// locked_connects
-		case "Locked_connects":
-			addPartialIfError(errs, m.mb.RecordMysqlLockedConnectsDataPoint(now, v))
 
 		// joins
 		case "Select_full_join":

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -261,6 +261,27 @@ resourceMetrics:
                         stringValue: tcpwrap
                   startTimeUnixNano: "1644862687825728000"
                   timeUnixNano: "1644862687825772000"
+                - asInt: "2"
+                  attributes:
+                    - key: error
+                      value:
+                        stringValue: aborted
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "1"
+                  attributes:
+                    - key: error
+                      value:
+                        stringValue: aborted_clients
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
+                - asInt: "293"
+                  attributes:
+                    - key: error
+                      value:
+                        stringValue: locked
+                  startTimeUnixNano: "1644862687825728000"
+                  timeUnixNano: "1644862687825772000"
               isMonotonic: true
             unit: "1"
           - description: The number of writes to the InnoDB doublewrite buffer.


### PR DESCRIPTION
**Description:**

Add missing metrics from #14138 as `mysql.connection.errors`:

- `mysql_aborted_clients`
- `mysql_aborted_connects`
- **duplicate** `mysql.locked_connects`

**Link to tracking Issue:** #14138

**Testing:** unit tests

**Documentation:** `metadata.yaml`