### PR TITLE
[ci] Specify 7 as arm version for arm build in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -395,6 +395,10 @@ jobs:
           - arm
           - arm64
           - ppc64le
+        include:
+          - os: linux
+          - arch: arm
+          - arm: 7
         exclude:
           - os: darwin
             arch: 386
@@ -429,7 +433,7 @@ jobs:
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make install-tools
       - name: Build Collector ${{ matrix.binary }}
-        run: make GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} otelcontribcol
+        run: make GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM=${{ matrix.arm }} otelcontribcol
       - name: Upload Collector Binaries
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
**Description:**

Currently, we specify arm architecture in the cross build test without specifying the `GOARM` variable. This means the `GOARM` value falls back to the default and the default value depends on the platform that we are building on. 

We are building on `linux/amd64` machine in github action, so the `GOARM` defaults to `5`. [There are changes to default to GOARM=7 for all non-arm systems in the upcoming golang version](https://go-review.googlesource.com/c/go/+/470695)

I'm looking to add an armv7 release, so without waiting for the newer golang version, I want to explicitly set the arm version in the CI to align with the release arm version.

In this pull request, I expanded the configuration for arm build by adding a new block with the arm version under `include`. Then introduce the `GOARM` environment variable when calling `make otelcontribcol`


**Testing:** 

Able to run `make GOOS=x GOARCH=y GOARM=z otelcontribcol` with the following configurations locally

- [x] `GOOS=linux`, `GOARCH=arm`, `GOARM=7`
- [x] `GOOS=linux`, `GOARCH=arm64`, `GOARM=` 
- [x] `GOOS=darwin`, `GOARCH=amd64`, `GOARM=`
- [x] `GOOS=window`, `GOARCH=amd64`, `GOARM=`