### PR TITLE
[admin] feat(ci/cd): add version validation to prepare-release

### DIFF
--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -3,6 +3,19 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+PATTERN="^[0-9]+\.[0-9]+\.[0-9]+.*"
+if ! [[ ${CURRENT_BETA} =~ $PATTERN ]]
+then
+    echo "CURRENT_BETA should follow a semver format and not be led by a v"
+    exit 1
+fi
+
+if ! [[ ${CANDIDATE_BETA} =~ $PATTERN ]]
+then
+    echo "CANDIDATE_BETA should follow a semver format and not be led by a v"
+    exit 1
+fi
+
 make chlog-update VERSION="v${CANDIDATE_BETA}"
 git config user.name opentelemetrybot
 git config user.email 107717825+opentelemetrybot@users.noreply.github.com


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Adding version validation to prepare-release
 I used the same regex already used in [set_release_tag.sh](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/7e74bd350192456ded06ae80fb5586bec921f2e0/.github/workflows/scripts/set_release_tag.sh#L7), just without the v.

**Link to tracking Issue:** <Issue number if applicable>
Fix https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21490

**Testing:** <Describe what testing was performed and which tests were added.>
I tested manually those few lines of the script.

---

Not related

I was looking for some sponsors to become a member of the OTEL community, I have [some contributions](https://github.com/open-telemetry/opentelemetry-collector-contrib/commits?author=paologallinaharbur) already in contrib :)