### PR TITLE
[chore] Update recombine example and add corresponding test

### DIFF
--- a/pkg/stanza/docs/operators/recombine.md
+++ b/pkg/stanza/docs/operators/recombine.md
@@ -101,8 +101,8 @@ This can be expressed with the following configuration:
 
 ```yaml
 - type: recombine
-  combine_field: body.message
-  is_first_entry: body.message matches "^[^\s]"
+  combine_field: body
+  is_first_entry: body matches "^[^\\s]"
 ```
 
 Given the following input file:
@@ -126,23 +126,17 @@ The following logs will be output:
   {
     "timestamp": "2020-12-04T13:03:38.41149-05:00",
     "severity": 0,
-    "body": {
-      "message": "Log message 1",
-    }
+    "body": "Log message 1"
   },
   {
     "timestamp": "2020-12-04T13:03:38.41149-05:00",
     "severity": 0,
-    "body": {
-      "message": "Error: java.lang.Exception: Stack trace\n        at java.lang.Thread.dumpStack(Thread.java:1336)\n        at Main.demo3(Main.java:15)\n        at Main.demo2(Main.java:12)\n        at Main.demo1(Main.java:9)\n        at Main.demo(Main.java:6)\n        at Main.main(Main.java:3)",
-    }
+    "body": "Error: java.lang.Exception: Stack trace\n        at java.lang.Thread.dumpStack(Thread.java:1336)\n        at Main.demo3(Main.java:15)\n        at Main.demo2(Main.java:12)\n        at Main.demo1(Main.java:9)\n        at Main.demo(Main.java:6)\n        at Main.main(Main.java:3)"
   },
   {
     "timestamp": "2020-12-04T13:03:38.41149-05:00",
     "severity": 0,
-    "body": {
-      "message": "Another log message",
-    }
+    "body": "Another log message",
   },
 ]
 ```


### PR DESCRIPTION
Changes to readme:
- Escape `\s` in match expression
- Switch stacktrace example to combine on `body`. This example has no reason to demonstrate `body.message`, but the other example does.

Added tests:
- Exactly the stacktrace example
- Previous version of the example
- Exactly the "logtag" example