### PR TITLE
[observer/ecs] Don't report EC2 tasks with unassigned container instances

### DIFF
--- a/.chloggen/ecsobserver-nil-container-arn-fix.yaml
+++ b/.chloggen/ecsobserver-nil-container-arn-fix.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: ecsobserver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Don't fail with error when finding a task of EC2 launch type and missing container instance, just ignore them. This fixes behavior when task is provisioning and its containers are not assigned to instances yet.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23279]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/extension/observer/ecsobserver/fetcher.go
+++ b/extension/observer/ecsobserver/fetcher.go
@@ -128,9 +128,9 @@ func newTaskFetcher(opts taskFetcherOptions) (*taskFetcher, error) {
 
 func (f *taskFetcher) fetchAndDecorate(ctx context.Context) ([]*taskAnnotated, error) {
 	// taskAnnotated
-	rawTasks, err := f.getAllTasks(ctx)
+	rawTasks, err := f.getDiscoverableTasks(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("getAllTasks failed: %w", err)
+		return nil, fmt.Errorf("getDiscoverableTasks failed: %w", err)
 	}
 	tasks, err := f.attachTaskDefinition(ctx, rawTasks)
 	if err != nil {
@@ -151,9 +151,10 @@ func (f *taskFetcher) fetchAndDecorate(ctx context.Context) ([]*taskAnnotated, e
 	return tasks, nil
 }
 
-// getAllTasks get arns of all running tasks and describe those tasks.
+// getDiscoverableTasks get arns of all running tasks and describe those tasks
+// and filter only fargate tasks or EC2 task which container instance is known.
 // There is no API to list task detail without arn so we need to call two APIs.
-func (f *taskFetcher) getAllTasks(ctx context.Context) ([]*ecs.Task, error) {
+func (f *taskFetcher) getDiscoverableTasks(ctx context.Context) ([]*ecs.Task, error) {
 	svc := f.ecs
 	cluster := aws.String(f.cluster)
 	req := ecs.ListTasksInput{Cluster: cluster}
@@ -171,7 +172,16 @@ func (f *taskFetcher) getAllTasks(ctx context.Context) ([]*ecs.Task, error) {
 		if err != nil {
 			return nil, fmt.Errorf("ecs.DescribeTasks failed: %w", err)
 		}
-		tasks = append(tasks, descRes.Tasks...)
+
+		for _, task := range descRes.Tasks {
+			// Preserve only fargate tasks or EC2 tasks with non-nil ContainerInstanceArn.
+			// When ECS task of EC2 launch type is in state Provisioning/Pending, it may
+			// not have EC2 instance. Such tasks have `nil` instance arn and the
+			// attachContainerInstance call will fail
+			if task.ContainerInstanceArn != nil || aws.StringValue(task.LaunchType) != ecs.LaunchTypeEc2 {
+				tasks = append(tasks, task)
+			}
+		}
 		if listRes.NextToken == nil {
 			break
 		}


### PR DESCRIPTION

When ECS task is in state Provisioning/Pending, it can contain container(s) which don't have EC2 instance yet. Such containers have `nil` instance arn.

This change fixes service discovery error:
```error ecsobserver@v0.78.0/error.go:77 attachContainerInstance failed:
describe container instanced failed offset=0: ecs.DescribeContainerInstance
failed: InvalidParameterException: Container instance can not be blank.
{"kind": "extension", "name": "ecs_observer", "ErrScope": "Unknown"}
```


**Testing:** Related unit test is added.