### PR TITLE
[receiver/k8scluster] Fix empty k8s.namespace.name in k8s.namespace.phase metrics

### DIFF
--- a/.chloggen/k8scluster-fix-empty-namespace-in-namespacephase.yaml
+++ b/.chloggen/k8scluster-fix-empty-namespace-in-namespacephase.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sclusterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix empty k8s.namespace.name attribute in k8s.namespace.phase metric
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23452]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/k8sclusterreceiver/internal/namespace/namespaces.go
+++ b/receiver/k8sclusterreceiver/internal/namespace/namespaces.go
@@ -18,7 +18,7 @@ func GetMetrics(set receiver.CreateSettings, ns *corev1.Namespace) pmetric.Metri
 	mb := imetadata.NewMetricsBuilder(imetadata.DefaultMetricsBuilderConfig(), set)
 	ts := pcommon.NewTimestampFromTime(time.Now())
 	mb.RecordK8sNamespacePhaseDataPoint(ts, int64(namespacePhaseValues[ns.Status.Phase]))
-	return mb.Emit(imetadata.WithK8sNamespaceUID(string(ns.UID)), imetadata.WithK8sNamespaceName(ns.Namespace), imetadata.WithOpencensusResourcetype("k8s"))
+	return mb.Emit(imetadata.WithK8sNamespaceUID(string(ns.UID)), imetadata.WithK8sNamespaceName(ns.Name), imetadata.WithOpencensusResourcetype("k8s"))
 }
 
 var namespacePhaseValues = map[corev1.NamespacePhase]int32{

--- a/receiver/k8sclusterreceiver/internal/namespace/namespaces_test.go
+++ b/receiver/k8sclusterreceiver/internal/namespace/namespaces_test.go
@@ -36,9 +36,8 @@ func TestNamespaceMetrics(t *testing.T) {
 func newNamespace(id string) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "test-namespace-" + id,
-			Namespace: "test-namespace",
-			UID:       types.UID("test-namespace-" + id + "-uid"),
+			Name: "test-namespace-" + id,
+			UID:  types.UID("test-namespace-" + id + "-uid"),
 			Labels: map[string]string{
 				"foo":  "bar",
 				"foo1": "",

--- a/receiver/k8sclusterreceiver/internal/namespace/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/namespace/testdata/expected.yaml
@@ -3,7 +3,7 @@ resourceMetrics:
       attributes:
         - key: k8s.namespace.name
           value:
-            stringValue: test-namespace
+            stringValue: test-namespace-1
         - key: k8s.namespace.uid
           value:
             stringValue: test-namespace-1-uid

--- a/receiver/k8sclusterreceiver/testdata/e2e/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/expected.yaml
@@ -3,7 +3,7 @@ resourceMetrics:
       attributes:
         - key: k8s.namespace.name
           value:
-            stringValue: ""
+            stringValue: kube-system
         - key: k8s.namespace.uid
           value:
             stringValue: 3604b135-20f2-404b-9c1a-175ef649793e
@@ -27,7 +27,7 @@ resourceMetrics:
       attributes:
         - key: k8s.namespace.name
           value:
-            stringValue: ""
+            stringValue: local-path-storage
         - key: k8s.namespace.uid
           value:
             stringValue: 414da07d-33d0-4043-ae7c-d6b264d134e5
@@ -51,7 +51,7 @@ resourceMetrics:
       attributes:
         - key: k8s.namespace.name
           value:
-            stringValue: ""
+            stringValue: kube-public
         - key: k8s.namespace.uid
           value:
             stringValue: 7516afba-1597-49e3-8569-9732b7b94865
@@ -75,7 +75,7 @@ resourceMetrics:
       attributes:
         - key: k8s.namespace.name
           value:
-            stringValue: ""
+            stringValue: kube-node-lease
         - key: k8s.namespace.uid
           value:
             stringValue: 8dd32894-d0ff-4cff-bd75-b818c20fc72b
@@ -99,7 +99,7 @@ resourceMetrics:
       attributes:
         - key: k8s.namespace.name
           value:
-            stringValue: ""
+            stringValue: default
         - key: k8s.namespace.uid
           value:
             stringValue: caa467a2-d3e8-4e66-8b76-a155464bac79


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Kubernetes namespace is a cluster-scoped resource and doesn't seem to have populated `namespace` field in Kubernetes (at least on 1.25.x and 1.26.x).

This PR changes it so the name of the namespace is simply taken from `name` field instead.

**Link to tracking Issue:** <Issue number if applicable>
#23452 

**Testing:** <Describe what testing was performed and which tests were added.>
There's already a test that covers it but it contained non-empty `namespace` field which in live Kubernetes is empty for namespaces.

**Documentation:** <Describe the documentation added.>
n/a