### PR TITLE
[chore] Fix datadog receiver flakey test.

### DIFF
--- a/cmd/otelcontribcol/receivers_test.go
+++ b/cmd/otelcontribcol/receivers_test.go
@@ -160,7 +160,7 @@ func TestDefaultReceivers(t *testing.T) {
 			receiver: "datadog",
 			getConfigFn: func() component.Config {
 				cfg := rcvrFactories["datadog"].CreateDefaultConfig().(*datadogreceiver.Config)
-				cfg.Endpoint = ":0" // Using a randomly assigned address
+				cfg.Endpoint = "localhost:0" // Using a randomly assigned address
 				return cfg
 			},
 		},

--- a/cmd/otelcontribcol/receivers_test.go
+++ b/cmd/otelcontribcol/receivers_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/chronyreceiver"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver"
@@ -157,6 +158,11 @@ func TestDefaultReceivers(t *testing.T) {
 		},
 		{
 			receiver: "datadog",
+			getConfigFn: func() component.Config {
+				cfg := rcvrFactories["datadog"].CreateDefaultConfig().(*datadogreceiver.Config)
+				cfg.Endpoint = ":0" // Using a randomly assigned address
+				return cfg
+			},
 		},
 		{
 			receiver:     "docker_stats",


### PR DESCRIPTION
**Description:** 

It tries to bind to an already established port, this uses `:0` to use a randomly assigned port to keep the lifecycle checks

**Link to tracking Issue:** 

closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23334
