### PR TITLE
[receiver/postgresql] Fix blocks read metric

### DIFF
--- a/.chloggen/fix-postgresql-incorrect-attribute-emit.yaml
+++ b/.chloggen/fix-postgresql-incorrect-attribute-emit.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: postgresqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fixed an issue where postgresql receiver was emitting the same attribute value "toast_hit" twice under postgresql.blocks_read metric.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23657]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -197,7 +197,7 @@ func (p *postgreSQLScraper) collectTables(ctx context.Context, now pcommon.Times
 			p.mb.RecordPostgresqlBlocksReadDataPointWithoutDatabaseAndTable(now, br.idxRead, metadata.AttributeSourceIdxRead)
 			p.mb.RecordPostgresqlBlocksReadDataPointWithoutDatabaseAndTable(now, br.idxHit, metadata.AttributeSourceIdxHit)
 			p.mb.RecordPostgresqlBlocksReadDataPointWithoutDatabaseAndTable(now, br.toastHit, metadata.AttributeSourceToastHit)
-			p.mb.RecordPostgresqlBlocksReadDataPointWithoutDatabaseAndTable(now, br.toastRead, metadata.AttributeSourceToastHit)
+			p.mb.RecordPostgresqlBlocksReadDataPointWithoutDatabaseAndTable(now, br.toastRead, metadata.AttributeSourceToastRead)
 			p.mb.RecordPostgresqlBlocksReadDataPointWithoutDatabaseAndTable(now, br.tidxRead, metadata.AttributeSourceTidxRead)
 			p.mb.RecordPostgresqlBlocksReadDataPointWithoutDatabaseAndTable(now, br.tidxHit, metadata.AttributeSourceTidxHit)
 		}

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_db.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_db.yaml
@@ -109,7 +109,7 @@ resourceMetrics:
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
+                        stringValue: toast_read
                   startTimeUnixNano: "1662565933924183000"
                   timeUnixNano: "1662565943934293000"
                 - asInt: "0"
@@ -259,7 +259,7 @@ resourceMetrics:
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
+                        stringValue: toast_read
                   startTimeUnixNano: "1662565933924183000"
                   timeUnixNano: "1662565943934293000"
                 - asInt: "0"
@@ -524,7 +524,7 @@ resourceMetrics:
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
+                        stringValue: toast_read
                   startTimeUnixNano: "1662565933924183000"
                   timeUnixNano: "1662565943934293000"
                 - asInt: "0"
@@ -674,7 +674,7 @@ resourceMetrics:
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
+                        stringValue: toast_read
                   startTimeUnixNano: "1662565933924183000"
                   timeUnixNano: "1662565943934293000"
                 - asInt: "0"

--- a/receiver/postgresqlreceiver/testdata/integration/expected_multi_db.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_multi_db.yaml
@@ -53,7 +53,7 @@ resourceMetrics:
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
+                        stringValue: toast_read
                   startTimeUnixNano: "1662565922919465000"
                   timeUnixNano: "1662565932919535000"
                 - asInt: "0"
@@ -203,7 +203,7 @@ resourceMetrics:
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
+                        stringValue: toast_read
                   startTimeUnixNano: "1662565922919465000"
                   timeUnixNano: "1662565932919535000"
                 - asInt: "0"
@@ -468,7 +468,7 @@ resourceMetrics:
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
+                        stringValue: toast_read
                   startTimeUnixNano: "1662565922919465000"
                   timeUnixNano: "1662565932919535000"
                 - asInt: "0"
@@ -618,7 +618,7 @@ resourceMetrics:
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
+                        stringValue: toast_read
                   startTimeUnixNano: "1662565922919465000"
                   timeUnixNano: "1662565932919535000"
                 - asInt: "0"

--- a/receiver/postgresqlreceiver/testdata/integration/expected_single_db.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_single_db.yaml
@@ -53,7 +53,7 @@ resourceMetrics:
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
+                        stringValue: toast_read
                   startTimeUnixNano: "1662565911916254000"
                   timeUnixNano: "1662565921917209000"
                 - asInt: "0"
@@ -203,7 +203,7 @@ resourceMetrics:
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
+                        stringValue: toast_read
                   startTimeUnixNano: "1662565911916254000"
                   timeUnixNano: "1662565921917209000"
                 - asInt: "0"

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
@@ -1,5 +1,6 @@
 resourceMetrics:
