### PR TITLE
feat(mysqlreceiver): deprecate `mysql.locked_connects` in favor of `mysql.connection.errors`

### DIFF
--- a/.chloggen/drosiek-deprecate-locked-connects.yaml
+++ b/.chloggen/drosiek-deprecate-locked-connects.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "deprecate `mysql.locked_accounts` in favor of `mysql.connection.errors`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [14138]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/drosiek-deprecate-locked-connects.yaml
+++ b/.chloggen/drosiek-deprecate-locked-connects.yaml
@@ -9,7 +9,7 @@ change_type: deprecation
 component: mysqlreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "deprecate `mysql.locked_accounts` in favor of `mysql.connection.errors`"
+note: "deprecate `mysql.locked_connects` in favor of `mysql.connection.errors`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [14138]

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -148,7 +148,7 @@ The total time of I/O wait events for an index.
 
 ### mysql.locked_connects
 
-The number of attempts to connect to locked user accounts.
+[DEPRECATED] The number of attempts to connect to locked user accounts.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -1775,7 +1775,7 @@ type metricMysqlLockedConnects struct {
 // init fills mysql.locked_connects metric with initial data.
 func (m *metricMysqlLockedConnects) init() {
 	m.data.SetName("mysql.locked_connects")
-	m.data.SetDescription("The number of attempts to connect to locked user accounts.")
+	m.data.SetDescription("[DEPRECATED] The number of attempts to connect to locked user accounts.")
 	m.data.SetUnit("1")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -513,7 +513,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["mysql.locked_connects"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "The number of attempts to connect to locked user accounts.", ms.At(i).Description())
+					assert.Equal(t, "[DEPRECATED] The number of attempts to connect to locked user accounts.", ms.At(i).Description())
 					assert.Equal(t, "1", ms.At(i).Unit())
 					assert.Equal(t, true, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -445,7 +445,7 @@ metrics:
     attributes: [schema, table_name, write_lock_type]
   mysql.locked_connects:
     enabled: true
-    description: The number of attempts to connect to locked user accounts.
+    description: "[DEPRECATED] The number of attempts to connect to locked user accounts."
     unit: 1
     sum:
       value_type: int

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -56,6 +56,10 @@ func (m *mySQLScraper) start(_ context.Context, _ component.Host) error {
 	}
 	m.sqlclient = sqlclient
 
+	if m.config.MetricsBuilderConfig.Metrics.MysqlLockedConnects.Enabled {
+		m.logger.Warn("`mysql.locked_connects` is deprecated and is going to be set as optional in `v0.81.0` and removed in `v0.82.0`. Please use `mysql.connection.errors` instead")
+	}
+
 	return nil
 }
 

--- a/receiver/mysqlreceiver/testdata/integration/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/integration/expected.yaml
@@ -302,7 +302,7 @@ resourceMetrics:
                   timeUnixNano: "1674545265375344000"
               isMonotonic: true
             unit: "1"
-          - description: The number of attempts to connect to locked user accounts.
+          - description: "[DEPRECATED] The number of attempts to connect to locked user accounts."
             name: mysql.locked_connects
             sum:
               aggregationTemporality: 2

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -601,7 +601,7 @@ resourceMetrics:
                   timeUnixNano: "1644862687825772000"
               isMonotonic: true
             unit: "1"
-          - description: The number of attempts to connect to locked user accounts.
+          - description: "[DEPRECATED] The number of attempts to connect to locked user accounts."
             name: mysql.locked_connects
             sum:
               aggregationTemporality: 2


### PR DESCRIPTION
**Description:**

deprecate `mysql.locked_accounts` in favor of `mysql.connection.errors`

```
2023-06-12T08:29:43.306+0200    info    service/telemetry.go:104        Setting up own telemetry...
2023-06-12T08:29:43.306+0200    info    service/telemetry.go:127        Serving Prometheus metrics      {"address": ":8888", "level": "Basic"}
2023-06-12T08:29:43.306+0200    info    exporter@v0.79.0/exporter.go:275        Development component. May change in the future.        {"kind": "exporter", "data_type": "metrics", "name": "logging"}
2023-06-12T08:29:43.308+0200    info    service/service.go:131  Starting otelcontribcol...      {"Version": "0.79.0-dev", "NumCPU": 16}
2023-06-12T08:29:43.308+0200    info    extensions/extensions.go:30     Starting extensions...
2023-06-12T08:29:43.308+0200    warn    mysqlreceiver@v0.79.0/scraper.go:60     `mysql.locked_connects` is deprecated and is going to be set as optional in `v0.80.0` and removed in `v0.81.0`. Please use `mysql.connection.errors` instead   {"kind": "receiver", "name": "mysql", "data_type": "metrics"}
2023-06-12T08:29:43.308+0200    info    service/service.go:148  Everything is ready. Begin running and processing data.
^C2023-06-12T08:29:44.055+0200  info    otelcol/collector.go:227        Received signal from OS {"signal": "interrupt"}
2023-06-12T08:29:44.056+0200    info    service/service.go:157  Starting shutdown...
```

**Link to tracking Issue:** #14138, #23211

**Testing:** Unit tests

**Documentation:** Update `metadata.yaml`