### PR TITLE
Revert "[chore] Remove skip flaky test for hostmetricsreceiver"

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
@@ -27,7 +27,13 @@ const (
 	bootTime     = 100
 )
 
+// Skips test without applying unused rule
+var skip = func(t *testing.T, why string) {
+	t.Skip(why)
+}
+
 func TestScrape(t *testing.T) {
+	skip(t, "Flaky test. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10030")
 	type testCase struct {
 		name         string
 		bootTimeFunc func() (uint64, error)


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#23874. The test is still flaky on Windows.