-  - resource: {}
+  - resource:
+      attributes: []
     scopeMetrics:
       - metrics:
           - description: Number of buffers allocated.
@@ -8,8 +9,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "10"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{buffers}'
           - description: Number of buffers written.
@@ -22,29 +23,29 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: backend
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "8"
                   attributes:
                     - key: source
                       value:
                         stringValue: backend_fsync
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "5"
                   attributes:
                     - key: source
                       value:
                         stringValue: bgwriter
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "9"
                   attributes:
                     - key: source
                       value:
                         stringValue: checkpoints
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{buffers}'
           - description: The number of checkpoints performed.
@@ -57,15 +58,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: requested
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "2"
                   attributes:
                     - key: type
                       value:
                         stringValue: scheduled
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{checkpoints}'
           - description: Total time spent writing and syncing files to disk by checkpoints.
@@ -78,15 +79,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: sync
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asDouble: 3.12
                   attributes:
                     - key: type
                       value:
                         stringValue: write
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: ms
           - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
@@ -95,15 +96,15 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "11"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
           - description: Configured maximum number of client connections allowed
             gauge:
               dataPoints:
                 - asInt: "100"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             name: postgresql.connection.max
             unit: '{connections}'
           - description: Number of user databases.
@@ -112,8 +113,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "3"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: '{databases}'
           - description: The amount of data delayed in replication.
             gauge:
@@ -123,16 +124,16 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             name: postgresql.replication.data_delay
             unit: By
           - description: Age of the oldest WAL file.
             gauge:
               dataPoints:
                 - asInt: "3600"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             name: postgresql.wal.age
             unit: s
           - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
@@ -146,8 +147,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "700"
                   attributes:
                     - key: operation
@@ -156,8 +157,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "800"
                   attributes:
                     - key: operation
@@ -166,8 +167,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             name: postgresql.wal.lag
             unit: s
         scope:
@@ -186,8 +187,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: "1"
           - description: The number of commits.
             name: postgresql.commits
@@ -195,8 +196,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The database disk usage.
@@ -205,8 +206,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "5"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: By
           - description: The number of rollbacks.
             name: postgresql.rollbacks
@@ -214,8 +215,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "3"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: Number of user tables in a database.
@@ -224,8 +225,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -242,8 +243,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "3"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: "1"
           - description: The number of commits.
             name: postgresql.commits
@@ -251,8 +252,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The database disk usage.
@@ -261,8 +262,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: By
           - description: The number of rollbacks.
             name: postgresql.rollbacks
@@ -270,8 +271,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: Number of user tables in a database.
@@ -280,8 +281,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -298,8 +299,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "5"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: "1"
           - description: The number of commits.
             name: postgresql.commits
@@ -307,8 +308,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "3"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The database disk usage.
@@ -317,8 +318,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "6"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: By
           - description: The number of rollbacks.
             name: postgresql.rollbacks
@@ -326,8 +327,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: Number of user tables in a database.
@@ -336,8 +337,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -361,57 +362,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "20"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "23"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "22"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "27"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "26"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "25"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "24"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -424,29 +425,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "43"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "40"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "41"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -459,15 +460,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "8"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -475,8 +476,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "44"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -484,8 +485,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "45"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -511,57 +512,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "28"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "31"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "30"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "35"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "34"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "33"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "32"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -574,29 +575,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "47"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "44"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "45"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -609,15 +610,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "10"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -625,8 +626,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "48"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -634,8 +635,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "49"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -661,57 +662,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "19"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "22"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "21"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "26"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "25"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "24"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "23"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -724,29 +725,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "39"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "40"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -759,15 +760,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "7"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -775,8 +776,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "43"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -784,8 +785,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "44"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -811,57 +812,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "27"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "30"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "29"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "34"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "33"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "32"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "31"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -874,29 +875,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "46"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "43"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "44"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -909,15 +910,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "9"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -925,8 +926,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "47"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -934,8 +935,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "48"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -961,57 +962,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "21"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "24"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "23"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "28"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "27"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "26"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "25"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -1024,29 +1025,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "44"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "41"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -1059,15 +1060,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "9"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -1075,8 +1076,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "45"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -1084,8 +1085,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "46"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -1111,57 +1112,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "29"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "32"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "31"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "36"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "35"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "34"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "33"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -1174,29 +1175,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "48"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "45"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "46"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -1209,15 +1210,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
                 - asInt: "11"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -1225,8 +1226,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "49"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -1234,8 +1235,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "50"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -1260,16 +1261,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "36"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "37"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -1294,16 +1295,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "38"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "39"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -1328,16 +1329,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "35"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "36"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -1362,16 +1363,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "37"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "38"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -1396,16 +1397,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "37"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "38"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -1430,16 +1431,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "39"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "40"
