### PR TITLE
[cmd/mdatagen] Add validation to metadata.yaml

### DIFF
--- a/.chloggen/add-validation-mdatagen.yaml
+++ b/.chloggen/add-validation-mdatagen.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds validation to mdatagen to ensure that all required fields are present, and their content is valid.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23783]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/provider/fileprovider"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.uber.org/multierr"
 )
 
 type metricName string
@@ -141,26 +140,12 @@ func (m *metric) Unmarshal(parser *confmap.Conf) error {
 	if !parser.IsSet("enabled") {
 		return errors.New("missing required field: `enabled`")
 	}
-	if !parser.IsSet("description") {
-		return errors.New("missing required field: `description`")
-	}
 	err := parser.Unmarshal(m, confmap.WithErrorUnused())
 	if err != nil {
 		return err
 	}
 	return nil
 }
-
-func (m *metric) Validate() error {
-	if m.Sum != nil {
-		return m.Sum.Validate()
-	}
-	if m.Gauge != nil {
-		return m.Gauge.Validate()
-	}
-	return nil
-}
-
 func (m metric) Data() MetricData {
 	if m.Sum != nil {
 		return m.Sum
@@ -193,20 +178,6 @@ type attribute struct {
 	Type ValueType `mapstructure:"type"`
 }
 
-func (attr *attribute) Unmarshal(parser *confmap.Conf) error {
-	if !parser.IsSet("description") {
-		return errors.New("missing required field: `description`")
-	}
-	if !parser.IsSet("type") {
-		return errors.New("missing required field: `type`")
-	}
-	err := parser.Unmarshal(attr, confmap.WithErrorUnused())
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 type metadata struct {
 	// Type of the component.
 	Type string `mapstructure:"type"`
@@ -224,60 +195,6 @@ type metadata struct {
 	Metrics map[metricName]metric `mapstructure:"metrics"`
 	// ScopeName of the metrics emitted by the component.
 	ScopeName string `mapstructure:"-"`
-}
-
-func (md *metadata) Validate() error {
-	var errs error
-
-	usedAttrs := map[attributeName]bool{}
-	for mn, m := range md.Metrics {
-		if m.Sum == nil && m.Gauge == nil {
-			errs = multierr.Append(errs, fmt.Errorf("metric %v doesn't have a metric type key, "+
-				"one of the following has to be specified: sum, gauge", mn))
-			continue
-		}
-		if m.Sum != nil && m.Gauge != nil {
-			errs = multierr.Append(errs, fmt.Errorf("metric %v has more than one metric type keys, "+
-				"only one of the following has to be specified: sum, gauge", mn))
-			continue
-		}
-
-		if err := m.Validate(); err != nil {
-			errs = multierr.Append(errs, fmt.Errorf(`metric "%v": %w`, mn, err))
-			continue
-		}
-
-		unknownAttrs := make([]attributeName, 0, len(m.Attributes))
-		for _, attr := range m.Attributes {
-			if _, ok := md.Attributes[attr]; ok {
-				usedAttrs[attr] = true
-			} else {
-				unknownAttrs = append(unknownAttrs, attr)
-			}
-		}
-		if len(unknownAttrs) > 0 {
-			errs = multierr.Append(errs, fmt.Errorf(`metric "%v" refers to undefined attributes: %v`, mn, unknownAttrs))
-		}
-	}
-
-	unusedAttrs := make([]attributeName, 0, len(md.Attributes))
-	for attr := range md.Attributes {
-		if !usedAttrs[attr] {
-			unusedAttrs = append(unusedAttrs, attr)
-		}
-	}
-	if len(unusedAttrs) > 0 {
-		errs = multierr.Append(errs, fmt.Errorf("unused attributes: %v", unusedAttrs))
-	}
-	if md.Status != nil {
-		if md.Status.Class == "" {
-			errs = multierr.Append(errs, errors.New("missing status class metadata"))
-		}
-		if len(md.Status.Stability) == 0 {
-			errs = multierr.Append(errs, errors.New("missing status stability metadata"))
-		}
-	}
-	return errs
 }
 
 type templateContext struct {

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -167,26 +167,14 @@ func Test_loadMetadata(t *testing.T) {
 			},
 		},
 		{
-			name:    "testdata/unknown_metric_attribute.yaml",
+			name:    "testdata/invalid_type_rattr.yaml",
 			want:    metadata{},
-			wantErr: "metric \"system.cpu.time\" refers to undefined attributes: [missing]",
-		},
-		{
-			name: "testdata/no_metric_type.yaml",
-			want: metadata{},
-			wantErr: "metric system.cpu.time doesn't have a metric type key, " +
-				"one of the following has to be specified: sum, gauge",
+			wantErr: "1 error(s) decoding:\n\n* error decoding 'resource_attributes[string.resource.attr].type': invalid type: \"invalidtype\"",
 		},
 		{
 			name:    "testdata/no_enabled.yaml",
 			want:    metadata{},
 			wantErr: "1 error(s) decoding:\n\n* error decoding 'metrics[system.cpu.time]': missing required field: `enabled`",
-		},
-		{
-			name: "testdata/two_metric_types.yaml",
-			want: metadata{},
-			wantErr: "metric system.cpu.time has more than one metric type keys, " +
-				"only one of the following has to be specified: sum, gauge",
 		},
 		{
 			name: "testdata/no_value_type.yaml",
@@ -195,16 +183,25 @@ func Test_loadMetadata(t *testing.T) {
 				"* error decoding 'sum': missing required field: `value_type`",
 		},
 		{
-			name: "testdata/unknown_value_type.yaml",
-			want: metadata{},
-			wantErr: "1 error(s) decoding:\n\n* error decoding 'metrics[system.cpu.time]': 1 error(s) decoding:\n\n" +
-				"* error decoding 'sum': 1 error(s) decoding:\n\n* error decoding 'value_type': invalid value_type: \"unknown\"",
+			name:    "testdata/unknown_value_type.yaml",
+			wantErr: "1 error(s) decoding:\n\n* error decoding 'metrics[system.cpu.time]': 1 error(s) decoding:\n\n* error decoding 'sum': 1 error(s) decoding:\n\n* error decoding 'value_type': invalid value_type: \"unknown\"",
 		},
 		{
-			name:    "testdata/unused_attribute.yaml",
+			name:    "testdata/no_aggregation.yaml",
 			want:    metadata{},
-			wantErr: "unused attributes: [unused_attr]",
+			wantErr: "1 error(s) decoding:\n\n* error decoding 'metrics[default.metric]': 1 error(s) decoding:\n\n* error decoding 'sum': missing required field: `aggregation`",
 		},
+		{
+			name:    "testdata/invalid_aggregation.yaml",
+			want:    metadata{},
+			wantErr: "1 error(s) decoding:\n\n* error decoding 'metrics[default.metric]': 1 error(s) decoding:\n\n* error decoding 'sum': 1 error(s) decoding:\n\n* error decoding 'aggregation': invalid aggregation: \"invalidaggregation\"",
+		},
+		{
+			name:    "testdata/invalid_type_attr.yaml",
+			want:    metadata{},
+			wantErr: "1 error(s) decoding:\n\n* error decoding 'attributes[used_attr].type': invalid type: \"invalidtype\"",
+		},
+
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -201,7 +201,6 @@ func Test_loadMetadata(t *testing.T) {
 			want:    metadata{},
 			wantErr: "1 error(s) decoding:\n\n* error decoding 'attributes[used_attr].type': invalid type: \"invalidtype\"",
 		},
-
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -31,7 +31,7 @@ func Test_runContents(t *testing.T) {
 			yml:                  "metrics_and_type.yaml",
 			wantMetricsGenerated: true,
 			wantConfigGenerated:  true,
-			wantStatusGenerated: true,
+			wantStatusGenerated:  true,
 		},
 		{
 			yml:                 "resource_attributes_only.yaml",

--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -31,10 +31,12 @@ func Test_runContents(t *testing.T) {
 			yml:                  "metrics_and_type.yaml",
 			wantMetricsGenerated: true,
 			wantConfigGenerated:  true,
+			wantStatusGenerated: true,
 		},
 		{
 			yml:                 "resource_attributes_only.yaml",
 			wantConfigGenerated: true,
+			wantStatusGenerated: true,
 		},
 		{
 			yml:                 "status_only.yaml",

--- a/cmd/mdatagen/metricdata.go
+++ b/cmd/mdatagen/metricdata.go
@@ -62,13 +62,6 @@ type MetricInputType struct {
 	InputType string `mapstructure:"input_type"`
 }
 
-func (mit MetricInputType) Validate() error {
-	if mit.InputType != "" && mit.InputType != "string" {
-		return fmt.Errorf("invalid `input_type` value \"%v\", must be \"\" or \"string\"", mit.InputType)
-	}
-	return nil
-}
-
 func (mit MetricInputType) HasMetricInputType() bool {
 	return mit.InputType != ""
 }
@@ -155,11 +148,25 @@ type sum struct {
 
 // Unmarshal is a custom unmarshaler for sum. Needed mostly to avoid MetricValueType.Unmarshal inheritance.
 func (d *sum) Unmarshal(parser *confmap.Conf) error {
+	if !parser.IsSet("aggregation") {
+		return errors.New("missing required field: `aggregation`")
+	}
 	if err := d.MetricValueType.Unmarshal(parser); err != nil {
 		return err
 	}
 	return parser.Unmarshal(d, confmap.WithErrorUnused())
 }
+
+// TODO: Currently, this func will not be called because of https://github.com/open-telemetry/opentelemetry-collector/issues/6671. Uncomment function and
+// add a test case to Test_loadMetadata for file no_monotonic.yaml once the issue is solved.
+//
+// Unmarshal is a custom unmarshaler for Mono.
+// func (m *Mono) Unmarshal(parser *confmap.Conf) error {
+// 	if !parser.IsSet("monotonic") {
+// 		return errors.New("missing required field: `monotonic`")
+// 	}
+// 	return parser.Unmarshal(m, confmap.WithErrorUnused())
+// }
 
 func (d sum) Type() string {
 	return "Sum"

--- a/cmd/mdatagen/testdata/invalid_aggregation.yaml
+++ b/cmd/mdatagen/testdata/invalid_aggregation.yaml
@@ -11,9 +11,12 @@ status:
     - Any additional information that should be brought to the consumer's attention
 
 metrics:
-  metric:
+  default.metric:
     enabled: true
-    description: Description.
+    description: Monotonic cumulative sum int metric enabled by default.
+    extended_documentation: The metric will be become optional soon.
     unit: s
-    gauge:
-      value_type: double
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation: invalidaggregation

--- a/cmd/mdatagen/testdata/invalid_class.yaml
+++ b/cmd/mdatagen/testdata/invalid_class.yaml
@@ -1,0 +1,8 @@
+type: test
+
+status:
+  class: incorrectclass
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]

--- a/cmd/mdatagen/testdata/invalid_input_type.yaml
+++ b/cmd/mdatagen/testdata/invalid_input_type.yaml
@@ -1,13 +1,20 @@
 type: metricreceiver
+
 status:
   class: receiver
   stability:
     development: [logs]
     beta: [traces]
     stable: [metrics]
+
 metrics:
   system.cpu.time:
     enabled: true
     description: Total CPU seconds broken down by different states.
     unit: s
+    sum:
+      value_type: double
+      monotonic: true
+      aggregation: cumulative
+      input_type: double
     attributes:

--- a/cmd/mdatagen/testdata/invalid_stability.yaml
+++ b/cmd/mdatagen/testdata/invalid_stability.yaml
@@ -1,0 +1,7 @@
+type: file
+status:
+  class: receiver
+  stability:
+    incorrectstability: [logs]
+    beta: [traces]
+    stable: [metrics]

--- a/cmd/mdatagen/testdata/invalid_stability_component.yaml
+++ b/cmd/mdatagen/testdata/invalid_stability_component.yaml
@@ -1,0 +1,7 @@
+type: file
+status:
+  class: receiver
+  stability:
+    development: [incorrectcomponent]
+    beta: [traces]
+    stable: [metrics]

--- a/cmd/mdatagen/testdata/invalid_type_attr.yaml
+++ b/cmd/mdatagen/testdata/invalid_type_attr.yaml
@@ -1,19 +1,24 @@
 type: metricreceiver
 
+sem_conv_version: 1.9.0
+
 status:
   class: receiver
   stability:
     development: [logs]
     beta: [traces]
     stable: [metrics]
-  distributions: [contrib]
-  warnings:
-    - Any additional information that should be brought to the consumer's attention
+
+attributes:
+  used_attr:
+    description: Used attribute.
+    type: invalidtype
 
 metrics:
   metric:
     enabled: true
-    description: Description.
-    unit: s
+    description: Metric.
+    unit: 1
     gauge:
       value_type: double
+    attributes: [used_attr]

--- a/cmd/mdatagen/testdata/invalid_type_rattr.yaml
+++ b/cmd/mdatagen/testdata/invalid_type_rattr.yaml
@@ -1,4 +1,6 @@
-type: test
+type: file
+
+sem_conv_version: 1.9.0
 
 status:
   class: receiver
@@ -11,7 +13,7 @@ status:
     - Any additional information that should be brought to the consumer's attention
 
 resource_attributes:
-  res.attr1:
-    description: Resource attribute 1.
-    type: string
+  string.resource.attr:
+    description: Resource attribute with any string value.
+    type: invalidtype
     enabled: true

--- a/cmd/mdatagen/testdata/no_aggregation.yaml
+++ b/cmd/mdatagen/testdata/no_aggregation.yaml
@@ -1,4 +1,4 @@
-type: test
+type: file
 
 status:
   class: receiver
@@ -10,8 +10,13 @@ status:
   warnings:
     - Any additional information that should be brought to the consumer's attention
 
-resource_attributes:
-  res.attr1:
-    description: Resource attribute 1.
-    type: string
+
+metrics:
+  default.metric:
     enabled: true
+    description: Monotonic cumulative sum int metric enabled by default.
+    extended_documentation: The metric will be become optional soon.
+    unit: s
+    sum:
+      value_type: int
+      monotonic: false

--- a/cmd/mdatagen/testdata/no_class.yaml
+++ b/cmd/mdatagen/testdata/no_class.yaml
@@ -1,0 +1,7 @@
+type: test
+
+status:
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]

--- a/cmd/mdatagen/testdata/no_description_attr.yaml
+++ b/cmd/mdatagen/testdata/no_description_attr.yaml
@@ -1,0 +1,33 @@
+# Sample metric metadata file with all available configurations.
+
+type: file
+
+sem_conv_version: 1.9.0
+
+status:
+  class: receiver
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]
+  distributions: [contrib]
+  warnings:
+    - Any additional information that should be brought to the consumer's attention
+
+attributes:
+  string_attr:
+    type: string
+
+metrics:
+  default.metric:
+    enabled: true
+    description: Monotonic cumulative sum int metric enabled by default.
+    extended_documentation: The metric will be become optional soon.
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation: cumulative
+    attributes: [string_attr]
+    warnings:
+      if_enabled_not_set: This metric will be disabled by default soon.

--- a/cmd/mdatagen/testdata/no_description_rattr.yaml
+++ b/cmd/mdatagen/testdata/no_description_rattr.yaml
@@ -1,0 +1,12 @@
+type: file
+status:
+  class: receiver
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]
+
+resource_attributes:
+  string.resource.attr:
+    type: string
+    enabled: true

--- a/cmd/mdatagen/testdata/no_enabled.yaml
+++ b/cmd/mdatagen/testdata/no_enabled.yaml
@@ -1,4 +1,12 @@
 type: metricreceiver
+
+status:
+  class: receiver
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]
+    
 metrics:
   system.cpu.time:
     description: Total CPU seconds broken down by different states.

--- a/cmd/mdatagen/testdata/no_metric_description.yaml
+++ b/cmd/mdatagen/testdata/no_metric_description.yaml
@@ -1,4 +1,4 @@
-type: test
+type: file
 
 status:
   class: receiver
@@ -10,8 +10,13 @@ status:
   warnings:
     - Any additional information that should be brought to the consumer's attention
 
-resource_attributes:
-  res.attr1:
-    description: Resource attribute 1.
-    type: string
+
+metrics:
+  default.metric:
     enabled: true
+    extended_documentation: The metric will be become optional soon.
+    unit: s
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation: cumulative

--- a/cmd/mdatagen/testdata/no_metric_unit.yaml
+++ b/cmd/mdatagen/testdata/no_metric_unit.yaml
@@ -1,4 +1,4 @@
-type: metricreceiver
+type: file
 
 status:
   class: receiver
@@ -10,10 +10,13 @@ status:
   warnings:
     - Any additional information that should be brought to the consumer's attention
 
+
 metrics:
-  metric:
+  default.metric:
     enabled: true
-    description: Description.
-    unit: s
-    gauge:
-      value_type: double
+    description: Monotonic cumulative sum int metric enabled by default.
+    extended_documentation: The metric will be become optional soon.
+    sum:
+      value_type: int
+      monotonic: true
+      aggregation: cumulative

--- a/cmd/mdatagen/testdata/no_monotonic.yaml
+++ b/cmd/mdatagen/testdata/no_monotonic.yaml
@@ -1,4 +1,4 @@
-type: metricreceiver
+type: file
 
 status:
   class: receiver
@@ -10,10 +10,13 @@ status:
   warnings:
     - Any additional information that should be brought to the consumer's attention
 
+
 metrics:
-  metric:
+  default.metric:
     enabled: true
-    description: Description.
+    description: Monotonic cumulative sum int metric enabled by default.
+    extended_documentation: The metric will be become optional soon.
     unit: s
-    gauge:
-      value_type: double
+    sum:
+      value_type: int
+      aggregation: cumulative

--- a/cmd/mdatagen/testdata/no_stability.yaml
+++ b/cmd/mdatagen/testdata/no_stability.yaml
@@ -1,0 +1,4 @@
+type: test
+
+status:
+  class: receiver

--- a/cmd/mdatagen/testdata/no_stability_component.yaml
+++ b/cmd/mdatagen/testdata/no_stability_component.yaml
@@ -1,0 +1,6 @@
+type: file
+status:
+  class: receiver
+  stability:
+    beta:
+    stable: [metrics]

--- a/cmd/mdatagen/testdata/no_status.yaml
+++ b/cmd/mdatagen/testdata/no_status.yaml
@@ -1,0 +1,1 @@
+type: test

--- a/cmd/mdatagen/testdata/no_type.yaml
+++ b/cmd/mdatagen/testdata/no_type.yaml
@@ -1,0 +1,6 @@
+status:
+  class: receiver
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]

--- a/cmd/mdatagen/testdata/no_type_attr.yaml
+++ b/cmd/mdatagen/testdata/no_type_attr.yaml
@@ -1,19 +1,23 @@
 type: metricreceiver
 
+sem_conv_version: 1.9.0
+
 status:
   class: receiver
   stability:
     development: [logs]
     beta: [traces]
     stable: [metrics]
-  distributions: [contrib]
-  warnings:
-    - Any additional information that should be brought to the consumer's attention
+
+attributes:
+  used_attr:
+    description: Used attribute.
 
 metrics:
   metric:
     enabled: true
-    description: Description.
-    unit: s
+    description: Metric.
+    unit: 1
     gauge:
       value_type: double
+    attributes: [used_attr]

--- a/cmd/mdatagen/testdata/no_type_rattr.yaml
+++ b/cmd/mdatagen/testdata/no_type_rattr.yaml
@@ -1,4 +1,6 @@
-type: test
+type: file
+
+sem_conv_version: 1.9.0
 
 status:
   class: receiver
@@ -11,7 +13,6 @@ status:
     - Any additional information that should be brought to the consumer's attention
 
 resource_attributes:
-  res.attr1:
-    description: Resource attribute 1.
-    type: string
+  string.resource.attr:
+    description: Resource attribute with any string value.
     enabled: true

--- a/cmd/mdatagen/testdata/no_value_type.yaml
+++ b/cmd/mdatagen/testdata/no_value_type.yaml
@@ -1,4 +1,16 @@
 type: metricreceiver
+
+status:
+  class: receiver
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]
+  distributions: [contrib]
+  warnings:
+    - Any additional information that should be brought to the consumer's attention
+
+
 metrics:
   system.cpu.time:
     enabled: true

--- a/cmd/mdatagen/testdata/two_metric_types.yaml
+++ b/cmd/mdatagen/testdata/two_metric_types.yaml
@@ -1,4 +1,12 @@
 type: metricreceiver
+
+status:
+  class: receiver
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]
+
 metrics:
   system.cpu.time:
     enabled: true

--- a/cmd/mdatagen/testdata/unknown_metric_attribute.yaml
+++ b/cmd/mdatagen/testdata/unknown_metric_attribute.yaml
@@ -1,4 +1,12 @@
 type: metricreceiver
+
+status:
+  class: receiver
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]
+    
 metrics:
   system.cpu.time:
     enabled: true

