### PR TITLE
feat: intial draft sending medatada in prometheus remote write

### DIFF
--- a/pkg/translator/prometheusremotewrite/otlp_to_openmetrics_metadata.go
+++ b/pkg/translator/prometheusremotewrite/otlp_to_openmetrics_metadata.go
@@ -1,0 +1,33 @@
+package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
+
+import (
+	"github.com/prometheus/prometheus/prompb"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// CreateMetadata converts pmetric.Metrics to prometheus remote write format.
+func CreateMetadata(md pmetric.Metrics) []prompb.MetricMetadata {
+	var metadata []prompb.MetricMetadata
+
+	resourceMetricsSlice := md.ResourceMetrics()
+	for i := 0; i < resourceMetricsSlice.Len(); i++ {
+		resourceMetrics := resourceMetricsSlice.At(i)
+		scopeMetricsSlice := resourceMetrics.ScopeMetrics()
+
+		for j := 0; j < scopeMetricsSlice.Len(); j++ {
+			scopeMetrics := scopeMetricsSlice.At(j)
+			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
+
+				entry := prompb.MetricMetadata{
+					Type:             prompb.MetricMetadata_MetricType(scopeMetrics.Metrics().At(k).Type()),
+					MetricFamilyName: scopeMetrics.Metrics().At(k).Name(),
+					Help:             scopeMetrics.Metrics().At(k).Description(),
+					Unit:             scopeMetrics.Metrics().At(k).Unit(),
+				}
+				metadata = append(metadata, entry)
+			}
+		}
+	}
+
+	return metadata
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

The initial draft of creating Openmetrics metadata and sending them as part of Prometheus remote write request.

As of now the prometheus remote write is not sending metadata described in the linked issue as it should per per the otel [spec](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#metric-metadata-1). This is draft of a PR to address it. 
This is not the final form, among other things it's missing tests, but I opened it to discuss from which part of the codebase should we send the metadata and whether introducing this should be behind a feature flag or configuration option.

* Openmetrics metadata can be sent as part of the same remote write request
  * Than we have to deal with batching (ideally sending metadata only relevant to the batched metrics and maintaining the max batch size)
* We could also send it as as separate request 
  * Than it's a question of where in the codebase is a good place to send it from
  * Should we wait for the request to finish before moving onto the next item?

Personally I lean towards just sending it as part of the same request and putting it behind a feature flag given the spec says the [metadata](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#metric-metadata-1) should be sent I would eventually set is as default behavior.

TODO:
* Write a design document with these options
  * Sent metadata with every request (prometheus doesn't do this to avoid significantly increase network egress costs)
  * Sent metadata with ever X-th request (risking not sending metadata for every metric)
  * Keep a map in memory of every metric name exported with the last time it was sent and send it every 5 min in a separate request (would increase memory usage)
  * Replicate Prometheus behavior
* Add tests
* Verify the translation to medatata is correct / follows spec
* Check if it generates empty metadata objects 
* Find out why certain metrics are still missing the description

**Link to tracking Issue:**  https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13849

**Testing:** <Describe what testing was performed and which tests were added.> Locally only for now, will add tests and do more testing after getting feedback.

**Documentation:** <Describe the documentation added.>