### PR TITLE
[exporter/signalfx] Keep container.cpu.time metric in the translations

### DIFF
--- a/.chloggen/signalfx-exporter-dont-drop-container-cpu-time.yaml
+++ b/.chloggen/signalfx-exporter-dont-drop-container-cpu-time.yaml
@@ -1,0 +1,15 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/signalfx
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not drop container.cpu.time metric in the default translations so it can be enabled in the include_metrics config.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23403]

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -21,7 +21,7 @@ translation_rules:
       k8s: true
       container: true
 
-- action: rename_metrics
+- action: copy_metrics
   mapping:
     # kubeletstats container cpu needed for calculation below
     container.cpu.time: sf_temp.container_cpu_utilization

--- a/exporter/signalfxexporter/internal/translation/default_metrics.go
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.go
@@ -130,10 +130,8 @@ exclude_metrics:
   - /^k8s\.(?i:(node)|(pod))\.filesystem\.capacity$/
   - /^k8s\.(?i:(node)|(pod))\.filesystem\.usage$/
 
-  # matches (k8s.node|k8s.pod).cpu.time
-  - /^k8s\.(?i:(node)|(pod))\.cpu\.time$/
-
-  # matches (container|k8s.node|k8s.pod).cpu.utilization
+  # matches (container|k8s.node|k8s.pod).cpu...
+  - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.cpu\.time$/
   - /^(?i:(container)|(k8s\.node)|(k8s\.pod))\.cpu\.utilization$/
 
   # matches k8s.node.network.io and k8s.node.network.errors


### PR DESCRIPTION
Do not drop `container.cpu.time` metric in the default translations so it can be enabled in the `include_metrics` config option.

This is the only metric that is dropped in the translations. All other metrics are being kept.