### PR TITLE
[chore] Deprecate unnecessary fileconsumer API

### DIFF
--- a/pkg/stanza/fileconsumer/finder.go
+++ b/pkg/stanza/fileconsumer/finder.go
@@ -14,7 +14,7 @@ type Finder struct {
 
 // FindFiles gets a list of paths given an array of glob patterns to include and exclude
 //
-// Deprecated: This will be made internal in a future release.
+// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
 func (f Finder) FindFiles() []string {
 	all := make([]string, 0, len(f.Include))
 	for _, include := range f.Include {

--- a/pkg/stanza/fileconsumer/finder.go
+++ b/pkg/stanza/fileconsumer/finder.go
@@ -13,6 +13,8 @@ type Finder struct {
 }
 
 // FindFiles gets a list of paths given an array of glob patterns to include and exclude
+//
+// Deprecated: This will be made internal in a future release.
 func (f Finder) FindFiles() []string {
 	all := make([]string, 0, len(f.Include))
 	for _, include := range f.Include {

--- a/pkg/stanza/fileconsumer/fingerprint.go
+++ b/pkg/stanza/fileconsumer/fingerprint.go
@@ -11,23 +11,23 @@ import (
 	"os"
 )
 
-// Deprecated: This will be made internal in a future release.
+// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
 const DefaultFingerprintSize = 1000 // bytes
 
-// Deprecated: This will be made internal in a future release.
+// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
 const MinFingerprintSize = 16 // bytes
 
 // Fingerprint is used to identify a file
 // A file's fingerprint is the first N bytes of the file
 //
-// Deprecated: This will be made internal in a future release.
+// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
 type Fingerprint struct {
 	FirstBytes []byte
 }
 
 // NewFingerprint creates a new fingerprint from an open file
 //
-// Deprecated: This will be made internal in a future release.
+// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
 func NewFingerprint(file *os.File, size int) (*Fingerprint, error) {
 	buf := make([]byte, size)
 

--- a/pkg/stanza/fileconsumer/fingerprint.go
+++ b/pkg/stanza/fileconsumer/fingerprint.go
@@ -11,16 +11,23 @@ import (
 	"os"
 )
 
+// Deprecated: This will be made internal in a future release.
 const DefaultFingerprintSize = 1000 // bytes
-const MinFingerprintSize = 16       // bytes
+
+// Deprecated: This will be made internal in a future release.
+const MinFingerprintSize = 16 // bytes
 
 // Fingerprint is used to identify a file
 // A file's fingerprint is the first N bytes of the file
+//
+// Deprecated: This will be made internal in a future release.
 type Fingerprint struct {
 	FirstBytes []byte
 }
 
 // NewFingerprint creates a new fingerprint from an open file
+//
+// Deprecated: This will be made internal in a future release.
 func NewFingerprint(file *os.File, size int) (*Fingerprint, error) {
 	buf := make([]byte, size)
 

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -23,6 +23,8 @@ type readerConfig struct {
 }
 
 // Reader manages a single file
+//
+// Deprecated: This will be made internal in a future release.
 type Reader struct {
 	*zap.SugaredLogger `json:"-"` // json tag excludes embedded fields from storage
 	*readerConfig

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -24,7 +24,7 @@ type readerConfig struct {
 
 // Reader manages a single file
 //
-// Deprecated: This will be made internal in a future release.
+// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
 type Reader struct {
 	*zap.SugaredLogger `json:"-"` // json tag excludes embedded fields from storage
 	*readerConfig

--- a/pkg/stanza/fileconsumer/scanner.go
+++ b/pkg/stanza/fileconsumer/scanner.go
@@ -15,7 +15,7 @@ const defaultBufSize = 16 * 1024
 
 // PositionalScanner is a scanner that maintains position
 //
-// Deprecated: This will be made internal in a future release.
+// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
 type PositionalScanner struct {
 	pos int64
 	*bufio.Scanner
@@ -23,7 +23,7 @@ type PositionalScanner struct {
 
 // NewPositionalScanner creates a new positional scanner
 //
-// Deprecated: This will be made internal in a future release.
+// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
 func NewPositionalScanner(r io.Reader, maxLogSize int, startOffset int64, splitFunc bufio.SplitFunc) *PositionalScanner {
 	ps := &PositionalScanner{
 		pos:     startOffset,

--- a/pkg/stanza/fileconsumer/scanner.go
+++ b/pkg/stanza/fileconsumer/scanner.go
@@ -14,12 +14,16 @@ import (
 const defaultBufSize = 16 * 1024
 
 // PositionalScanner is a scanner that maintains position
+//
+// Deprecated: This will be made internal in a future release.
 type PositionalScanner struct {
 	pos int64
 	*bufio.Scanner
 }
 
 // NewPositionalScanner creates a new positional scanner
+//
+// Deprecated: This will be made internal in a future release.
 func NewPositionalScanner(r io.Reader, maxLogSize int, startOffset int64, splitFunc bufio.SplitFunc) *PositionalScanner {
 	ps := &PositionalScanner{
 		pos:     startOffset,


### PR DESCRIPTION
In an effort to tighten up the API, I'd like to deprecate these components were never explicitly intended to be part of the package's API. Later I will export them or move them to an internal package.