### PR TITLE
[receiver/awsecscontainermetrics] Fix possible panics from unchecked de-references

### DIFF
--- a/.chloggen/ecsRecvDeRefCheck.yaml
+++ b/.chloggen/ecsRecvDeRefCheck.yaml
@@ -12,7 +12,7 @@ component: awsecscontainermetricsreceiver
 note: Fix possible panics in awsecscontainerrmetrics receiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [23644]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/ecsRecvDeRefCheck.yaml
+++ b/.chloggen/ecsRecvDeRefCheck.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsecscontainermetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix possible panics in awsecscontainerrmetrics receiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/ecsRecvDeRefCheck.yaml
+++ b/.chloggen/ecsRecvDeRefCheck.yaml
@@ -9,7 +9,7 @@ change_type: bug_fix
 component: awsecscontainermetricsreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix possible panics in awsecscontainerrmetrics receiver
+note: Fix possible panics in awsecscontainermetrics receiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [23644]

--- a/receiver/awsecscontainermetricsreceiver/go.mod
+++ b/receiver/awsecscontainermetricsreceiver/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecs
 go 1.19
 
 require (
+	github.com/aws/aws-sdk-go v1.44.287
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.80.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.80.0
 	github.com/stretchr/testify v1.8.4

--- a/receiver/awsecscontainermetricsreceiver/go.sum
+++ b/receiver/awsecscontainermetricsreceiver/go.sum
@@ -11,6 +11,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aws/aws-sdk-go v1.44.287 h1:CUq2/h0gZ2LOCF61AgQSEMPMfas4gTiQfHBO88gGET0=
+github.com/aws/aws-sdk-go v1.44.287/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2/config v1.8.3/go.mod h1:4AEiLtAb8kLs7vgw2ZV3p2VZ1+hBavOc84hqxVNpCyw=
 github.com/aws/aws-sdk-go-v2/credentials v1.4.3/go.mod h1:FNNC6nQZQUuyhq5aE5c7ata8o9e4ECGmS4lAXC7o1mQ=
@@ -141,6 +143,7 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -260,6 +263,7 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=
 go.etcd.io/etcd/client/pkg/v3 v3.5.4/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/gq3kiY=
@@ -320,6 +324,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -329,6 +334,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -346,6 +352,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.11.0 h1:Gi2tvZIJyBtO9SDr1q9h5hEQCp/4L2RQ+ar0qjx2oNU=
 golang.org/x/net v0.11.0/go.mod h1:2L/ixqYpgIVXmeoSA/4Lu7BzTG4KIyPIryS4IsOd1oQ=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -360,6 +368,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -390,16 +399,24 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
 golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.10.0 h1:UpjohKhiEgNc0CSauXmwYftY1+LlaC75SJwh0SgCX58=
 golang.org/x/text v0.10.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -414,6 +431,7 @@ golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
@@ -15,7 +15,7 @@ func getContainerMetrics(stats *ContainerStats, logger *zap.Logger) ECSMetrics {
 	if stats.Memory != nil {
 		m.MemoryUsage = aws.Uint64Value(stats.Memory.Usage)
 		m.MemoryMaxUsage = aws.Uint64Value(stats.Memory.MaxUsage)
-		m.MemoryLimit = *stats.Memory.Limit
+		m.MemoryLimit = aws.Uint64Value(stats.Memory.Limit)
 
 		if stats.Memory.Stats != nil {
 			m.MemoryUtilized = (aws.Uint64Value(stats.Memory.Usage) - stats.Memory.Stats["cache"]) / bytesInMiB

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
@@ -48,8 +48,8 @@ func getContainerMetrics(stats *ContainerStats, logger *zap.Logger) ECSMetrics {
 	}
 
 	if stats.NetworkRate != nil {
-		m.NetworkRateRxBytesPerSecond = *stats.NetworkRate.RxBytesPerSecond
-		m.NetworkRateTxBytesPerSecond = *stats.NetworkRate.TxBytesPerSecond
+		m.NetworkRateRxBytesPerSecond = aws.Float64Value(stats.NetworkRate.RxBytesPerSecond)
+		m.NetworkRateTxBytesPerSecond = aws.Float64Value(stats.NetworkRate.TxBytesPerSecond)
 	} else {
 		logger.Debug("Nil NetworkRate stats found for docker container:" + stats.Name)
 	}

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
@@ -30,14 +30,14 @@ func getContainerMetrics(stats *ContainerStats, logger *zap.Logger) ECSMetrics {
 
 		cpuUsageInVCpu := float64(0)
 		if timeDiffSinceLastRead > 0 {
-			cpuDelta := (float64)(*stats.CPU.CPUUsage.TotalUsage - *stats.PreviousCPU.CPUUsage.TotalUsage)
+			cpuDelta := (float64)(aws.Uint64Value(stats.CPU.CPUUsage.TotalUsage) - aws.Uint64Value(stats.PreviousCPU.CPUUsage.TotalUsage))
 			cpuUsageInVCpu = cpuDelta / timeDiffSinceLastRead
 		}
 		cpuUtilized := cpuUsageInVCpu * 100
 
-		m.CPUTotalUsage = *stats.CPU.CPUUsage.TotalUsage
-		m.CPUUsageInKernelmode = *stats.CPU.CPUUsage.UsageInKernelmode
-		m.CPUUsageInUserMode = *stats.CPU.CPUUsage.UsageInUserMode
+		m.CPUTotalUsage = aws.Uint64Value(stats.CPU.CPUUsage.TotalUsage)
+		m.CPUUsageInKernelmode = aws.Uint64Value(stats.CPU.CPUUsage.UsageInKernelmode)
+		m.CPUUsageInUserMode = aws.Uint64Value(stats.CPU.CPUUsage.UsageInUserMode)
 		m.NumOfCPUCores = numOfCores
 		m.CPUOnlineCpus = aws.Uint64Value(stats.CPU.OnlineCpus)
 		m.SystemCPUUsage = aws.Uint64Value(stats.CPU.SystemCPUUsage)

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
@@ -24,7 +24,9 @@ func getContainerMetrics(stats *ContainerStats, logger *zap.Logger) ECSMetrics {
 		logger.Debug("Nil memory stats found for docker container:" + stats.Name)
 	}
 
-	if stats.CPU != nil && stats.CPU.CPUUsage != nil {
+	if stats.CPU != nil && stats.CPU.CPUUsage != nil &&
+		stats.PreviousCPU != nil && stats.PreviousCPU.CPUUsage != nil {
+
 		numOfCores := (uint64)(len(stats.CPU.CPUUsage.PerCPUUsage))
 		timeDiffSinceLastRead := (float64)(stats.Read.Sub(stats.PreviousRead).Nanoseconds())
 

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
@@ -85,15 +85,15 @@ func getContainerMetrics(stats *ContainerStats, logger *zap.Logger) ECSMetrics {
 func getNetworkStats(stats map[string]NetworkStats) [8]uint64 {
 	var netStatArray [8]uint64
 	for _, netStat := range stats {
-		netStatArray[0] += *netStat.RxBytes
-		netStatArray[1] += *netStat.RxPackets
-		netStatArray[2] += *netStat.RxErrors
-		netStatArray[3] += *netStat.RxDropped
+		netStatArray[0] += aws.Uint64Value(netStat.RxBytes)
+		netStatArray[1] += aws.Uint64Value(netStat.RxPackets)
+		netStatArray[2] += aws.Uint64Value(netStat.RxErrors)
+		netStatArray[3] += aws.Uint64Value(netStat.RxDropped)
 
-		netStatArray[4] += *netStat.TxBytes
-		netStatArray[5] += *netStat.TxPackets
-		netStatArray[6] += *netStat.TxErrors
-		netStatArray[7] += *netStat.TxDropped
+		netStatArray[4] += aws.Uint64Value(netStat.TxBytes)
+		netStatArray[5] += aws.Uint64Value(netStat.TxPackets)
+		netStatArray[6] += aws.Uint64Value(netStat.TxErrors)
+		netStatArray[7] += aws.Uint64Value(netStat.TxDropped)
 	}
 	return netStatArray
 }

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
@@ -39,8 +39,8 @@ func getContainerMetrics(stats *ContainerStats, logger *zap.Logger) ECSMetrics {
 		m.CPUUsageInKernelmode = *stats.CPU.CPUUsage.UsageInKernelmode
 		m.CPUUsageInUserMode = *stats.CPU.CPUUsage.UsageInUserMode
 		m.NumOfCPUCores = numOfCores
-		m.CPUOnlineCpus = *stats.CPU.OnlineCpus
-		m.SystemCPUUsage = *stats.CPU.SystemCPUUsage
+		m.CPUOnlineCpus = aws.Uint64Value(stats.CPU.OnlineCpus)
+		m.SystemCPUUsage = aws.Uint64Value(stats.CPU.SystemCPUUsage)
 		m.CPUUsageInVCPU = cpuUsageInVCpu
 		m.CPUUtilized = cpuUtilized
 	} else {

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
@@ -109,9 +109,9 @@ func extractStorageUsage(stats *DiskStats) (uint64, uint64) {
 	for _, blockStat := range stats.IoServiceBytesRecursives {
 		switch op := blockStat.Op; op {
 		case "Read":
-			readBytes = *blockStat.Value
+			readBytes = aws.Uint64Value(blockStat.Value)
 		case "Write":
-			writeBytes = *blockStat.Value
+			writeBytes = aws.Uint64Value(blockStat.Value)
 		default:
 			// ignoring "Async", "Total", "Sum", etc
 			continue

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
@@ -14,7 +14,7 @@ func getContainerMetrics(stats *ContainerStats, logger *zap.Logger) ECSMetrics {
 
 	if stats.Memory != nil {
 		m.MemoryUsage = aws.Uint64Value(stats.Memory.Usage)
-		m.MemoryMaxUsage = *stats.Memory.MaxUsage
+		m.MemoryMaxUsage = aws.Uint64Value(stats.Memory.MaxUsage)
 		m.MemoryLimit = *stats.Memory.Limit
 
 		if stats.Memory.Stats != nil {

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper.go
@@ -4,6 +4,7 @@
 package awsecscontainermetrics // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics"
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"go.uber.org/zap"
 )
 
@@ -12,12 +13,12 @@ func getContainerMetrics(stats *ContainerStats, logger *zap.Logger) ECSMetrics {
 	m := ECSMetrics{}
 
 	if stats.Memory != nil {
-		m.MemoryUsage = *stats.Memory.Usage
+		m.MemoryUsage = aws.Uint64Value(stats.Memory.Usage)
 		m.MemoryMaxUsage = *stats.Memory.MaxUsage
 		m.MemoryLimit = *stats.Memory.Limit
 
 		if stats.Memory.Stats != nil {
-			m.MemoryUtilized = (*stats.Memory.Usage - stats.Memory.Stats["cache"]) / bytesInMiB
+			m.MemoryUtilized = (aws.Uint64Value(stats.Memory.Usage) - stats.Memory.Stats["cache"]) / bytesInMiB
 		}
 	} else {
 		logger.Debug("Nil memory stats found for docker container:" + stats.Name)

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -101,6 +101,7 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 		memoryStats MemoryStats
 		testName    string
 		cpuStats    CPUStats
+		networkRate NetworkRateStats
 	}{
 		{
 			memoryStats: MemoryStats{
@@ -111,8 +112,9 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				MemoryUtilized: nil,
 				Stats:          nil,
 			},
-			testName: "nil memory stats values",
-			cpuStats: cpuStats,
+			testName:    "nil memory stats values",
+			cpuStats:    cpuStats,
+			networkRate: netRate,
 		},
 		{
 			memoryStats: mem,
@@ -124,6 +126,7 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				CPUReserved:    nil,
 				CPUUtilized:    nil,
 			},
+			networkRate: netRate,
 		},
 		{
 			memoryStats: mem,
@@ -140,6 +143,16 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				CPUReserved:    nil,
 				CPUUtilized:    nil,
 			},
+			networkRate: netRate,
+		},
+		{
+			memoryStats: mem,
+			testName:    "net network rate values",
+			cpuStats:    cpuStats,
+			networkRate: NetworkRateStats{
+				RxBytesPerSecond: nil,
+				TxBytesPerSecond: nil,
+			},
 		},
 	}
 
@@ -153,7 +166,7 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				Memory:       &test.memoryStats,
 				Disk:         &disk,
 				Network:      net,
-				NetworkRate:  &netRate,
+				NetworkRate:  &test.networkRate,
 				CPU:          &test.cpuStats,
 				PreviousCPU:  &previousCPUStats,
 			}

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -125,6 +125,22 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				CPUUtilized:    nil,
 			},
 		},
+		{
+			memoryStats: mem,
+			testName:    "nil cpuUsage and CPUstats values",
+			cpuStats: CPUStats{
+				CPUUsage: &CPUUsage{
+					TotalUsage:        nil,
+					UsageInKernelmode: nil,
+					UsageInUserMode:   nil,
+					PerCPUUsage:       nil,
+				},
+				OnlineCpus:     nil,
+				SystemCPUUsage: nil,
+				CPUReserved:    nil,
+				CPUUtilized:    nil,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -112,6 +112,17 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 			},
 			testName: "nil usage",
 		},
+		{
+			memoryStats: MemoryStats{
+				Usage:          &v,
+				MaxUsage:       nil,
+				Limit:          &v,
+				MemoryReserved: &v,
+				MemoryUtilized: &v,
+				Stats:          memStats,
+			},
+			testName: "nil MaxUsage",
+		},
 	}
 
 	for _, test := range tests {

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -100,28 +100,19 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 	tests := []struct {
 		memoryStats MemoryStats
 		testName    string
+		cpuStats    CPUStats
 	}{
 		{
 			memoryStats: MemoryStats{
 				Usage:          nil,
-				MaxUsage:       &v,
-				Limit:          &v,
-				MemoryReserved: &v,
-				MemoryUtilized: &v,
-				Stats:          memStats,
-			},
-			testName: "nil usage",
-		},
-		{
-			memoryStats: MemoryStats{
-				Usage:          &v,
 				MaxUsage:       nil,
-				Limit:          &v,
-				MemoryReserved: &v,
-				MemoryUtilized: &v,
-				Stats:          memStats,
+				Limit:          nil,
+				MemoryReserved: nil,
+				MemoryUtilized: nil,
+				Stats:          nil,
 			},
-			testName: "nil MaxUsage",
+			testName: "nil memory stats values",
+			cpuStats: cpuStats,
 		},
 	}
 
@@ -136,7 +127,7 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				Disk:         &disk,
 				Network:      net,
 				NetworkRate:  &netRate,
-				CPU:          &cpuStats,
+				CPU:          &test.cpuStats,
 				PreviousCPU:  &previousCPUStats,
 			}
 

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -95,6 +95,47 @@ func TestGetContainerMetricsMissingMemory(t *testing.T) {
 	require.EqualValues(t, v, containerMetrics.StorageWriteBytes)
 }
 
+func TestGetContainerDereferenceCheck(t *testing.T) {
+
+	tests := []struct {
+		memoryStats MemoryStats
+		testName    string
+	}{
+		{
+			memoryStats: MemoryStats{
+				Usage:          nil,
+				MaxUsage:       &v,
+				Limit:          &v,
+				MemoryReserved: &v,
+				MemoryUtilized: &v,
+				Stats:          memStats,
+			},
+			testName: "nil usage",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			containerStats = ContainerStats{
+				Name:         "test",
+				ID:           "001",
+				Read:         time.Now(),
+				PreviousRead: time.Now().Add(-10 * time.Second),
+				Memory:       &test.memoryStats,
+				Disk:         &disk,
+				Network:      net,
+				NetworkRate:  &netRate,
+				CPU:          &cpuStats,
+				PreviousCPU:  &previousCPUStats,
+			}
+
+			require.NotPanics(t, func() {
+				getContainerMetrics(&containerStats, logger)
+			})
+		})
+	}
+}
+
 func TestGetContainerMetricsMissingCpu(t *testing.T) {
 	containerStats = ContainerStats{
 		Name:         "test",

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -177,6 +177,32 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				CPUUtilized:    nil,
 			},
 		},
+		{
+			memoryStats: mem,
+			testName:    "nil prevcpu.cpuUsage stats values",
+			cpuStats:    cpuStats,
+			networkRate: netRate,
+			prevCpuStats: CPUStats{
+				CPUUsage:       nil,
+				OnlineCpus:     nil,
+				SystemCPUUsage: nil,
+				CPUReserved:    nil,
+				CPUUtilized:    nil,
+			},
+		},
+		{
+			memoryStats: mem,
+			testName:    "nil cpu.cpuUsage",
+			cpuStats: CPUStats{
+				CPUUsage:       nil,
+				OnlineCpus:     nil,
+				SystemCPUUsage: nil,
+				CPUReserved:    nil,
+				CPUUtilized:    nil,
+			},
+			networkRate:  netRate,
+			prevCpuStats: previousCPUStats,
+		},
 	}
 
 	for _, test := range tests {

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -98,14 +98,14 @@ func TestGetContainerMetricsMissingMemory(t *testing.T) {
 func TestGetContainerDereferenceCheck(t *testing.T) {
 
 	tests := []struct {
-		memoryStats  MemoryStats
+		memoryStats  *MemoryStats
 		testName     string
-		cpuStats     CPUStats
-		networkRate  NetworkRateStats
-		prevCpuStats CPUStats
+		cpuStats     *CPUStats
+		networkRate  *NetworkRateStats
+		prevCPUStats *CPUStats
 	}{
 		{
-			memoryStats: MemoryStats{
+			memoryStats: &MemoryStats{
 				Usage:          nil,
 				MaxUsage:       nil,
 				Limit:          nil,
@@ -114,27 +114,27 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				Stats:          nil,
 			},
 			testName:     "nil memory stats values",
-			cpuStats:     cpuStats,
-			networkRate:  netRate,
-			prevCpuStats: previousCPUStats,
+			cpuStats:     &cpuStats,
+			networkRate:  &netRate,
+			prevCPUStats: &previousCPUStats,
 		},
 		{
-			memoryStats: mem,
+			memoryStats: &mem,
 			testName:    "nil cpuStats values",
-			cpuStats: CPUStats{
+			cpuStats: &CPUStats{
 				CPUUsage:       &cpuUsage,
 				OnlineCpus:     nil,
 				SystemCPUUsage: nil,
 				CPUReserved:    nil,
 				CPUUtilized:    nil,
 			},
-			networkRate:  netRate,
-			prevCpuStats: previousCPUStats,
+			networkRate:  &netRate,
+			prevCPUStats: &previousCPUStats,
 		},
 		{
-			memoryStats: mem,
+			memoryStats: &mem,
 			testName:    "nil cpuUsage and CPUstats values",
-			cpuStats: CPUStats{
+			cpuStats: &CPUStats{
 				CPUUsage: &CPUUsage{
 					TotalUsage:        nil,
 					UsageInKernelmode: nil,
@@ -146,25 +146,25 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				CPUReserved:    nil,
 				CPUUtilized:    nil,
 			},
-			networkRate:  netRate,
-			prevCpuStats: previousCPUStats,
+			networkRate:  &netRate,
+			prevCPUStats: &previousCPUStats,
 		},
 		{
-			memoryStats: mem,
+			memoryStats: &mem,
 			testName:    "nil network rate values",
-			cpuStats:    cpuStats,
-			networkRate: NetworkRateStats{
+			cpuStats:    &cpuStats,
+			networkRate: &NetworkRateStats{
 				RxBytesPerSecond: nil,
 				TxBytesPerSecond: nil,
 			},
-			prevCpuStats: previousCPUStats,
+			prevCPUStats: &previousCPUStats,
 		},
 		{
-			memoryStats: mem,
+			memoryStats: &mem,
 			testName:    "nil prev cpu stats values",
-			cpuStats:    cpuStats,
-			networkRate: netRate,
-			prevCpuStats: CPUStats{
+			cpuStats:    &cpuStats,
+			networkRate: &netRate,
+			prevCPUStats: &CPUStats{
 				CPUUsage: &CPUUsage{
 					TotalUsage:        nil,
 					UsageInKernelmode: nil,
@@ -178,11 +178,11 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 			},
 		},
 		{
-			memoryStats: mem,
+			memoryStats: &mem,
 			testName:    "nil prevcpu.cpuUsage stats values",
-			cpuStats:    cpuStats,
-			networkRate: netRate,
-			prevCpuStats: CPUStats{
+			cpuStats:    &cpuStats,
+			networkRate: &netRate,
+			prevCPUStats: &CPUStats{
 				CPUUsage:       nil,
 				OnlineCpus:     nil,
 				SystemCPUUsage: nil,
@@ -191,17 +191,17 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 			},
 		},
 		{
-			memoryStats: mem,
+			memoryStats: &mem,
 			testName:    "nil cpu.cpuUsage",
-			cpuStats: CPUStats{
+			cpuStats: &CPUStats{
 				CPUUsage:       nil,
 				OnlineCpus:     nil,
 				SystemCPUUsage: nil,
 				CPUReserved:    nil,
 				CPUUtilized:    nil,
 			},
-			networkRate:  netRate,
-			prevCpuStats: previousCPUStats,
+			networkRate:  &netRate,
+			prevCPUStats: &previousCPUStats,
 		},
 	}
 
@@ -212,12 +212,12 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				ID:           "001",
 				Read:         time.Now(),
 				PreviousRead: time.Now().Add(-10 * time.Second),
-				Memory:       &test.memoryStats,
+				Memory:       test.memoryStats,
 				Disk:         &disk,
 				Network:      net,
-				NetworkRate:  &test.networkRate,
-				CPU:          &test.cpuStats,
-				PreviousCPU:  &test.prevCpuStats,
+				NetworkRate:  test.networkRate,
+				CPU:          test.cpuStats,
+				PreviousCPU:  test.prevCPUStats,
 			}
 
 			require.NotPanics(t, func() {

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -98,10 +98,11 @@ func TestGetContainerMetricsMissingMemory(t *testing.T) {
 func TestGetContainerDereferenceCheck(t *testing.T) {
 
 	tests := []struct {
-		memoryStats MemoryStats
-		testName    string
-		cpuStats    CPUStats
-		networkRate NetworkRateStats
+		memoryStats  MemoryStats
+		testName     string
+		cpuStats     CPUStats
+		networkRate  NetworkRateStats
+		prevCpuStats CPUStats
 	}{
 		{
 			memoryStats: MemoryStats{
@@ -112,9 +113,10 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				MemoryUtilized: nil,
 				Stats:          nil,
 			},
-			testName:    "nil memory stats values",
-			cpuStats:    cpuStats,
-			networkRate: netRate,
+			testName:     "nil memory stats values",
+			cpuStats:     cpuStats,
+			networkRate:  netRate,
+			prevCpuStats: previousCPUStats,
 		},
 		{
 			memoryStats: mem,
@@ -126,7 +128,8 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				CPUReserved:    nil,
 				CPUUtilized:    nil,
 			},
-			networkRate: netRate,
+			networkRate:  netRate,
+			prevCpuStats: previousCPUStats,
 		},
 		{
 			memoryStats: mem,
@@ -143,15 +146,35 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				CPUReserved:    nil,
 				CPUUtilized:    nil,
 			},
-			networkRate: netRate,
+			networkRate:  netRate,
+			prevCpuStats: previousCPUStats,
 		},
 		{
 			memoryStats: mem,
-			testName:    "net network rate values",
+			testName:    "nil network rate values",
 			cpuStats:    cpuStats,
 			networkRate: NetworkRateStats{
 				RxBytesPerSecond: nil,
 				TxBytesPerSecond: nil,
+			},
+			prevCpuStats: previousCPUStats,
+		},
+		{
+			memoryStats: mem,
+			testName:    "nil prev cpu stats values",
+			cpuStats:    cpuStats,
+			networkRate: netRate,
+			prevCpuStats: CPUStats{
+				CPUUsage: &CPUUsage{
+					TotalUsage:        nil,
+					UsageInKernelmode: nil,
+					UsageInUserMode:   nil,
+					PerCPUUsage:       nil,
+				},
+				OnlineCpus:     nil,
+				SystemCPUUsage: nil,
+				CPUReserved:    nil,
+				CPUUtilized:    nil,
 			},
 		},
 	}
@@ -168,7 +191,7 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 				Network:      net,
 				NetworkRate:  &test.networkRate,
 				CPU:          &test.cpuStats,
-				PreviousCPU:  &previousCPUStats,
+				PreviousCPU:  &test.prevCpuStats,
 			}
 
 			require.NotPanics(t, func() {

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -114,6 +114,17 @@ func TestGetContainerDereferenceCheck(t *testing.T) {
 			testName: "nil memory stats values",
 			cpuStats: cpuStats,
 		},
+		{
+			memoryStats: mem,
+			testName:    "nil cpuStats values",
+			cpuStats: CPUStats{
+				CPUUsage:       &cpuUsage,
+				OnlineCpus:     nil,
+				SystemCPUUsage: nil,
+				CPUReserved:    nil,
+				CPUUtilized:    nil,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -382,3 +382,21 @@ func TestGetNetworkStats(t *testing.T) {
 	}
 	require.EqualValues(t, 800, sum)
 }
+
+func TestGetNetworkStatsDereferenceCheck(t *testing.T) {
+	stats := make(map[string]NetworkStats)
+	stats["eth0"] = NetworkStats{
+		RxBytes:   nil,
+		RxPackets: nil,
+		RxErrors:  nil,
+		RxDropped: nil,
+		TxBytes:   nil,
+		TxPackets: nil,
+		TxErrors:  nil,
+		TxDropped: nil,
+	}
+
+	require.NotPanics(t, func() {
+		getNetworkStats(stats)
+	})
+}

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_helper_test.go
@@ -360,6 +360,21 @@ func TestExtractStorageUsage(t *testing.T) {
 	require.EqualValues(t, v, write)
 }
 
+func TestExtractStorageUsageDereferenceCheck(t *testing.T) {
+	disk := &DiskStats{
+		IoServiceBytesRecursives: []IoServiceBytesRecursive{
+			{Op: "Read", Value: nil},
+			{Op: "Write", Value: nil},
+			{Op: "Total", Value: nil},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		extractStorageUsage(disk)
+	})
+
+}
+
 func TestGetNetworkStats(t *testing.T) {
 	v := uint64(100)
 	stats := make(map[string]NetworkStats)


### PR DESCRIPTION
**Description:** Fixes possible panics from unchecked de-references in metrics helper in `awsecscontainermetrics` receiver. 
**Link to tracking Issue:** https://github.com/aws-observability/aws-otel-collector/issues/2110

**Testing:** Added unit tests for these de-references

**Documentation:** n//a