### PR TITLE
add option to skip log tokenization

### DIFF
--- a/.chloggen/add-udp-tokenize-flag.yaml
+++ b/.chloggen/add-udp-tokenize-flag.yaml
@@ -2,7 +2,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: stanza/udp
+component: pkg/stanza
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: add option to skip log tokenization. use the 'OneLogPerPacket' to skip log tokenization if multiline is not used. this will boost the components performance.

--- a/.chloggen/add-udp-tokenize-flag.yaml
+++ b/.chloggen/add-udp-tokenize-flag.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: pkg/stanza
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: add option to skip log tokenization. use the 'OneLogPerPacket' to skip log tokenization if multiline is not used. this will boost the components performance.
+note: Add option to skip log tokenization. use the 'one_log_per_packet' setting to skip log tokenization if multiline is not used.
 
 # One or more tracking issues related to the change
 issues: []

--- a/.chloggen/add-udp-tokenize-flag.yaml
+++ b/.chloggen/add-udp-tokenize-flag.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: stanza/udp
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add option to skip log tokenization. use the 'OneLogPerPacket' to skip log tokenization if multiline is not used. this will boost the components performance.
+
+# One or more tracking issues related to the change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/add-udp-tokenize-flag.yaml
+++ b/.chloggen/add-udp-tokenize-flag.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: pkg/stanza
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add option to skip log tokenization. use the 'one_log_per_packet' setting to skip log tokenization if multiline is not used.
+note: Add option to skip log tokenization for both tcp and udp receivers. use the 'one_log_per_packet' setting to skip log tokenization if multiline is not used.
 
 # One or more tracking issues related to the change
 issues: [23440]

--- a/.chloggen/add-udp-tokenize-flag.yaml
+++ b/.chloggen/add-udp-tokenize-flag.yaml
@@ -8,7 +8,7 @@ component: pkg/stanza
 note: Add option to skip log tokenization. use the 'one_log_per_packet' setting to skip log tokenization if multiline is not used.
 
 # One or more tracking issues related to the change
-issues: []
+issues: [23440]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/stanza/docs/operators/tcp_input.md
+++ b/pkg/stanza/docs/operators/tcp_input.md
@@ -4,20 +4,21 @@ The `tcp_input` operator listens for logs on one or more TCP connections. The op
 
 ### Configuration Fields
 
-| Field                           | Default          | Description |
-| ---                             | ---              | ---         |
-| `id`                            | `tcp_input`      | A unique identifier for the operator. |
-| `output`                        | Next in pipeline | The connected operator(s) that will receive all outbound entries. |
-| `max_log_size`                  | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory. |
-| `listen_address`                | required         | A listen address of the form `<ip>:<port>`. |
-| `tls`                           | nil              | An optional `TLS` configuration (see the TLS configuration section). |
-| `attributes`                    | {}               | A map of `key: value` pairs to add to the entry's attributes. |
-| `resource`                      | {}               | A map of `key: value` pairs to add to the entry's resource. |
-| `add_attributes`                | false            | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes]. |
+| Field                                   | Default              | Description |
+| ---                                     | ---                  | ---         |
+| `id`                                    | `tcp_input`          | A unique identifier for the operator. |
+| `output`                                | Next in pipeline     | The connected operator(s) that will receive all outbound entries. |
+| `max_log_size`                          | `1MiB`               | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory. |
+| `listen_address`                        | required             | A listen address of the form `<ip>:<port>`. |
+| `tls`                                   | nil                  | An optional `TLS` configuration (see the TLS configuration section). |
+| `attributes`                            | {}                   | A map of `key: value` pairs to add to the entry's attributes. |
+| `one_log_per_packet`                    | false               | Skip log tokenization, set to true if logs contains one log per record and multiline is not used.  This will improve performance. |
+| `resource`                              | {}                   | A map of `key: value` pairs to add to the entry's resource. |
+| `add_attributes`                        | false                | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes]. |
 | `multiline`                     |                  | A `multiline` configuration block. See below for details. |
-| `preserve_leading_whitespaces`  | false            | Whether to preserve leading whitespaces.                                                                                                                                                                                                                         |
-| `preserve_trailing_whitespaces` | false            | Whether to preserve trailing whitespaces.                                                                                                                                                                                                                            |
-| `encoding`                      | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options. |
+| `preserve_leading_whitespaces`          | false                | Whether to preserve leading whitespaces.                                                                                                                                                                                                                         |
+| `preserve_trailing_whitespaces`         | false                | Whether to preserve trailing whitespaces.                                                                                                                                                                                                                            |
+| `encoding`                              | `utf-8`              | The encoding of the file being read. See the list of supported encodings below for available options. |
 
 #### TLS Configuration
 

