### PR TITLE
feat(journaldreceiver): fail if unsufficient permissions for journalctl command

### DIFF
--- a/.chloggen/drosiek-journald-exit-stderr.yaml
+++ b/.chloggen/drosiek-journald-exit-stderr.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: journaldreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: log error in case of journald fail
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [20906]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/drosiek-journald-exit-stderr.yaml
+++ b/.chloggen/drosiek-journald-exit-stderr.yaml
@@ -9,7 +9,7 @@ change_type: enhancement
 component: journaldreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: log error in case of journald fail
+note: fail if unsufficient permissions for journalctl command
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [20906]

--- a/pkg/stanza/operator/input/journald/journald_test.go
+++ b/pkg/stanza/operator/input/journald/journald_test.go
@@ -35,6 +35,15 @@ func (f *fakeJournaldCmd) StdoutPipe() (io.ReadCloser, error) {
 	return io.NopCloser(reader), nil
 }
 
+func (f *fakeJournaldCmd) StderrPipe() (io.ReadCloser, error) {
+	reader := bytes.NewReader([]byte{})
+	return io.NopCloser(reader), nil
+}
+
+func (f *fakeJournaldCmd) Wait() error {
+	return nil
+}
+
 func TestInputJournald(t *testing.T) {
 	cfg := NewConfigWithID("my_journald_input")
 	cfg.OutputIDs = []string{"output"}

--- a/pkg/stanza/operator/input/journald/journald_test.go
+++ b/pkg/stanza/operator/input/journald/journald_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -22,7 +23,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
-type fakeJournaldCmd struct{}
+type fakeJournaldCmd struct {
+	exitError *exec.ExitError
+	stdErr    string
+}
 
 func (f *fakeJournaldCmd) Start() error {
 	return nil
@@ -36,12 +40,16 @@ func (f *fakeJournaldCmd) StdoutPipe() (io.ReadCloser, error) {
 }
 
 func (f *fakeJournaldCmd) StderrPipe() (io.ReadCloser, error) {
-	reader := bytes.NewReader([]byte{})
+	reader := bytes.NewReader([]byte(f.stdErr))
 	return io.NopCloser(reader), nil
 }
 
 func (f *fakeJournaldCmd) Wait() error {
-	return nil
+	if f.exitError == nil {
+		return nil
+	}
+
+	return f.exitError
 }
 
 func TestInputJournald(t *testing.T) {
@@ -65,7 +73,7 @@ func TestInputJournald(t *testing.T) {
 	}
 
 	err = op.Start(testutil.NewMockPersister("test"))
-	require.NoError(t, err)
+	assert.EqualError(t, err, "journalctl command exited")
 	defer func() {
 		require.NoError(t, op.Stop())
 	}()
@@ -198,5 +206,41 @@ func TestBuildConfig(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.Expected, args)
 		})
+	}
+}
+
+func TestInputJournaldError(t *testing.T) {
+	cfg := NewConfigWithID("my_journald_input")
+	cfg.OutputIDs = []string{"output"}
+
+	op, err := cfg.Build(testutil.Logger(t))
+	require.NoError(t, err)
+
+	mockOutput := testutil.NewMockOperator("output")
+	received := make(chan *entry.Entry)
+	mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		received <- args.Get(1).(*entry.Entry)
+	}).Return(nil)
+
+	err = op.SetOutputs([]operator.Operator{mockOutput})
+	require.NoError(t, err)
+
+	op.(*Input).newCmd = func(ctx context.Context, cursor []byte) cmd {
+		return &fakeJournaldCmd{
+			exitError: &exec.ExitError{},
+			stdErr:    "stderr output\n",
+		}
+	}
+
+	err = op.Start(testutil.NewMockPersister("test"))
+	assert.EqualError(t, err, "journalctl command failed (<nil>): stderr output\n")
+	defer func() {
+		require.NoError(t, op.Stop())
+	}()
+
+	select {
+	case <-received:
+	case <-time.After(time.Second):
+		require.FailNow(t, "Timed out waiting for entry to be read")
 	}
 }


### PR DESCRIPTION
**Description:**

Wait for journalctl to finish and log error in case there is any issue

**Link to tracking Issue:** #20906 

**Testing:** 

```
2023-06-13T11:07:31.283+0200    info    service/telemetry.go:104        Setting up own telemetry...
2023-06-13T11:07:31.283+0200    info    service/telemetry.go:127        Serving Prometheus metrics      {"address": ":8888", "level": "Basic"}
2023-06-13T11:07:31.284+0200    info    exporter@v0.79.0/exporter.go:275        Development component. May change in the future.        {"kind": "exporter", "data_type": "logs", "name": "logging"}
2023-06-13T11:07:31.285+0200    info    service/service.go:131  Starting otelcontribcol...      {"Version": "0.79.0-dev", "NumCPU": 16}
2023-06-13T11:07:31.285+0200    info    extensions/extensions.go:30     Starting extensions...
2023-06-13T11:07:31.285+0200    info    adapter/receiver.go:45  Starting stanza receiver        {"kind": "receiver", "name": "journald", "data_type": "logs"}
2023-06-13T11:07:31.285+0200    info    service/service.go:148  Everything is ready. Begin running and processing data.
2023-06-13T11:07:31.288+0200    error   journald/journald.go:240        journalctl command failed {"kind": "receiver", "name": "journald", "data_type": "logs", "operator_id": "journald_input", "operator_type": "journald_input", "error": "exit status 1", "output": "No journal files were opened due to insufficient permissions.\n"}
github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/journald.(*Input).Start.func1
        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.79.0/operator/input/journald/journald.go:240


```

**Documentation:** N/A