### PR TITLE
[exporter/splunkhec] Add the ability to specify a Failover Endpoint and Enable a Circuit Breaker

### DIFF
--- a/.chloggen/splunkhec-exporter-add-failover-circuit-breaker.yaml
+++ b/.chloggen/splunkhec-exporter-add-failover-circuit-breaker.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow a failover endpoint to be specified along with a Circuit Breaker that adds resiliency.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23821]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -1449,7 +1449,7 @@ func Test_pushLogData_InvalidLog(t *testing.T) {
 
 func Test_pushLogData_PostError(t *testing.T) {
 	c := newLogsClient(exportertest.NewNopCreateSettings(), NewFactory().CreateDefaultConfig().(*Config))
-	c.hecWorker = &defaultHecWorker{url: &url.URL{Host: "in va lid"}}
+	c.hecWorker = &defaultHecWorker{url: &url.URL{Host: "in va lid"}, logger: zap.NewNop()}
 
 	// 2000 log records -> ~371888 bytes when JSON encoded.
 	logs := createLogData(1, 1, 2000)
@@ -1494,7 +1494,7 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 
 	// An HTTP client that returns status code 400 and response body responseBody.
 	httpClient, _ := newTestClient(400, responseBody)
-	splunkClient.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo())}
+	splunkClient.hecWorker = &defaultHecWorker{url: url, client: httpClient, headers: buildHTTPHeaders(config, component.NewDefaultBuildInfo()), logger: zap.NewNop()}
 	// Sending logs using the client.
 	err := splunkClient.pushLogData(context.Background(), logs)
 	require.True(t, consumererror.IsPermanent(err), "Expecting permanent error")
@@ -1504,7 +1504,7 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 
 	// An HTTP client that returns some other status code other than 400 and response body responseBody.
 	httpClient, _ = newTestClient(500, responseBody)
-	splunkClient.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo())}
+	splunkClient.hecWorker = &defaultHecWorker{url: url, client: httpClient, headers: buildHTTPHeaders(config, component.NewDefaultBuildInfo()), logger: zap.NewNop()}
 	// Sending logs using the client.
 	err = splunkClient.pushLogData(context.Background(), logs)
 	require.False(t, consumererror.IsPermanent(err), "Expecting non-permanent error")
@@ -1527,7 +1527,7 @@ func Test_pushLogData_ShouldReturnUnsentLogsOnly(t *testing.T) {
 
 	// The first record is to be sent successfully, the second one should not
 	httpClient, _ := newTestClientWithPresetResponses([]int{200, 400}, []string{"OK", "NOK"})
-	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo())}
+	c.hecWorker = &defaultHecWorker{url: url, client: httpClient, headers: buildHTTPHeaders(config, component.NewDefaultBuildInfo()), logger: zap.NewNop()}
 
 	err := c.pushLogData(context.Background(), logs)
 	require.Error(t, err)
@@ -1554,7 +1554,7 @@ func Test_pushLogData_ShouldAddHeadersForProfilingData(t *testing.T) {
 
 	httpClient, headers := newTestClient(200, "OK")
 	url := &url.URL{Scheme: "http", Host: "splunk"}
-	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo())}
+	c.hecWorker = &defaultHecWorker{url: url, client: httpClient, headers: buildHTTPHeaders(config, component.NewDefaultBuildInfo()), logger: zap.NewNop()}
 
 	err := c.pushLogData(context.Background(), logs)
 	require.NoError(t, err)
@@ -1837,7 +1837,7 @@ func Test_pushLogData_Small_MaxContentLength(t *testing.T) {
 		config.DisableCompression = disable
 
 		c := newLogsClient(exportertest.NewNopCreateSettings(), config)
-		c.hecWorker = &defaultHecWorker{&url.URL{Scheme: "http", Host: "splunk"}, http.DefaultClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo())}
+		c.hecWorker = &defaultHecWorker{url: &url.URL{Scheme: "http", Host: "splunk"}, client: http.DefaultClient, headers: buildHTTPHeaders(config, component.NewDefaultBuildInfo()), logger: zap.NewNop()}
 
 		err := c.pushLogData(context.Background(), logs)
 		require.Error(t, err)
@@ -1949,7 +1949,7 @@ func TestPushLogsPartialSuccess(t *testing.T) {
 	// The first request succeeds, the second fails.
 	httpClient, _ := newTestClientWithPresetResponses([]int{200, 503}, []string{"OK", "NOK"})
 	url := &url.URL{Scheme: "http", Host: "splunk"}
-	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(cfg, component.NewDefaultBuildInfo())}
+	c.hecWorker = &defaultHecWorker{url: url, client: httpClient, headers: buildHTTPHeaders(cfg, component.NewDefaultBuildInfo()), logger: zap.NewNop()}
 
 	logs := plog.NewLogs()
 	logRecords := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords()
