### PR TITLE
 [receiver/httpcheck] support scraping multiple targets 

### DIFF
--- a/.chloggen/multiple-targets.yaml
+++ b/.chloggen/multiple-targets.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: httpcheckreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: support scraping multiple targets
+
+# One or more tracking issues related to the change
+issues: [18823]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/httpcheckreceiver/README.md
+++ b/receiver/httpcheckreceiver/README.md
@@ -40,9 +40,13 @@ The following configuration settings are optional:
 ```yaml
 receivers:
   httpcheck:
-    endpoint: http://endpoint:80
-    method: GET
-    collection_interval: 10s
+    targets:
+      - endpoint: http://endpoint:80
+        method: GET
+        collection_interval: 10s
+      - endpoint: http://localhost:8080/health
+        method: GET
+        collection_interval: 10s
 ```
 
 ## Metrics

--- a/receiver/httpcheckreceiver/config_test.go
+++ b/receiver/httpcheckreceiver/config_test.go
@@ -21,7 +21,11 @@ func TestValidate(t *testing.T) {
 		{
 			desc: "missing endpoint",
 			cfg: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{},
+				Targets: []*targetConfig{
+					{
+						HTTPClientSettings: confighttp.HTTPClientSettings{},
+					},
+				},
 			},
 			expectedErr: multierr.Combine(
 				errMissingEndpoint,
@@ -30,8 +34,12 @@ func TestValidate(t *testing.T) {
 		{
 			desc: "invalid endpoint",
 			cfg: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
-					Endpoint: "invalid://endpoint:  12efg",
+				Targets: []*targetConfig{
+					{
+						HTTPClientSettings: confighttp.HTTPClientSettings{
+							Endpoint: "invalid://endpoint:  12efg",
+						},
+					},
 				},
 			},
 			expectedErr: multierr.Combine(
@@ -41,8 +49,12 @@ func TestValidate(t *testing.T) {
 		{
 			desc: "valid config",
 			cfg: &Config{
-				HTTPClientSettings: confighttp.HTTPClientSettings{
-					Endpoint: "https://opentelemetry.io",
+				Targets: []*targetConfig{
+					{
+						HTTPClientSettings: confighttp.HTTPClientSettings{
+							Endpoint: "https://opentelemetry.io",
+						},
+					},
 				},
 			},
 			expectedErr: nil,

--- a/receiver/httpcheckreceiver/config_test.go
+++ b/receiver/httpcheckreceiver/config_test.go
@@ -47,6 +47,26 @@ func TestValidate(t *testing.T) {
 			),
 		},
 		{
+			desc: "invalid config with multiple targets",
+			cfg: &Config{
+				Targets: []*targetConfig{
+					{
+						HTTPClientSettings: confighttp.HTTPClientSettings{
+							Endpoint: "https://localhost:80",
+						},
+					},
+					{
+						HTTPClientSettings: confighttp.HTTPClientSettings{
+							Endpoint: "invalid://endpoint:  12efg",
+						},
+					},
+				},
+			},
+			expectedErr: multierr.Combine(
+				fmt.Errorf("%w: %s", errInvalidEndpoint, `parse "invalid://endpoint:  12efg": invalid port ":  12efg" after host`),
+			),
+		},
+		{
 			desc: "valid config",
 			cfg: &Config{
 				Targets: []*targetConfig{

--- a/receiver/httpcheckreceiver/factory.go
+++ b/receiver/httpcheckreceiver/factory.go
@@ -36,9 +36,13 @@ func createDefaultConfig() component.Config {
 
 	return &Config{
 		ScraperControllerSettings: cfg,
-		HTTPClientSettings:        httpSettings,
 		MetricsBuilderConfig:      metadata.DefaultMetricsBuilderConfig(),
-		Method:                    "GET",
+		Targets: []*targetConfig{
+			{
+				HTTPClientSettings: httpSettings,
+				Method:             "GET",
+			},
+		},
 	}
 }
 

--- a/receiver/httpcheckreceiver/factory_test.go
+++ b/receiver/httpcheckreceiver/factory_test.go
@@ -43,9 +43,13 @@ func TestNewFactory(t *testing.T) {
 						CollectionInterval: 60 * time.Second,
 						InitialDelay:       time.Second,
 					},
-					HTTPClientSettings:   httpSettings,
 					MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
-					Method:               "GET",
+					Targets: []*targetConfig{
+						{
+							HTTPClientSettings: httpSettings,
+							Method:             "GET",
+						},
+					},
 				}
 
 				require.Equal(t, expectedCfg, factory.CreateDefaultConfig())

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver/internal/metadata"
 )
@@ -23,7 +26,7 @@ var (
 )
 
 type httpcheckScraper struct {
-	client   *http.Client
+	clients  []*http.Client
 	cfg      *Config
 	settings component.TelemetrySettings
 	mb       *metadata.MetricsBuilder
@@ -31,42 +34,63 @@ type httpcheckScraper struct {
 
 // start starts the scraper by creating a new HTTP Client on the scraper
 func (h *httpcheckScraper) start(_ context.Context, host component.Host) (err error) {
-	h.client, err = h.cfg.ToClient(host, h.settings)
+	for _, target := range h.cfg.Targets {
+		client, clentErr := target.ToClient(host, h.settings)
+		if clentErr != nil {
+			err = multierr.Append(err, clentErr)
+		}
+		h.clients = append(h.clients, client)
+	}
 	return
 }
 
 // scrape connects to the endpoint and produces metrics based on the response
 func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
-	if h.client == nil {
+	if h.clients == nil || len(h.clients) == 0 {
 		return pmetric.NewMetrics(), errClientNotInit
 	}
 
-	now := pcommon.NewTimestampFromTime(time.Now())
+	var wg sync.WaitGroup
+	wg.Add(len(h.clients))
+	var mux sync.Mutex
 
-	req, err := http.NewRequestWithContext(ctx, h.cfg.Method, h.cfg.Endpoint, http.NoBody)
-	if err != nil {
-		return pmetric.Metrics{}, err
+	for idx, client := range h.clients {
+		go func(client *http.Client, idx int) {
+			defer wg.Done()
+
+			now := pcommon.NewTimestampFromTime(time.Now())
+
+			req, err := http.NewRequestWithContext(ctx, h.cfg.Targets[idx].Method, h.cfg.Targets[idx].Endpoint, http.NoBody)
+			if err != nil {
+				h.settings.Logger.Error("failed to create request", zap.Error(err))
+				return
+			}
+
+			start := time.Now()
+			resp, err := client.Do(req)
+			mux.Lock()
+			h.mb.RecordHttpcheckDurationDataPoint(now, time.Since(start).Milliseconds(), h.cfg.Targets[idx].Endpoint)
+
+			statusCode := 0
+			if err != nil {
+				h.mb.RecordHttpcheckErrorDataPoint(now, int64(1), h.cfg.Targets[idx].Endpoint, err.Error())
+			} else {
+				statusCode = resp.StatusCode
+			}
+
+			for class, intVal := range httpResponseClasses {
+				if statusCode/100 == intVal {
+					h.mb.RecordHttpcheckStatusDataPoint(now, int64(1), h.cfg.Targets[idx].Endpoint, int64(statusCode), req.Method, class)
+				} else {
+					h.mb.RecordHttpcheckStatusDataPoint(now, int64(0), h.cfg.Targets[idx].Endpoint, int64(statusCode), req.Method, class)
+				}
+
+			}
+			mux.Unlock()
+		}(client, idx)
 	}
 
-	start := time.Now()
-	resp, err := h.client.Do(req)
-	h.mb.RecordHttpcheckDurationDataPoint(now, time.Since(start).Milliseconds(), h.cfg.Endpoint)
-
-	statusCode := 0
-	if err != nil {
-		h.mb.RecordHttpcheckErrorDataPoint(now, int64(1), h.cfg.Endpoint, err.Error())
-	} else {
-		statusCode = resp.StatusCode
-	}
-
-	for class, intVal := range httpResponseClasses {
-		if statusCode/100 == intVal {
-			h.mb.RecordHttpcheckStatusDataPoint(now, int64(1), h.cfg.Endpoint, int64(statusCode), req.Method, class)
-		} else {
-			h.mb.RecordHttpcheckStatusDataPoint(now, int64(0), h.cfg.Endpoint, int64(statusCode), req.Method, class)
-		}
-
-	}
+	wg.Wait()
 
 	return h.mb.Emit(), nil
 }

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/multiple_targets.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/multiple_targets.yaml
@@ -1,0 +1,294 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - description: Measures the duration of the HTTP check.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                - asInt: "0"
+                  attributes:
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                - asInt: "0"
+                  attributes:
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+            name: httpcheck.duration
+            unit: ms
+
+          - description: Records errors occurring during HTTP check.
+            name: httpcheck.error
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: error.message
+                      value:
+                        stringValue: 'Get "": unsupported protocol scheme ""'
+                    - key: http.url
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+            unit: "{error}"
+
+
+          - description: 1 if the check resulted in status_code matching the status_class, otherwise 0.
+            name: httpcheck.status
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 1xx
+                    - key: http.status_code
+                      value:
+                        intValue: "0"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 2xx
+                    - key: http.status_code
+                      value:
+                        intValue: "0"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 3xx
+                    - key: http.status_code
+                      value:
+                        intValue: "0"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 4xx
+                    - key: http.status_code
+                      value:
+                        intValue: "0"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 5xx
+                    - key: http.status_code
+                      value:
+                        intValue: "0"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 1xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "1"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 2xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 3xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 4xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 5xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 1xx
+                    - key: http.status_code
+                      value:
+                        intValue: "404"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 2xx
+                    - key: http.status_code
+                      value:
+                        intValue: "404"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 3xx
+                    - key: http.status_code
+                      value:
+                        intValue: "404"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "1"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 4xx
+                    - key: http.status_code
+                      value:
+                        intValue: "404"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 5xx
+                    - key: http.status_code
+                      value:
+                        intValue: "404"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1651783208655196000"
+                  timeUnixNano: "1651783208656862000"
+
+            unit: "1"
+
+        scope:
+          name: otelcol/httpcheckreceiver
+          version: latest


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

httpcheck receiver now supports configuring multiple targets

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18823

**Testing:** Added unit tests
