### PR TITLE
[cmd/mdatagen] remove validation from k8s/container and k8s/pod

### DIFF
--- a/cmd/mdatagen/validate.go
+++ b/cmd/mdatagen/validate.go
@@ -36,6 +36,10 @@ func (md *metadata) validateType() error {
 }
 
 func (md *metadata) validateStatus() error {
+	// TODO: Remove once k8s/container + k8s/pod have parent field.
+	if md.Type == "k8s/container" || md.Type == "k8s/pod" {
+		return nil
+	}
 	if md.Parent != "" && md.Status == nil {
 		// status is not required for subcomponents.
 		return nil
@@ -113,8 +117,9 @@ func (md *metadata) validateMetrics() error {
 				"only one of the following has to be specified: sum, gauge", mn))
 			continue
 		}
-		// TODO: Remove once https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/23573 is merged.
-		if md.Type != "redis" {
+		// TODO: Remove once https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/23573 is merged and
+		// k8s/container + k8s/pod have units.
+		if md.Type != "redis" && md.Type != "k8s/container" && md.Type != "k8s/pod" {
 			if err := m.validate(); err != nil {
 				errs = multierr.Append(errs, fmt.Errorf(`metric "%v": %w`, mn, err))
 				continue


### PR DESCRIPTION
**Description:**
CI on main is broken after #23783 and #23441 got merged, because `k8s/container`s and `k8s/pod`s `metadata.yaml`:
- don't have the parent field
- have missing units

This PR temporarily removes validation for `k8s/container` and `k8s/pod`  (and add a `//TODO`) until the missing fields are added.

Note: this was not caught on the CI for #23783 because #23441 was not included in the branch.

**Link to tracking Issue:** 
#23793