--- a/pkg/stanza/docs/operators/udp_input.md
+++ b/pkg/stanza/docs/operators/udp_input.md
@@ -4,18 +4,19 @@ The `udp_input` operator listens for logs from UDP packets.
 
 ### Configuration Fields
 
-| Field                           | Default          | Description |
-| ---                             | ---              | ---         |
-| `id`                            | `udp_input`      | A unique identifier for the operator. |
-| `output`                        | Next in pipeline | The connected operator(s) that will receive all outbound entries. |
-| `listen_address`                | required         | A listen address of the form `<ip>:<port>`. |
-| `attributes`                    | {}               | A map of `key: value` pairs to add to the entry's attributes. |
-| `resource`                      | {}               | A map of `key: value` pairs to add to the entry's resource. |
-| `add_attributes`                | false            | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes]. |
+| Field                                   | Default              | Description |
+| ---                                     | ---                  | ---         |
+| `id`                                    | `udp_input`          | A unique identifier for the operator. |
+| `output`                                | Next in pipeline     | The connected operator(s) that will receive all outbound entries. |
+| `listen_address`                        | required             | A listen address of the form `<ip>:<port>`. |
+| `attributes`                            | {}                   | A map of `key: value` pairs to add to the entry's attributes. |
+| `one_log_per_packet`                    | false                | Skip log tokenization, set to true if logs contains one log per record and multiline is not used.  This will improve performance. |
+| `resource`                              | {}                   | A map of `key: value` pairs to add to the entry's resource. |
+| `add_attributes`                        | false                | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes]. |
 | `multiline`                     |                  | A `multiline` configuration block. See below for details. |
-| `preserve_leading_whitespaces`  | false            | Whether to preserve leading whitespaces.                                                                                                                                                                                                                         |
-| `preserve_trailing_whitespaces` | false            | Whether to preserve trailing whitespaces.                                                                                                                                                                                                                            |
-| `encoding`                      | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options. |
+| `preserve_leading_whitespaces`          | false            | Whether to preserve leading whitespaces.                                                                                                                                                                                                                         |
+| `preserve_trailing_whitespaces`             | false            | Whether to preserve trailing whitespaces.                                                                                                                                                                                                                            |
+| `encoding`                              | `utf-8`              | The encoding of the file being read. See the list of supported encodings below for available options. |
 
 #### `multiline` configuration
 

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -5,10 +5,12 @@ package tcp // import "github.com/open-telemetry/opentelemetry-collector-contrib
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"sync"
@@ -48,8 +50,9 @@ func NewConfigWithID(operatorID string) *Config {
 	return &Config{
 		InputConfig: helper.NewInputConfig(operatorID, operatorType),
 		BaseConfig: BaseConfig{
-			Multiline: helper.NewMultilineConfig(),
-			Encoding:  helper.NewEncodingConfig(),
+			OneLogPerPacket: false,
+			Multiline:       helper.NewMultilineConfig(),
+			Encoding:        helper.NewEncodingConfig(),
 		},
 	}
 }
