### PR TITLE
[hostmetricsreceiver]: support reporting amount of available logical and physical CPUs

### DIFF
--- a/.chloggen/hostmetricsreceiver_support_cpu_count.yaml
+++ b/.chloggen/hostmetricsreceiver_support_cpu_count.yaml
@@ -17,4 +17,5 @@ issues: [22099]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: | 
+  Use the `system.cpu.logical.count::enabled` and `system.cpu.physical.count::enabled` flags to enable them

--- a/.chloggen/hostmetricsreceiver_support_cpu_count.yaml
+++ b/.chloggen/hostmetricsreceiver_support_cpu_count.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Report  logical and physical number of CPUs as metric.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22099]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper.go
@@ -67,5 +67,17 @@ func (s *scraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		return pmetric.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
 	}
 
+	numCPU, err := cpu.Counts(false)
+	if err != nil {
+		return pmetric.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
+	}
+	s.mb.RecordSystemCPUPhysicalCountDataPoint(now, int64(numCPU))
+
+	numCPU, err = cpu.Counts(true)
+	if err != nil {
+		return pmetric.NewMetrics(), scrapererror.NewPartialScrapeError(err, metricsLen)
+	}
+	s.mb.RecordSystemCPULogicalCountDataPoint(now, int64(numCPU))
+
 	return s.mb.Emit(), nil
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -335,7 +335,7 @@ func assertDatapointValueAndStringAttributes(t *testing.T, dp pmetric.NumberData
 func assertCPUMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
 	expected := pmetric.NewMetric()
 	expected.SetName("system.cpu.time")
-	expected.SetDescription("Total CPU seconds broken down by different states.")
+	expected.SetDescription("Total seconds each logical CPU spent on each mode.")
 	expected.SetUnit("s")
 	expected.SetEmptySum()
 	internal.AssertDescriptorEqual(t, expected, metric)
@@ -368,7 +368,7 @@ func assertCPUMetricHasLinuxSpecificStateLabels(t *testing.T, metric pmetric.Met
 func assertCPUUtilizationMetricValid(t *testing.T, metric pmetric.Metric, startTime pcommon.Timestamp) {
 	expected := pmetric.NewMetric()
 	expected.SetName("system.cpu.utilization")
-	expected.SetDescription("Percentage of CPU time broken down by different states.")
+	expected.SetDescription("Difference in system.cpu.time since the last measurement, divided by the elapsed time and number of logical CPUs.")
 	expected.SetUnit("1")
 	expected.SetEmptyGauge()
 	internal.AssertDescriptorEqual(t, expected, metric)

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
@@ -16,7 +16,7 @@ metrics:
 
 ### system.cpu.time
 
-Total CPU seconds broken down by different states.
+Total seconds each logical CPU spent on each mode.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
@@ -26,7 +26,7 @@ Total CPU seconds broken down by different states.
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| cpu | CPU number starting at 0. | Any Str |
+| cpu | Logical CPU number starting at 0. | Any Str |
 | state | Breakdown of CPU usage by type. | Str: ``idle``, ``interrupt``, ``nice``, ``softirq``, ``steal``, ``system``, ``user``, ``wait`` |
 
 ## Optional Metrics
@@ -39,9 +39,25 @@ metrics:
     enabled: true
 ```
 
+### system.cpu.logical.count
+
+Number of available logical CPUs.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {cpu} | Sum | Int | Cumulative | false |
+
+### system.cpu.physical.count
+
+Number of available physical CPUs.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {cpu} | Sum | Int | Cumulative | false |
+
 ### system.cpu.utilization
 
-Percentage of CPU time broken down by different states.
+Difference in system.cpu.time since the last measurement, divided by the elapsed time and number of logical CPUs.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -51,5 +67,5 @@ Percentage of CPU time broken down by different states.
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| cpu | CPU number starting at 0. | Any Str |
+| cpu | Logical CPU number starting at 0. | Any Str |
 | state | Breakdown of CPU usage by type. | Str: ``idle``, ``interrupt``, ``nice``, ``softirq``, ``steal``, ``system``, ``user``, ``wait`` |

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
@@ -25,12 +25,20 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for hostmetricsreceiver/cpu metrics.
 type MetricsConfig struct {
-	SystemCPUTime        MetricConfig `mapstructure:"system.cpu.time"`
-	SystemCPUUtilization MetricConfig `mapstructure:"system.cpu.utilization"`
+	SystemCPULogicalCount  MetricConfig `mapstructure:"system.cpu.logical.count"`
+	SystemCPUPhysicalCount MetricConfig `mapstructure:"system.cpu.physical.count"`
+	SystemCPUTime          MetricConfig `mapstructure:"system.cpu.time"`
+	SystemCPUUtilization   MetricConfig `mapstructure:"system.cpu.utilization"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
+		SystemCPULogicalCount: MetricConfig{
+			Enabled: false,
+		},
+		SystemCPUPhysicalCount: MetricConfig{
+			Enabled: false,
+		},
 		SystemCPUTime: MetricConfig{
 			Enabled: true,
 		},

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config_test.go
@@ -26,8 +26,10 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					SystemCPUTime:        MetricConfig{Enabled: true},
-					SystemCPUUtilization: MetricConfig{Enabled: true},
+					SystemCPULogicalCount:  MetricConfig{Enabled: true},
+					SystemCPUPhysicalCount: MetricConfig{Enabled: true},
+					SystemCPUTime:          MetricConfig{Enabled: true},
+					SystemCPUUtilization:   MetricConfig{Enabled: true},
 				},
 			},
 		},