-                  startTimeUnixNano: "1684786281207476000"
-                  timeUnixNano: "1684786281207521000"
+                  startTimeUnixNano: "1687536677505800000"
+                  timeUnixNano: "1687536677505826000"
             name: postgresql.index.size
             unit: By
         scope:

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_with_resource.yaml
@@ -1,5 +1,6 @@
 resourceMetrics:
-  - resource: {}
+  - resource:
+      attributes: []
     scopeMetrics:
       - metrics:
           - description: Number of buffers allocated.
@@ -8,8 +9,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "10"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{buffers}'
           - description: Number of buffers written.
@@ -22,29 +23,29 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: backend
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "8"
                   attributes:
                     - key: source
                       value:
                         stringValue: backend_fsync
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "5"
                   attributes:
                     - key: source
                       value:
                         stringValue: bgwriter
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "9"
                   attributes:
                     - key: source
                       value:
                         stringValue: checkpoints
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{buffers}'
           - description: The number of checkpoints performed.
@@ -57,15 +58,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: requested
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "2"
                   attributes:
                     - key: type
                       value:
                         stringValue: scheduled
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{checkpoints}'
           - description: Total time spent writing and syncing files to disk by checkpoints.
@@ -78,15 +79,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: sync
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asDouble: 3.12
                   attributes:
                     - key: type
                       value:
                         stringValue: write
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: ms
           - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
@@ -95,15 +96,15 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "11"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
           - description: Configured maximum number of client connections allowed
             gauge:
               dataPoints:
                 - asInt: "100"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             name: postgresql.connection.max
             unit: '{connections}'
           - description: Number of user databases.
@@ -112,8 +113,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "3"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: '{databases}'
           - description: The amount of data delayed in replication.
             gauge:
@@ -123,16 +124,16 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             name: postgresql.replication.data_delay
             unit: By
           - description: Age of the oldest WAL file.
             gauge:
               dataPoints:
                 - asInt: "3600"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             name: postgresql.wal.age
             unit: s
           - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
@@ -146,8 +147,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "700"
                   attributes:
                     - key: operation
@@ -156,8 +157,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "800"
                   attributes:
                     - key: operation
@@ -166,8 +167,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             name: postgresql.wal.lag
             unit: s
         scope:
@@ -186,8 +187,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: "1"
           - description: The number of commits.
             name: postgresql.commits
@@ -195,8 +196,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The database disk usage.
@@ -205,8 +206,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "5"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: By
           - description: The number of rollbacks.
             name: postgresql.rollbacks
@@ -214,8 +215,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "3"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: Number of user tables in a database.
@@ -224,8 +225,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -242,8 +243,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "3"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: "1"
           - description: The number of commits.
             name: postgresql.commits
@@ -251,8 +252,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The database disk usage.
@@ -261,8 +262,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: By
           - description: The number of rollbacks.
             name: postgresql.rollbacks
@@ -270,8 +271,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: Number of user tables in a database.
@@ -280,8 +281,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -298,8 +299,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "5"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: "1"
           - description: The number of commits.
             name: postgresql.commits
@@ -307,8 +308,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "3"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The database disk usage.
@@ -317,8 +318,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "6"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: By
           - description: The number of rollbacks.
             name: postgresql.rollbacks
