### PR TITLE
[processor/k8sattributes] Only store necessary Pod data

### DIFF
--- a/.chloggen/feat_k8sattributes_set-transform.yaml
+++ b/.chloggen/feat_k8sattributes_set-transform.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributesprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Store only necessary Pod data
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23226]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -846,8 +846,12 @@ func TestExtractionRules(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			c.Rules = tc.rules
+
+			// manually call the data removal function here
+			// normally the informer does this, but fully emulating the informer in this test is annoying
+			transformedPod := removeUnnecessaryPodData(pod, c.Rules)
 			c.handleReplicaSetAdd(replicaset)
-			c.handlePodAdd(pod)
+			c.handlePodAdd(transformedPod)
 			p, ok := c.GetPod(newPodIdentifier("connection", "", pod.Status.PodIP))
 			require.True(t, ok)
 
@@ -996,8 +1000,12 @@ func TestReplicaSetExtractionRules(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c.Rules = tc.rules
 			replicaset.OwnerReferences = tc.ownerReferences
+
+			// manually call the data removal function here
+			// normally the informer does this, but fully emulating the informer in this test is annoying
+			transformedPod := removeUnnecessaryPodData(pod, c.Rules)
 			c.handleReplicaSetAdd(replicaset)
-			c.handlePodAdd(pod)
+			c.handlePodAdd(transformedPod)
 			p, ok := c.GetPod(newPodIdentifier("connection", "", pod.Status.PodIP))
 			require.True(t, ok)
 
@@ -1462,7 +1470,10 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := WatchClient{Rules: tt.rules}
-			assert.Equal(t, tt.want, c.extractPodContainersAttributes(&tt.pod))
+			// manually call the data removal function here
+			// normally the informer does this, but fully emulating the informer in this test is annoying
+			transformedPod := removeUnnecessaryPodData(&tt.pod, c.Rules)
+			assert.Equal(t, tt.want, c.extractPodContainersAttributes(transformedPod))
 		})
 	}
 }

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -208,6 +208,29 @@ type ExtractionRules struct {
 	Labels      []FieldExtractionRule
 }
 
+// IncludesOwnerMetadata determines whether the ExtractionRules include metadata about Pod Owners
+func (rules *ExtractionRules) IncludesOwnerMetadata() bool {
+	rulesNeedingOwnerMetadata := []bool{
+		rules.CronJobName,
+		rules.DeploymentName,
+		rules.DeploymentUID,
+		rules.DaemonSetUID,
+		rules.DaemonSetName,
+		rules.JobName,
+		rules.JobUID,
+		rules.ReplicaSetID,
+		rules.ReplicaSetName,
+		rules.StatefulSetUID,
+		rules.StatefulSetName,
+	}
+	for _, ruleEnabled := range rulesNeedingOwnerMetadata {
+		if ruleEnabled {
+			return true
+		}
+	}
+	return false
+}
+
 // FieldExtractionRule is used to specify which fields to extract from pod fields
 // and inject into spans as attributes.
 type FieldExtractionRule struct {


### PR DESCRIPTION
**Description:**
Only store Pod data we actually use for attributes in the informer store. By default, informers store all data about K8s objects, as they're primarily intended to act as a local cache for the API Server. For our use case, most of that data is unnecessary, and it eats a significant amount of memory in larger clusters. This PR uses a transform function to remove the unnecessary data from the informer store.

I've measured the gains synthetically, and we use nearly 70% less memory per stored Pod. I haven't included the benchmark function in this PR, as it's a bit complicated and hacky, and I'm not convinced there's value in adding it to the codebase permanently.

**Link to tracking Issue:** #23226 

**Testing:**
Testing this feature is somewhat awkward. We effectively need to guarantee that the transform function preserves the data necessary to compute the attributes. Unit tests for the transform function don't seem to add any value in that respect. Testing it end-to-end is also annoying, as it requires a real informer instead of the mocks we use in other unit tests.

In the end, I just manually added the transform function invocation to tests checking attribute generation. This way, as long as the attribute generation itself has good test coverage, the same will be true for the transform function.
