### PR TITLE
DSET-3468: update dataset-go to latest, send more details in user-agent

### DIFF
--- a/.chloggen/dataset-more-detailed-user-agent.yaml
+++ b/.chloggen/dataset-more-detailed-user-agent.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/datasetexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add more details to User-Agent header for DataSet HTTP requests"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [20660]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -548,7 +548,7 @@ require (
 	github.com/relvacode/iso8601 v1.3.0 // indirect
 	github.com/rs/cors v1.9.0 // indirect
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.14 // indirect
-	github.com/scalyr/dataset-go v0.0.8 // indirect
+	github.com/scalyr/dataset-go v0.0.9 // indirect
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.5.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -2764,8 +2764,8 @@ github.com/sanposhiho/wastedassign v0.1.3/go.mod h1:LGpq5Hsv74QaqM47WtIsRSF/ik9k
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.14 h1:yFl3jyaSVLNYXlnNYM5z2pagEk1dYQhfr1p20T1NyKY=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.14/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
-github.com/scalyr/dataset-go v0.0.8 h1:sHPmMjrv6HcZ9CfaJY/XAhg2JaucE+AUOb5U6EP5Mx8=
-github.com/scalyr/dataset-go v0.0.8/go.mod h1:yEieK44nks7tirqZSbne9c//p3E7bYbWEGOEnMfiT40=
+github.com/scalyr/dataset-go v0.0.9 h1:eV9UCv41JfnHECi4D03p/CUIVhKl45N1DxvbgmajDlo=
+github.com/scalyr/dataset-go v0.0.9/go.mod h1:yEieK44nks7tirqZSbne9c//p3E7bYbWEGOEnMfiT40=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -568,7 +568,7 @@ require (
 	github.com/rs/cors v1.9.0 // indirect
 	github.com/samber/lo v1.37.0 // indirect
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.14 // indirect
-	github.com/scalyr/dataset-go v0.0.8 // indirect
+	github.com/scalyr/dataset-go v0.0.9 // indirect
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.5.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect

--- a/cmd/otelcontribcol/go.sum
+++ b/cmd/otelcontribcol/go.sum
@@ -2761,8 +2761,8 @@ github.com/sanposhiho/wastedassign v0.1.3/go.mod h1:LGpq5Hsv74QaqM47WtIsRSF/ik9k
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.14 h1:yFl3jyaSVLNYXlnNYM5z2pagEk1dYQhfr1p20T1NyKY=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.14/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
-github.com/scalyr/dataset-go v0.0.8 h1:sHPmMjrv6HcZ9CfaJY/XAhg2JaucE+AUOb5U6EP5Mx8=
-github.com/scalyr/dataset-go v0.0.8/go.mod h1:yEieK44nks7tirqZSbne9c//p3E7bYbWEGOEnMfiT40=
+github.com/scalyr/dataset-go v0.0.9 h1:eV9UCv41JfnHECi4D03p/CUIVhKl45N1DxvbgmajDlo=
+github.com/scalyr/dataset-go v0.0.9/go.mod h1:yEieK44nks7tirqZSbne9c//p3E7bYbWEGOEnMfiT40=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=

--- a/exporter/datasetexporter/go.mod
+++ b/exporter/datasetexporter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.3.0
 	// github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage v0.77.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.80.0
-	github.com/scalyr/dataset-go v0.0.8
+	github.com/scalyr/dataset-go v0.0.9
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector/component v0.80.0
 	go.opentelemetry.io/collector/confmap v0.80.0

--- a/exporter/datasetexporter/go.sum
+++ b/exporter/datasetexporter/go.sum
@@ -251,8 +251,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
-github.com/scalyr/dataset-go v0.0.8 h1:sHPmMjrv6HcZ9CfaJY/XAhg2JaucE+AUOb5U6EP5Mx8=
-github.com/scalyr/dataset-go v0.0.8/go.mod h1:yEieK44nks7tirqZSbne9c//p3E7bYbWEGOEnMfiT40=
+github.com/scalyr/dataset-go v0.0.9 h1:eV9UCv41JfnHECi4D03p/CUIVhKl45N1DxvbgmajDlo=
+github.com/scalyr/dataset-go v0.0.9/go.mod h1:yEieK44nks7tirqZSbne9c//p3E7bYbWEGOEnMfiT40=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/exporter/datasetexporter/logs_exporter.go
+++ b/exporter/datasetexporter/logs_exporter.go
@@ -21,7 +21,7 @@ var now = time.Now
 
 func createLogsExporter(ctx context.Context, set exporter.CreateSettings, config component.Config) (exporter.Logs, error) {
 	cfg := castConfig(config)
-	e, err := newDatasetExporter("logs", cfg, set.Logger)
+	e, err := newDatasetExporter("logs", cfg, set)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get DataSetExpoter: %w", err)
 	}

--- a/exporter/datasetexporter/traces_exporter.go
+++ b/exporter/datasetexporter/traces_exporter.go
@@ -23,7 +23,7 @@ const ServiceNameKey = "service.name"
 
 func createTracesExporter(ctx context.Context, set exporter.CreateSettings, config component.Config) (exporter.Traces, error) {
 	cfg := castConfig(config)
-	e, err := newDatasetExporter("logs", cfg, set.Logger)
+	e, err := newDatasetExporter("logs", cfg, set)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get DataSetExpoter: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -548,7 +548,7 @@ require (
 	github.com/rs/cors v1.9.0 // indirect
 	github.com/samber/lo v1.37.0 // indirect
 	github.com/scaleway/scaleway-sdk-go v1.0.0-beta.14 // indirect
-	github.com/scalyr/dataset-go v0.0.8 // indirect
+	github.com/scalyr/dataset-go v0.0.9 // indirect
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.5.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2768,8 +2768,8 @@ github.com/sanposhiho/wastedassign v0.1.3/go.mod h1:LGpq5Hsv74QaqM47WtIsRSF/ik9k
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.14 h1:yFl3jyaSVLNYXlnNYM5z2pagEk1dYQhfr1p20T1NyKY=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.14/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
-github.com/scalyr/dataset-go v0.0.8 h1:sHPmMjrv6HcZ9CfaJY/XAhg2JaucE+AUOb5U6EP5Mx8=
-github.com/scalyr/dataset-go v0.0.8/go.mod h1:yEieK44nks7tirqZSbne9c//p3E7bYbWEGOEnMfiT40=
+github.com/scalyr/dataset-go v0.0.9 h1:eV9UCv41JfnHECi4D03p/CUIVhKl45N1DxvbgmajDlo=
+github.com/scalyr/dataset-go v0.0.9/go.mod h1:yEieK44nks7tirqZSbne9c//p3E7bYbWEGOEnMfiT40=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=


### PR DESCRIPTION
**Description:** updated dataset-go library, send more details in user-agent
For more details see https://github.com/scalyr/dataset-go/releases/tag/v0.0.9

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20660 / DSET-3468

**Testing:** verified via unit tests and also e2e with DataSet environment

**Documentation:** see https://github.com/scalyr/dataset-go/blob/fbaead7856a9c5669262564dfa4a13aa14a0775d/examples/readme/main.go#L81