### PR TITLE
[chore] forwardconnector was not listed in the modules script

### DIFF
--- a/internal/buildscripts/modules
+++ b/internal/buildscripts/modules
@@ -3,6 +3,7 @@
 beta_modules=(
   "go.opentelemetry.io/collector/component"
   "go.opentelemetry.io/collector/confmap"
+  "go.opentelemetry.io/collector/connector/forwardconnector"
   "go.opentelemetry.io/collector/consumer"
   "go.opentelemetry.io/collector/exporter"
   "go.opentelemetry.io/collector/exporter/loggingexporter"


### PR DESCRIPTION
this was causing check-collector-module-version to not check that this module was up to the same version as the others consistently