--- a/cmd/mdatagen/testdata/unknown_value_type.yaml
+++ b/cmd/mdatagen/testdata/unknown_value_type.yaml
@@ -1,4 +1,12 @@
 type: metricreceiver
+
+status:
+  class: receiver
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]
+
 metrics:
   system.cpu.time:
     enabled: true

--- a/cmd/mdatagen/testdata/unused_attribute.yaml
+++ b/cmd/mdatagen/testdata/unused_attribute.yaml
@@ -2,6 +2,13 @@ type: metricreceiver
 
 sem_conv_version: 1.9.0
 
+status:
+  class: receiver
+  stability:
+    development: [logs]
+    beta: [traces]
+    stable: [metrics]
+
 attributes:
   used_attr:
     description: Used attribute.

--- a/cmd/mdatagen/validate.go
+++ b/cmd/mdatagen/validate.go
@@ -136,10 +136,10 @@ func (md *metadata) validateMetrics() error {
 func (m *metric) validate() error {
 	var errs error
 	if m.Description == "" {
-		errs = multierr.Append(errs, fmt.Errorf(`missing metric description`))
+		errs = multierr.Append(errs, errors.New(`missing metric description`))
 	}
 	if m.Unit == "" {
-		errs = multierr.Append(errs, fmt.Errorf(`missing metric unit`))
+		errs = multierr.Append(errs, errors.New(`missing metric unit`))
 	}
 	if m.Sum != nil {
 		errs = multierr.Append(errs, m.Sum.Validate())

--- a/cmd/mdatagen/validate.go
+++ b/cmd/mdatagen/validate.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (
@@ -177,4 +180,3 @@ func (md *metadata) validateAttributes(usedAttrs map[attributeName]bool) error {
 	}
 	return errs
 }
-

--- a/cmd/mdatagen/validate.go
+++ b/cmd/mdatagen/validate.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/multierr"
+)
+
+func (md *metadata) Validate() error {
+	var errs error
+	if err := md.validateType(); err != nil {
+		errs = multierr.Append(errs, err)
+	}
+	if err := md.validateStatus(); err != nil {
+		errs = multierr.Append(errs, err)
+	}
+	if err := md.validateResourceAttributes(); err != nil {
+		errs = multierr.Append(errs, err)
+	}
+	if err := md.validateMetrics(); err != nil {
+		errs = multierr.Append(errs, err)
+	}
+	return errs
+}
+
+func (md *metadata) validateType() error {
+	if md.Type == "" {
+		return errors.New("missing type")
+	}
+	return nil
+}
+
+func (md *metadata) validateStatus() error {
+	if md.Parent != "" && md.Status == nil {
+		// status is not required for subcomponents.
+		return nil
+	}
+
+	var errs error
+	if md.Status == nil {
+		return errors.New("missing status")
+	}
+	if err := md.Status.validateClass(); err != nil {
+		errs = multierr.Append(errs, err)
+	}
+	if err := md.Status.validateStability(); err != nil {
+		errs = multierr.Append(errs, err)
+	}
+	return errs
+}
+
+func (s *Status) validateClass() error {
+	if s.Class == "" {
+		return errors.New("missing class")
+	}
+	if s.Class != "receiver" && s.Class != "processor" && s.Class != "exporter" && s.Class != "connector" && s.Class != "extension" && s.Class != "cmd" {
+		return fmt.Errorf("invalid class: %v", s.Class)
+	}
+	return nil
+}
+
+func (s *Status) validateStability() error {
+	var errs error
+	if len(s.Stability) == 0 {
+		return errors.New("missing stability")
+	}
+	for stability, component := range s.Stability {
+		if stability != "development" && stability != "alpha" && stability != "beta" && stability != "stable" && stability != "deprecated" && stability != "unmaintained" {
+			errs = multierr.Append(errs, fmt.Errorf("invalid stability: %v", stability))
+		}
+		if component == nil {
+			errs = multierr.Append(errs, fmt.Errorf("missing component for stability: %v", stability))
+		}
+		for _, c := range component {
+			if c != "metrics" && c != "traces" && c != "logs" && c != "traces_to_metrics" && c != "metrics_to_metrics" && c != "logs_to_metrics" && c != "extension" {
+				errs = multierr.Append(errs, fmt.Errorf("invalid component: %v", c))
+			}
+		}
+	}
+	return errs
+}
+
+func (md *metadata) validateResourceAttributes() error {
+	var errs error
+	for name, attr := range md.ResourceAttributes {
+		if attr.Description == "" {
+			errs = multierr.Append(errs, fmt.Errorf("empty description for resource attribute: %v", name))
+		}
+		empty := ValueType{ValueType: pcommon.ValueTypeEmpty}
+		if attr.Type == empty {
+			errs = multierr.Append(errs, fmt.Errorf("empty type for resource attribute: %v", name))
+		}
+	}
+	return errs
+}
+
+func (md *metadata) validateMetrics() error {
+	var errs error
+	usedAttrs := map[attributeName]bool{}
+	for mn, m := range md.Metrics {
+		if m.Sum == nil && m.Gauge == nil {
+			errs = multierr.Append(errs, fmt.Errorf("metric %v doesn't have a metric type key, "+
+				"one of the following has to be specified: sum, gauge", mn))
+			continue
+		}
+		if m.Sum != nil && m.Gauge != nil {
+			errs = multierr.Append(errs, fmt.Errorf("metric %v has more than one metric type keys, "+
+				"only one of the following has to be specified: sum, gauge", mn))
+			continue
+		}
+		// TODO: Remove once https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/23573 is merged.
+		if md.Type != "redis" {
+			if err := m.validate(); err != nil {
+				errs = multierr.Append(errs, fmt.Errorf(`metric "%v": %w`, mn, err))
+				continue
+			}
+		}
+		unknownAttrs := make([]attributeName, 0, len(m.Attributes))
+		for _, attr := range m.Attributes {
+			if _, ok := md.Attributes[attr]; ok {
+				usedAttrs[attr] = true
+			} else {
+				unknownAttrs = append(unknownAttrs, attr)
+			}
+		}
+		if len(unknownAttrs) > 0 {
+			errs = multierr.Append(errs, fmt.Errorf(`metric "%v" refers to undefined attributes: %v`, mn, unknownAttrs))
+		}
+	}
+	errs = multierr.Append(errs, md.validateAttributes(usedAttrs))
+	return errs
+}
+
+func (m *metric) validate() error {
+	var errs error
+	if m.Description == "" {
+		errs = multierr.Append(errs, fmt.Errorf(`missing metric description`))
+	}
+	if m.Unit == "" {
+		errs = multierr.Append(errs, fmt.Errorf(`missing metric unit`))
+	}
+	if m.Sum != nil {
+		errs = multierr.Append(errs, m.Sum.Validate())
+	}
+	if m.Gauge != nil {
+		errs = multierr.Append(errs, m.Gauge.Validate())
+	}
+	return errs
+}
+
+func (mit MetricInputType) Validate() error {
+	if mit.InputType != "" && mit.InputType != "string" {
+		return fmt.Errorf("invalid `input_type` value \"%v\", must be \"\" or \"string\"", mit.InputType)
+	}
+	return nil
+}
+
+func (md *metadata) validateAttributes(usedAttrs map[attributeName]bool) error {
+	var errs error
+	unusedAttrs := make([]attributeName, 0, len(md.Attributes))
+	for attrName, attr := range md.Attributes {
+		if attr.Description == "" {
+			errs = multierr.Append(errs, fmt.Errorf(`missing attribute description for: %v`, attrName))
+		}
+		empty := ValueType{ValueType: pcommon.ValueTypeEmpty}
+		if attr.Type == empty {
+			errs = multierr.Append(errs, fmt.Errorf("empty type for attribute: %v", attrName))
+		}
+		if !usedAttrs[attrName] {
+			unusedAttrs = append(unusedAttrs, attrName)
+		}
+	}
+	if len(unusedAttrs) > 0 {
+		errs = multierr.Append(errs, fmt.Errorf("unused attributes: %v", unusedAttrs))
+	}
+	return errs
+}
+

--- a/cmd/mdatagen/validate_test.go
+++ b/cmd/mdatagen/validate_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr string
+	}{
+		{
+			name:    "testdata/no_type.yaml",
+			wantErr: "missing type",
+		},
+		{
+			name:    "testdata/no_status.yaml",
+			wantErr: "missing status",
+		},
+		{
+			name:    "testdata/no_class.yaml",
+			wantErr: "missing class",
+		},
+		{
+			name:    "testdata/invalid_class.yaml",
+			wantErr: "invalid class: incorrectclass",
+		},
+		{
+			name:    "testdata/no_stability.yaml",
+			wantErr: "missing stability",
+		},
+		{
+			name:    "testdata/invalid_stability.yaml",
+			wantErr: "invalid stability: incorrectstability",
+		},
+		{
+			name:    "testdata/no_stability_component.yaml",
+			wantErr: "missing component for stability: beta",
+		},
+		{
+			name:    "testdata/invalid_stability_component.yaml",
+			wantErr: "invalid component: incorrectcomponent",
+		},
+		{
+			name:    "testdata/no_description_rattr.yaml",
+			wantErr: "empty description for resource attribute: string.resource.attr",
+		},
+		{
+			name:    "testdata/no_type_rattr.yaml",
+			wantErr: "empty type for resource attribute: string.resource.attr",
+		},
+		{
+			name: "testdata/no_metric_description.yaml",
+			wantErr: "metric \"default.metric\": missing metric description",
+		},
+		{
+			name: "testdata/no_metric_unit.yaml",
+			wantErr: "metric \"default.metric\": missing metric unit",
+		},
+		{
+			name: "testdata/no_metric_type.yaml",
+			wantErr: "metric system.cpu.time doesn't have a metric type key, " +
+				"one of the following has to be specified: sum, gauge",
+		},
+		{
+			name: "testdata/two_metric_types.yaml",
+			wantErr: "metric system.cpu.time has more than one metric type keys, " +
+				"only one of the following has to be specified: sum, gauge",
+		},
+		{
+			name: "testdata/invalid_input_type.yaml",
+			wantErr: "metric \"system.cpu.time\": invalid `input_type` value \"double\", must be \"\" or \"string\"",
+		},
+		{
+			name:    "testdata/unknown_metric_attribute.yaml",
+			wantErr: "metric \"system.cpu.time\" refers to undefined attributes: [missing]",
+		},
+		{
+			name:    "testdata/unused_attribute.yaml",
+			wantErr: "unused attributes: [unused_attr]",
+		},
+		{
+			name:    "testdata/no_description_attr.yaml",
+			wantErr: "missing attribute description for: string_attr",
+		},
+		{
+			name:    "testdata/no_type_attr.yaml",
+			wantErr: "empty type for attribute: used_attr",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadMetadata(tt.name)
+			require.Error(t, err)
+			require.EqualError(t, err, tt.wantErr)
+		})
+	}
+}

