### PR TITLE
[receiver/purefa] Ensuring test efficiency for the endpoints scraped on Mock server

### DIFF
--- a/receiver/purefareceiver/internal/scraper.go
+++ b/receiver/purefareceiver/internal/scraper.go
@@ -64,8 +64,8 @@ func (h *scraper) ToPrometheusReceiverConfig(host component.Host, _ receiver.Fac
 			return nil, err
 		}
 
-		bearerToken, err := RetrieveBearerToken(arr.Auth, host.GetExtensions())
-		if err != nil {
+		httpConfig, err := getHTTPConfig(arr, host)
+		if err != nil {			
 			return nil, err
 		}
 
@@ -100,4 +100,17 @@ func (h *scraper) ToPrometheusReceiverConfig(host component.Host, _ receiver.Fac
 	}
 
 	return scrapeCfgs, nil
+}
+
+func getHTTPConfig(scCfgs ScraperConfig, host component.Host) (configutil.HTTPClientConfig, error){
+	ret := configutil.HTTPClientConfig{}
+	if scCfgs.Auth != nil {
+		bearerToken, err := RetrieveBearerToken(*scCfgs.Auth, host.GetExtensions())
+		if err != nil {
+			return ret, err
+		}
+
+		ret.BearerToken = configutil.Secret(bearerToken)
+	}
+	return ret, nil
 }

--- a/receiver/purefareceiver/internal/scraper.go
+++ b/receiver/purefareceiver/internal/scraper.go
@@ -69,9 +69,6 @@ func (h *scraper) ToPrometheusReceiverConfig(host component.Host, _ receiver.Fac
 			return nil, err
 		}
 
-		httpConfig := configutil.HTTPClientConfig{}
-		httpConfig.BearerToken = configutil.Secret(bearerToken)
-
 		scrapeConfig := &config.ScrapeConfig{
 			HTTPClientConfig: httpConfig,
 			ScrapeInterval:   model.Duration(h.scrapeInterval),

--- a/receiver/purefareceiver/internal/scraper_test.go
+++ b/receiver/purefareceiver/internal/scraper_test.go
@@ -41,7 +41,7 @@ func TestToPrometheusConfig(t *testing.T) {
 	cfgs := []ScraperConfig{
 		{
 			Address: "array01",
-			Auth: configauth.Authentication{
+			Auth: &configauth.Authentication{
 				AuthenticatorID: component.NewIDWithName("bearertokenauth", "array01"),
 			},
 		},

--- a/receiver/purefareceiver/internal/scraperconfig.go
+++ b/receiver/purefareceiver/internal/scraperconfig.go
@@ -7,5 +7,5 @@ import "go.opentelemetry.io/collector/config/configauth"
 
 type ScraperConfig struct {
 	Address string                    `mapstructure:"address"`
-	Auth    configauth.Authentication `mapstructure:"auth"`
+	Auth    *configauth.Authentication `mapstructure:"auth"`
 }

--- a/receiver/purefareceiver/testdata/array.txt
+++ b/receiver/purefareceiver/testdata/array.txt
@@ -1,0 +1,15 @@
+# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 3.7743e-05
+go_gc_duration_seconds{quantile="0.25"} 6.0311e-05
+go_gc_duration_seconds{quantile="0.5"} 8.5667e-05
+go_gc_duration_seconds{quantile="0.75"} 0.000104831
+go_gc_duration_seconds{quantile="1"} 0.000112094
+go_gc_duration_seconds_sum 0.000486284
+go_gc_duration_seconds_count 6
+# HELP purefa_array_performance_average_bytes FlashArray array average operations size
+# TYPE purefa_array_performance_average_bytes gauge
+purefa_array_performance_average_bytes{dimension="bytes_per_mirrored_write"} 0
+purefa_array_performance_average_bytes{dimension="bytes_per_op"} 88064
+purefa_array_performance_average_bytes{dimension="bytes_per_read"} 0
+purefa_array_performance_average_bytes{dimension="bytes_per_mirrored_write}


### PR DESCRIPTION
**Description:**
It is crucial to validate that the httpserver library effectively scrapes all the necessary data from the endpoints during the Mock test. This validation ensures the accuracy and completeness of the purefareceiver.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14886

**Testing:**
The validation test must be made by the default configs on config.yaml that is present on README.md and using Debugging session from the VSCode.

**Documentation:**
Present on README