### PR TITLE
feat(statsdReceiver): add name and version to scope

### DIFF
--- a/.chloggen/statsd-version-name-in-metrics.yaml
+++ b/.chloggen/statsd-version-name-in-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: statsdreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: All receivers are setting receiver name and version when sending data. This change introduces the same behaviour to the statsd receiver.
+
+# One or more tracking issues related to the change
+issues: [23563]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -6,7 +6,6 @@ package protocol // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"errors"
 	"fmt"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"net"
 	"strconv"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	"github.com/lightstep/go-expohisto/structure"
 	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/attribute"
 )

--- a/receiver/statsdreceiver/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/protocol/statsd_parser.go
@@ -6,6 +6,7 @@ package protocol // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"errors"
 	"fmt"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"net"
 	"strconv"
 	"strings"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/lightstep/go-expohisto/structure"
 	"go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -48,6 +50,8 @@ const (
 	DisableObserver   ObserverType = "disabled"
 
 	DefaultObserverType = DisableObserver
+
+	receiverName = "otelcol/statsdreceiver"
 )
 
 type TimerHistogramMapping struct {
@@ -77,6 +81,7 @@ type StatsDParser struct {
 	timerEvents          ObserverCategory
 	histogramEvents      ObserverCategory
 	lastIntervalTime     time.Time
+	BuildInfo            component.BuildInfo
 }
 
 type instruments struct {
@@ -189,36 +194,42 @@ func (p *StatsDParser) GetMetrics() []BatchMetrics {
 		}
 		rm := batch.Metrics.ResourceMetrics().AppendEmpty()
 		for _, metric := range instrument.gauges {
-			metric.CopyTo(rm.ScopeMetrics().AppendEmpty())
+			p.copyMetricAndScope(rm, metric)
 		}
 
 		for _, metric := range instrument.timersAndDistributions {
-			metric.CopyTo(rm.ScopeMetrics().AppendEmpty())
+			p.copyMetricAndScope(rm, metric)
 		}
 
 		for _, metric := range instrument.counters {
 			setTimestampsForCounterMetric(metric, p.lastIntervalTime, now)
-			metric.CopyTo(rm.ScopeMetrics().AppendEmpty())
+			p.copyMetricAndScope(rm, metric)
 		}
 
 		for desc, summaryMetric := range instrument.summaries {
+			ilm := rm.ScopeMetrics().AppendEmpty()
+			p.setVersionAndNameScope(ilm.Scope())
+
 			buildSummaryMetric(
 				desc,
 				summaryMetric,
 				p.lastIntervalTime,
 				now,
 				statsDDefaultPercentiles,
-				rm.ScopeMetrics().AppendEmpty(),
+				ilm,
 			)
 		}
 
 		for desc, histogramMetric := range instrument.histograms {
+			ilm := rm.ScopeMetrics().AppendEmpty()
+			p.setVersionAndNameScope(ilm.Scope())
+
 			buildHistogramMetric(
 				desc,
 				histogramMetric,
 				p.lastIntervalTime,
 				now,
-				rm.ScopeMetrics().AppendEmpty(),
+				ilm,
 			)
 		}
 
@@ -226,6 +237,17 @@ func (p *StatsDParser) GetMetrics() []BatchMetrics {
 	}
 	p.resetState(now)
 	return batchMetrics
+}
+
+func (p *StatsDParser) copyMetricAndScope(rm pmetric.ResourceMetrics, metric pmetric.ScopeMetrics) {
+	ilm := rm.ScopeMetrics().AppendEmpty()
+	metric.CopyTo(ilm)
+	p.setVersionAndNameScope(ilm.Scope())
+}
+
+func (p *StatsDParser) setVersionAndNameScope(ilm pcommon.InstrumentationScope) {
+	ilm.SetVersion(p.BuildInfo.Version)
+	ilm.SetName(receiverName)
 }
 
 var timeNowFunc = time.Now

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -59,7 +59,9 @@ func New(
 		config:       &config,
 		nextConsumer: nextConsumer,
 		reporter:     rep,
-		parser:       &protocol.StatsDParser{},
+		parser: &protocol.StatsDParser{
+			BuildInfo: set.BuildInfo,
+		},
 	}
 	return r, nil
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Following the same approach of  https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/20903

I am adding the scope whenever the metric is copied. We could also add the _scope_ at creation time, however, it would change the signature of several functions having already too many parameters. 

**Link to tracking Issue:** <Issue number if applicable>
Fix https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23563

**Testing:** 
Added a test to cover the new use case

