### PR TITLE
[translator/loki] fix converting attributes to labels when hint is a slice and severity_number is present in log record

### DIFF
--- a/.chloggen/fix-loki-level-to-label.yaml
+++ b/.chloggen/fix-loki-level-to-label.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: lokitranslator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug when attributes targeted in slice hint not converted to labels when log record has severity_number
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22038]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/translator/loki/logs_to_loki.go
+++ b/pkg/translator/loki/logs_to_loki.go
@@ -216,7 +216,7 @@ func addHint(log plog.LogRecord) {
 		case pcommon.ValueTypeSlice:
 			value.Slice().AppendEmpty().SetStr(levelAttributeName)
 		case pcommon.ValueTypeStr:
-			log.Attributes().PutStr(hintAttributes, value.AsString()+","+levelAttributeName)
+			log.Attributes().PutStr(hintAttributes, fmt.Sprintf("%s,%s", value.AsString(), levelAttributeName))
 		}
 	} else {
 		log.Attributes().PutStr(hintAttributes, levelAttributeName)

--- a/pkg/translator/loki/logs_to_loki.go
+++ b/pkg/translator/loki/logs_to_loki.go
@@ -5,7 +5,6 @@ package loki // import "github.com/open-telemetry/opentelemetry-collector-contri
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/grafana/loki/pkg/push"
 	"github.com/prometheus/common/model"
@@ -212,8 +211,13 @@ func addLogLevelAttributeAndHint(log plog.LogRecord) {
 }
 
 func addHint(log plog.LogRecord) {
-	if value, found := log.Attributes().Get(hintAttributes); found && !strings.Contains(value.AsString(), levelAttributeName) {
-		log.Attributes().PutStr(hintAttributes, fmt.Sprintf("%s,%s", value.AsString(), levelAttributeName))
+	if value, found := log.Attributes().Get(hintAttributes); found {
+		switch value.Type() {
+		case pcommon.ValueTypeSlice:
+			value.Slice().AppendEmpty().SetStr(levelAttributeName)
+		case pcommon.ValueTypeStr:
+			log.Attributes().PutStr(hintAttributes, value.AsString()+","+levelAttributeName)
+		}
 	} else {
 		log.Attributes().PutStr(hintAttributes, levelAttributeName)
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
When `loki.attribute.labels` hint is a slice and `severity_number` is present in log record, nothing except level was promoted to labels

This config didn't work, `event.domain` and `event.name` were not promoted to loki labels in case if `severity_number` exists in log record
```
processor:
   attributes:
     actions:
        - action: insert
           key: loki.attribute.labels
           value:
             - event.domain
             - event.name 
```

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22038

**Testing:** Added unit tests

**Documentation:** <Describe the documentation added.>