### PR TITLE
Harubins/udp performance update

### DIFF
--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -230,6 +230,7 @@ func handleMessage(u *Input, ctx context.Context, remoteAddr net.Addr, log []byt
 	u.Write(ctx, entry)
 }
 
+// readMessage will read log messages from the connection.
 func (u *Input) readMessage() ([]byte, net.Addr, error) {
 	n, addr, err := u.connection.ReadFrom(u.buffer)
 	if err != nil {

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -1,16 +1,5 @@
 // Copyright The OpenTelemetry Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package udp // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/udp"
 
@@ -140,7 +129,7 @@ type Input struct {
 }
 
 // Start will start listening for messages on a socket.
-func (u *Input) Start(persister operator.Persister) error {
+func (u *Input) Start(_ operator.Persister) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	u.cancel = cancel
 
@@ -248,7 +237,7 @@ func (u *Input) readMessage() ([]byte, net.Addr, error) {
 	}
 
 	// Remove trailing characters and NULs
-	for ; (n > 0) && (u.buffer[n-1] < 32); n-- {
+	for ; (n > 0) && (u.buffer[n-1] < 32); n-- { // nolint
 	}
 
 	return u.buffer[:n], addr, nil


### PR DESCRIPTION
**Description:**  Performance improving for UDP receiver.
Currently, UDP created on each log line a scanner object with split functions, even if there was no need for log tokenizing.
this PR adds a new config option 'tokenize_log' (default value set to true) which lets you decide if this is the behavior you want.
if set as false the scanner object is not created and the performance is increased significantly (up to 3X)

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/discussions/23237

**Testing:** 
Created a local build of the UDP receiver and tested that the logs arrive and exported as expected.
