### PR TITLE
[exporter/splunkhec] apply multimetric metric merge for the whole batch

### DIFF
--- a/.chloggen/splunkhec-exporter-multimetric-batch.yaml
+++ b/.chloggen/splunkhec-exporter-multimetric-batch.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Apply multi-metric merge at the level of the whole batch rather than within events emitted for one metric.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23365]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -277,8 +277,8 @@ func (c *client) fillMetricsBuffer(metrics pmetric.Metrics, buf buffer, is iterS
 				fmt.Errorf("dropped metric event: error: event size %d bytes larger than configured max"+
 					" content length %d bytes", len(b), c.config.MaxContentLengthMetrics)))
 			return iterState{
-				record: i,
-				done:   false,
+				record: i + 1,
+				done:   i+1 != len(events),
 			}, permanentErrors
 		} else if err != nil {
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf(
@@ -336,8 +336,8 @@ func (c *client) fillMetricsBufferMultiMetrics(metrics pmetric.Metrics, buf buff
 				fmt.Errorf("dropped metric event: error: event size %d bytes larger than configured max"+
 					" content length %d bytes", len(b), c.config.MaxContentLengthMetrics)))
 			return iterState{
-				record: i,
-				done:   false,
+				record: i + 1,
+				done:   i+1 != len(merged),
 			}, permanentErrors
 		} else if err != nil {
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf(

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -406,10 +406,8 @@ func (c *client) pushMultiMetricsDataInBatches(ctx context.Context, md pmetric.M
 
 	for !is.done {
 		buf.Reset()
-		var latestIterState iterState
-		var batchPermanentErrors []error
 
-		latestIterState, batchPermanentErrors = c.fillMetricsBufferMultiMetrics(merged, buf, is)
+		latestIterState, batchPermanentErrors := c.fillMetricsBufferMultiMetrics(merged, buf, is)
 		permanentErrors = append(permanentErrors, batchPermanentErrors...)
 		if !buf.Empty() {
 			if err := c.postEvents(ctx, buf, headers); err != nil {
@@ -434,9 +432,7 @@ func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metric
 
 	for !is.done {
 		buf.Reset()
-		var latestIterState iterState
-		var batchPermanentErrors []error
-		latestIterState, batchPermanentErrors = c.fillMetricsBuffer(md, buf, is)
+		latestIterState, batchPermanentErrors := c.fillMetricsBuffer(md, buf, is)
 		permanentErrors = append(permanentErrors, batchPermanentErrors...)
 		if !buf.Empty() {
 			if err := c.postEvents(ctx, buf, headers); err != nil {

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -85,7 +85,7 @@ func createMetricsData(resourcesNum, dataPointsNum int) pmetric.Metrics {
 			tsUnix := time.Unix(int64(count), int64(count)*time.Millisecond.Nanoseconds())
 			ilm := rm.ScopeMetrics().AppendEmpty()
 			metric := ilm.Metrics().AppendEmpty()
-			metric.SetName("gauge_double_with_dims")
+			metric.SetName(fmt.Sprintf("gauge_double_with_dims_%d", j))
 			doublePt := metric.SetEmptyGauge().DataPoints().AppendEmpty()
 			doublePt.SetTimestamp(pcommon.NewTimestampFromTime(tsUnix))
 			doublePt.SetDoubleValue(doubleVal)
@@ -1605,6 +1605,148 @@ func benchPushLogData(b *testing.B, numResources int, numRecords int, bufSize ui
 
 	for i := 0; i < b.N; i++ {
 		err := exp.ConsumeLogs(context.Background(), logs)
+		require.NoError(b, err)
+	}
+}
+
+// 10 resources, 10 records, 1Kb max HEC batch: 17 HEC batches
+func Benchmark_pushMetricData_10_10_1024(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 1024, false, false)
+}
+
+// 10 resources, 10 records, 8Kb max HEC batch: 2 HEC batches
+func Benchmark_pushMetricData_10_10_8K(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 8*1024, false, false)
+}
+
+// 10 resources, 10 records, 1Mb max HEC batch: 1 HEC batch
+func Benchmark_pushMetricData_10_10_2M(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 2*1024*1024, false, false)
+}
+
+// 10 resources, 200 records, 2Mb max HEC batch: 1 HEC batch
+func Benchmark_pushMetricData_10_200_2M(b *testing.B) {
+	benchPushMetricData(b, 10, 200, 2*1024*1024, false, false)
+}
+
+// 100 resources, 200 records, 2Mb max HEC batch: 2 HEC batches
+func Benchmark_pushMetricData_100_200_2M(b *testing.B) {
+	benchPushMetricData(b, 100, 200, 2*1024*1024, false, false)
+}
+
+// 100 resources, 200 records, 5Mb max HEC batch: 1 HEC batches
+func Benchmark_pushMetricData_100_200_5M(b *testing.B) {
+	benchPushMetricData(b, 100, 200, 5*1024*1024, false, false)
+}
+
+// 10 resources, 10 records, 1Kb max HEC batch: 2 HEC batches
+func Benchmark_pushMetricData_compressed_10_10_1024(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 1024, true, false)
+}
+
+// 10 resources, 10 records, 8Kb max HEC batch: 1 HEC batche
+func Benchmark_pushMetricData_compressed_10_10_8K(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 8*1024, true, false)
+}
+
+// 10 resources, 10 records, 1Mb max HEC batch: 1 HEC batch
+func Benchmark_pushMetricData_compressed_10_10_2M(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 2*1024*1024, true, false)
+}
+
+// 10 resources, 200 records, 2Mb max HEC batch: 1 HEC batch
+func Benchmark_pushMetricData_compressed_10_200_2M(b *testing.B) {
+	benchPushMetricData(b, 10, 200, 2*1024*1024, true, false)
+}
+
+// 100 resources, 200 records, 2Mb max HEC batch: 1 HEC batch
+func Benchmark_pushMetricData_compressed_100_200_2M(b *testing.B) {
+	benchPushMetricData(b, 100, 200, 2*1024*1024, true, false)
+}
+
+// 100 resources, 200 records, 5Mb max HEC batch: 1 HEC batches
+func Benchmark_pushMetricData_compressed_100_200_5M(b *testing.B) {
+	benchPushMetricData(b, 100, 200, 5*1024*1024, true, false)
+}
+
+// 10 resources, 10 records, 1Kb max HEC batch: 17 HEC batches
+func Benchmark_pushMetricData_10_10_1024_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 1024, false, true)
+}
+
+// 10 resources, 10 records, 8Kb max HEC batch: 2 HEC batches
+func Benchmark_pushMetricData_10_10_8K_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 8*1024, false, true)
+}
+
+// 10 resources, 10 records, 1Mb max HEC batch: 1 HEC batch
+func Benchmark_pushMetricData_10_10_2M_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 2*1024*1024, false, true)
+}
+
+// 10 resources, 200 records, 2Mb max HEC batch: 1 HEC batch
+func Benchmark_pushMetricData_10_200_2M_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 10, 200, 2*1024*1024, false, true)
+}
+
+// 100 resources, 200 records, 2Mb max HEC batch: 2 HEC batches
+func Benchmark_pushMetricData_100_200_2M_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 100, 200, 2*1024*1024, false, true)
+}
+
+// 100 resources, 200 records, 5Mb max HEC batch: 1 HEC batches
+func Benchmark_pushMetricData_100_200_5M_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 100, 200, 5*1024*1024, false, true)
+}
+
+// 10 resources, 10 records, 1Kb max HEC batch: 2 HEC batches
+func Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 1024, true, true)
+}
+
+// 10 resources, 10 records, 8Kb max HEC batch: 1 HEC batche
+func Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 8*1024, true, true)
+}
+
+// 10 resources, 10 records, 1Mb max HEC batch: 1 HEC batch
+func Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 10, 10, 2*1024*1024, true, true)
+}
+
+// 10 resources, 200 records, 2Mb max HEC batch: 1 HEC batch
+func Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 10, 200, 2*1024*1024, true, true)
+}
+
+// 100 resources, 200 records, 2Mb max HEC batch: 1 HEC batch
+func Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 100, 200, 2*1024*1024, true, true)
+}
+
+// 100 resources, 200 records, 5Mb max HEC batch: 1 HEC batches
+func Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric(b *testing.B) {
+	benchPushMetricData(b, 100, 200, 5*1024*1024, true, true)
+}
+
+func benchPushMetricData(b *testing.B, numResources int, numRecords int, bufSize uint, compressionEnabled bool, useMultiMetricFormat bool) {
+	config := NewFactory().CreateDefaultConfig().(*Config)
+	config.MaxContentLengthMetrics = bufSize
+	config.DisableCompression = !compressionEnabled
+	config.UseMultiMetricFormat = useMultiMetricFormat
+	c := newLogsClient(exportertest.NewNopCreateSettings(), config)
+	c.hecWorker = &mockHecWorker{}
+	exp, err := exporterhelper.NewMetricsExporter(context.Background(), exportertest.NewNopCreateSettings(), config,
+		c.pushMetricsData)
+	require.NoError(b, err)
+
+	metrics := createMetricsData(numResources, numRecords)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		err := exp.ConsumeMetrics(context.Background(), metrics)
 		require.NoError(b, err)
 	}
 }

