### PR TITLE
[chore] [cmd/mdatagen] Remove unused (md *metadata) Unmarshal func

### DIFF
--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -224,17 +224,6 @@ type metadata struct {
 	ScopeName string `mapstructure:"-"`
 }
 
-func (md *metadata) Unmarshal(parser *confmap.Conf) error {
-	if !parser.IsSet("name") {
-		return errors.New("missing required field: `description`")
-	}
-	err := parser.Unmarshal(md, confmap.WithErrorUnused())
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func (md *metadata) Validate() error {
 	var errs error
 


### PR DESCRIPTION
**Description:**

This func is not used. Because the receiver is the metadata struct, it would need to be called directly.

This also tests field Name -- which does not exist anymore (replaced by Type).

**Note:** Validation of Type will be done as part of #23424