### PR TITLE
Make sed replace statements more resilient

### DIFF
--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -30,8 +30,11 @@ find . -name "*.bak" -type f -delete
 git add versions.yaml
 git commit -m "update version.yaml ${CANDIDATE_BETA}"
 
-sed -i.bak "s/${CURRENT_BETA}/${CANDIDATE_BETA}/g" ./cmd/oteltestbedcol/builder-config.yaml
-sed -i.bak "s/${CURRENT_BETA}/${CANDIDATE_BETA}/g" ./cmd/otelcontribcol/builder-config.yaml
+sed -i.bak "s/v${CURRENT_BETA}/v${CANDIDATE_BETA}/g" ./cmd/oteltestbedcol/builder-config.yaml
+sed -i.bak "s/v${CURRENT_BETA}/v${CANDIDATE_BETA}/g" ./cmd/otelcontribcol/builder-config.yaml
+sed -i.bak "s/${CURRENT_BETA}-dev/${CANDIDATE_BETA}-dev/g" ./cmd/otelcontribcol/builder-config.yaml
+sed -i.bak "s/${CURRENT_BETA}-dev/${CANDIDATE_BETA}-dev/g" ./cmd/oteltestbedcol/builder-config.yaml
+
 find . -name "*.bak" -type f -delete
 make genotelcontribcol
 make genoteltestbedcol


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

While working on open-telemetry/opentelemetry-collector/issues/8033, I got the following error ([full logs](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/5461142477/jobs/9938863136)):

```
github.com/open-telemetry/opentelemetry-collector-contrib/cmd/otelcontribcol imports
	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver imports
	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/collection imports
	github.com/openshift/api/quota/v1: reading github.com/openshift/api/go.mod at revision v0.0.0-20.81.01171038-322a19404e37: unknown revision v0.0.0-20.81.01171038-322a19404e37
```

This is because the script for preparing releases has the following sed statement: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/10e46605b7b9f775a3658f4e2ba59960ffe33847/cmd/otelcontribcol/builder-config.yaml#L416
which ends up replacing `018080` within the `openshift/api` pseudoversion by `0.81.0`.

To work around this, we make the replace statements more specific. An alternative would be something like https://stackoverflow.com/a/2705678, but this approach is still broken if a dependency we are replacing has exactly the version we are updating from, so I think ultimately we need a different approach.

**Testing:** I tested this on https://github.com/mx-psi/opentelemetry-collector-contrib/actions/runs/5462095129/jobs/9940974190; the job is able to run until the point of creating the PR, where it fails because the bot account does not have permission to create a PR.