### PR TITLE
[receiver/iis] Fix error log when no items are in the request queue

### DIFF
--- a/.chloggen/fix_iis-scrape-queue-failure.yaml
+++ b/.chloggen/fix_iis-scrape-queue-failure.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: iisreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Removes error message on every scrape where no items are present in the queue.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [14575]

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
@@ -25,7 +25,6 @@ type PerformanceQuery interface {
 	AddCounterToQuery(counterPath string) (PDH_HCOUNTER, error)
 	AddEnglishCounterToQuery(counterPath string) (PDH_HCOUNTER, error)
 	GetCounterPath(counterHandle PDH_HCOUNTER) (string, error)
-	ExpandWildCardPath(counterPath string) ([]string, error)
 	GetFormattedCounterValueDouble(hCounter PDH_HCOUNTER) (float64, error)
 	GetFormattedCounterArrayDouble(hCounter PDH_HCOUNTER) ([]CounterValue, error)
 	CollectData() error

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
@@ -125,24 +125,6 @@ func (m *PerformanceQueryImpl) GetCounterPath(counterHandle PDH_HCOUNTER) (strin
 	return "", NewPdhError(ret)
 }
 
-// ExpandWildCardPath  examines local computer and returns those counter paths that match the given counter path which contains wildcard characters.
-func (m *PerformanceQueryImpl) ExpandWildCardPath(counterPath string) ([]string, error) {
-	var bufSize uint32
-	var buff []uint16
-	var ret uint32
-
-	if ret = PdhExpandWildCardPath(counterPath, nil, &bufSize); ret == PDH_MORE_DATA {
-		buff = make([]uint16, bufSize)
-		bufSize = uint32(len(buff))
-		ret = PdhExpandWildCardPath(counterPath, &buff[0], &bufSize)
-		if ret == ERROR_SUCCESS {
-			list := UTF16ToStringArray(buff)
-			return list, nil
-		}
-	}
-	return nil, NewPdhError(ret)
-}
-
 // GetFormattedCounterValueDouble computes a displayable value for the specified counter
 func (m *PerformanceQueryImpl) GetFormattedCounterValueDouble(hCounter PDH_HCOUNTER) (float64, error) {
 	var counterType uint32
@@ -208,6 +190,24 @@ func (m *PerformanceQueryImpl) CollectDataWithTime() (time.Time, error) {
 
 func (m *PerformanceQueryImpl) IsVistaOrNewer() bool {
 	return PdhAddEnglishCounterSupported()
+}
+
+// ExpandWildCardPath  examines local computer and returns those counter paths that match the given counter path which contains wildcard characters.
+func ExpandWildCardPath(counterPath string) ([]string, error) {
+	var bufSize uint32
+	var buff []uint16
+	var ret uint32
+
+	if ret = PdhExpandWildCardPath(counterPath, nil, &bufSize); ret == PDH_MORE_DATA {
+		buff = make([]uint16, bufSize)
+		bufSize = uint32(len(buff))
+		ret = PdhExpandWildCardPath(counterPath, &buff[0], &bufSize)
+		if ret == ERROR_SUCCESS {
+			list := UTF16ToStringArray(buff)
+			return list, nil
+		}
+	}
+	return nil, NewPdhError(ret)
 }
 
 // UTF16PtrToString converts Windows API LPTSTR (pointer to string) to go string

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
@@ -191,7 +191,7 @@ func (m *PerformanceQueryImpl) IsVistaOrNewer() bool {
 	return PdhAddEnglishCounterSupported()
 }
 
-// ExpandWildCardPath  examines local computer and returns those counter paths that match the given counter path which contains wildcard characters.
+// ExpandWildCardPath examines local computer and returns those counter paths that match the given counter path which contains wildcard characters.
 func ExpandWildCardPath(counterPath string) ([]string, error) {
 	var bufSize uint32
 	var buff []uint16

--- a/pkg/winperfcounters/watcher.go
+++ b/pkg/winperfcounters/watcher.go
@@ -45,6 +45,15 @@ func NewWatcher(object, instance, counterName string) (PerfCounterWatcher, error
 	return counter, nil
 }
 
+// NewWatcherFromPath creates new PerfCounterWatcher by provided path.
+func NewWatcherFromPath(path string) (PerfCounterWatcher, error) {
+	counter, err := newPerfCounter(path, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create perf counter with path %v: %w", path, err)
+	}
+	return counter, nil
+}
+
 func counterPath(object, instance, counterName string) string {
 	if instance != "" {
 		instance = fmt.Sprintf("(%s)", instance)
@@ -116,6 +125,11 @@ func (pc *perfCounter) ScrapeData() ([]CounterValue, error) {
 
 	vals = removeTotalIfMultipleValues(vals)
 	return vals, nil
+}
+
+// ExpandWildCardPath examines local computer and returns those counter paths that match the given counter path which contains wildcard characters.
+func ExpandWildCardPath(counterPath string) ([]string, error) {
+	return win_perf_counters.ExpandWildCardPath(counterPath)
 }
 
 func removeTotalIfMultipleValues(vals []CounterValue) []CounterValue {

--- a/pkg/winperfcounters/watcher.go
+++ b/pkg/winperfcounters/watcher.go
@@ -127,7 +127,7 @@ func (pc *perfCounter) ScrapeData() ([]CounterValue, error) {
 	return vals, nil
 }
 
-// ExpandWildCardPath examines local computer and returns those counter paths that match the given counter path which contains wildcard characters.
+// ExpandWildCardPath examines the local computer and returns those counter paths that match the given counter path which contains wildcard characters.
 func ExpandWildCardPath(counterPath string) ([]string, error) {
 	return win_perf_counters.ExpandWildCardPath(counterPath)
 }

--- a/receiver/iisreceiver/recorder.go
+++ b/receiver/iisreceiver/recorder.go
@@ -101,9 +101,10 @@ var appPoolPerfCounterRecorders = []perfCounterRecorderConf{
 			"CurrentQueueSize": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
 				mb.RecordIisRequestQueueCountDataPoint(ts, int64(val))
 			},
-			"MaxQueueItemAge": func(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
-				mb.RecordIisRequestQueueAgeMaxDataPoint(ts, int64(val))
-			},
 		},
 	},
+}
+
+func recordMaxQueueItemAge(mb *metadata.MetricsBuilder, ts pcommon.Timestamp, val float64) {
+	mb.RecordIisRequestQueueAgeMaxDataPoint(ts, int64(val))
 }

--- a/receiver/iisreceiver/scraper.go
+++ b/receiver/iisreceiver/scraper.go
@@ -8,6 +8,8 @@ package iisreceiver // import "github.com/open-telemetry/opentelemetry-collector
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -30,10 +32,12 @@ type iisReceiver struct {
 	totalWatcherRecorders   []watcherRecorder
 	siteWatcherRecorders    []watcherRecorder
 	appPoolWatcherRecorders []watcherRecorder
+	queueMaxAgeWatchers     []instanceWatcher
 	metricBuilder           *metadata.MetricsBuilder
 
 	// for mocking
-	newWatcher func(string, string, string) (winperfcounters.PerfCounterWatcher, error)
+	newWatcher         func(string, string, string) (winperfcounters.PerfCounterWatcher, error)
+	newWatcherFromPath func(string) (winperfcounters.PerfCounterWatcher, error)
 }
 
 // watcherRecorder is a struct containing perf counter watcher along with corresponding value recorder.
@@ -42,14 +46,20 @@ type watcherRecorder struct {
 	recorder recordFunc
 }
 
+type instanceWatcher struct {
+	watcher  winperfcounters.PerfCounterWatcher
+	instance string
+}
+
 // newIisReceiver returns an iisReceiver
 func newIisReceiver(settings receiver.CreateSettings, cfg *Config, consumer consumer.Metrics) *iisReceiver {
 	return &iisReceiver{
-		params:        settings.TelemetrySettings,
-		config:        cfg,
-		consumer:      consumer,
-		metricBuilder: metadata.NewMetricsBuilder(cfg.MetricsBuilderConfig, settings),
-		newWatcher:    winperfcounters.NewWatcher,
+		params:             settings.TelemetrySettings,
+		config:             cfg,
+		consumer:           consumer,
+		metricBuilder:      metadata.NewMetricsBuilder(cfg.MetricsBuilderConfig, settings),
+		newWatcher:         winperfcounters.NewWatcher,
+		newWatcherFromPath: winperfcounters.NewWatcherFromPath,
 	}
 }
 
@@ -69,8 +79,19 @@ func (rcvr *iisReceiver) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	var errs error
 	now := pcommon.NewTimestampFromTime(time.Now())
 
-	rcvr.scrapeInstanceMetrics(now, rcvr.siteWatcherRecorders, metadata.WithIisSite)
-	rcvr.scrapeInstanceMetrics(now, rcvr.appPoolWatcherRecorders, metadata.WithIisApplicationPool)
+	// Maintain maps of site -> {val, recordFunc} and app -> {val, recordFunc}
+	// so that we can emit all metrics for a particular instance (site, app_pool) at once,
+	// keeping them in a single resource metric.
+
+	siteToRecorders := map[string][]valRecorder{}
+	rcvr.scrapeInstanceMetrics(rcvr.siteWatcherRecorders, siteToRecorders)
+	rcvr.emitInstanceMap(now, siteToRecorders, metadata.WithIisSite)
+
+	appToRecorders := map[string][]valRecorder{}
+	rcvr.scrapeInstanceMetrics(rcvr.appPoolWatcherRecorders, appToRecorders)
+	rcvr.scrapeMaxQueueAgeMetrics(appToRecorders)
+	rcvr.emitInstanceMap(now, appToRecorders, metadata.WithIisApplicationPool)
+
 	rcvr.scrapeTotalMetrics(now)
 
 	return rcvr.metricBuilder.Emit(), errs
@@ -100,11 +121,7 @@ type valRecorder struct {
 	record recordFunc
 }
 
-func (rcvr *iisReceiver) scrapeInstanceMetrics(now pcommon.Timestamp, wrs []watcherRecorder, resourceOption func(string) metadata.ResourceMetricsOption) {
-	// Maintain a map of instance -> {val, recordFunc}
-	// so that we can emit all metrics for a particular instance (site, app_pool) at once,
-	// keeping them in a single resource metric.
-	instanceToRecorders := map[string][]valRecorder{}
+func (rcvr *iisReceiver) scrapeInstanceMetrics(wrs []watcherRecorder, instanceToRecorders map[string][]valRecorder) {
 
 	for _, wr := range wrs {
 		counterValues, err := wr.watcher.ScrapeData()
@@ -130,6 +147,9 @@ func (rcvr *iisReceiver) scrapeInstanceMetrics(now pcommon.Timestamp, wrs []watc
 		}
 	}
 
+}
+
+func (rcvr *iisReceiver) emitInstanceMap(now pcommon.Timestamp, instanceToRecorders map[string][]valRecorder, resourceOption func(string) metadata.ResourceMetricsOption) {
 	// record all metrics for each instance, then emit them all as a single resource metric
 	for instanceName, recorders := range instanceToRecorders {
 		for _, recorder := range recorders {
@@ -140,12 +160,36 @@ func (rcvr *iisReceiver) scrapeInstanceMetrics(now pcommon.Timestamp, wrs []watc
 	}
 }
 
+func (rcvr *iisReceiver) scrapeMaxQueueAgeMetrics(appToRecorders map[string][]valRecorder) {
+	for _, wr := range rcvr.queueMaxAgeWatchers {
+		counterValues, err := wr.watcher.ScrapeData()
+		// TODO: Compare error, record 0 if specific error
+		if err != nil {
+			rcvr.params.Logger.Warn("some performance counters could not be scraped; ", zap.Error(err))
+			continue
+		}
+
+		if len(counterValues) == 0 {
+			continue
+		}
+
+		cv := counterValues[0]
+
+		appToRecorders[cv.InstanceName] = append(appToRecorders[cv.InstanceName],
+			valRecorder{
+				val:    counterValues[0].Value,
+				record: recordMaxQueueItemAge,
+			})
+	}
+}
+
 // shutdown closes the watchers
 func (rcvr iisReceiver) shutdown(ctx context.Context) error {
 	var errs error
 	errs = multierr.Append(errs, closeWatcherRecorders(rcvr.totalWatcherRecorders))
 	errs = multierr.Append(errs, closeWatcherRecorders(rcvr.siteWatcherRecorders))
 	errs = multierr.Append(errs, closeWatcherRecorders(rcvr.appPoolWatcherRecorders))
+	errs = multierr.Append(errs, closeInstanceWatchers(rcvr.queueMaxAgeWatchers))
 	return errs
 }
 
@@ -166,7 +210,56 @@ func (rcvr *iisReceiver) buildWatcherRecorders(confs []perfCounterRecorderConf, 
 	return wrs
 }
 
+var pathRegex = regexp.MustCompile(`^\\HTTP Service Request Queues\\((?P<instance>[^)]+\))\\MaxQueueItemAge$`)
+
+func (rcvr *iisReceiver) buildMaxQueueItemAgeWatchers(scrapeErrors *scrapererror.ScrapeErrors) []instanceWatcher {
+	wrs := []instanceWatcher{}
+
+	paths, err := winperfcounters.ExpandWildCardPath(`\HTTP Service Request Queues(*)\MaxQueueItemAge`)
+	if err != nil {
+		scrapeErrors.AddPartial(1, fmt.Errorf("failed to expand wildcard path for MaxQueueItemAge: %w", err))
+		return wrs
+	}
+
+	for _, path := range paths {
+		matches := pathRegex.FindStringSubmatch(path)
+		if len(matches) != 2 {
+			scrapeErrors.AddPartial(1, fmt.Errorf("failed to extract instance from %q: %w", path, err))
+			continue
+		}
+
+		if matches[1] == "_Total" {
+			// skip total instance
+			continue
+		}
+
+		watcher, err := rcvr.newWatcherFromPath(path)
+		if err != nil {
+			scrapeErrors.AddPartial(1, fmt.Errorf("failed to create watcher from %q: %w", path, err))
+			continue
+		}
+
+		rcvr.queueMaxAgeWatchers = append(rcvr.queueMaxAgeWatchers, instanceWatcher{
+			instance: matches[1],
+			watcher:  watcher,
+		})
+	}
+
+	return wrs
+}
+
 func closeWatcherRecorders(wrs []watcherRecorder) error {
+	var errs error
+	for _, wr := range wrs {
+		err := wr.watcher.Close()
+		if err != nil {
+			errs = multierr.Append(errs, err)
+		}
+	}
+	return errs
+}
+
+func closeInstanceWatchers(wrs []instanceWatcher) error {
 	var errs error
 	for _, wr := range wrs {
 		err := wr.watcher.Close()

--- a/receiver/iisreceiver/testdata/integration/expected.yaml
+++ b/receiver/iisreceiver/testdata/integration/expected.yaml
@@ -161,6 +161,14 @@ resourceMetrics:
             stringValue: '---1'
     scopeMetrics:
       - metrics:
+          - description: Age of oldest request in the queue.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1686199451535881700"
+                  timeUnixNano: "1686199511675213400"
+            name: iis.request.queue.age.max
+            unit: ms
           - description: Current number of requests in the queue.
             name: iis.request.queue.count
             sum:
@@ -190,6 +198,14 @@ resourceMetrics:
             stringValue: DefaultAppPool
     scopeMetrics:
       - metrics:
+          - description: Age of oldest request in the queue.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1686199451535881700"
+                  timeUnixNano: "1686199511675213400"
+            name: iis.request.queue.age.max
+            unit: ms
           - description: Current number of requests in the queue.
             name: iis.request.queue.count
             sum:

--- a/receiver/iisreceiver/testdata/integration/expected.yaml
+++ b/receiver/iisreceiver/testdata/integration/expected.yaml
@@ -14,7 +14,7 @@ resourceMetrics:
                 - asInt: "0"
                   startTimeUnixNano: "1664375532837715300"
                   timeUnixNano: "1664375533465547100"
-            unit: '{connections}'
+            unit: "{connections}"
           - description: Number of connections established anonymously.
             name: iis.connection.anonymous
             sum:
@@ -24,7 +24,7 @@ resourceMetrics:
                   startTimeUnixNano: "1664375532837715300"
                   timeUnixNano: "1664375533465547100"
               isMonotonic: true
-            unit: '{connections}'
+            unit: "{connections}"
           - description: Total number of attempts to connect to the server.
             name: iis.connection.attempt.count
             sum:
@@ -34,7 +34,7 @@ resourceMetrics:
                   startTimeUnixNano: "1664375532837715300"
                   timeUnixNano: "1664375533465547100"
               isMonotonic: true
-            unit: '{attempts}'
+            unit: "{attempts}"
           - description: Number of bytes blocked due to bandwidth throttling.
             name: iis.network.blocked
             sum:
@@ -65,7 +65,7 @@ resourceMetrics:
                   startTimeUnixNano: "1664375532837715300"
                   timeUnixNano: "1664375533465547100"
               isMonotonic: true
-            unit: '{files}'
+            unit: "{files}"
           - description: Total amount of bytes sent and received.
             name: iis.network.io
             sum:
@@ -142,7 +142,7 @@ resourceMetrics:
                   startTimeUnixNano: "1664375532837715300"
                   timeUnixNano: "1664375533465547100"
               isMonotonic: true
-            unit: '{requests}'
+            unit: "{requests}"
           - description: The amount of time the server has been up.
             gauge:
               dataPoints:
@@ -158,7 +158,7 @@ resourceMetrics:
       attributes:
         - key: iis.application_pool
           value:
-            stringValue: '---1'
+            stringValue: "---1"
     scopeMetrics:
       - metrics:
           - description: Age of oldest request in the queue.
@@ -177,7 +177,7 @@ resourceMetrics:
                 - asInt: "0"
                   startTimeUnixNano: "1664375532837715300"
                   timeUnixNano: "1664375533465547100"
-            unit: '{requests}'
+            unit: "{requests}"
           - description: Total number of requests rejected.
             name: iis.request.rejected
             sum:
@@ -187,7 +187,7 @@ resourceMetrics:
                   startTimeUnixNano: "1664375532837715300"
                   timeUnixNano: "1664375533465547100"
               isMonotonic: true
-            unit: '{requests}'
+            unit: "{requests}"
         scope:
           name: otelcol/iisreceiver
           version: latest
@@ -214,7 +214,7 @@ resourceMetrics:
                 - asInt: "0"
                   startTimeUnixNano: "1664375532837715300"
                   timeUnixNano: "1664375533465547100"
-            unit: '{requests}'
+            unit: "{requests}"
           - description: Total number of requests rejected.
             name: iis.request.rejected
             sum:
@@ -224,7 +224,7 @@ resourceMetrics:
                   startTimeUnixNano: "1664375532837715300"
                   timeUnixNano: "1664375533465547100"
               isMonotonic: true
-            unit: '{requests}'
+            unit: "{requests}"
         scope:
           name: otelcol/iisreceiver
           version: latest
@@ -239,7 +239,7 @@ resourceMetrics:
                 - asInt: "1266"
                   startTimeUnixNano: "1664375532837715300"
                   timeUnixNano: "1664375533465547100"
-            unit: '{threads}'
+            unit: "{threads}"
         scope:
           name: otelcol/iisreceiver
           version: latest

--- a/receiver/iisreceiver/testdata/scraper/expected_negative_denominator.yaml
+++ b/receiver/iisreceiver/testdata/scraper/expected_negative_denominator.yaml
@@ -1,0 +1,19 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: iis.application_pool
+          value:
+            stringValue: Instance
+    scopeMetrics:
+      - metrics:
+          - description: Age of oldest request in the queue.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1686201140051043100"
+                  timeUnixNano: "1686201140051043100"
+            name: iis.request.queue.age.max
+            unit: ms
+        scope:
+          name: otelcol/iisreceiver
+          version: latest


### PR DESCRIPTION
**Description:** <Describe what has changed.>
* Removes the error log when no items are in the request queue; Instead, a 0 will be recorded as the datapoint for `iis.request.queue.age.max` when no items are in the queue.

**Link to tracking Issue:** Closes #14575

**Testing:** <Describe what testing was performed and which tests were added.>
* Added a test for situation where error is negative denominator,  and when error is not a negative denominator
* Update integration test payload with expected data
* Ran manually on an IIS box, observed 0 is recorded and error is not logged.