### PR TITLE
Add EKS/K8s identifier as part of X-Ray segment name

### DIFF
--- a/.chloggen/awsxray-add-eks-identifiers-to-segment-name.yaml
+++ b/.chloggen/awsxray-add-eks-identifiers-to-segment-name.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add EKS/K8s cluster name and namespace as part of X-Ray segment name if it exist(s)
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23561]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
In X-Ray, the segment with the same name will be merged into one single node in the console. Besides the UI/backend changes in X-Ray backend, we also propose to append EKS/K8s identifiers(ClusterName and Namespace) to the segment name for supporting the latest AWS APM use cases. 

**Link to tracking Issue:** <Issue number if applicable>
n/a

**Testing:** 
unit test

**Documentation:** <Describe the documentation added.>
n/a