### PR TITLE
feat!(mysqlreceiver): set `mysql.locked_connects` as optional in order to remove it in next release

### DIFF
--- a/.chloggen/drosiek-locked-accounts-optional.yaml
+++ b/.chloggen/drosiek-locked-accounts-optional.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "set `mysql.locked_connects` as optional in order to remove it in next release"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [14138, 23274]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/mysqlreceiver/documentation.md
+++ b/receiver/mysqlreceiver/documentation.md
@@ -146,14 +146,6 @@ The total time of I/O wait events for an index.
 | schema | The schema of the object. | Any Str |
 | index | The name of the index. | Any Str |
 
-### mysql.locked_connects
-
-[DEPRECATED] The number of attempts to connect to locked user accounts.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| 1 | Sum | Int | Cumulative | true |
-
 ### mysql.locks
 
 The number of MySQL locks.
@@ -437,6 +429,14 @@ The number of joins that perform table scans.
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | kind | The kind of join. | Str: ``full``, ``full_range``, ``range``, ``range_check``, ``scan`` |
+
+### mysql.locked_connects
+
+[DEPRECATED] The number of attempts to connect to locked user accounts.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| 1 | Sum | Int | Cumulative | true |
 
 ### mysql.mysqlx_worker_threads
 

--- a/receiver/mysqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_config.go
@@ -119,7 +119,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		MysqlLockedConnects: MetricConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		MysqlLocks: MetricConfig{
 			Enabled: true,

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics_test.go
@@ -109,7 +109,6 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordMysqlJoinsDataPoint(ts, "1", AttributeJoinKind(1))
 
-			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordMysqlLockedConnectsDataPoint(ts, "1")
 

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -444,7 +444,7 @@ metrics:
       aggregation: cumulative
     attributes: [schema, table_name, write_lock_type]
   mysql.locked_connects:
-    enabled: true
+    enabled: false
     description: "[DEPRECATED] The number of attempts to connect to locked user accounts."
     unit: 1
     sum:

--- a/receiver/mysqlreceiver/scraper.go
+++ b/receiver/mysqlreceiver/scraper.go
@@ -57,7 +57,7 @@ func (m *mySQLScraper) start(_ context.Context, _ component.Host) error {
 	m.sqlclient = sqlclient
 
 	if m.config.MetricsBuilderConfig.Metrics.MysqlLockedConnects.Enabled {
-		m.logger.Warn("`mysql.locked_connects` is deprecated and is going to be set as optional in `v0.81.0` and removed in `v0.82.0`. Please use `mysql.connection.errors` instead")
+		m.logger.Warn("`mysql.locked_connects` is deprecated and is going to be and removed in `v0.82.0`. Please use `mysql.connection.errors` instead")
 	}
 
 	return nil

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -53,6 +53,8 @@ func TestScrape(t *testing.T) {
 
 		cfg.MetricsBuilderConfig.Metrics.MysqlConnectionCount.Enabled = true
 
+		cfg.MetricsBuilderConfig.Metrics.MysqlLockedConnects.Enabled = true
+
 		scraper := newMySQLScraper(receivertest.NewNopCreateSettings(), cfg)
 		scraper.sqlclient = &mockClient{
 			globalStatsFile:             "global_stats",

--- a/receiver/mysqlreceiver/testdata/integration/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/integration/expected.yaml
@@ -302,16 +302,6 @@ resourceMetrics:
                   timeUnixNano: "1674545265375344000"
               isMonotonic: true
             unit: "1"
-          - description: "[DEPRECATED] The number of attempts to connect to locked user accounts."
-            name: mysql.locked_connects
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  startTimeUnixNano: "1674545255370693000"
-                  timeUnixNano: "1674545265375344000"
-              isMonotonic: true
-            unit: "1"
           - description: The number of MySQL locks.
             name: mysql.locks
             sum:


### PR DESCRIPTION
**Description:**

Set `mysql.locked_connects` as optional, as it is duplication of `mysql.connection.errors` metric

**Link to tracking Issue:** #14138 #23274

**Testing:** unit tests

**Documentation:**

`make generate`