### PR TITLE
aerospikereceiver: Add missing units in metadata.yaml

### DIFF
--- a/.chloggen/add-units-aerospikereceiver.yaml
+++ b/.chloggen/add-units-aerospikereceiver.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: aerospikereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds unit to metrics where this was missing.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23572]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Affected metrics can be found below.
+  - aerospike.node.query.tracked

--- a/receiver/aerospikereceiver/documentation.md
+++ b/receiver/aerospikereceiver/documentation.md
@@ -189,7 +189,7 @@ Number of queries which ran more than query untracked_time (default 1 sec), Aero
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-|  | Sum | Int | Cumulative | true |
+| {queries} | Sum | Int | Cumulative | true |
 
 ## Resource Attributes
 

--- a/receiver/aerospikereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/aerospikereceiver/internal/metadata/generated_metrics.go
@@ -1029,7 +1029,7 @@ type metricAerospikeNodeQueryTracked struct {
 func (m *metricAerospikeNodeQueryTracked) init() {
 	m.data.SetName("aerospike.node.query.tracked")
 	m.data.SetDescription("Number of queries tracked by the system.")
-	m.data.SetUnit("")
+	m.data.SetUnit("{queries}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(true)
 	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)

--- a/receiver/aerospikereceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/aerospikereceiver/internal/metadata/generated_metrics_test.go
@@ -364,7 +364,7 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
 					assert.Equal(t, "Number of queries tracked by the system.", ms.At(i).Description())
-					assert.Equal(t, "", ms.At(i).Unit())
+					assert.Equal(t, "{queries}", ms.At(i).Unit())
 					assert.Equal(t, true, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
 					dp := ms.At(i).Sum().DataPoints().At(0)

--- a/receiver/aerospikereceiver/metadata.yaml
+++ b/receiver/aerospikereceiver/metadata.yaml
@@ -141,6 +141,7 @@ metrics:
     enabled: true
     description: Number of queries tracked by the system.
     extended_documentation: Number of queries which ran more than query untracked_time (default 1 sec), Aerospike metric query_tracked
+    unit: '{queries}'
     sum:
       value_type: int
       input_type: string

--- a/receiver/aerospikereceiver/testdata/integration/expected.yaml
+++ b/receiver/aerospikereceiver/testdata/integration/expected.yaml
@@ -3,7 +3,7 @@ resourceMetrics:
       attributes:
         - key: aerospike.node.name
           value:
-            stringValue: BB9040011AC4202
+            stringValue: BB9030011AC4202
     scopeMetrics:
       - metrics:
           - description: Number of connections opened and closed to the node
@@ -11,66 +11,66 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "0"
+                - asInt: "346"
                   attributes:
-                    - key: type
-                      value:
-                        stringValue: fabric
                     - key: operation
                       value:
-                        stringValue: open
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "2"
-                  attributes:
+                        stringValue: close
                     - key: type
                       value:
                         stringValue: client
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
                     - key: operation
                       value:
                         stringValue: close
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: heartbeat
-                    - key: operation
-                      value:
-                        stringValue: open
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: heartbeat
-                    - key: operation
-                      value:
-                        stringValue: close
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
                     - key: type
                       value:
                         stringValue: fabric
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
                     - key: operation
                       value:
                         stringValue: close
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "53"
-                  attributes:
                     - key: type
                       value:
-                        stringValue: client
+                        stringValue: heartbeat
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "397"
+                  attributes:
                     - key: operation
                       value:
                         stringValue: open
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                    - key: type
+                      value:
+                        stringValue: client
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: open
+                    - key: type
+                      value:
+                        stringValue: fabric
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: open
+                    - key: type
+                      value:
+                        stringValue: heartbeat
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
               isMonotonic: true
             unit: '{connections}'
           - description: Current number of open connections to the node
@@ -78,34 +78,34 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: heartbeat
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
                 - asInt: "51"
                   attributes:
                     - key: type
                       value:
                         stringValue: client
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
                 - asInt: "0"
                   attributes:
                     - key: type
                       value:
                         stringValue: fabric
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: heartbeat
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
             unit: '{connections}'
           - description: Percentage of the node's memory which is still free
             gauge:
               dataPoints:
-                - asInt: "76"
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                - asInt: "55"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
             name: aerospike.node.memory.free
             unit: '%'
         scope:
@@ -118,15 +118,15 @@ resourceMetrics:
             stringValue: test
         - key: aerospike.node.name
           value:
-            stringValue: BB9040011AC4202
+            stringValue: BB9030011AC4202
     scopeMetrics:
       - metrics:
           - description: Minimum percentage of contiguous disk space free to the namespace across all devices
             gauge:
               dataPoints:
                 - asInt: "99"
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
             name: aerospike.namespace.disk.available
             unit: '%'
           - description: Number of cell coverings for query region queried
@@ -135,8 +135,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "9"
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
               isMonotonic: true
             unit: '{cells}'
           - description: Number of points outside the region.
@@ -145,8 +145,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
               isMonotonic: true
             unit: '{points}'
           - description: Number of points within the region.
@@ -155,8 +155,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
               isMonotonic: true
             unit: '{points}'
           - description: Number of geojson queries on the system since the uptime of the node.
@@ -165,16 +165,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
               isMonotonic: true
             unit: '{queries}'
           - description: Percentage of the namespace's memory which is still free
             gauge:
               dataPoints:
                 - asInt: "96"
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
             name: aerospike.namespace.memory.free
             unit: '%'
           - description: Memory currently used by each component of the namespace
@@ -182,34 +182,34 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "33554432"
-                  attributes:
-                    - key: component
-                      value:
-                        stringValue: secondary_index
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "6720"
-                  attributes:
-                    - key: component
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
                 - asInt: "0"
                   attributes:
                     - key: component
                       value:
                         stringValue: data
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "6720"
+                  attributes:
+                    - key: component
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "33554432"
+                  attributes:
+                    - key: component
+                      value:
+                        stringValue: secondary_index
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
                 - asInt: "0"
                   attributes:
                     - key: component
                       value:
                         stringValue: set_index
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
             unit: By
           - description: Number of query operations performed on the namespace
             name: aerospike.namespace.query.count
@@ -218,342 +218,342 @@ resourceMetrics:
               dataPoints:
                 - asInt: "0"
                   attributes:
-                    - key: type
-                      value:
-                        stringValue: udf_background
                     - key: index
                       value:
-                        stringValue: secondary
+                        stringValue: primary
                     - key: result
                       value:
                         stringValue: abort
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                    - key: type
+                      value:
+                        stringValue: aggregation
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
                 - asInt: "0"
                   attributes:
+                    - key: index
+                      value:
+                        stringValue: primary
+                    - key: result
+                      value:
+                        stringValue: abort
                     - key: type
                       value:
                         stringValue: long_basic
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
                     - key: index
                       value:
-                        stringValue: secondary
+                        stringValue: primary
                     - key: result
                       value:
-                        stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "1"
-                  attributes:
+                        stringValue: abort
                     - key: type
                       value:
-                        stringValue: short_basic
+                        stringValue: ops_background
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: primary
+                    - key: result
+                      value:
+                        stringValue: abort
+                    - key: type
+                      value:
+                        stringValue: udf_background
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "1"
+                  attributes:
                     - key: index
                       value:
                         stringValue: primary
                     - key: result
                       value:
                         stringValue: complete
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
+                    - key: type
+                      value:
+                        stringValue: aggregation
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "1"
                   attributes:
+                    - key: index
+                      value:
+                        stringValue: primary
+                    - key: result
+                      value:
+                        stringValue: complete
+                    - key: type
+                      value:
+                        stringValue: long_basic
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "1"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: primary
+                    - key: result
+                      value:
+                        stringValue: complete
+                    - key: type
+                      value:
+                        stringValue: short_basic
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "1"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: primary
+                    - key: result
+                      value:
+                        stringValue: complete
                     - key: type
                       value:
                         stringValue: udf_background
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
                     - key: index
                       value:
                         stringValue: primary
                     - key: result
                       value:
                         stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
                     - key: type
                       value:
-                        stringValue: long_basic
+                        stringValue: aggregation
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
                     - key: index
                       value:
                         stringValue: primary
                     - key: result
                       value:
-                        stringValue: abort
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: aggregation
-                    - key: index
-                      value:
-                        stringValue: secondary
-                    - key: result
-                      value:
-                        stringValue: abort
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
+                        stringValue: error
                     - key: type
                       value:
                         stringValue: long_basic
-                    - key: index
-                      value:
-                        stringValue: secondary
-                    - key: result
-                      value:
-                        stringValue: abort
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
                 - asInt: "0"
                   attributes:
+                    - key: index
+                      value:
+                        stringValue: primary
+                    - key: result
+                      value:
+                        stringValue: error
                     - key: type
                       value:
                         stringValue: short_basic
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: primary
+                    - key: result
+                      value:
+                        stringValue: error
+                    - key: type
+                      value:
+                        stringValue: udf_background
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
                     - key: index
                       value:
                         stringValue: primary
                     - key: result
                       value:
                         stringValue: timeout
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
                     - key: type
                       value:
                         stringValue: short_basic
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
                     - key: index
                       value:
                         stringValue: secondary
-                    - key: result
-                      value:
-                        stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "1"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: aggregation
-                    - key: index
-                      value:
-                        stringValue: secondary
-                    - key: result
-                      value:
-                        stringValue: complete
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: short_basic
-                    - key: index
-                      value:
-                        stringValue: primary
-                    - key: result
-                      value:
-                        stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: long_basic
-                    - key: index
-                      value:
-                        stringValue: primary
-                    - key: result
-                      value:
-                        stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "1"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: short_basic
-                    - key: index
-                      value:
-                        stringValue: secondary
-                    - key: result
-                      value:
-                        stringValue: complete
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "1"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: long_basic
-                    - key: index
-                      value:
-                        stringValue: primary
-                    - key: result
-                      value:
-                        stringValue: complete
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "1"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: udf_background
-                    - key: index
-                      value:
-                        stringValue: primary
-                    - key: result
-                      value:
-                        stringValue: complete
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: aggregation
-                    - key: index
-                      value:
-                        stringValue: primary
-                    - key: result
-                      value:
-                        stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: udf_background
-                    - key: index
-                      value:
-                        stringValue: primary
                     - key: result
                       value:
                         stringValue: abort
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                    - key: type
+                      value:
+                        stringValue: aggregation
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: secondary
+                    - key: result
+                      value:
+                        stringValue: abort
+                    - key: type
+                      value:
+                        stringValue: long_basic
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: secondary
+                    - key: result
+                      value:
+                        stringValue: abort
+                    - key: type
+                      value:
+                        stringValue: ops_background
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: secondary
+                    - key: result
+                      value:
+                        stringValue: abort
+                    - key: type
+                      value:
+                        stringValue: udf_background
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "1"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: secondary
+                    - key: result
+                      value:
+                        stringValue: complete
+                    - key: type
+                      value:
+                        stringValue: aggregation
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
                 - asInt: "2"
                   attributes:
+                    - key: index
+                      value:
+                        stringValue: secondary
+                    - key: result
+                      value:
+                        stringValue: complete
                     - key: type
                       value:
                         stringValue: long_basic
-                    - key: index
-                      value:
-                        stringValue: secondary
-                    - key: result
-                      value:
-                        stringValue: complete
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: ops_background
-                    - key: index
-                      value:
-                        stringValue: secondary
-                    - key: result
-                      value:
-                        stringValue: abort
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: udf_background
-                    - key: index
-                      value:
-                        stringValue: secondary
-                    - key: result
-                      value:
-                        stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
                 - asInt: "1"
                   attributes:
-                    - key: type
-                      value:
-                        stringValue: aggregation
-                    - key: index
-                      value:
-                        stringValue: primary
-                    - key: result
-                      value:
-                        stringValue: complete
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: aggregation
-                    - key: index
-                      value:
-                        stringValue: primary
-                    - key: result
-                      value:
-                        stringValue: abort
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: aggregation
-                    - key: index
-                      value:
-                        stringValue: secondary
-                    - key: result
-                      value:
-                        stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "1"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: udf_background
                     - key: index
                       value:
                         stringValue: secondary
                     - key: result
                       value:
                         stringValue: complete
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: ops_background
-                    - key: index
-                      value:
-                        stringValue: primary
-                    - key: result
-                      value:
-                        stringValue: abort
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
                     - key: type
                       value:
                         stringValue: short_basic
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "1"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: secondary
+                    - key: result
+                      value:
+                        stringValue: complete
+                    - key: type
+                      value:
+                        stringValue: udf_background
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: secondary
+                    - key: result
+                      value:
+                        stringValue: error
+                    - key: type
+                      value:
+                        stringValue: aggregation
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: secondary
+                    - key: result
+                      value:
+                        stringValue: error
+                    - key: type
+                      value:
+                        stringValue: long_basic
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: secondary
+                    - key: result
+                      value:
+                        stringValue: error
+                    - key: type
+                      value:
+                        stringValue: short_basic
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: index
+                      value:
+                        stringValue: secondary
+                    - key: result
+                      value:
+                        stringValue: error
+                    - key: type
+                      value:
+                        stringValue: udf_background
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
                     - key: index
                       value:
                         stringValue: secondary
                     - key: result
                       value:
                         stringValue: timeout
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                    - key: type
+                      value:
+                        stringValue: short_basic
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
               isMonotonic: true
             unit: '{queries}'
           - description: Number of transactions performed on the namespace
@@ -563,174 +563,174 @@ resourceMetrics:
               dataPoints:
                 - asInt: "0"
                   attributes:
-                    - key: type
-                      value:
-                        stringValue: read
-                    - key: result
-                      value:
-                        stringValue: success
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: write
-                    - key: result
-                      value:
-                        stringValue: timeout
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: write
-                    - key: result
-                      value:
-                        stringValue: filtered_out
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: read
-                    - key: result
-                      value:
-                        stringValue: timeout
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: delete
-                    - key: result
-                      value:
-                        stringValue: not_found
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: delete
-                    - key: result
-                      value:
-                        stringValue: success
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: read
-                    - key: result
-                      value:
-                        stringValue: filtered_out
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: read
                     - key: result
                       value:
                         stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                    - key: type
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
                 - asInt: "0"
                   attributes:
+                    - key: result
+                      value:
+                        stringValue: error
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: result
+                      value:
+                        stringValue: error
                     - key: type
                       value:
                         stringValue: udf
-                    - key: result
-                      value:
-                        stringValue: filtered_out
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
                 - asInt: "0"
                   attributes:
-                    - key: type
-                      value:
-                        stringValue: delete
-                    - key: result
-                      value:
-                        stringValue: timeout
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: delete
                     - key: result
                       value:
                         stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: result
+                      value:
+                        stringValue: filtered_out
+                    - key: type
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: result
+                      value:
+                        stringValue: filtered_out
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: result
+                      value:
+                        stringValue: filtered_out
+                    - key: type
+                      value:
+                        stringValue: udf
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: result
+                      value:
+                        stringValue: filtered_out
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: result
+                      value:
+                        stringValue: not_found
+                    - key: type
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: result
+                      value:
+                        stringValue: not_found
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: result
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: result
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
                 - asInt: "105"
                   attributes:
-                    - key: type
-                      value:
-                        stringValue: write
                     - key: result
                       value:
                         stringValue: success
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: udf
-                    - key: result
-                      value:
-                        stringValue: timeout
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
                     - key: type
                       value:
                         stringValue: write
-                    - key: result
-                      value:
-                        stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
                 - asInt: "0"
                   attributes:
-                    - key: type
-                      value:
-                        stringValue: read
                     - key: result
                       value:
-                        stringValue: not_found
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
-                    - key: type
-                      value:
-                        stringValue: udf
-                    - key: result
-                      value:
-                        stringValue: error
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
-                - asInt: "0"
-                  attributes:
+                        stringValue: timeout
                     - key: type
                       value:
                         stringValue: delete
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
                     - key: result
                       value:
-                        stringValue: filtered_out
-                  startTimeUnixNano: "1663263782604581000"
-                  timeUnixNano: "1663263782711204000"
+                        stringValue: timeout
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: result
+                      value:
+                        stringValue: timeout
+                    - key: type
+                      value:
+                        stringValue: udf
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
+                - asInt: "0"
+                  attributes:
+                    - key: result
+                      value:
+                        stringValue: timeout
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1687249906301031000"
+                  timeUnixNano: "1687249907414652000"
               isMonotonic: true
             unit: '{transactions}'
         scope:


### PR DESCRIPTION
**Description:**

Metric unit is required, see: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/cmd/mdatagen/metadata-schema.yaml#L72-L73.

This PR adds the unit to metrics where this is missing:

- aerospike.node.query.tracked