@@ -66,6 +69,7 @@ type BaseConfig struct {
 	ListenAddress               string                      `mapstructure:"listen_address,omitempty"`
 	TLS                         *configtls.TLSServerSetting `mapstructure:"tls,omitempty"`
 	AddAttributes               bool                        `mapstructure:"add_attributes,omitempty"`
+	OneLogPerPacket             bool                        `mapstructure:"one_log_per_packet,omitempty"`
 	Encoding                    helper.EncodingConfig       `mapstructure:",squash,omitempty"`
 	Multiline                   helper.MultilineConfig      `mapstructure:"multiline,omitempty"`
 	PreserveLeadingWhitespaces  bool                        `mapstructure:"preserve_leading_whitespaces,omitempty"`
@@ -114,12 +118,13 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 	}
 
 	tcpInput := &Input{
-		InputOperator: inputOperator,
-		address:       c.ListenAddress,
-		MaxLogSize:    int(c.MaxLogSize),
-		addAttributes: c.AddAttributes,
-		encoding:      encoding,
-		splitFunc:     splitFunc,
+		InputOperator:   inputOperator,
+		address:         c.ListenAddress,
+		MaxLogSize:      int(c.MaxLogSize),
+		addAttributes:   c.AddAttributes,
+		OneLogPerPacket: c.OneLogPerPacket,
+		encoding:        encoding,
+		splitFunc:       splitFunc,
 		backoff: backoff.Backoff{
 			Max: 3 * time.Second,
 		},
@@ -139,9 +144,10 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 // Input is an operator that listens for log entries over tcp.
 type Input struct {
 	helper.InputOperator
-	address       string
-	MaxLogSize    int
-	addAttributes bool
+	address         string
+	MaxLogSize      int
+	addAttributes   bool
+	OneLogPerPacket bool
 
 	listener net.Listener
 	cancel   context.CancelFunc
@@ -239,48 +245,75 @@ func (t *Input) goHandleMessages(ctx context.Context, conn net.Conn, cancel cont
 		defer t.wg.Done()
 		defer cancel()
 
+		if t.OneLogPerPacket {
+			var buf bytes.Buffer
+			io.Copy(&buf, conn)
+			log := truncateMaxLog(buf.Bytes(), t.MaxLogSize)
+			handleMessage(ctx, conn, t, log)
+			return
+		}
+
 		buf := make([]byte, 0, t.MaxLogSize)
+
 		scanner := bufio.NewScanner(conn)
 		scanner.Buffer(buf, t.MaxLogSize)
 
 		scanner.Split(t.splitFunc)
 
 		for scanner.Scan() {
-			decoded, err := t.encoding.Decode(scanner.Bytes())
-			if err != nil {
-				t.Errorw("Failed to decode data", zap.Error(err))
-				continue
-			}
-
-			entry, err := t.NewEntry(string(decoded))
-			if err != nil {
-				t.Errorw("Failed to create entry", zap.Error(err))
-				continue
-			}
-
-			if t.addAttributes {
-				entry.AddAttribute("net.transport", "IP.TCP")
-				if addr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
-					ip := addr.IP.String()
-					entry.AddAttribute("net.peer.ip", ip)
-					entry.AddAttribute("net.peer.port", strconv.FormatInt(int64(addr.Port), 10))
-					entry.AddAttribute("net.peer.name", t.resolver.GetHostFromIP(ip))
-				}
-
-				if addr, ok := conn.LocalAddr().(*net.TCPAddr); ok {
-					ip := addr.IP.String()
-					entry.AddAttribute("net.host.ip", addr.IP.String())
-					entry.AddAttribute("net.host.port", strconv.FormatInt(int64(addr.Port), 10))
-					entry.AddAttribute("net.host.name", t.resolver.GetHostFromIP(ip))
-				}
-			}
-
-			t.Write(ctx, entry)
+			handleMessage(ctx, conn, t, scanner.Bytes())
 		}
+
 		if err := scanner.Err(); err != nil {
 			t.Errorw("Scanner error", zap.Error(err))
 		}
 	}()
+}
+
+func handleMessage(ctx context.Context, conn net.Conn, t *Input, log []byte) {
+	decoded, err := t.encoding.Decode(log)
+	if err != nil {
+		t.Errorw("Failed to decode data", zap.Error(err))
+		return
+	}
+
+	entry, err := t.NewEntry(string(decoded))
+	if err != nil {
+		t.Errorw("Failed to create entry", zap.Error(err))
+		return
+	}
+
+	if t.addAttributes {
+		entry.AddAttribute("net.transport", "IP.TCP")
+		if addr, ok := conn.RemoteAddr().(*net.TCPAddr); ok {
+			ip := addr.IP.String()
+			entry.AddAttribute("net.peer.ip", ip)
+			entry.AddAttribute("net.peer.port", strconv.FormatInt(int64(addr.Port), 10))
+			entry.AddAttribute("net.peer.name", t.resolver.GetHostFromIP(ip))
+		}
+
+		if addr, ok := conn.LocalAddr().(*net.TCPAddr); ok {
+			ip := addr.IP.String()
+			entry.AddAttribute("net.host.ip", addr.IP.String())
+			entry.AddAttribute("net.host.port", strconv.FormatInt(int64(addr.Port), 10))
+			entry.AddAttribute("net.host.name", t.resolver.GetHostFromIP(ip))
+		}
+	}
+
+	t.Write(ctx, entry)
+}
+
+func truncateMaxLog(data []byte, maxLogSize int) (token []byte) {
+	dataLength := len(data)
+
+	if dataLength >= maxLogSize {
+		return data[:maxLogSize]
+	}
+
+	if dataLength == 0 {
+		return nil
+	}
+	return data
 }
 
 // Stop will stop listening for log entries over TCP.

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -39,7 +39,8 @@ func NewConfigWithID(operatorID string) *Config {
 	return &Config{
 		InputConfig: helper.NewInputConfig(operatorID, operatorType),
 		BaseConfig: BaseConfig{
-			Encoding: helper.NewEncodingConfig(),
+			Encoding:    helper.NewEncodingConfig(),
+			TokenizeLog: true,
 			Multiline: helper.MultilineConfig{
 				LineStartPattern: "",
 				LineEndPattern:   ".^", // Use never matching regex to not split data by default
@@ -57,6 +58,7 @@ type Config struct {
 // BaseConfig is the details configuration of a udp input operator.
 type BaseConfig struct {
 	ListenAddress               string                 `mapstructure:"listen_address,omitempty"`
+	TokenizeLog                 bool                   `mapstructure:"tokenize_log,omitempty"`
 	AddAttributes               bool                   `mapstructure:"add_attributes,omitempty"`
 	Encoding                    helper.EncodingConfig  `mapstructure:",squash,omitempty"`
 	Multiline                   helper.MultilineConfig `mapstructure:"multiline,omitempty"`
@@ -104,6 +106,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		encoding:      encoding,
 		splitFunc:     splitFunc,
 		resolver:      resolver,
+		tokenizeLog:   c.TokenizeLog,
 	}
 	return udpInput, nil
 }
@@ -114,6 +117,7 @@ type Input struct {
 	helper.InputOperator
 	address       *net.UDPAddr
 	addAttributes bool
+	tokenizeLog   bool
 
 	connection net.PacketConn
 	cancel     context.CancelFunc
@@ -159,48 +163,71 @@ func (u *Input) goHandleMessages(ctx context.Context) {
 				break
 			}
 
+			if !u.tokenizeLog {
+				log := VerifyLog(message)
+				handleMessage(u, ctx, remoteAddr, log)
+				continue
+			}
+
 			scanner := bufio.NewScanner(bytes.NewReader(message))
 			scanner.Buffer(buf, MaxUDPSize)
 
 			scanner.Split(u.splitFunc)
 
 			for scanner.Scan() {
-				decoded, err := u.encoding.Decode(scanner.Bytes())
-				if err != nil {
-					u.Errorw("Failed to decode data", zap.Error(err))
-					continue
-				}
-
-				entry, err := u.NewEntry(string(decoded))
-				if err != nil {
-					u.Errorw("Failed to create entry", zap.Error(err))
-					continue
-				}
-
-				if u.addAttributes {
-					entry.AddAttribute("net.transport", "IP.UDP")
-					if addr, ok := u.connection.LocalAddr().(*net.UDPAddr); ok {
-						ip := addr.IP.String()
-						entry.AddAttribute("net.host.ip", addr.IP.String())
-						entry.AddAttribute("net.host.port", strconv.FormatInt(int64(addr.Port), 10))
-						entry.AddAttribute("net.host.name", u.resolver.GetHostFromIP(ip))
-					}
-
-					if addr, ok := remoteAddr.(*net.UDPAddr); ok {
-						ip := addr.IP.String()
-						entry.AddAttribute("net.peer.ip", ip)
-						entry.AddAttribute("net.peer.port", strconv.FormatInt(int64(addr.Port), 10))
-						entry.AddAttribute("net.peer.name", u.resolver.GetHostFromIP(ip))
-					}
-				}
-
-				u.Write(ctx, entry)
+				handleMessage(u, ctx, remoteAddr, scanner.Bytes())
 			}
 			if err := scanner.Err(); err != nil {
 				u.Errorw("Scanner error", zap.Error(err))
 			}
 		}
 	}()
+}
+
+func VerifyLog(data []byte) (token []byte) {
+	dataLength := len(data)
+	if dataLength >= MaxUDPSize {
+		return data[:MaxUDPSize]
+	}
+
+	if dataLength == 0 {
+		return nil
+	}
+
+	return data
+}
+
+func handleMessage(u *Input, ctx context.Context, remoteAddr net.Addr, log []byte) {
+	decoded, err := u.encoding.Decode(log)
+	if err != nil {
+		u.Errorw("Failed to decode data", zap.Error(err))
+		return
+	}
+
+	entry, err := u.NewEntry(string(decoded))
+	if err != nil {
+		u.Errorw("Failed to create entry", zap.Error(err))
+		return
+	}
+
+	if u.addAttributes {
+		entry.AddAttribute("net.transport", "IP.UDP")
+		if addr, ok := u.connection.LocalAddr().(*net.UDPAddr); ok {
+			ip := addr.IP.String()
+			entry.AddAttribute("net.host.ip", addr.IP.String())
+			entry.AddAttribute("net.host.port", strconv.FormatInt(int64(addr.Port), 10))
+			entry.AddAttribute("net.host.name", u.resolver.GetHostFromIP(ip))
+		}
+
+		if addr, ok := remoteAddr.(*net.UDPAddr); ok {
+			ip := addr.IP.String()
+			entry.AddAttribute("net.peer.ip", ip)
+			entry.AddAttribute("net.peer.port", strconv.FormatInt(int64(addr.Port), 10))
+			entry.AddAttribute("net.peer.name", u.resolver.GetHostFromIP(ip))
+		}
+	}
+
+	u.Write(ctx, entry)
 }
 
 // readMessage will read log messages from the connection.

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -164,7 +164,7 @@ func (u *Input) goHandleMessages(ctx context.Context) {
 			}
 
 			if u.OneLogPerPacket {
-				log := VerifyLog(message)
+				log := truncateMaxLog(message)
 				handleMessage(u, ctx, remoteAddr, log)
 				continue
 			}

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -165,7 +165,7 @@ func (u *Input) goHandleMessages(ctx context.Context) {
 
 			if u.OneLogPerPacket {
 				log := truncateMaxLog(message)
-				handleMessage(u, ctx, remoteAddr, log)
+				handleMessage(ctx, u, remoteAddr, log)
 				continue
 			}
 
@@ -175,7 +175,7 @@ func (u *Input) goHandleMessages(ctx context.Context) {
 			scanner.Split(u.splitFunc)
 
 			for scanner.Scan() {
-				handleMessage(u, ctx, remoteAddr, scanner.Bytes())
+				handleMessage(ctx, u, remoteAddr, scanner.Bytes())
 			}
 			if err := scanner.Err(); err != nil {
 				u.Errorw("Scanner error", zap.Error(err))
@@ -197,7 +197,7 @@ func truncateMaxLog(data []byte) (token []byte) {
 	return data
 }
 
-func handleMessage(u *Input, ctx context.Context, remoteAddr net.Addr, log []byte) {
+func handleMessage(ctx context.Context, u *Input, remoteAddr net.Addr, log []byte) {
 	decoded, err := u.encoding.Decode(log)
 	if err != nil {
 		u.Errorw("Failed to decode data", zap.Error(err))

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -184,7 +184,7 @@ func (u *Input) goHandleMessages(ctx context.Context) {
 	}()
 }
 
-func VerifyLog(data []byte) (token []byte) {
+func truncateMaxLog(data []byte) (token []byte) {
 	dataLength := len(data)
 	if dataLength >= MaxUDPSize {
 		return data[:MaxUDPSize]

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -165,7 +165,7 @@ func (u *Input) goHandleMessages(ctx context.Context) {
 
 			if u.OneLogPerPacket {
 				log := truncateMaxLog(message)
-				handleMessage(ctx, u, remoteAddr, log)
+				u.handleMessage(ctx, remoteAddr, log)
 				continue
 			}
 
@@ -175,7 +175,7 @@ func (u *Input) goHandleMessages(ctx context.Context) {
 			scanner.Split(u.splitFunc)
 
 			for scanner.Scan() {
-				handleMessage(ctx, u, remoteAddr, scanner.Bytes())
+				u.handleMessage(ctx, remoteAddr, scanner.Bytes())
 			}
 			if err := scanner.Err(); err != nil {
 				u.Errorw("Scanner error", zap.Error(err))
@@ -185,19 +185,18 @@ func (u *Input) goHandleMessages(ctx context.Context) {
 }
 
 func truncateMaxLog(data []byte) (token []byte) {
-	dataLength := len(data)
-	if dataLength >= MaxUDPSize {
+	if len(data) >= MaxUDPSize {
 		return data[:MaxUDPSize]
 	}
 
-	if dataLength == 0 {
+	if len(data) == 0 {
 		return nil
 	}
 
 	return data
 }
 
-func handleMessage(ctx context.Context, u *Input, remoteAddr net.Addr, log []byte) {
+func (u *Input) handleMessage(ctx context.Context, remoteAddr net.Addr, log []byte) {
 	decoded, err := u.encoding.Decode(log)
 	if err != nil {
 		u.Errorw("Failed to decode data", zap.Error(err))

--- a/receiver/tcplogreceiver/README.md
+++ b/receiver/tcplogreceiver/README.md
@@ -17,17 +17,18 @@ Receives logs over TCP.
 
 ## Configuration
 
-| Field             | Default          | Description                                                                                                        |
-| ---               | ---              | ---                                                                                                                |
-| `max_log_size`    | `1MiB`           | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
-| `listen_address`  | required         | A listen address of the form `<ip>:<port>`                                                                         |
-| `tls`             | nil              | An optional `TLS` configuration (see the TLS configuration section)                                                |
-| `attributes`      | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
-| `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                                                         |
-| `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes] |
-| `multiline`       |                  | A `multiline` configuration block. See below for details                                                           |
-| `encoding`        | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
-| `operators`       | []               | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |
+| Field                     | Default              | Description                                                                                                        |
+| ---                       | ---                  | ---                                                                                                                |
+| `max_log_size`            | `1MiB`               | The maximum size of a log entry to read before failing. Protects against reading large amounts of data into memory |
+| `listen_address`          | required             | A listen address of the form `<ip>:<port>`                                                                         |
+| `tls`                     | nil                  | An optional `TLS` configuration (see the TLS configuration section)                                                |
+| `attributes`              | {}                   | A map of `key: value` pairs to add to the entry's attributes                                                       |
+| `one_log_per_packet`      | false                | Skip log tokenization, set to true if logs contains one log per record and multiline is not used.  This will improve performance.                                                 |
+| `resource`                | {}                   | A map of `key: value` pairs to add to the entry's resource                                                         |
+| `add_attributes`          | false                | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes] |
+| `multiline`               |                      | A `multiline` configuration block. See below for details                                                           |
+| `encoding`                | `utf-8`              | The encoding of the file being read. See the list of supported encodings below for available options               |
+| `operators`               | []                   | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |
 
 ### TLS Configuration
 

--- a/receiver/udplogreceiver/README.md
+++ b/receiver/udplogreceiver/README.md
@@ -16,15 +16,16 @@ Receives logs over UDP.
 
 ## Configuration Fields
 
-| Field             | Default          | Description                                                                                                        |
-| ---               | ---              | ---                                                                                                                |
-| `listen_address`  | required         | A listen address of the form `<ip>:<port>`                                                                         |
-| `attributes`      | {}               | A map of `key: value` pairs to add to the entry's attributes                                                       |
-| `resource`        | {}               | A map of `key: value` pairs to add to the entry's resource                                                         |
-| `add_attributes`  | false            | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes] |
-| `multiline`       |                  | A `multiline` configuration block. See below for details                                                           |
-| `encoding`        | `utf-8`          | The encoding of the file being read. See the list of supported encodings below for available options               |
-| `operators`       | []               | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |
+| Field                     | Default              | Description                                                                                                        |
+| ---                       | ---                  | ---                                                                                                                |
+| `listen_address`          | required             | A listen address of the form `<ip>:<port>`                                                                         |
+| `attributes`              | {}                   | A map of `key: value` pairs to add to the entry's attributes                                                       |
+| `one_log_per_packet`      | false                | Skip log tokenization, set to true if logs contains one log per record and multiline is not used.  This will improve performance.                                                 |
+| `resource`                | {}                   | A map of `key: value` pairs to add to the entry's resource                                                         |
+| `add_attributes`          | false                | Adds `net.*` attributes according to [semantic convention][https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes] |
+| `multiline`               |                      | A `multiline` configuration block. See below for details                                                           |
+| `encoding`                | `utf-8`              | The encoding of the file being read. See the list of supported encodings below for available options               |
+| `operators`               | []                   | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |
 
 ### Operators
 


### PR DESCRIPTION
Description: Performance improvement for UDP receiver.
Currently, UDP created on each log line a scanner object with split functions, even if there was no need for log tokenizing.
this PR adds a new config option 'tokenize_log' (default value set to true) which lets you decide if this is the behavior you want.
if set as false the scanner object is not created and the performance is increased significantly (up to 3X)

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/discussions/23237

Testing:
Created a local build of the UDP receiver and tested that the logs arrive and exported as expected.