### PR TITLE
[testbed] Allow setting path of child process Collector executable

### DIFF
--- a/.chloggen/testbed-configurable-executable.yaml
+++ b/.chloggen/testbed-configurable-executable.yaml
@@ -12,7 +12,7 @@ component: testbed
 note: Add `WithAgentExePath`, which allows setting the path of the Collector executable.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [23258]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/testbed-configurable-executable.yaml
+++ b/.chloggen/testbed-configurable-executable.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: testbed
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `WithAgentExePath`, which allows setting the path of the Collector executable.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/testbed/testbed/child_process_collector_test.go
+++ b/testbed/testbed/child_process_collector_test.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package testbed // import "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentExeOption(t *testing.T) {
+	path := "bin/otelcontribcol"
+	col := NewChildProcessCollector(WithAgentExePath(path))
+
+	cpc, ok := col.(*childProcessCollector)
+
+	require.True(t, ok)
+	require.Equal(t, path, cpc.agentExePath)
+}


### PR DESCRIPTION
**Description:**

A refactor that unexported the struct unintentionally made it so the executable path could not be set. This keeps the struct unexported, but adds an option to allow setting the path. I'm open to making the struct public again if that's preferred, this just seemed like the most straightforward method.

I also made `agentExePath` private to make it clear it's not meant to be accessed outside the package.

**Testing:**

A unit test was added to verify the change.

**Documentation:**

Godoc was added to the option function.