@@ -326,8 +327,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: Number of user tables in a database.
@@ -336,8 +337,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -361,57 +362,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "20"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "23"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "22"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "27"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "26"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "25"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "24"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -424,29 +425,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "43"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "40"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "41"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -459,15 +460,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "8"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -475,8 +476,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "44"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -484,8 +485,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "45"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -511,57 +512,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "28"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "31"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "30"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "35"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "34"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "33"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "32"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -574,29 +575,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "47"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "44"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "45"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -609,15 +610,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "10"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -625,8 +626,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "48"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -634,8 +635,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "49"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -661,57 +662,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "19"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "22"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "21"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "26"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "25"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "24"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "23"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -724,29 +725,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "39"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "40"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -759,15 +760,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "7"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -775,8 +776,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "43"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -784,8 +785,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "44"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -811,57 +812,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "27"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "30"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "29"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "34"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "33"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "32"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "31"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -874,29 +875,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "46"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "43"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "44"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -909,15 +910,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "9"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -925,8 +926,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "47"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -934,8 +935,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "48"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -961,57 +962,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "21"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "24"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "23"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "28"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "27"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "26"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "25"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -1024,29 +1025,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "44"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "41"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -1059,15 +1060,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "9"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -1075,8 +1076,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "45"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -1084,8 +1085,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "46"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -1111,57 +1112,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "29"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "32"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "31"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "36"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "35"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "34"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "33"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -1174,29 +1175,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "48"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "45"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "46"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -1209,15 +1210,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
                 - asInt: "11"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -1225,8 +1226,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "49"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -1234,8 +1235,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "50"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -1260,16 +1261,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "36"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "37"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -1294,16 +1295,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "38"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "39"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -1328,16 +1329,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "35"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "36"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -1362,16 +1363,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "37"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "38"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -1396,16 +1397,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "37"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "38"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -1430,16 +1431,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "39"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "40"
-                  startTimeUnixNano: "1660755376404913000"
-                  timeUnixNano: "1660755376405089000"
+                  startTimeUnixNano: "1687536677517433000"
+                  timeUnixNano: "1687536677517468000"
             name: postgresql.index.size
             unit: By
         scope:

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
@@ -1,5 +1,6 @@
 resourceMetrics:
-  - resource: {}
+  - resource:
+      attributes: []
     scopeMetrics:
       - metrics:
           - description: Number of buffers allocated.
@@ -8,8 +9,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "10"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: '{buffers}'
           - description: Number of buffers written.
@@ -22,29 +23,29 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: backend
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "8"
                   attributes:
                     - key: source
                       value:
                         stringValue: backend_fsync
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "5"
                   attributes:
                     - key: source
                       value:
                         stringValue: bgwriter
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "9"
                   attributes:
                     - key: source
                       value:
                         stringValue: checkpoints
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: '{buffers}'
           - description: The number of checkpoints performed.
@@ -57,15 +58,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: requested
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "2"
                   attributes:
                     - key: type
                       value:
                         stringValue: scheduled
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: '{checkpoints}'
           - description: Total time spent writing and syncing files to disk by checkpoints.
@@ -78,15 +79,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: sync
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asDouble: 3.12
                   attributes:
                     - key: type
                       value:
                         stringValue: write
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: ms
           - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
@@ -95,15 +96,15 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "11"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
           - description: Configured maximum number of client connections allowed
             gauge:
               dataPoints:
                 - asInt: "100"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             name: postgresql.connection.max
             unit: '{connections}'
           - description: Number of user databases.
@@ -112,8 +113,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             unit: '{databases}'
           - description: The amount of data delayed in replication.
             gauge:
@@ -123,16 +124,16 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             name: postgresql.replication.data_delay
             unit: By
           - description: Age of the oldest WAL file.
             gauge:
               dataPoints:
                 - asInt: "3600"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             name: postgresql.wal.age
             unit: s
           - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
@@ -146,8 +147,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "700"
                   attributes:
                     - key: operation
@@ -156,8 +157,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "800"
                   attributes:
                     - key: operation
@@ -166,8 +167,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             name: postgresql.wal.lag
             unit: s
         scope:
@@ -186,8 +187,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "3"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             unit: "1"
           - description: The number of commits.
             name: postgresql.commits
@@ -195,8 +196,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: "1"
           - description: The database disk usage.
@@ -205,8 +206,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             unit: By
           - description: The number of rollbacks.
             name: postgresql.rollbacks
@@ -214,8 +215,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: "1"
           - description: Number of user tables in a database.
