### PR TITLE
[awss3exporter]: add Sumo Logic marshaler for logs in Installed Collector format

### DIFF
--- a/.chloggen/awss3-sumologic-ic-marshaller.yaml
+++ b/.chloggen/awss3-sumologic-ic-marshaller.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awss3exporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add Sumo Logic Installed Collector marshaller
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23212]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/awss3-sumologic-ic-marshaller.yaml
+++ b/.chloggen/awss3-sumologic-ic-marshaller.yaml
@@ -9,7 +9,7 @@ change_type: enhancement
 component: awss3exporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: add Sumo Logic Installed Collector marshaller
+note: add Sumo Logic Installed Collector marshaler
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [23212]

--- a/exporter/awss3exporter/README.md
+++ b/exporter/awss3exporter/README.md
@@ -28,8 +28,16 @@ The following exporter configuration parameters are supported.
 | `s3_prefix`    | prefix for the S3 key (root directory inside bucket).                                                |             |
 | `s3_partition` | time granularity of S3 key: hour or minute                                                           | "minute"    |
 | `file_prefix`  | file prefix defined by user                                                                          |             |
-| `marshaler`    | marshaler used to produce output data otlp_json                                                      |             |
+| `marshaler`    | marshaler used to produce output data                                                                | `otlp_json` |
 | `endpoint`     | overrides the endpoint used by the exporter instead of constructing it from `region` and `s3_bucket` |             |
