### PR TITLE
[cmd/mdatagen] Document input_type

### DIFF
--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -80,5 +80,8 @@ metrics:
       # Required for sum metric: whether reported values incorporate previous measurements
       # (cumulative) or not (delta).
       aggregation: <delta|cumulative>
+       # Optional: Indicates the type the metric needs to be parsed from. If set, the generated
+       # functions will parse the value from string to value_type.
+      input_type: string
     # Optional: array of attributes that were defined in the attributes section that are emitted by this metric.
     attributes: [string]


### PR DESCRIPTION
**Description:** 

`input_type` was added in: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/8986. This PR documents this in `metadata-schema.yaml`.
