### PR TITLE
Add workflow to auto-update the JMX metrics gatherer

### DIFF
--- a/.github/workflows/auto-update-jmx-metrics-component.yml
+++ b/.github/workflows/auto-update-jmx-metrics-component.yml
@@ -1,0 +1,116 @@
+name: Auto-update JMX metrics component
+
+on:
+  schedule:
+    # Daily at 01:30 (UTC)
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      latest-version: ${{ steps.check-versions.outputs.latest-version }}
+      already-added: ${{ steps.check-versions.outputs.already-added }}
+      already-opened: ${{ steps.check-versions.outputs.already-opened }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: check-versions
+        name: Check versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest_version=$(gh release view \
+                               --repo open-telemetry/opentelemetry-java-contrib \
+                               --json tagName \
+                               --jq .tagName \
+                             | sed 's/^v//')
+
+          # jmx metric gatherer is currently alpha
+          latest_version=$latest_version-alpha
+
+          if grep -Pzo "version: \"$latest_version\",\s*jar:\s*\"JMX metrics gatherer\"" receiver/jmxreceiver/supported_jars.go; then
+            already_added=true
+          fi
+
+          matches=$(gh pr list \
+                        --author opentelemetrybot \
+                        --state open \
+                        --search "in:title \"Add JMX metrics gatherer version $latest_version\"")
+          if [ ! -z "$matches" ]
+          then
+            already_opened=true
+          fi
+
+          echo "latest-version=$latest_version" >> $GITHUB_OUTPUT
+          echo "already-added=$already_added" >> $GITHUB_OUTPUT
+          echo "already-opened=$already_opened" >> $GITHUB_OUTPUT
+
+  update-jmx-metrics-component:
+    runs-on: ubuntu-latest
+    if: |
+      needs.check-versions.outputs.already-added != 'true' &&
+      needs.check-versions.outputs.already-opened != 'true'
+    needs:
+      - check-versions
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update version
+        env:
+          VERSION: ${{ needs.check-versions.outputs.latest-version }}
+        run: |
+          if [[ ! $VERSION =~ -alpha$ ]]; then
+            echo currently expecting jmx metrics version to end with "-alpha"
+            exit 1
+          fi
+
+          version=${VERSION//-alpha/}
+          hash=$(curl -L https://github.com/open-telemetry/opentelemetry-java-contrib/releases/download/v$version/opentelemetry-jmx-metrics.jar \
+                         | sha256sum \
+                         | cut -d ' ' -f 1)
+
+          # NOTE there are intentional tab characters in the line below
+          sed -i "/^var jmxMetricsGathererVersions/a \	\"$hash\": {\n		version: \"$VERSION\",\n		jar:     \"JMX metrics gatherer\",\n	}," receiver/jmxreceiver/supported_jars.go
+          git diff
+
+      - name: Use CLA approved github bot
+        run: |
+          git config user.name opentelemetrybot
+          git config user.email 107717825+opentelemetrybot@users.noreply.github.com
+
+      - name: Create pull request against main
+        env:
+          VERSION: ${{ needs.check-versions.outputs.latest-version }}
+          # not using secrets.GITHUB_TOKEN since pull requests from that token do not run workflows
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+        run: |
+          message="Add JMX metrics gatherer version $VERSION"
+          body="Add JMX metrics gatherer version \`$VERSION\`.
+
+          cc @open-telemetry/java-contrib-approvers
+          "
+          branch="opentelemetrybot/add-jmx-metrics-gatherer-${VERSION}"
+
+          git checkout -b $branch
+          git commit -a -m "$message"
+          git push --set-upstream origin $branch
+          url=$(gh pr create --title "$message" \
+                             --body "$body" \
+                             --base main)
+
+          pull_request_number=${url//*\//}
+          
+          # see the template for change log entry file at blob/main/.chloggen/TEMPLATE.yaml
+          cat > .chloggen/add-jmx-metrics-gatherer-$VERSION.yaml << EOF
+          change_type: enhancement
+          component: jmxreceiver
+          note: Add the JMX metrics gatherer version $VERSION to the supported jars hash list
+          issues: [ $pull_request_number ]
+          EOF
+
+          git add .chloggen/add-jmx-metrics-gatherer-$VERSION.yaml
+
+          git commit -m "Add change log entry"
+          git push


### PR DESCRIPTION
We would like to move this automation from `opentelemetry-java-contrib` repo to this repo, so that it can open the PR on a branch in this repo, instead of needing to maintain a fork of this repo to submit the PR from.

**Testing:** Manually tested against my fork.