--- a/exporter/splunkhecexporter/metricdata_to_splunk.go
+++ b/exporter/splunkhecexporter/metricdata_to_splunk.go
@@ -278,10 +278,11 @@ func mergeEventsToMultiMetricFormat(events []*splunk.Event) ([]*splunk.Event, er
 	hashes := map[uint32]*splunk.Event{}
 	hasher := fnv.New32a()
 	var merged []*splunk.Event
+	marshaler := jsoniter.ConfigCompatibleWithStandardLibrary
 
 	for _, e := range events {
 		cloned := copyEventWithoutValues(e)
-		marshaler := jsoniter.ConfigCompatibleWithStandardLibrary
+
 		data, err := marshaler.Marshal(cloned)
 		if err != nil {
 			return nil, err

--- a/exporter/splunkhecexporter/testdata/hec_metric_event.json
+++ b/exporter/splunkhecexporter/testdata/hec_metric_event.json
@@ -5,7 +5,7 @@
     "k/n1": "vn1",
     "k/r0": "vr0",
     "k/r1": "vr1",
-    "metric_name:gauge_double_with_dims": 1234.5678,
+    "metric_name:gauge_double_with_dims_0": 1234.5678,
     "metric_type": "Gauge",
     "k0": "v0",
     "k1": "v1",


### PR DESCRIPTION
**Description:**
Apply multi-metric merge at the level of the whole batch rather than within events emitted for one metric. 

**Link to tracking Issue:**
Fixes #23365

**Testing:**
Existing tests pass. Added benchmarks as well for metrics. Added a few tests to make sure we cover the code paths involved.

**Documentation:**
N/A