### PR TITLE
[receiver/mongodbatlas] Document access log requirements

### DIFF
--- a/receiver/mongodbatlasreceiver/README.md
+++ b/receiver/mongodbatlasreceiver/README.md
@@ -31,6 +31,8 @@ In order to collect project events, the requesting API key needs the appropriate
 
 In order to collect organization events, the requesting API key needs the appropriate permission which at minimum is the `Organization Member` role. Organization events are collected across all the projects hosted on Atlas within the organization. These events are not associated with a project.
 
+In order to collect access logs, the requesting API key needs the appropriate permission which requires wither the `Project Owner` or `Organization Owner` role. Access logs are collected per project and per cluster based on configuration.
+
 MongoDB Atlas [Documentation](https://www.mongodb.com/docs/atlas/reference/api/logs/#logs) recommends a polling interval of 5 minutes.
 
 - `public_key` (required for metrics, logs, or alerts in `poll` mode)

--- a/receiver/mongodbatlasreceiver/README.md
+++ b/receiver/mongodbatlasreceiver/README.md
@@ -31,7 +31,7 @@ In order to collect project events, the requesting API key needs the appropriate
 
 In order to collect organization events, the requesting API key needs the appropriate permission which at minimum is the `Organization Member` role. Organization events are collected across all the projects hosted on Atlas within the organization. These events are not associated with a project.
 
-In order to collect access logs, the requesting API key needs the appropriate permission which requires wither the `Project Owner` or `Organization Owner` role. Access logs are collected per project and per cluster based on configuration.
+In order to collect access logs, the requesting API key needs the appropriate permission which requires either the `Project Owner` or `Organization Owner` role. Access logs are specific to each cluster.
 
 MongoDB Atlas [Documentation](https://www.mongodb.com/docs/atlas/reference/api/logs/#logs) recommends a polling interval of 5 minutes.
 


### PR DESCRIPTION
**Description:** Access Logs required permissions for monitoring were not documented in the receiver README.

**Link to tracking Issue:** <Issue number if applicable> should have been documented for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21182
