### PR TITLE
[chore] Add 'test' as prerequisite to default module-level make target

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -92,7 +92,7 @@ all-pkg-dirs:
 .DEFAULT_GOAL := common
 
 .PHONY: common
-common: lint
+common: lint test
 
 .PHONY: test
 test:


### PR DESCRIPTION
We've documented the intended approach to our default targets [here](https://github.com/open-telemetry/opentelemetry-collector/blob/5852d09fb7b519e18610b99fc5a9da8cddbbf790/CONTRIBUTING.md?plain=1#L589-L591). In `Makefile.Common`, the default target is `common`. This adds the `test` target as a prerequisite.