@@ -1970,7 +1970,7 @@ func TestPushLogsRetryableFailureMultipleResources(t *testing.T) {
 
 	httpClient, _ := newTestClientWithPresetResponses([]int{503}, []string{"NOK"})
 	url := &url.URL{Scheme: "http", Host: "splunk"}
-	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(c.config, component.NewDefaultBuildInfo())}
+	c.hecWorker = &defaultHecWorker{url: url, client: httpClient, headers: buildHTTPHeaders(c.config, component.NewDefaultBuildInfo()), logger: zap.NewNop()}
 
 	logs := plog.NewLogs()
 	logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("log-1")

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -58,11 +58,53 @@ type HecTelemetry struct {
 	ExtraAttributes map[string]string `mapstructure:"extra_attributes"`
 }
 
+type BreakerSettings struct {
+	// Enabled indicates whether to not retry sending batches in case of export failure.
+	Enabled           bool          `mapstructure:"enabled"`
+	FailureThreshold  uint32        `mapstructure:"threshold"`
+	ThresholdDuration time.Duration `mapstructure:"threshold_duration"`
+
+	// Timeout the time to wait after the failure threshold is met before sending a test request
+	Timeout time.Duration `mapstructure:"timeout"`
+
+	// Uncomment for exponential backoff
+	// // RandomizationFactor is a random factor used to calculate next backoffs
+	// // Randomized interval = RetryInterval * (1 ± RandomizationFactor)
+	// RandomizationFactor float64 `mapstructure:"randomization_factor"`
+	// // Multiplier is the value multiplied by the backoff interval bounds
+	// Multiplier float64 `mapstructure:"multiplier"`
+	// // MaxInterval is the upper bound on backoff interval. Once this value is reached the delay between
+	// // consecutive retries will always be `MaxInterval`.
+	// MaxInterval time.Duration `mapstructure:"max_interval"`
+	// // MaxElapsedTime is the maximum amount of time (including retries) spent trying to send a request/batch.
+	// // Once this value is reached, the data is discarded.
+	// MaxElapsedTime time.Duration `mapstructure:"max_elapsed_time"`
+}
+
+func NewDefaultBreakerSettings() BreakerSettings {
+	return BreakerSettings{
+		Enabled:           true,
+		FailureThreshold:  5,
+		ThresholdDuration: 30 * time.Second,
+		Timeout:           5 * time.Second,
+
+		// Uncomment for exponential backoff
+		// InitialInterval:     5 * time.Second,
+		// RandomizationFactor: backoff.DefaultRandomizationFactor,
+		// Multiplier:          backoff.DefaultMultiplier,
+		// MaxInterval:         30 * time.Second,
+		// MaxElapsedTime:      5 * time.Minute,
+	}
+}
+
 // Config defines configuration for Splunk exporter.
 type Config struct {
 	confighttp.HTTPClientSettings `mapstructure:",squash"`
 	exporterhelper.QueueSettings  `mapstructure:"sending_queue"`
 	exporterhelper.RetrySettings  `mapstructure:"retry_on_failure"`
+	BreakerSettings               `mapstructure:"circuit_breaker"`
+
+	FailoverEndpoint string `mapstructure:"failover_endpoint"`
 
 	// LogDataEnabled can be used to disable sending logs by the exporter.
 	LogDataEnabled bool `mapstructure:"log_data_enabled"`
@@ -141,6 +183,24 @@ func (cfg *Config) getURL() (out *url.URL, err error) {
 	if err != nil {
 		return out, err
 	}
+	if out.Path == "" || out.Path == "/" {
+		out.Path = path.Join(out.Path, hecPath)
+	}
+
+	return
+}
+
+func (cfg *Config) getFailoverURL() (out *url.URL) {
+
+	if cfg.FailoverEndpoint == "" {
+		return nil
+	}
+
+	out, err := url.Parse(cfg.FailoverEndpoint)
+	if err != nil {
+		return nil
+	}
+
 	if out.Path == "" || out.Path == "/" {
 		out.Path = path.Join(out.Path, hecPath)
 	}

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -87,6 +87,12 @@ func TestLoadConfig(t *testing.T) {
 					NumConsumers: 2,
 					QueueSize:    10,
 				},
+				BreakerSettings: BreakerSettings{
+					Enabled:           true,
+					FailureThreshold:  5,
+					ThresholdDuration: 30 * time.Second,
+					Timeout:           5 * time.Second,
+				},
 				HecToOtelAttrs: splunk.HecToOtelAttrs{
 					Source:     "mysource",
 					SourceType: "mysourcetype",

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -63,6 +63,7 @@ func createDefaultConfig() component.Config {
 		SplunkAppName:           defaultSplunkAppName,
 		RetrySettings:           exporterhelper.NewDefaultRetrySettings(),
 		QueueSettings:           exporterhelper.NewDefaultQueueSettings(),
+		BreakerSettings:         NewDefaultBreakerSettings(),
 		DisableCompression:      false,
 		MaxContentLengthLogs:    defaultContentLengthLogsLimit,
 		MaxContentLengthMetrics: defaultContentLengthMetricsLimit,

--- a/exporter/splunkhecexporter/hec_worker.go
+++ b/exporter/splunkhecexporter/hec_worker.go
@@ -5,31 +5,170 @@ package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
+	"time"
 
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
 
+type BreakerState int
+
+const (
+	Open BreakerState = iota
+	HalfOpen
+	Closed
+)
+
 type hecWorker interface {
-	send(context.Context, buffer, map[string]string) error
+	send(context.Context, buffer, map[string]string, bool) error
+}
+
+type CircuitBreaker struct {
+	enabled           bool
+	currentState      BreakerState
+	timeout           time.Duration
+	threshold         uint32
+	thresholdDuration time.Duration
+	failures          uint32
+	lastFailure       time.Time
+	breakerOpened     time.Time
+	mutex             sync.Mutex
+	logger            *zap.Logger
+}
+
+func (cb *CircuitBreaker) canExecute(failover bool) bool {
+
+	if !cb.enabled {
+		return true
+	}
+
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+	if cb.currentState == Open && !cb.breakerOpened.IsZero() && time.Now().After(cb.breakerOpened.Add(cb.timeout)) {
+		cb.logger.Info("Breaker Half Open.", zap.Bool("failover", failover))
+		cb.currentState = HalfOpen
+	} else if cb.currentState == Closed && !cb.lastFailure.IsZero() && time.Now().After(cb.lastFailure.Add(cb.thresholdDuration)) {
+		cb.logger.Info("Reset Last Failure.", zap.Bool("failover", failover))
+		cb.failures = 0
+		cb.lastFailure = time.Time{}
+	}
+
+	return cb.currentState != Open
+}
+
+func (cb *CircuitBreaker) updateState(successfulRequest bool, failover bool) {
+
+	if !cb.enabled || cb.threshold == 0 {
+		return
+	}
+
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+	if successfulRequest {
+		if cb.currentState == HalfOpen {
+			cb.logger.Info("Breaker Closed.", zap.Bool("failover", failover))
+			cb.currentState = Closed
+			cb.breakerOpened = time.Time{}
+			cb.lastFailure = time.Time{}
+		}
+	} else {
+		now := time.Now()
+		cb.lastFailure = now
+		if cb.currentState == HalfOpen {
+			cb.logger.Info("Breaker Open.", zap.Uint32("threshold", cb.threshold), zap.Uint32("failures", cb.failures), zap.Bool("failover", failover))
+			cb.currentState = Open
+			cb.breakerOpened = now
+		} else if cb.currentState == Closed {
+			cb.failures++
+			if cb.failures > cb.threshold {
+				cb.logger.Info("Breaker Open.", zap.Uint32("threshold", cb.threshold), zap.Uint32("failures", cb.failures), zap.Bool("failover", failover))
+				cb.currentState = Open
+				cb.breakerOpened = now
+			}
+		}
+	}
 }
 
 type defaultHecWorker struct {
-	url     *url.URL
-	client  *http.Client
-	headers map[string]string
+	url             *url.URL
+	client          *http.Client
+	headers         map[string]string
+	logger          *zap.Logger
+	primaryBreaker  *CircuitBreaker
+	failoverURL     *url.URL
+	failoverBreaker *CircuitBreaker
 }
 
-func (hec *defaultHecWorker) send(ctx context.Context, buf buffer, headers map[string]string) error {
-	req, err := http.NewRequestWithContext(ctx, "POST", hec.url.String(), buf)
+func NewDefaultHecWorker(primaryURL *url.URL, failoverURL *url.URL, breakerConfig BreakerSettings, client *http.Client, headers map[string]string, logger *zap.Logger) hecWorker {
+	logger.Info("Breaker Settings", zap.Any("bs", breakerConfig))
+	return &defaultHecWorker{
+		url:         primaryURL,
+		failoverURL: failoverURL,
+		client:      client,
+		headers:     headers,
+		logger:      logger,
+		primaryBreaker: &CircuitBreaker{
+			enabled:           breakerConfig.Enabled,
+			currentState:      Closed,
+			timeout:           breakerConfig.Timeout,
+			threshold:         breakerConfig.FailureThreshold,
+			thresholdDuration: breakerConfig.ThresholdDuration,
+			failures:          0,
+			lastFailure:       time.Time{},
+			breakerOpened:     time.Time{},
+			logger:            logger,
+		},
+		failoverBreaker: &CircuitBreaker{
+			enabled:           breakerConfig.Enabled,
+			currentState:      Closed,
+			timeout:           breakerConfig.Timeout,
+			threshold:         breakerConfig.FailureThreshold,
+			thresholdDuration: breakerConfig.ThresholdDuration,
+			failures:          0,
+			lastFailure:       time.Time{},
+			breakerOpened:     time.Time{},
+			logger:            logger,
+		},
+	}
+}
+
+func (hec *defaultHecWorker) send(ctx context.Context, buf buffer, headers map[string]string, failover bool) error {
+
+	if !failover && hec.primaryBreaker != nil && !hec.primaryBreaker.canExecute(false) {
+		hec.logger.Info("Primary Breaker Open!")
+		return fmt.Errorf("primary breaker open")
+	} else if failover && hec.failoverBreaker != nil && !hec.failoverBreaker.canExecute(true) {
+		hec.logger.Info("Failover Breaker Open!")
+		return fmt.Errorf("failover breaker open")
+	}
+
+	reqURL := hec.url.String()
+	if failover {
+		if hec.failoverURL == nil {
+			return nil
+		}
+
+		hec.logger.Info("Sending Failover Request")
+		reqURL = hec.failoverURL.String()
+	} else {
+		hec.logger.Info("Sending Request")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", reqURL, buf)
 	if err != nil {
+		hec.logger.Info("Get Request Error!", zap.Error(err))
+		hec.updateState(false, failover)
 		return consumererror.NewPermanent(err)
 	}
+
 	req.ContentLength = int64(buf.Len())
 
 	// Set the headers configured for the client
@@ -46,14 +185,18 @@ func (hec *defaultHecWorker) send(ctx context.Context, buf buffer, headers map[s
 		req.Header.Set("Content-Encoding", "gzip")
 	}
 
-	resp, err := hec.client.Do(req)
-	if err != nil {
-		return err
+	resp, respErr := hec.client.Do(req)
+	if respErr != nil {
+		hec.logger.Info("Response Error!", zap.Error(respErr))
+		hec.updateState(false, failover)
+		return respErr
 	}
 	defer resp.Body.Close()
 
 	err = splunk.HandleHTTPCode(resp)
 	if err != nil {
+		hec.logger.Info("Status Error!", zap.Error((err)))
+		hec.updateState(false, failover)
 		return err
 	}
 
@@ -64,7 +207,18 @@ func (hec *defaultHecWorker) send(ctx context.Context, buf buffer, headers map[s
 		_, errCopy := io.Copy(io.Discard, resp.Body)
 		err = multierr.Combine(err, errCopy)
 	}
+
+	hec.logger.Info("Successful Request!", zap.Bool("failover", failover))
+	hec.updateState(true, failover)
 	return err
+}
+
+func (hec *defaultHecWorker) updateState(success bool, failover bool) {
+	if !failover && hec.primaryBreaker != nil {
+		hec.primaryBreaker.updateState(success, failover)
+	} else if failover && hec.failoverBreaker != nil {
+		hec.failoverBreaker.updateState(success, failover)
+	}
 }
 
 var _ hecWorker = &defaultHecWorker{}

--- a/exporter/splunkhecexporter/hec_worker_test.go
+++ b/exporter/splunkhecexporter/hec_worker_test.go
@@ -14,7 +14,7 @@ type mockHecWorker struct {
 	failSend bool
 }
 
-func (m *mockHecWorker) send(_ context.Context, _ buffer, _ map[string]string) error {
+func (m *mockHecWorker) send(_ context.Context, _ buffer, _ map[string]string, _ bool) error {
 	if m.failSend {
 		return errHecSendFailed
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Add the ability to specify an alternative Splunk HEC Endpoint when the primary endpoint is failing.  In addition, if failures are occurring on a regular basis allow each endpoint to be disabled with a Circuit Breaker pattern.

**Link to tracking Issue:**
[23821](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23821)

**Testing:**
Testing locally by setting a primary endpoint that would always fail and a secondary that would fail or succeed.  Working on testing end-to-end in Test Environment.

**Documentation:**
Not completed yet.