### PR TITLE
[exporter/loki] Add setting default_labels_enabled to the config

### DIFF
--- a/.chloggen/add-default-labels-enabled-lokiexporter.yaml
+++ b/.chloggen/add-default-labels-enabled-lokiexporter.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: lokiexporter, lokitranslator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added setting `default_labels_enabled`. This setting allows to make default labels `exporter`, `job`, `instance`, `level` optional
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22156]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/lokiexporter/README.md
+++ b/exporter/lokiexporter/README.md
@@ -22,7 +22,8 @@ The following settings are required:
 - `default_labels_enabled` (optional): The map that allows to disable default labels: `exporter`, `job`, `instance`, `level`. 
 If `default_labels_enabled` is omitted then default labels will be added. If one of the labels is omitted in `default_labels_enabled` then this label will be added.
 **Important to remember**: 
-If all default labels are disabled and there are no other labels added then the log entry would be dropped because at least one label should be present to successfully put the log record into Loki 
+If all default labels are disabled and there are no other labels added then the log entry would be dropped because at least one label should be present to successfully put the log record into Loki.
+The metric `otelcol_lokiexporter_send_failed_due_to_missing_labels` shows how many log records were dropped because no labels were specified 
 
 Example:
 ```yaml

--- a/exporter/lokiexporter/README.md
+++ b/exporter/lokiexporter/README.md
@@ -19,12 +19,19 @@ Exports data via HTTP to [Loki](https://grafana.com/docs/loki/latest/).
 The following settings are required:
 
 - `endpoint` (no default): The target URL to send Loki log streams to (e.g.: `http://loki:3100/loki/api/v1/push`).
+- `default_labels_enabled` (optional): The map that allows to disable default labels: `exporter`, `job`, `instance`, `level`. 
+If `default_labels_enabled` is omitted then default labels will be added. If one of the labels is omitted in `default_labels_enabled` then this label will be added.
+**Important to remember**: 
+If all default labels are disabled and there are no other labels added then the log entry would be dropped because at least one label should be present to successfully put the log record into Loki 
 
 Example:
 ```yaml
 exporters:
   loki:
     endpoint: https://loki.example.com:3100/loki/api/v1/push
+    default_labels_enabled:
+      exporter: false
+      job: true
 ```
 
 ## Configuration via attribute hints
@@ -70,12 +77,11 @@ processors:
         value: service.name, service.namespace
 ```
 
-Default labels:
+Default labels are always set unless they are disabled with `default_labels_enabled` setting:
 - `job=service.namespace/service.name`
 - `instance=service.instance.id`
 - `exporter=OTLP`
-
-`exporter=OTLP` is always set.
+- `level=severity`
 
 If `service.name` and `service.namespace` are present then `job=service.namespace/service.name` is set
 

--- a/exporter/lokiexporter/config.go
+++ b/exporter/lokiexporter/config.go
@@ -16,6 +16,8 @@ type Config struct {
 	confighttp.HTTPClientSettings `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct.
 	exporterhelper.QueueSettings  `mapstructure:"sending_queue"`
 	exporterhelper.RetrySettings  `mapstructure:"retry_on_failure"`
+
+	DefaultLabelsEnabled map[string]bool `mapstructure:"default_labels_enabled"`
 }
 
 func (c *Config) Validate() error {

--- a/exporter/lokiexporter/config_test.go
+++ b/exporter/lokiexporter/config_test.go
@@ -65,6 +65,12 @@ func TestLoadConfigNewExporter(t *testing.T) {
 					NumConsumers: 2,
 					QueueSize:    10,
 				},
+				DefaultLabelsEnabled: map[string]bool{
+					"exporter": false,
+					"job":      true,
+					"instance": true,
+					"level":    false,
+				},
 			},
 		},
 	}

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -44,7 +44,7 @@ func newExporter(config *Config, settings component.TelemetrySettings) *lokiExpo
 }
 
 func (l *lokiExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
-	requests := loki.LogsToLokiRequests(ld)
+	requests := loki.LogsToLokiRequests(ld, l.config.DefaultLabelsEnabled)
 
 	var errs error
 	for tenant, request := range requests {

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"go.opencensus.io/stats"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -24,7 +26,8 @@ import (
 )
 
 const (
-	maxErrMsgLen = 1024
+	maxErrMsgLen          = 1024
+	missingLabelsErrorMsg = "error at least one label pair is required per stream"
 )
 
 type lokiExporter struct {
@@ -49,6 +52,10 @@ func (l *lokiExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
 	var errs error
 	for tenant, request := range requests {
 		err := l.sendPushRequest(ctx, tenant, request, ld)
+		if isErrMissingLabels(err) {
+			stats.Record(ctx, lokiExporterFailedToSendLogRecordsDueToMissingLabels.M(int64(ld.LogRecordCount())))
+		}
+
 		errs = multierr.Append(errs, err)
 	}
 
@@ -141,4 +148,11 @@ func (l *lokiExporter) start(_ context.Context, host component.Host) (err error)
 func (l *lokiExporter) stop(context.Context) (err error) {
 	l.wg.Wait()
 	return nil
+}
+
+func isErrMissingLabels(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), missingLabelsErrorMsg)
 }

--- a/exporter/lokiexporter/factory.go
+++ b/exporter/lokiexporter/factory.go
@@ -38,6 +38,12 @@ func createDefaultConfig() component.Config {
 		},
 		RetrySettings: exporterhelper.NewDefaultRetrySettings(),
 		QueueSettings: exporterhelper.NewDefaultQueueSettings(),
+		DefaultLabelsEnabled: map[string]bool{
+			"exporter": true,
+			"job":      true,
+			"instance": true,
+			"level":    true,
+		},
 	}
 }
 

