### PR TITLE
[chore] Fix spark integration test by pinning version

### DIFF
--- a/receiver/apachesparkreceiver/integration_test.go
+++ b/receiver/apachesparkreceiver/integration_test.go
@@ -23,7 +23,6 @@ import (
 const sparkPort = "4040"
 
 func TestIntegration(t *testing.T) {
-	t.Skip("The test is failing. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23670")
 	scraperinttest.NewIntegrationTest(
 		NewFactory(),
 		scraperinttest.WithContainerRequest(

--- a/receiver/apachesparkreceiver/testdata/integration/Dockerfile.apache-spark
+++ b/receiver/apachesparkreceiver/testdata/integration/Dockerfile.apache-spark
@@ -1,4 +1,4 @@
-FROM apache/spark
+FROM apache/spark:3.4.0-python3
 
 COPY sparkprograms/long_running.py /opt/spark/examples/src/main/python/long_running.py
 RUN chmod +x /opt/spark/examples/src/main/python/long_running.py

--- a/renovate.json
+++ b/renovate.json
@@ -8,11 +8,10 @@
     ],
     "schedule": ["every tuesday"],
     "ignorePaths": [
-      "**/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_0_0",
+      "**/receiver/apachesparkreceiver/testdata/integration/Dockerfile.apache-spark",
       "**/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_16_3",
       "**/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_9_3",
       "**/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_0",
-      "**/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_2",
       "**/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.4_4.lpu",
       "**/receiver/mongodbreceiver/testdata/integration/Dockerfile.mongodb.5_0"
     ],


### PR DESCRIPTION
Fixes #23670

The test appears to have begun failing when the [`latest`](https://hub.docker.com/layers/apache/spark/latest/images/sha256-a1dd2487a97fb5e35c5a5b409e830b501a92919029c62f9a559b13c4f5c50f63?context=explore) tag of for the image was updated. This PR just pins the version.
