### PR TITLE
[chore] bump go version for linting

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "1.20"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -155,7 +155,7 @@ fmt: $(GOIMPORTS)
 
 .PHONY: lint
 lint: $(LINT) checklicense misspell
-	$(LINT) run --allow-parallel-runners --build-tags integration --path-prefix $(shell basename "$(CURDIR)")
+	$(LINT) run --allow-parallel-runners --verbose --build-tags integration --path-prefix $(shell basename "$(CURDIR)")
 
 .PHONY: govulncheck
 govulncheck: $(GOVULNCHECK)


### PR DESCRIPTION
After digging into what was causing linting time outs, it looks like golangci-lint was using up a significant amount of memory to run lint against otelcontribcol. After digging I came across this issue that mentions memory usage: https://github.com/golangci/golangci-lint/issues/3565#issuecomment-1449363237

I've tested bumping the linters to go 1.20 and so far it looks like the avg memory is lower than it was w/ go 1.19. I've also enabled verbose logging for linting to give us a bit more info when there are issues.