@@ -224,8 +225,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -249,57 +250,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "19"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "22"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "21"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "26"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "25"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "24"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "23"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -312,29 +313,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "39"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "40"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -347,15 +348,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "7"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -363,8 +364,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "43"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -372,8 +373,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "44"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -399,57 +400,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "27"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "30"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "29"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "34"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "33"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "32"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "31"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -462,29 +463,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "46"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "43"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "44"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -497,15 +498,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
                 - asInt: "9"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -513,8 +514,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "47"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -522,8 +523,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "48"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -548,16 +549,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "35"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "36"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -582,16 +583,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "37"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "38"
-                  startTimeUnixNano: "1684786281201767000"
-                  timeUnixNano: "1684786281201820000"
+                  startTimeUnixNano: "1687536677498986000"
+                  timeUnixNano: "1687536677499123000"
             name: postgresql.index.size
             unit: By
         scope:

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_with_resource.yaml
@@ -1,5 +1,6 @@
 resourceMetrics:
-  - resource: {}
+  - resource:
+      attributes: []
     scopeMetrics:
       - metrics:
           - description: Number of buffers allocated.
@@ -8,8 +9,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "10"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: '{buffers}'
           - description: Number of buffers written.
@@ -22,29 +23,29 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: backend
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "8"
                   attributes:
                     - key: source
                       value:
                         stringValue: backend_fsync
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "5"
                   attributes:
                     - key: source
                       value:
                         stringValue: bgwriter
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "9"
                   attributes:
                     - key: source
                       value:
                         stringValue: checkpoints
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: '{buffers}'
           - description: The number of checkpoints performed.
@@ -57,15 +58,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: requested
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "2"
                   attributes:
                     - key: type
                       value:
                         stringValue: scheduled
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: '{checkpoints}'
           - description: Total time spent writing and syncing files to disk by checkpoints.
@@ -78,15 +79,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: sync
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asDouble: 3.12
                   attributes:
                     - key: type
                       value:
                         stringValue: write
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: ms
           - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
@@ -95,15 +96,15 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "11"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
           - description: Configured maximum number of client connections allowed
             gauge:
               dataPoints:
                 - asInt: "100"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             name: postgresql.connection.max
             unit: '{connections}'
           - description: Number of user databases.
@@ -112,8 +113,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             unit: '{databases}'
           - description: The amount of data delayed in replication.
             gauge:
@@ -123,16 +124,16 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             name: postgresql.replication.data_delay
             unit: By
           - description: Age of the oldest WAL file.
             gauge:
               dataPoints:
                 - asInt: "3600"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             name: postgresql.wal.age
             unit: s
           - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
@@ -146,8 +147,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "700"
                   attributes:
                     - key: operation
@@ -156,8 +157,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "800"
                   attributes:
                     - key: operation
@@ -166,8 +167,8 @@ resourceMetrics:
                     - key: replication_client
                       value:
                         stringValue: unix
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             name: postgresql.wal.lag
             unit: s
         scope:
@@ -186,8 +187,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "3"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             unit: "1"
           - description: The number of commits.
             name: postgresql.commits
@@ -195,8 +196,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: "1"
           - description: The database disk usage.
@@ -205,8 +206,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "4"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             unit: By
           - description: The number of rollbacks.
             name: postgresql.rollbacks
@@ -214,8 +215,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: "1"
           - description: Number of user tables in a database.
@@ -224,8 +225,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -249,57 +250,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "19"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "22"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "21"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "26"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "25"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "24"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "23"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -312,29 +313,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "39"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "40"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -347,15 +348,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "7"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -363,8 +364,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "43"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -372,8 +373,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "44"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -399,57 +400,57 @@ resourceMetrics:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "27"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "30"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "29"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "34"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "33"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "32"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "31"
                   attributes:
                     - key: source
                       value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -462,29 +463,29 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "46"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "43"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "44"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -497,15 +498,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
                 - asInt: "9"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             unit: "1"
           - description: Disk space used by a table.
             name: postgresql.table.size
@@ -513,8 +514,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "47"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
@@ -522,8 +523,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "48"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -548,16 +549,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "35"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "36"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -582,16 +583,16 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "37"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
                 - asInt: "38"
-                  startTimeUnixNano: "1660755387092164000"
-                  timeUnixNano: "1660755387092521000"
+                  startTimeUnixNano: "1687536677528497000"
+                  timeUnixNano: "1687536677528540000"
             name: postgresql.index.size
             unit: By
         scope:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
fixed an issue where postgresql receiver was emitting the same attribute value "toast_hit" twice under postgresql.blocks_read metric.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>