+
+### Marshaler
+
+Marshaler determines the format of data sent to AWS S3. Currently, the following marshalers are implemented:
+
+- `otlp_json` (default): the [OpenTelemetry Protocol format](https://github.com/open-telemetry/opentelemetry-proto), represented as json.
+- `sumo_ic`: the [Sumo Logic Installed Collector Archive format](https://help.sumologic.com/docs/manage/data-archiving/archive/).
+  **This format is supported only for logs.**
 
 # Example Configuration
 

--- a/exporter/awss3exporter/config.go
+++ b/exporter/awss3exporter/config.go
@@ -24,6 +24,7 @@ type MarshalerType string
 
 const (
 	OtlpJSON MarshalerType = "otlp_json"
+	Sumo     MarshalerType = "sumo"
 )
 
 // Config contains the main configuration options for the s3 exporter

--- a/exporter/awss3exporter/config.go
+++ b/exporter/awss3exporter/config.go
@@ -24,7 +24,7 @@ type MarshalerType string
 
 const (
 	OtlpJSON MarshalerType = "otlp_json"
-	Sumo     MarshalerType = "sumo"
+	SumoIC   MarshalerType = "sumo_ic"
 )
 
 // Config contains the main configuration options for the s3 exporter

--- a/exporter/awss3exporter/config_test.go
+++ b/exporter/awss3exporter/config_test.go
@@ -143,6 +143,7 @@ func TestMarshallerName(t *testing.T) {
 		&Config{
 			S3Uploader: S3UploaderConfig{
 				Region:      "us-east-1",
+				S3Bucket:    "foo",
 				S3Partition: "minute",
 			},
 			MarshalerName: "sumo_ic",

--- a/exporter/awss3exporter/config_test.go
+++ b/exporter/awss3exporter/config_test.go
@@ -124,3 +124,28 @@ func TestConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestMarshallerName(t *testing.T) {
+	factories, err := otelcoltest.NopFactories()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Exporters[factory.Type()] = factory
+	cfg, err := otelcoltest.LoadConfigAndValidate(
+		filepath.Join("testdata", "marshaler.yaml"), factories)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	e := cfg.Exporters[component.NewID("awss3")].(*Config)
+
+	assert.Equal(t, e,
+		&Config{
+			S3Uploader: S3UploaderConfig{
+				Region:      "us-east-1",
+				S3Partition: "minute",
+			},
+			MarshalerName: "sumo_ic",
+		},
+	)
+}

--- a/exporter/awss3exporter/factory.go
+++ b/exporter/awss3exporter/factory.go
@@ -5,6 +5,7 @@ package awss3exporter // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
@@ -57,6 +58,10 @@ func createMetricsExporter(ctx context.Context,
 		return nil, err
 	}
 
+	if config.(*Config).MarshalerName == SumoIC {
+		return nil, fmt.Errorf("metrics are not supported by sumo_ic output format")
+	}
+
 	return exporterhelper.NewMetricsExporter(ctx, params,
 		config,
 		s3Exporter.ConsumeMetrics)
@@ -69,6 +74,10 @@ func createTracesExporter(ctx context.Context,
 	s3Exporter, err := newS3Exporter(config.(*Config), params)
 	if err != nil {
 		return nil, err
+	}
+
+	if config.(*Config).MarshalerName == SumoIC {
+		return nil, fmt.Errorf("traces are not supported by sumo_ic output format")
 	}
 
 	return exporterhelper.NewTracesExporter(ctx,

--- a/exporter/awss3exporter/factory_test.go
+++ b/exporter/awss3exporter/factory_test.go
@@ -48,3 +48,21 @@ func TestCreateLogsExporter(t *testing.T) {
 	assert.NoError(t, err)
 	require.NotNil(t, exp)
 }
+
+func TestUnsupportedMarshalerOptions(t *testing.T) {
+	cfg := createDefaultConfig()
+	cfg.(*Config).MarshalerName = SumoIC
+	exp, err := createMetricsExporter(
+		context.Background(),
+		exportertest.NewNopCreateSettings(),
+		cfg)
+	assert.Error(t, err)
+	require.Nil(t, exp)
+
+	exp2, err := createTracesExporter(
+		context.Background(),
+		exportertest.NewNopCreateSettings(),
+		cfg)
+	assert.Error(t, err)
+	require.Nil(t, exp2)
+}

--- a/exporter/awss3exporter/marshaler.go
+++ b/exporter/awss3exporter/marshaler.go
@@ -36,7 +36,7 @@ func NewMarshaler(mType MarshalerType, logger *zap.Logger) (marshaler, error) {
 		marshaler.logsMarshaler = &sumomarshaler
 		marshaler.tracesMarshaler = &sumomarshaler
 		marshaler.metricsMarshaler = &sumomarshaler
-		marshaler.fileFormat = "json"
+		marshaler.fileFormat = "sumo_ic"
 	default:
 		return nil, ErrUnknownMarshaler
 	}

--- a/exporter/awss3exporter/marshaler.go
+++ b/exporter/awss3exporter/marshaler.go
@@ -34,7 +34,7 @@ func NewMarshaler(mType MarshalerType, logger *zap.Logger) (marshaler, error) {
 	case SumoIC:
 		sumomarshaler := newSumoICMarshaler()
 		marshaler.logsMarshaler = &sumomarshaler
-		marshaler.fileFormat = "sumo_ic"
+		marshaler.fileFormat = "json.gz"
 	default:
 		return nil, ErrUnknownMarshaler
 	}

--- a/exporter/awss3exporter/marshaler.go
+++ b/exporter/awss3exporter/marshaler.go
@@ -31,6 +31,12 @@ func NewMarshaler(mType MarshalerType, logger *zap.Logger) (marshaler, error) {
 		marshaler.tracesMarshaler = &ptrace.JSONMarshaler{}
 		marshaler.metricsMarshaler = &pmetric.JSONMarshaler{}
 		marshaler.fileFormat = "json"
+	case Sumo:
+		sumomarshaler := NewSumoMarshaler()
+		marshaler.logsMarshaler = &sumomarshaler
+		marshaler.tracesMarshaler = &sumomarshaler
+		marshaler.metricsMarshaler = &sumomarshaler
+		marshaler.fileFormat = "json"
 	default:
 		return nil, ErrUnknownMarshaler
 	}

--- a/exporter/awss3exporter/marshaler.go
+++ b/exporter/awss3exporter/marshaler.go
@@ -32,10 +32,8 @@ func NewMarshaler(mType MarshalerType, logger *zap.Logger) (marshaler, error) {
 		marshaler.metricsMarshaler = &pmetric.JSONMarshaler{}
 		marshaler.fileFormat = "json"
 	case SumoIC:
-		sumomarshaler := NewSumoMarshaler()
+		sumomarshaler := newSumoICMarshaler()
 		marshaler.logsMarshaler = &sumomarshaler
-		marshaler.tracesMarshaler = &sumomarshaler
-		marshaler.metricsMarshaler = &sumomarshaler
 		marshaler.fileFormat = "sumo_ic"
 	default:
 		return nil, ErrUnknownMarshaler

--- a/exporter/awss3exporter/marshaler.go
+++ b/exporter/awss3exporter/marshaler.go
@@ -31,7 +31,7 @@ func NewMarshaler(mType MarshalerType, logger *zap.Logger) (marshaler, error) {
 		marshaler.tracesMarshaler = &ptrace.JSONMarshaler{}
 		marshaler.metricsMarshaler = &pmetric.JSONMarshaler{}
 		marshaler.fileFormat = "json"
-	case Sumo:
+	case SumoIC:
 		sumomarshaler := NewSumoMarshaler()
 		marshaler.logsMarshaler = &sumomarshaler
 		marshaler.tracesMarshaler = &sumomarshaler

--- a/exporter/awss3exporter/marshaler_test.go
+++ b/exporter/awss3exporter/marshaler_test.go
@@ -19,6 +19,12 @@ func TestMarshaler(t *testing.T) {
 		assert.Equal(t, m.format(), "json")
 	}
 	{
+		m, err := NewMarshaler("sumo_ic", zap.NewNop())
+		assert.NoError(t, err)
+		require.NotNil(t, m)
+		assert.Equal(t, m.format(), "sumo_ic")
+	}
+	{
 		m, err := NewMarshaler("unknown", zap.NewNop())
 		assert.Error(t, err)
 		require.Nil(t, m)

--- a/exporter/awss3exporter/marshaler_test.go
+++ b/exporter/awss3exporter/marshaler_test.go
@@ -22,7 +22,7 @@ func TestMarshaler(t *testing.T) {
 		m, err := NewMarshaler("sumo_ic", zap.NewNop())
 		assert.NoError(t, err)
 		require.NotNil(t, m)
-		assert.Equal(t, m.format(), "sumo_ic")
+		assert.Equal(t, m.format(), "json.gz")
 	}
 	{
 		m, err := NewMarshaler("unknown", zap.NewNop())

--- a/exporter/awss3exporter/sumo_marshaler.go
+++ b/exporter/awss3exporter/sumo_marshaler.go
@@ -84,7 +84,7 @@ func mapToString(m pcommon.Map) string {
 const (
 	SourceCategoryKey = "_sourceCategory"
 	SourceHostKey     = "_sourceHost"
-	SourceNameKey     = "log.file.path_resolved"
+	SourceNameKey     = "_sourceName"
 )
 
 func (SumoMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
@@ -112,7 +112,7 @@ func (SumoMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 				if !exists {
 					return nil, errors.New("_sourceName attribute does not exists")
 				}
-				logEntry(&buf, "{\"data\": \"%s\",\"sourceName\":\"%s\",\"sourceHost\":\"%s\",\"sourceCategory\":\"%s\",\"fields\":{},\"message\":\"%s\"}",
+				logEntry(&buf, "{\"date\": \"%s\",\"sourceName\":\"%s\",\"sourceHost\":\"%s\",\"sourceCategory\":\"%s\",\"fields\":{},\"message\":\"%s\"}",
 					dateVal, attributeValueToString(sourceName), attributeValueToString(sourceHost), attributeValueToString(sourceCategory), body)
 			}
 		}

--- a/exporter/awss3exporter/sumo_marshaler.go
+++ b/exporter/awss3exporter/sumo_marshaler.go
@@ -23,7 +23,7 @@ const (
 
 type sumoMarshaler struct{}
 
-func (marshaler *sumoMarshaler) format() string {
+func (*sumoMarshaler) format() string {
 	return string(SumoIC)
 }
 

--- a/exporter/awss3exporter/sumo_marshaler.go
+++ b/exporter/awss3exporter/sumo_marshaler.go
@@ -49,6 +49,8 @@ func attributeValueToString(v pcommon.Value) string {
 		return sliceToString(v.Slice())
 	case pcommon.ValueTypeMap:
 		return mapToString(v.Map())
+	case pcommon.ValueTypeEmpty:
+		return ""
 	default:
 		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", v.Type())
 	}
@@ -120,10 +122,10 @@ func (SumoMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (SumoMarshaler) MarshalTraces(traces ptrace.Traces) ([]byte, error) {
+func (SumoMarshaler) MarshalTraces(_ ptrace.Traces) ([]byte, error) {
 	return nil, nil
 }
 
-func (SumoMarshaler) MarshalMetrics(md pmetric.Metrics) ([]byte, error) {
+func (SumoMarshaler) MarshalMetrics(_ pmetric.Metrics) ([]byte, error) {
 	return nil, nil
 }

--- a/exporter/awss3exporter/sumo_marshaler.go
+++ b/exporter/awss3exporter/sumo_marshaler.go
@@ -40,7 +40,7 @@ func attributeValueToString(v pcommon.Value) string {
 	case pcommon.ValueTypeBool:
 		return strconv.FormatBool(v.Bool())
 	case pcommon.ValueTypeBytes:
-		return fmt.Sprint(v.Bytes().AsRaw())
+		return bytesToString(v.Bytes())
 	case pcommon.ValueTypeDouble:
 		return strconv.FormatFloat(v.Double(), 'f', -1, 64)
 	case pcommon.ValueTypeInt:
@@ -54,6 +54,21 @@ func attributeValueToString(v pcommon.Value) string {
 	default:
 		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", v.Type())
 	}
+}
+
+func bytesToString(bs pcommon.ByteSlice) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i := 0; i < bs.Len(); i++ {
+		if i < bs.Len()-1 {
+			fmt.Fprintf(&b, "%v, ", bs.At(i))
+		} else {
+			b.WriteString(fmt.Sprint(bs.At(i)))
+		}
+	}
+
+	b.WriteByte(']')
+	return b.String()
 }
 
 func sliceToString(s pcommon.Slice) string {

--- a/exporter/awss3exporter/sumo_marshaler.go
+++ b/exporter/awss3exporter/sumo_marshaler.go
@@ -1,16 +1,5 @@
-// Copyright 2022, OpenTelemetry Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 package awss3exporter
 

--- a/exporter/awss3exporter/sumo_marshaler.go
+++ b/exporter/awss3exporter/sumo_marshaler.go
@@ -1,0 +1,139 @@
+// Copyright 2022, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awss3exporter
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+type SumoMarshaler struct {
+	format string
+}
+
+func (marshaler *SumoMarshaler) Format() string {
+	return marshaler.format
+}
+
+func NewSumoMarshaler() SumoMarshaler {
+	return SumoMarshaler{}
+}
+
+func logEntry(buf *bytes.Buffer, format string, a ...interface{}) {
+	buf.WriteString(fmt.Sprintf(format, a...))
+	buf.WriteString("\n")
+}
+
+func attributeValueToString(v pcommon.Value) string {
+	// TODO: chceck all types and add missing
+	switch v.Type() {
+	case pcommon.ValueTypeStr:
+		return v.Str()
+	case pcommon.ValueTypeBool:
+		return strconv.FormatBool(v.Bool())
+	case pcommon.ValueTypeDouble:
+		return strconv.FormatFloat(v.Double(), 'f', -1, 64)
+	case pcommon.ValueTypeInt:
+		return strconv.FormatInt(v.Int(), 10)
+	case pcommon.ValueTypeSlice:
+		return sliceToString(v.Slice())
+	case pcommon.ValueTypeMap:
+		return mapToString(v.Map())
+	default:
+		return fmt.Sprintf("<Unknown OpenTelemetry attribute value type %q>", v.Type())
+	}
+}
+
+func sliceToString(s pcommon.Slice) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i := 0; i < s.Len(); i++ {
+		if i < s.Len()-1 {
+			fmt.Fprintf(&b, "%s, ", attributeValueToString(s.At(i)))
+		} else {
+			b.WriteString(attributeValueToString(s.At(i)))
+		}
+	}
+
+	b.WriteByte(']')
+	return b.String()
+}
+
+func mapToString(m pcommon.Map) string {
+	var b strings.Builder
+	b.WriteString("{\n")
+
+	m.Range(func(k string, v pcommon.Value) bool {
+		fmt.Fprintf(&b, "     -> %s: %s(%s)\n", k, v.Type(), v.AsString())
+		return true
+	})
+	b.WriteByte('}')
+	return b.String()
+}
+
+const (
+	SourceCategoryKey = "_sourceCategory"
+	SourceHostKey     = "_sourceHost"
+	SourceNameKey     = "log.file.path_resolved"
+)
+
+func (SumoMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
+	buf := bytes.Buffer{}
+	rls := ld.ResourceLogs()
+	for i := 0; i < rls.Len(); i++ {
+		rl := rls.At(i)
+		sourceCategory, exists := rl.Resource().Attributes().Get(SourceCategoryKey)
+		if !exists {
+			return nil, errors.New("_sourceCategory attribute does not exists")
+		}
+		sourceHost, exists := rl.Resource().Attributes().Get(SourceHostKey)
+		if !exists {
+			return nil, errors.New("_sourceHost attribute does not exists")
+		}
+		ills := rl.ScopeLogs()
+		for j := 0; j < ills.Len(); j++ {
+			ils := ills.At(j)
+			logs := ils.LogRecords()
+			for k := 0; k < logs.Len(); k++ {
+				lr := logs.At(k)
+				dateVal := lr.ObservedTimestamp()
+				body := attributeValueToString(lr.Body())
+				sourceName, exists := lr.Attributes().Get(SourceNameKey)
+				if !exists {
+					return nil, errors.New("_sourceName attribute does not exists")
+				}
+				logEntry(&buf, "{\"data\": \"%s\",\"sourceName\":\"%s\",\"sourceHost\":\"%s\",\"sourceCategory\":\"%s\",\"fields\":{},\"message\":\"%s\"}",
+					dateVal, attributeValueToString(sourceName), attributeValueToString(sourceHost), attributeValueToString(sourceCategory), body)
+			}
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func (SumoMarshaler) MarshalTraces(traces ptrace.Traces) ([]byte, error) {
+	return nil, nil
+}
+
+func (SumoMarshaler) MarshalMetrics(md pmetric.Metrics) ([]byte, error) {
+	return nil, nil
+}

--- a/exporter/awss3exporter/sumo_marshaler.go
+++ b/exporter/awss3exporter/sumo_marshaler.go
@@ -102,6 +102,10 @@ func (SumoMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 		if !exists {
 			return nil, errors.New("_sourceHost attribute does not exists")
 		}
+		sourceName, exists := rl.Resource().Attributes().Get(SourceNameKey)
+		if !exists {
+			return nil, errors.New("_sourceName attribute does not exists")
+		}
 		ills := rl.ScopeLogs()
 		for j := 0; j < ills.Len(); j++ {
 			ils := ills.At(j)
@@ -110,10 +114,7 @@ func (SumoMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 				lr := logs.At(k)
 				dateVal := lr.ObservedTimestamp()
 				body := attributeValueToString(lr.Body())
-				sourceName, exists := lr.Attributes().Get(SourceNameKey)
-				if !exists {
-					return nil, errors.New("_sourceName attribute does not exists")
-				}
+
 				logEntry(&buf, "{\"date\": \"%s\",\"sourceName\":\"%s\",\"sourceHost\":\"%s\",\"sourceCategory\":\"%s\",\"fields\":{},\"message\":\"%s\"}",
 					dateVal, attributeValueToString(sourceName), attributeValueToString(sourceHost), attributeValueToString(sourceCategory), body)
 			}

--- a/exporter/awss3exporter/sumo_marshaler.go
+++ b/exporter/awss3exporter/sumo_marshaler.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package awss3exporter
+package awss3exporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter"
 
 import (
 	"bytes"

--- a/exporter/awss3exporter/sumo_marshaler.go
+++ b/exporter/awss3exporter/sumo_marshaler.go
@@ -34,12 +34,13 @@ func logEntry(buf *bytes.Buffer, format string, a ...interface{}) {
 }
 
 func attributeValueToString(v pcommon.Value) string {
-	// TODO: chceck all types and add missing
 	switch v.Type() {
 	case pcommon.ValueTypeStr:
 		return v.Str()
 	case pcommon.ValueTypeBool:
 		return strconv.FormatBool(v.Bool())
+	case pcommon.ValueTypeBytes:
+		return fmt.Sprint(v.Bytes().AsRaw())
 	case pcommon.ValueTypeDouble:
 		return strconv.FormatFloat(v.Double(), 'f', -1, 64)
 	case pcommon.ValueTypeInt:

--- a/exporter/awss3exporter/sumo_marshaler_test.go
+++ b/exporter/awss3exporter/sumo_marshaler_test.go
@@ -1,0 +1,102 @@
+// Copyright 2022, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awss3exporter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestMarshalerMissingAttributes(t *testing.T) {
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.ScopeLogs().AppendEmpty()
+	marshaler := &SumoMarshaler{"txt"}
+	require.NotNil(t, marshaler)
+	_, err := marshaler.MarshalLogs(logs)
+	assert.Error(t, err)
+}
+
+func TestMarshalerMissingSourceHost(t *testing.T) {
+	logs := plog.NewLogs()
+	rls := logs.ResourceLogs().AppendEmpty()
+	rls.Resource().Attributes().PutStr("_sourceCategory", "testcategory")
+
+	marshaler := &SumoMarshaler{"txt"}
+	require.NotNil(t, marshaler)
+	_, err := marshaler.MarshalLogs(logs)
+	assert.Error(t, err)
+}
+
+func TestMarshalerMissingScopedLogs(t *testing.T) {
+	logs := plog.NewLogs()
+	rls := logs.ResourceLogs().AppendEmpty()
+	rls.Resource().Attributes().PutStr("_sourceCategory", "testcategory")
+	rls.Resource().Attributes().PutStr("_sourceHost", "testHost")
+
+	marshaler := &SumoMarshaler{"txt"}
+	require.NotNil(t, marshaler)
+	_, err := marshaler.MarshalLogs(logs)
+	assert.NoError(t, err)
+}
+
+func TestMarshalerMissingSourceName(t *testing.T) {
+	logs := plog.NewLogs()
+	rls := logs.ResourceLogs().AppendEmpty()
+	rls.Resource().Attributes().PutStr("_sourceCategory", "testcategory")
+	rls.Resource().Attributes().PutStr("_sourceHost", "testHost")
+
+	sl := rls.ScopeLogs().AppendEmpty()
+	const recordNum = 0
+
+	ts := pcommon.Timestamp(int64(recordNum) * time.Millisecond.Nanoseconds())
+	logRecord := sl.LogRecords().AppendEmpty()
+	logRecord.Body().SetStr("entry1")
+	logRecord.SetTimestamp(ts)
+
+	marshaler := &SumoMarshaler{"txt"}
+	require.NotNil(t, marshaler)
+	_, err := marshaler.MarshalLogs(logs)
+	assert.Error(t, err)
+}
+
+func TestMarshalerOkStructure(t *testing.T) {
+	logs := plog.NewLogs()
+	rls := logs.ResourceLogs().AppendEmpty()
+	rls.Resource().Attributes().PutStr("_sourceCategory", "testcategory")
+	rls.Resource().Attributes().PutStr("_sourceHost", "testHost")
+
+	sl := rls.ScopeLogs().AppendEmpty()
+	const recordNum = 0
+
+	ts := pcommon.Timestamp(int64(recordNum) * time.Millisecond.Nanoseconds())
+	logRecord := sl.LogRecords().AppendEmpty()
+	logRecord.Body().SetStr("entry1")
+	logRecord.Attributes().PutStr("log.file.path_resolved", "testSourceName")
+	logRecord.SetTimestamp(ts)
+
+	marshaler := &SumoMarshaler{"txt"}
+	require.NotNil(t, marshaler)
+	buf, err := marshaler.MarshalLogs(logs)
+	assert.NoError(t, err)
+	expectedEntry := "{\"data\": \"1970-01-01 00:00:00 +0000 UTC\",\"sourceName\":\"testSourceName\",\"sourceHost\":\"testHost\""
+	expectedEntry = expectedEntry + ",\"sourceCategory\":\"testcategory\",\"fields\":{},\"message\":\"entry1\"}\n"
+	assert.Equal(t, string(buf), expectedEntry)
+}

--- a/exporter/awss3exporter/sumo_marshaler_test.go
+++ b/exporter/awss3exporter/sumo_marshaler_test.go
@@ -103,7 +103,7 @@ func TestAttributeValueToString(t *testing.T) {
 		},
 		{
 			value:  pcommon.NewValueBytes(),
-			result: "[42 33 77 255 0]",
+			result: "[42, 33, 77, 255, 0]",
 			init: func(v pcommon.Value) {
 				v.Bytes().Append(42, 33, 77, 255, 0)
 			},
@@ -135,7 +135,7 @@ func TestAttributeValueToString(t *testing.T) {
 		},
 		{
 			value:  pcommon.NewValueSlice(),
-			result: "[110.37, [true], [1 2 3], asdfg]",
+			result: "[110.37, [true], [1, 2, 3], asdfg]",
 			init: func(v pcommon.Value) {
 				s := v.Slice()
 				s.AppendEmpty().SetDouble(110.37)

--- a/exporter/awss3exporter/sumo_marshaler_test.go
+++ b/exporter/awss3exporter/sumo_marshaler_test.go
@@ -39,6 +39,7 @@ func TestMarshalerMissingScopedLogs(t *testing.T) {
 	rls := logs.ResourceLogs().AppendEmpty()
 	rls.Resource().Attributes().PutStr("_sourceCategory", "testcategory")
 	rls.Resource().Attributes().PutStr("_sourceHost", "testHost")
+	rls.Resource().Attributes().PutStr("_sourceName", "testName")
 
 	marshaler := &SumoMarshaler{"txt"}
 	require.NotNil(t, marshaler)
@@ -71,6 +72,7 @@ func TestMarshalerOkStructure(t *testing.T) {
 	rls := logs.ResourceLogs().AppendEmpty()
 	rls.Resource().Attributes().PutStr("_sourceCategory", "testcategory")
 	rls.Resource().Attributes().PutStr("_sourceHost", "testHost")
+	rls.Resource().Attributes().PutStr("_sourceName", "testSourceName")
 
 	sl := rls.ScopeLogs().AppendEmpty()
 	const recordNum = 0
@@ -78,7 +80,6 @@ func TestMarshalerOkStructure(t *testing.T) {
 	ts := pcommon.Timestamp(int64(recordNum) * time.Millisecond.Nanoseconds())
 	logRecord := sl.LogRecords().AppendEmpty()
 	logRecord.Body().SetStr("entry1")
-	logRecord.Attributes().PutStr("_sourceName", "testSourceName")
 	logRecord.SetTimestamp(ts)
 
 	marshaler := &SumoMarshaler{"txt"}

--- a/exporter/awss3exporter/sumo_marshaler_test.go
+++ b/exporter/awss3exporter/sumo_marshaler_test.go
@@ -110,7 +110,7 @@ func TestAttributeValueToString(t *testing.T) {
 		},
 		{
 			value:  pcommon.NewValueBytes(),
-			result: "[42, 33, 77, 255, 0]",
+			result: "\"KiFN/wA=\"",
 			init: func(v pcommon.Value) {
 				v.Bytes().Append(42, 33, 77, 255, 0)
 			},
@@ -142,12 +142,12 @@ func TestAttributeValueToString(t *testing.T) {
 		},
 		{
 			value:  pcommon.NewValueSlice(),
-			result: "[110.37, [true], [1, 2, 3], asdfg]",
+			result: "[110.37,[true],\"YWJj\",\"asdfg\"]",
 			init: func(v pcommon.Value) {
 				s := v.Slice()
 				s.AppendEmpty().SetDouble(110.37)
 				s.AppendEmpty().SetEmptySlice().AppendEmpty().SetBool(true)
-				s.AppendEmpty().SetEmptyBytes().Append(1, 2, 3)
+				s.AppendEmpty().SetEmptyBytes().Append(97, 98, 99)
 				s.AppendEmpty().SetStr("asdfg")
 			},
 		},
@@ -163,6 +163,6 @@ func TestAttributeValueToString(t *testing.T) {
 		}
 		val, err := attributeValueToString(testCase.value)
 		assert.NoError(t, err)
-		assert.Equal(t, val, testCase.result)
+		assert.Equal(t, testCase.result, val)
 	}
 }

--- a/exporter/awss3exporter/sumo_marshaler_test.go
+++ b/exporter/awss3exporter/sumo_marshaler_test.go
@@ -86,7 +86,7 @@ func TestMarshalerOkStructure(t *testing.T) {
 	buf, err := marshaler.MarshalLogs(logs)
 	assert.NoError(t, err)
 	expectedEntry := "{\"date\": \"1970-01-01 00:00:00 +0000 UTC\",\"sourceName\":\"testSourceName\",\"sourceHost\":\"testHost\""
-	expectedEntry = expectedEntry + ",\"sourceCategory\":\"testcategory\",\"fields\":{},\"message\":\"entry1\"}\n"
+	expectedEntry += ",\"sourceCategory\":\"testcategory\",\"fields\":{},\"message\":\"entry1\"}\n"
 	assert.Equal(t, expectedEntry, string(buf))
 }
 

--- a/exporter/awss3exporter/sumo_marshaler_test.go
+++ b/exporter/awss3exporter/sumo_marshaler_test.go
@@ -1,16 +1,5 @@
-// Copyright 2022, OpenTelemetry Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 package awss3exporter
 

--- a/exporter/awss3exporter/sumo_marshaler_test.go
+++ b/exporter/awss3exporter/sumo_marshaler_test.go
@@ -78,16 +78,16 @@ func TestMarshalerOkStructure(t *testing.T) {
 	ts := pcommon.Timestamp(int64(recordNum) * time.Millisecond.Nanoseconds())
 	logRecord := sl.LogRecords().AppendEmpty()
 	logRecord.Body().SetStr("entry1")
-	logRecord.Attributes().PutStr("log.file.path_resolved", "testSourceName")
+	logRecord.Attributes().PutStr("_sourceName", "testSourceName")
 	logRecord.SetTimestamp(ts)
 
 	marshaler := &SumoMarshaler{"txt"}
 	require.NotNil(t, marshaler)
 	buf, err := marshaler.MarshalLogs(logs)
 	assert.NoError(t, err)
-	expectedEntry := "{\"data\": \"1970-01-01 00:00:00 +0000 UTC\",\"sourceName\":\"testSourceName\",\"sourceHost\":\"testHost\""
+	expectedEntry := "{\"date\": \"1970-01-01 00:00:00 +0000 UTC\",\"sourceName\":\"testSourceName\",\"sourceHost\":\"testHost\""
 	expectedEntry = expectedEntry + ",\"sourceCategory\":\"testcategory\",\"fields\":{},\"message\":\"entry1\"}\n"
-	assert.Equal(t, string(buf), expectedEntry)
+	assert.Equal(t, expectedEntry, string(buf))
 }
 
 func TestAttributeValueToString(t *testing.T) {

--- a/exporter/awss3exporter/sumo_marshaler_test.go
+++ b/exporter/awss3exporter/sumo_marshaler_test.go
@@ -81,13 +81,14 @@ func TestMarshalerOkStructure(t *testing.T) {
 	logRecord := sl.LogRecords().AppendEmpty()
 	logRecord.Body().SetStr("entry1")
 	logRecord.SetTimestamp(ts)
+	logRecord.Attributes().PutStr("key", "value")
 
 	marshaler := &SumoMarshaler{"txt"}
 	require.NotNil(t, marshaler)
 	buf, err := marshaler.MarshalLogs(logs)
 	assert.NoError(t, err)
 	expectedEntry := "{\"date\": \"1970-01-01 00:00:00 +0000 UTC\",\"sourceName\":\"testSourceName\",\"sourceHost\":\"testHost\""
-	expectedEntry += ",\"sourceCategory\":\"testcategory\",\"fields\":{},\"message\":\"entry1\"}\n"
+	expectedEntry += ",\"sourceCategory\":\"testcategory\",\"fields\":{},\"message\":{\"key\":\"value\",\"log\":\"entry1\"}}\n"
 	assert.Equal(t, expectedEntry, string(buf))
 }
 

--- a/exporter/awss3exporter/testdata/marshaler.yaml
+++ b/exporter/awss3exporter/testdata/marshaler.yaml
@@ -1,0 +1,16 @@
+receivers:
+  nop:
+
+exporters:
+  awss3:
+    marshaler: sumo_ic
+
+processors:
+  nop:
+
+service:
+  pipelines:
+    traces:
+      receivers: [nop]
+      processors: [nop]
+      exporters: [awss3]

--- a/exporter/awss3exporter/testdata/marshaler.yaml
+++ b/exporter/awss3exporter/testdata/marshaler.yaml
@@ -3,6 +3,8 @@ receivers:
 
 exporters:
   awss3:
+    s3uploader:
+      s3_bucket: "foo"
     marshaler: sumo_ic
 
 processors:


### PR DESCRIPTION
**Description:** This PR adds a new marshaller for `awss3` exporter. It exports logs in the format of Sumo Logic Installed Collector. Metrics and traces are not supported - creating an exporter for them will result in an error.
Currently, nested typed (eg. map inside a map) might not be supported correctly - I have to confirm the IC's behavior with them, but I wanted to create the PR so that it can be reviewed early.

**Link to tracking Issue:** #23212

**Testing:** Unit tests and manual e2e tests. Some automatic e2e tests will come later, but they will not be part of this repo, they will be a test for integrating the ingest with Sumo Logic's backend.

**Documentation:** Readme updated.