### PR TITLE
[chore] bump go compile version

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -43,7 +43,7 @@ jobs:
         run: Install-WindowsFeature -name Web-Server -IncludeManagementTools
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.8
+          go-version: ~1.19.10
           cache: false
       - name: Cache Go
         id: go-mod-cache

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.8
+          go-version: ~1.19.10
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.8
+          go-version: ~1.19.10
           cache: false
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -12,7 +12,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install zsh
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.8
+          go-version: ~1.19.10
           cache: false
       - name: Run dependabot-pr.sh
         run: ./.github/workflows/scripts/dependabot-pr.sh

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,7 +26,7 @@ jobs:
           path: opentelemetry-collector-contrib
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.8
+          go-version: ~1.19.10
           cache: false
       - name: Prepare release for contrib
         working-directory: opentelemetry-collector-contrib

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -26,7 +26,7 @@ jobs:
           path: opentelemetry-collector-contrib
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.8
+          go-version: ~1.19.10
           cache: false
       - name: Cache Go
         id: go-cache


### PR DESCRIPTION
This is to address https://pkg.go.dev/vuln/GO-2023-1840
