### PR TITLE
[exporter/datadog] Add trace configs compute_stats_by_span_kind and peer_service_aggregation

### DIFF
--- a/.chloggen/datadogexporter-new-trace-configs.yaml
+++ b/.chloggen/datadogexporter-new-trace-configs.yaml
@@ -9,7 +9,7 @@ change_type: enhancement
 component: datadogexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add trace configs compute_stats_by_span_kind and peer_service_aggregation
+note: "Add `traces::compute_stats_by_span_kind` and `traces::peer_service_aggregation` configuration flags"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [23240]

--- a/.chloggen/datadogexporter-new-trace-configs.yaml
+++ b/.chloggen/datadogexporter-new-trace-configs.yaml
@@ -17,4 +17,5 @@ issues: [23240]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: Config `traces::compute_stats_by_span_kind` enables an additional stats computation check on span kind. |
+    Config `traces::peer_service_aggregation` enables `peer.service` aggregation in the exporter.

--- a/.chloggen/datadogexporter-new-trace-configs.yaml
+++ b/.chloggen/datadogexporter-new-trace-configs.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add trace configs compute_stats_by_span_kind and peer_service_aggregation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23240]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -239,7 +239,7 @@ type TracesConfig struct {
 	// NOTE: For stats computed from OTel traces, only top-level spans are considered when this option is off.
 	ComputeStatsBySpanKind bool `mapstructure:"compute_stats_by_span_kind"`
 
-	// If set to true, enables `peer.service` aggregation in the agent. If disabled, aggregated trace stats will not include `peer.service` as a dimension.
+	// If set to true, enables `peer.service` aggregation in the exporter. If disabled, aggregated trace stats will not include `peer.service` as a dimension.
 	// For the best experience with `peer.service`, it is recommended to also enable `compute_stats_by_span_kind`.
 	// If enabling both causes the datadog exporter to consume too many resources, try disabling `compute_stats_by_span_kind` first.
 	// If the overhead remains high, it will be due to a high cardinality of `peer.service` values from the traces. You may need to check your instrumentation.

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -234,6 +234,17 @@ type TracesConfig struct {
 	// The default value is `false`.
 	SpanNameAsResourceName bool `mapstructure:"span_name_as_resource_name"`
 
+	// If set to true, enables an additional stats computation check on spans to see they have an eligible `span.kind` (server, consumer, client, producer).
+	// If enabled, a span with an eligible `span.kind` will have stats computed. If disabled, only top-level and measured spans will have stats computed.
+	// NOTE: For stats computed from OTel traces, only top-level spans are considered when this option is off.
+	ComputeStatsBySpanKind bool `mapstructure:"compute_stats_by_span_kind"`
+
+	// If set to true, enables `peer.service` aggregation in the agent. If disabled, aggregated trace stats will not include `peer.service` as a dimension.
+	// For the best experience with `peer.service`, it is recommended to also enable `compute_stats_by_span_kind`.
+	// If enabling both causes the datadog exporter to consume too many resources, try disabling `compute_stats_by_span_kind` first.
+	// If the overhead remains high, it will be due to a high cardinality of `peer.service` values from the traces. You may need to check your instrumentation.
+	PeerServiceAggregation bool `mapstructure:"peer_service_aggregation"`
+
 	// flushInterval defines the interval in seconds at which the writer flushes traces
 	// to the intake; used in tests.
 	flushInterval float64

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -170,6 +170,8 @@ func newTraceAgent(ctx context.Context, params exporter.CreateSettings, cfg *Con
 	acfg.ReceiverPort = 0 // disable HTTP receiver
 	acfg.AgentVersion = fmt.Sprintf("datadogexporter-%s-%s", params.BuildInfo.Command, params.BuildInfo.Version)
 	acfg.SkipSSLValidation = cfg.LimitedHTTPClientSettings.TLSSetting.InsecureSkipVerify
+	acfg.ComputeStatsBySpanKind = cfg.Traces.ComputeStatsBySpanKind
+	acfg.PeerServiceAggregation = cfg.Traces.PeerServiceAggregation
 	if v := cfg.Traces.flushInterval; v > 0 {
 		acfg.TraceWriter.FlushPeriodSeconds = v
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Add two new trace configs to datadog exporter and pass them onto the DD trace agent configs.

- `compute_stats_by_span_kind` enables an additional stats computation check on spans to see they have an eligible `span.kind` (server, consumer, client, producer).

- `peer_service_aggregation` enables `peer.service` aggregation in the agent. If disabled, aggregated trace stats will not include `peer.service` as a dimension.

Mirrors https://github.com/DataDog/datadog-agent/pull/16103.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>