### PR TITLE
[receiver/filelog] added example, additional info to configs and info on log rotation

### DIFF
--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -19,35 +19,35 @@ Tails and parses logs from files.
 
 | Field                               | Default                              | Description                                                                                                                                                                                                                                                     |
 |-------------------------------------|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `include`                           | required                             | A list of file glob patterns that match the file paths to be read                                                                                                                                                                                               |
-| `exclude`                           | []                                   | A list of file glob patterns to exclude from reading                                                                                                                                                                                                            |
-| `start_at`                          | `end`                                | At startup, where to start reading logs from the file. Options are `beginning` or `end`                                                                                                                                                                         |
-| `multiline`                         |                                      | A `multiline` configuration block. See below for more details                                                                                                                                                                                                   |
-| `force_flush_period`                | `500ms`                              | Time since last read of data from file, after which currently buffered log should be send to pipeline. Takes `time.Duration` (e.g. `10s`, `1m`, or `500ms`) as value. Zero means waiting for new data forever                                                   |
-| `encoding`                          | `utf-8`                              | The encoding of the file being read. See the list of supported encodings below for available options                                                                                                                                                            |
+| `include`                           | required                             | A list of file glob patterns that match the file paths to be read.                                                                                                                                                                                              |
+| `exclude`                           | []                                   | A list of file glob patterns to exclude from reading.                                                                                                                                                                                                           |
+| `start_at`                          | `end`                                | At startup, where to start reading logs from the file. Options are `beginning` or `end`.                                                                                                                                                                        |
+| `multiline`                         |                                      | A `multiline` configuration block. See [below](#multiline-configuration) for more details.                                                                                                                                                                      |
+| `force_flush_period`                | `500ms`                              | [Time](#time-parameters) since last read of data from file, after which currently buffered log should be send to pipeline. A value of `0` will disable forced flushing.                                                                                         |
+| `encoding`                          | `utf-8`                              | The encoding of the file being read. See the list of [supported encodings below](#supported-encodings) for available options.                                                                                                                                   |
 | `preserve_leading_whitespaces`      | `false`                              | Whether to preserve leading whitespaces.                                                                                                                                                                                                                        |
 | `preserve_trailing_whitespaces`     | `false`                              | Whether to preserve trailing whitespaces.                                                                                                                                                                                                                       |
 | `include_file_name`                 | `true`                               | Whether to add the file name as the attribute `log.file.name`.                                                                                                                                                                                                  |
 | `include_file_path`                 | `false`                              | Whether to add the file path as the attribute `log.file.path`.                                                                                                                                                                                                  |
 | `include_file_name_resolved`        | `false`                              | Whether to add the file name after symlinks resolution as the attribute `log.file.name_resolved`.                                                                                                                                                               |
 | `include_file_path_resolved`        | `false`                              | Whether to add the file path after symlinks resolution as the attribute `log.file.path_resolved`.                                                                                                                                                               |
-| `poll_interval`                     | 200ms                                | The duration between filesystem polls                                                                                                                                                                                                                           |
+| `poll_interval`                     | 200ms                                | The [duration](#time-parameters) between filesystem polls.                                                                                                                                                                                                      |
 | `fingerprint_size`                  | `1kb`                                | The number of bytes with which to identify a file. The first bytes in the file are used as the fingerprint. Decreasing this value at any point will cause existing fingerprints to forgotten, meaning that all files will be read from the beginning (one time) |
-| `max_log_size`                      | `1MiB`                               | The maximum size of a log entry to read. A log entry will be truncated if it is larger than `max_log_size`. Protects against reading large amounts of data into memory                                                                                          |
+| `max_log_size`                      | `1MiB`                               | The maximum size of a log entry to read. A log entry will be truncated if it is larger than `max_log_size`. Protects against reading large amounts of data into memory.                                                                                         |
 | `max_concurrent_files`              | 1024                                 | The maximum number of log files from which logs will be read concurrently. If the number of files matched in the `include` pattern exceeds this number, then files will be processed in batches.                                                                |
 | `max_batches`                       | 0                                    | Only applicable when files must be batched in order to respect `max_concurrent_files`. This value limits the number of batches that will be processed during a single poll interval. A value of 0 indicates no limit.                                           |
-| `delete_after_read`                 | `false`                              | If `true`, each log file will be read and then immediately deleted. Requires that the `filelog.allowFileDeletion` feature gate is enabled.                                                                                                                      |
-| `attributes`                        | {}                                   | A map of `key: value` pairs to add to the entry's attributes                                                                                                                                                                                                    |
-| `resource`                          | {}                                   | A map of `key: value` pairs to add to the entry's resource                                                                                                                                                                                                      |
-| `operators`                         | []                                   | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details                                                                                                                                     |
+| `delete_after_read`                 | `false`                              | If `true`, each log file will be read and then immediately deleted. Requires that the `filelog.allowFileDeletion` feature gate is enabled. Must be `false` when `start_at` is set to `end`.                                                                     |
+| `attributes`                        | {}                                   | A map of `key: value` pairs to add to the entry's attributes.                                                                                                                                                                                                   |
+| `resource`                          | {}                                   | A map of `key: value` pairs to add to the entry's resource.                                                                                                                                                                                                     |
+| `operators`                         | []                                   | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details.                                                                                                                                    |
 | `storage`                           | none                                 | The ID of a storage extension to be used to store file checkpoints. File checkpoints allow the receiver to pick up where it left off in the case of a collector restart. If no storage extension is used, the receiver will manage checkpoints in memory only.  |
-| `header`                            | nil                                  | Specifies options for parsing header metadata. Requires that the `filelog.allowHeaderMetadataParsing` feature gate is enabled. See below for details.                                                                                                           |
+| `header`                            | nil                                  | Specifies options for parsing header metadata. Requires that the `filelog.allowHeaderMetadataParsing` feature gate is enabled. See below for details. Must be `false` when `start_at` is set to `end`.                                                          |
 | `header.pattern`                    | required for header metadata parsing | A regex that matches every header line.                                                                                                                                                                                                                         |
 | `header.metadata_operators`         | required for header metadata parsing | A list of operators used to parse metadata from the header.                                                                                                                                                                                                     |
 | `retry_on_failure.enabled`          | `false`                              | If `true`, the receiver will pause reading a file and attempt to resend the current batch of logs if it encounters an error from downstream components.                                                                                                         |
-| `retry_on_failure.initial_interval` | `1 second`                           | Time to wait after the first failure before retrying.                                                                                                                                                                                                           |
-| `retry_on_failure.max_interval`     | `30 seconds`                         | Upper bound on retry backoff interval. Once this value is reached the delay between consecutive retries will remain constant at the specified value.                                                                                                            |
-| `retry_on_failure.max_elapsed_time` | `5 minutes`                          | Maximum amount of time (including retries) spent trying to send a logs batch to a downstream consumer. Once this value is reached, the data is discarded. Retrying never stops if set to `0`.                                                                   |
+| `retry_on_failure.initial_interval` | `1s`                                 | [Time](#time-parameters) to wait after the first failure before retrying.                                                                                                                                                                                       |
+| `retry_on_failure.max_interval`     | `30s`                                | Upper bound on retry backoff [interval](#time-parameters). Once this value is reached the delay between consecutive retries will remain constant at the specified value.                                                                                        |
+| `retry_on_failure.max_elapsed_time` | `5m`                                 | Maximum amount of [time](#time-parameters) (including retries) spent trying to send a logs batch to a downstream consumer. Once this value is reached, the data is discarded. Retrying never stops if set to `0`.                                               |
 
 Note that _by default_, no logs will be read from a file that is not actively being written to because `start_at` defaults to `end`.
 
@@ -98,6 +98,14 @@ The header lines are not emitted by the receiver.
 
 Many parsers operators can be configured to embed certain followup operations such as timestamp and severity parsing. For more information, see [complex parsers](../../pkg/stanza/docs/types/parsers.md#complex-parsers).
 
+### Time parameters
+
+All time parameters must have the unit of time specified. e.g.: `200ms`, `1s`, `1m`. 
+
+### Log Rotation
+
+File Log Receiver can read files that are being rotated. 
+
 ## Example - Tailing a simple json file
 
 Receiver Configuration
@@ -111,4 +119,28 @@ receivers:
           parse_from: attributes.time
           layout: '%Y-%m-%d %H:%M:%S'
 ```
+
+## Example - Tailing a plaintext file
+
+Receiver Configuration
+```yaml
+receivers:
+  filelog:
+    include: [ /simple.log ]
+    operators:
+      - type: regex_parser
+        regex: '^(?P<time>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$'
+        timestamp:
+          parse_from: attributes.time
+          layout: '%Y-%m-%d %H:%M:%S'
+        severity:
+          parse_from: attributes.sev
+```
+
+The above configuration will read logs from the "simple.log" file. Some examples of logs that it will read:
+```
+2023-06-19 05:20:50 ERROR This is a test error message
+2023-06-20 12:50:00 DEBUG This is a test debug message
+```
+
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Added example on how to use filelog receiver with log files. Also, added some details to the configuration descriptions and added anchor to some sections in the document. Additionally, added information on log rotation.

**Link to tracking Issue:** [23277](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23277)

**Testing:** N/A

**Documentation:** 

- Added example on how to use filelog receiver with log files
- Also, added some details to the configuration descriptions
- Added information on log rotation
- Added anchors to some sections