@@ -35,8 +37,10 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					SystemCPUTime:        MetricConfig{Enabled: false},
-					SystemCPUUtilization: MetricConfig{Enabled: false},
+					SystemCPULogicalCount:  MetricConfig{Enabled: false},
+					SystemCPUPhysicalCount: MetricConfig{Enabled: false},
+					SystemCPUTime:          MetricConfig{Enabled: false},
+					SystemCPUUtilization:   MetricConfig{Enabled: false},
 				},
 			},
 		},

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
@@ -62,6 +62,108 @@ var MapAttributeState = map[string]AttributeState{
 	"wait":      AttributeStateWait,
 }
 
+type metricSystemCPULogicalCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	config   MetricConfig   // metric config provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills system.cpu.logical.count metric with initial data.
+func (m *metricSystemCPULogicalCount) init() {
+	m.data.SetName("system.cpu.logical.count")
+	m.data.SetDescription("Number of available logical CPUs.")
+	m.data.SetUnit("{cpu}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricSystemCPULogicalCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSystemCPULogicalCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSystemCPULogicalCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSystemCPULogicalCount(cfg MetricConfig) metricSystemCPULogicalCount {
+	m := metricSystemCPULogicalCount{config: cfg}
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
+type metricSystemCPUPhysicalCount struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	config   MetricConfig   // metric config provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills system.cpu.physical.count metric with initial data.
+func (m *metricSystemCPUPhysicalCount) init() {
+	m.data.SetName("system.cpu.physical.count")
+	m.data.SetDescription("Number of available physical CPUs.")
+	m.data.SetUnit("{cpu}")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricSystemCPUPhysicalCount) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSystemCPUPhysicalCount) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSystemCPUPhysicalCount) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSystemCPUPhysicalCount(cfg MetricConfig) metricSystemCPUPhysicalCount {
+	m := metricSystemCPUPhysicalCount{config: cfg}
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSystemCPUTime struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	config   MetricConfig   // metric config provided by user.
@@ -71,7 +173,7 @@ type metricSystemCPUTime struct {
 // init fills system.cpu.time metric with initial data.
 func (m *metricSystemCPUTime) init() {
 	m.data.SetName("system.cpu.time")
-	m.data.SetDescription("Total CPU seconds broken down by different states.")
+	m.data.SetDescription("Total seconds each logical CPU spent on each mode.")
 	m.data.SetUnit("s")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
@@ -125,7 +227,7 @@ type metricSystemCPUUtilization struct {
 // init fills system.cpu.utilization metric with initial data.
 func (m *metricSystemCPUUtilization) init() {
 	m.data.SetName("system.cpu.utilization")
-	m.data.SetDescription("Percentage of CPU time broken down by different states.")
+	m.data.SetDescription("Difference in system.cpu.time since the last measurement, divided by the elapsed time and number of logical CPUs.")
 	m.data.SetUnit("1")
 	m.data.SetEmptyGauge()
 	m.data.Gauge().DataPoints().EnsureCapacity(m.capacity)
@@ -171,13 +273,15 @@ func newMetricSystemCPUUtilization(cfg MetricConfig) metricSystemCPUUtilization 
 // MetricsBuilder provides an interface for scrapers to report metrics while taking care of all the transformations
 // required to produce metric representation defined in metadata and user config.
 type MetricsBuilder struct {
-	config                     MetricsBuilderConfig // config of the metrics builder.
-	startTime                  pcommon.Timestamp    // start time that will be applied to all recorded data points.
-	metricsCapacity            int                  // maximum observed number of metrics per resource.
-	metricsBuffer              pmetric.Metrics      // accumulates metrics data before emitting.
-	buildInfo                  component.BuildInfo  // contains version information.
-	metricSystemCPUTime        metricSystemCPUTime
-	metricSystemCPUUtilization metricSystemCPUUtilization
+	config                       MetricsBuilderConfig // config of the metrics builder.
+	startTime                    pcommon.Timestamp    // start time that will be applied to all recorded data points.
+	metricsCapacity              int                  // maximum observed number of metrics per resource.
+	metricsBuffer                pmetric.Metrics      // accumulates metrics data before emitting.
+	buildInfo                    component.BuildInfo  // contains version information.
+	metricSystemCPULogicalCount  metricSystemCPULogicalCount
+	metricSystemCPUPhysicalCount metricSystemCPUPhysicalCount
+	metricSystemCPUTime          metricSystemCPUTime
+	metricSystemCPUUtilization   metricSystemCPUUtilization
 }
 
 // metricBuilderOption applies changes to default metrics builder.
@@ -192,12 +296,14 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSettings, options ...metricBuilderOption) *MetricsBuilder {
 	mb := &MetricsBuilder{
-		config:                     mbc,
-		startTime:                  pcommon.NewTimestampFromTime(time.Now()),
-		metricsBuffer:              pmetric.NewMetrics(),
-		buildInfo:                  settings.BuildInfo,
-		metricSystemCPUTime:        newMetricSystemCPUTime(mbc.Metrics.SystemCPUTime),
-		metricSystemCPUUtilization: newMetricSystemCPUUtilization(mbc.Metrics.SystemCPUUtilization),
+		config:                       mbc,
+		startTime:                    pcommon.NewTimestampFromTime(time.Now()),
+		metricsBuffer:                pmetric.NewMetrics(),
+		buildInfo:                    settings.BuildInfo,
+		metricSystemCPULogicalCount:  newMetricSystemCPULogicalCount(mbc.Metrics.SystemCPULogicalCount),
+		metricSystemCPUPhysicalCount: newMetricSystemCPUPhysicalCount(mbc.Metrics.SystemCPUPhysicalCount),
+		metricSystemCPUTime:          newMetricSystemCPUTime(mbc.Metrics.SystemCPUTime),
+		metricSystemCPUUtilization:   newMetricSystemCPUUtilization(mbc.Metrics.SystemCPUUtilization),
 	}
 	for _, op := range options {
 		op(mb)
@@ -255,6 +361,8 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	ils.Scope().SetName("otelcol/hostmetricsreceiver/cpu")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
+	mb.metricSystemCPULogicalCount.emit(ils.Metrics())
+	mb.metricSystemCPUPhysicalCount.emit(ils.Metrics())
 	mb.metricSystemCPUTime.emit(ils.Metrics())
 	mb.metricSystemCPUUtilization.emit(ils.Metrics())
 
@@ -275,6 +383,16 @@ func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 	metrics := mb.metricsBuffer
 	mb.metricsBuffer = pmetric.NewMetrics()
 	return metrics
+}
+
+// RecordSystemCPULogicalCountDataPoint adds a data point to system.cpu.logical.count metric.
+func (mb *MetricsBuilder) RecordSystemCPULogicalCountDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricSystemCPULogicalCount.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSystemCPUPhysicalCountDataPoint adds a data point to system.cpu.physical.count metric.
+func (mb *MetricsBuilder) RecordSystemCPUPhysicalCountDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricSystemCPUPhysicalCount.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSystemCPUTimeDataPoint adds a data point to system.cpu.time metric.

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
@@ -54,6 +54,12 @@ func TestMetricsBuilder(t *testing.T) {
 			defaultMetricsCount := 0
 			allMetricsCount := 0
 
+			allMetricsCount++
+			mb.RecordSystemCPULogicalCountDataPoint(ts, 1)
+
+			allMetricsCount++
+			mb.RecordSystemCPUPhysicalCountDataPoint(ts, 1)
+
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSystemCPUTimeDataPoint(ts, 1, "cpu-val", AttributeStateIdle)
@@ -83,12 +89,40 @@ func TestMetricsBuilder(t *testing.T) {
 			validatedMetrics := make(map[string]bool)
 			for i := 0; i < ms.Len(); i++ {
 				switch ms.At(i).Name() {
+				case "system.cpu.logical.count":
+					assert.False(t, validatedMetrics["system.cpu.logical.count"], "Found a duplicate in the metrics slice: system.cpu.logical.count")
+					validatedMetrics["system.cpu.logical.count"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+					assert.Equal(t, "Number of available logical CPUs.", ms.At(i).Description())
+					assert.Equal(t, "{cpu}", ms.At(i).Unit())
+					assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+					dp := ms.At(i).Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "system.cpu.physical.count":
+					assert.False(t, validatedMetrics["system.cpu.physical.count"], "Found a duplicate in the metrics slice: system.cpu.physical.count")
+					validatedMetrics["system.cpu.physical.count"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+					assert.Equal(t, "Number of available physical CPUs.", ms.At(i).Description())
+					assert.Equal(t, "{cpu}", ms.At(i).Unit())
+					assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+					dp := ms.At(i).Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
 				case "system.cpu.time":
 					assert.False(t, validatedMetrics["system.cpu.time"], "Found a duplicate in the metrics slice: system.cpu.time")
 					validatedMetrics["system.cpu.time"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "Total CPU seconds broken down by different states.", ms.At(i).Description())
+					assert.Equal(t, "Total seconds each logical CPU spent on each mode.", ms.At(i).Description())
 					assert.Equal(t, "s", ms.At(i).Unit())
 					assert.Equal(t, true, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
@@ -108,7 +142,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["system.cpu.utilization"] = true
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
-					assert.Equal(t, "Percentage of CPU time broken down by different states.", ms.At(i).Description())
+					assert.Equal(t, "Difference in system.cpu.time since the last measurement, divided by the elapsed time and number of logical CPUs.", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/testdata/config.yaml
@@ -1,12 +1,20 @@
 default:
 all_set:
   metrics:
+    system.cpu.logical.count:
+      enabled: true
+    system.cpu.physical.count:
+      enabled: true
     system.cpu.time:
       enabled: true
     system.cpu.utilization:
       enabled: true
 none_set:
   metrics:
+    system.cpu.logical.count:
+      enabled: false
+    system.cpu.physical.count:
+      enabled: false
     system.cpu.time:
       enabled: false
     system.cpu.utilization:

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -6,7 +6,7 @@ sem_conv_version: 1.9.0
 
 attributes:
   cpu:
-    description: CPU number starting at 0.
+    description: Logical CPU number starting at 0.
     type: string
 
   state:
@@ -17,7 +17,7 @@ attributes:
 metrics:
   system.cpu.time:
     enabled: true
-    description: Total CPU seconds broken down by different states.
+    description: Total seconds each logical CPU spent on each mode.
     unit: s
     sum:
       value_type: double
@@ -27,8 +27,26 @@ metrics:
 
   system.cpu.utilization:
     enabled: false
-    description: Percentage of CPU time broken down by different states.
+    description: Difference in system.cpu.time since the last measurement, divided by the elapsed time and number of logical CPUs.
     unit: 1
     gauge:
       value_type: double
     attributes: [cpu, state]
+
+  system.cpu.physical.count:
+    enabled: false
+    description: Number of available physical CPUs.
+    unit: "{cpu}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation: cumulative
+
+  system.cpu.logical.count:
+    enabled: false
+    description: Number of available logical CPUs.
+    unit: "{cpu}"
+    sum:
+      value_type: int
+      monotonic: false
+      aggregation: cumulative


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>
- #22099 

**Testing:** <Describe what testing was performed and which tests were added.>
Manually:
```yaml
---
receivers:
  hostmetrics:
    collection_interval: 30s
    scrapers:
      cpu:
        metrics:
          system.cpu.time:
            enabled: false
          system.cpu.utilization:
            enabled: false
          system.cpu.count:
            enabled: true

exporters:
  logging:
    verbosity: detailed
  prometheus:
    endpoint: "127.0.0.1:9090"

service:
  pipelines:
    metrics:
      receivers: [hostmetrics]
      exporters: [logging, prometheus]
```

Got:
```
Resource SchemaURL: https://opentelemetry.io/schemas/1.9.0
ScopeMetrics #0
ScopeMetrics SchemaURL: 
InstrumentationScope otelcol/hostmetricsreceiver/cpu 0.79.0-dev
Metric #0
Descriptor:
     -> Name: system.cpu.count
     -> Description: Number of available CPUs.
     -> Unit: 1
     -> DataType: Gauge
NumberDataPoints #0
Data point attributes:
     -> machine-id: Str(1819479dc7174971967d4f2f1ba7b794)
StartTimestamp: 2023-06-08 13:40:33 +0000 UTC
Timestamp: 2023-06-08 14:11:56.118141589 +0000 UTC
Value: 8
	{"kind": "exporter", "data_type": "metrics", "name": "logging"}


---


# HELP system_cpu_count_ratio Nnumber of available CPUs.
# TYPE system_cpu_count_ratio gauge
system_cpu_count_ratio{machine_id="1819479dc7174971967d4f2f1ba7b794"} 8
```

**Documentation:** <Describe the documentation added.>

`documentation.md` was automatically updated by `mdatagen`.