--- a/exporter/lokiexporter/factory.go
+++ b/exporter/lokiexporter/factory.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"time"
 
+	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
@@ -20,6 +21,8 @@ import (
 
 // NewFactory creates a factory for the legacy Loki exporter.
 func NewFactory() exporter.Factory {
+	_ = view.Register(MetricViews()...)
+
 	return exporter.NewFactory(
 		metadata.Type,
 		createDefaultConfig,

--- a/exporter/lokiexporter/go.mod
+++ b/exporter/lokiexporter/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.81.0
 	github.com/prometheus/common v0.44.0
 	github.com/stretchr/testify v1.8.4
+	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector v0.81.0
 	go.opentelemetry.io/collector/component v0.81.0
 	go.opentelemetry.io/collector/config/confighttp v0.81.0
@@ -55,7 +56,6 @@ require (
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/prometheus/prometheus v0.43.1 // indirect
 	github.com/rs/cors v1.9.0 // indirect
-	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.81.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v0.81.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.81.0 // indirect

--- a/exporter/lokiexporter/metrics.go
+++ b/exporter/lokiexporter/metrics.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package lokiexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter"
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+var (
+	lokiExporterFailedToSendLogRecordsDueToMissingLabels = stats.Int64("lokiexporter_send_failed_due_to_missing_labels", "Number of log records failed to send because labels were missing", stats.UnitDimensionless)
+)
+
+func MetricViews() []*view.View {
+	return []*view.View{
+		{
+			Name:        "lokiexporter_send_failed_due_to_missing_labels",
+			Description: "Number of log records failed to send because labels were missing",
+			Measure:     lokiExporterFailedToSendLogRecordsDueToMissingLabels,
+			Aggregation: view.Count(),
+		},
+	}
+}

--- a/exporter/lokiexporter/testdata/config.yaml
+++ b/exporter/lokiexporter/testdata/config.yaml
@@ -21,3 +21,6 @@ loki/allsettings:
     max_elapsed_time: 10m
   headers:
     "X-Custom-Header": "loki_rocks"
+  default_labels_enabled:
+    exporter: false
+    level: false

--- a/pkg/translator/loki/convert.go
+++ b/pkg/translator/loki/convert.go
@@ -27,17 +27,13 @@ const (
 	formatRaw    string = "raw"
 )
 
-func convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs pcommon.Map) model.LabelSet {
-	out := model.LabelSet{"exporter": "OTLP"}
+const (
+	exporterLabel string = "exporter"
+	levelLabel    string = "level"
+)
 
-	// Map service.namespace + service.name to job
-	if job, ok := extractJob(resAttrs); ok {
-		out[model.JobLabel] = model.LabelValue(job)
-	}
-	// Map service.instance.id to instance
-	if instance, ok := extractInstance(resAttrs); ok {
-		out[model.InstanceLabel] = model.LabelValue(instance)
-	}
+func convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs pcommon.Map, defaultLabelsEnabled map[string]bool) model.LabelSet {
+	out := getDefaultLabels(resAttrs, defaultLabelsEnabled)
 
 	if resourcesToLabel, found := resAttrs.Get(hintResources); found {
 		labels := convertAttributesToLabels(resAttrs, resourcesToLabel)
@@ -69,6 +65,28 @@ func convertAttributesAndMerge(logAttrs pcommon.Map, resAttrs pcommon.Map) model
 		out = out.Merge(labels)
 	}
 
+	return out
+}
+
+func getDefaultLabels(resAttrs pcommon.Map, defaultLabelsEnabled map[string]bool) model.LabelSet {
+	out := model.LabelSet{}
+	if enabled, ok := defaultLabelsEnabled[exporterLabel]; enabled || !ok {
+		out[model.LabelName(exporterLabel)] = "OTLP"
+	}
+
+	if enabled, ok := defaultLabelsEnabled[model.JobLabel]; enabled || !ok {
+		// Map service.namespace + service.name to job
+		if job, ok := extractJob(resAttrs); ok {
+			out[model.JobLabel] = model.LabelValue(job)
+		}
+	}
+
+	if enabled, ok := defaultLabelsEnabled[model.InstanceLabel]; enabled || !ok {
+		// Map service.instance.id to instance
+		if instance, ok := extractInstance(resAttrs); ok {
+			out[model.InstanceLabel] = model.LabelValue(instance)
+		}
+	}
 	return out
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Added new setting `default_labels_enabled` into the loki exporter config.
When this setting is passed loki exporter will not set default labels if the setting value is false, for example:

```
loki:
  endpoint: ...
  default_labels_enabled:
    job: true
    instance: false
    exporter: false
    level: false
```
In this example, only the `job` label will be added, `instance`, `exporter`, and `level` will not be added as Loki labels.

If `default_labels_enabled` is omitted the current behavior will be applied: default labels will be added (exporter, job, instance, label)
If one of the labels is omitted in `default_labels_enabled` then the current behavior will be applied: this label will be added

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22156

**Testing:** unit tests added

**Documentation:** README updated