--- a/cmd/mdatagen/validate_test.go
+++ b/cmd/mdatagen/validate_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (
@@ -52,11 +55,11 @@ func TestValidate(t *testing.T) {
 			wantErr: "empty type for resource attribute: string.resource.attr",
 		},
 		{
-			name: "testdata/no_metric_description.yaml",
+			name:    "testdata/no_metric_description.yaml",
 			wantErr: "metric \"default.metric\": missing metric description",
 		},
 		{
-			name: "testdata/no_metric_unit.yaml",
+			name:    "testdata/no_metric_unit.yaml",
 			wantErr: "metric \"default.metric\": missing metric unit",
 		},
 		{
@@ -70,7 +73,7 @@ func TestValidate(t *testing.T) {
 				"only one of the following has to be specified: sum, gauge",
 		},
 		{
-			name: "testdata/invalid_input_type.yaml",
+			name:    "testdata/invalid_input_type.yaml",
 			wantErr: "metric \"system.cpu.time\": invalid `input_type` value \"double\", must be \"\" or \"string\"",
 		},
 		{


### PR DESCRIPTION
**Description:**
This PR adds validation to mdatagen. It ensures that all required fields are present, and validates their content.

The validation lies mostly in `validate.go` (and for tests `validate_test.go`), however validation that needs to be done via decoding lies in `loader.go` + `metricdata.go` (and for tests `loader_test.go`).

**Link to tracking Issue:**
#23424.