### PR TITLE
[chore] make codecov upload retrying more resilient

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -298,8 +298,8 @@ jobs:
           with: |
             fail_ci_if_error: true
             verbose: true
-          attempt_limit: 5
-          attempt_delay: 10000
+          attempt_limit: 10
+          attempt_delay: 15000
 
   integration-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Move from retrying 5 times to retrying 10 times, and delays between retries from 10 to 15s.

This is based off the recent failures witnessed here:
https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/5416168149/jobs/9845939438?pr=23845