### PR TITLE
[chore] [receiver/apachespark] Disable failing integration test

### DIFF
--- a/receiver/apachesparkreceiver/integration_test.go
+++ b/receiver/apachesparkreceiver/integration_test.go
@@ -23,6 +23,7 @@ import (
 const sparkPort = "4040"
 
 func TestIntegration(t *testing.T) {
+	t.Skip("The test is failing. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23670")
 	scraperinttest.NewIntegrationTest(
 		NewFactory(),
 		scraperinttest.WithContainerRequest(


### PR DESCRIPTION
Temporarily disable the integration test to unblock the CI.

Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23670