### PR TITLE
[fileconsumer] Move fingerprint into internal package

### DIFF
--- a/.chloggen/fileconsumer-internal.yaml
+++ b/.chloggen/fileconsumer-internal.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make fileconsumer.Fingerprint internal
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23998]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -108,7 +109,7 @@ func BenchmarkFileInput(b *testing.B) {
 				cfg.Include = []string{
 					"file*.log",
 				}
-				cfg.FingerprintSize = 10 * DefaultFingerprintSize
+				cfg.FingerprintSize = 10 * fingerprint.DefaultSize
 				return cfg
 			},
 		},
@@ -122,7 +123,7 @@ func BenchmarkFileInput(b *testing.B) {
 				cfg.Include = []string{
 					"file*.log",
 				}
-				cfg.FingerprintSize = DefaultFingerprintSize / 10
+				cfg.FingerprintSize = fingerprint.DefaultSize / 10
 				return cfg
 			},
 		},

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
@@ -45,7 +46,7 @@ func NewConfig() *Config {
 		PollInterval:            200 * time.Millisecond,
 		Splitter:                helper.NewSplitterConfig(),
 		StartAt:                 "end",
-		FingerprintSize:         DefaultFingerprintSize,
+		FingerprintSize:         fingerprint.DefaultSize,
 		MaxLogSize:              defaultMaxLogSize,
 		MaxConcurrentFiles:      defaultMaxConcurrentFiles,
 		MaxBatches:              0,
@@ -205,8 +206,8 @@ func (c Config) validate() error {
 		return fmt.Errorf("`max_concurrent_files` must be greater than 1")
 	}
 
-	if c.FingerprintSize < MinFingerprintSize {
-		return fmt.Errorf("`fingerprint_size` must be at least %d bytes", MinFingerprintSize)
+	if c.FingerprintSize < fingerprint.MinSize {
+		return fmt.Errorf("`fingerprint_size` must be at least %d bytes", fingerprint.MinSize)
 	}
 
 	if c.DeleteAfterRead && c.StartAt == "end" {

--- a/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint.go
+++ b/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
+package fingerprint // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 
 import (
 	"bytes"
@@ -11,24 +11,18 @@ import (
 	"os"
 )
 
-// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
-const DefaultFingerprintSize = 1000 // bytes
+const DefaultSize = 1000 // bytes
 
-// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
-const MinFingerprintSize = 16 // bytes
+const MinSize = 16 // bytes
 
 // Fingerprint is used to identify a file
 // A file's fingerprint is the first N bytes of the file
-//
-// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
 type Fingerprint struct {
 	FirstBytes []byte
 }
 
-// NewFingerprint creates a new fingerprint from an open file
-//
-// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
-func NewFingerprint(file *os.File, size int) (*Fingerprint, error) {
+// New creates a new fingerprint from an open file
+func New(file *os.File, size int) (*Fingerprint, error) {
 	buf := make([]byte, size)
 
 	n, err := file.ReadAt(buf, 0)

--- a/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
+++ b/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
@@ -1,19 +1,18 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package fileconsumer
+package fingerprint
 
 import (
 	"fmt"
 	"math/rand"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewFingerprintDoesNotModifyOffset(t *testing.T) {
+func TestNewDoesNotModifyOffset(t *testing.T) {
 	fingerprint := "this is the fingerprint"
 	next := "this comes after the fingerprint and is substantially longer than the fingerprint"
 	extra := "fin"
@@ -21,15 +20,11 @@ func TestNewFingerprintDoesNotModifyOffset(t *testing.T) {
 	fileContents := fmt.Sprintf("%s%s%s\n", fingerprint, next, extra)
 
 	tempDir := t.TempDir()
-	cfg := NewConfig().includeDir(tempDir)
-	cfg.StartAt = "beginning"
-	operator, _ := buildTestManager(t, cfg)
+	temp, err := os.CreateTemp(tempDir, "")
+	require.NoError(t, err)
 
-	operator.readerFactory.readerConfig.fingerprintSize = len(fingerprint)
-
-	// Create a new file
-	temp := openTemp(t, tempDir)
-	writeString(t, temp, fileContents)
+	_, err = temp.WriteString(fileContents)
+	require.NoError(t, err)
 
 	// Validate that the file is actually the expected size after writing
 	info, err := temp.Stat()
@@ -40,7 +35,7 @@ func TestNewFingerprintDoesNotModifyOffset(t *testing.T) {
 	_, err = temp.Seek(0, 0)
 	require.NoError(t, err)
 
-	fp, err := operator.readerFactory.newFingerprint(temp)
+	fp, err := New(temp, len(fingerprint))
 	require.NoError(t, err)
 
 	// Validate the fingerprint is the correct size
@@ -55,7 +50,7 @@ func TestNewFingerprintDoesNotModifyOffset(t *testing.T) {
 	require.Equal(t, fileContents[:len(allButExtra)], string(allButExtra))
 }
 
-func TestNewFingerprint(t *testing.T) {
+func TestNew(t *testing.T) {
 	cases := []struct {
 		name            string
 		fingerprintSize int
@@ -64,39 +59,39 @@ func TestNewFingerprint(t *testing.T) {
 	}{
 		{
 			name:            "defaultExactFileSize",
-			fingerprintSize: DefaultFingerprintSize,
-			fileSize:        DefaultFingerprintSize,
-			expectedLen:     DefaultFingerprintSize,
+			fingerprintSize: DefaultSize,
+			fileSize:        DefaultSize,
+			expectedLen:     DefaultSize,
 		},
 		{
 			name:            "defaultWithFileHalfOfFingerprint",
-			fingerprintSize: DefaultFingerprintSize,
-			fileSize:        DefaultFingerprintSize / 2,
-			expectedLen:     DefaultFingerprintSize / 2,
+			fingerprintSize: DefaultSize,
+			fileSize:        DefaultSize / 2,
+			expectedLen:     DefaultSize / 2,
 		},
 		{
 			name:            "defaultWithFileTwiceFingerprint",
-			fingerprintSize: DefaultFingerprintSize,
-			fileSize:        DefaultFingerprintSize * 2,
-			expectedLen:     DefaultFingerprintSize,
+			fingerprintSize: DefaultSize,
+			fileSize:        DefaultSize * 2,
+			expectedLen:     DefaultSize,
 		},
 		{
 			name:            "minFingerprintExactFileSize",
-			fingerprintSize: MinFingerprintSize,
-			fileSize:        MinFingerprintSize,
-			expectedLen:     MinFingerprintSize,
+			fingerprintSize: MinSize,
+			fileSize:        MinSize,
+			expectedLen:     MinSize,
 		},
 		{
 			name:            "minFingerprintWithSmallerFileSize",
-			fingerprintSize: MinFingerprintSize,
-			fileSize:        MinFingerprintSize / 2,
-			expectedLen:     MinFingerprintSize / 2,
+			fingerprintSize: MinSize,
+			fileSize:        MinSize / 2,
+			expectedLen:     MinSize / 2,
 		},
 		{
 			name:            "minFingerprintWithLargerFileSize",
-			fingerprintSize: MinFingerprintSize,
-			fileSize:        DefaultFingerprintSize,
-			expectedLen:     MinFingerprintSize,
+			fingerprintSize: MinSize,
+			fileSize:        DefaultSize,
+			expectedLen:     MinSize,
 		},
 		{
 			name:            "largeFingerprintSmallFile",
@@ -117,22 +112,18 @@ func TestNewFingerprint(t *testing.T) {
 			t.Parallel()
 
 			tempDir := t.TempDir()
-			cfg := NewConfig().includeDir(tempDir)
-			cfg.StartAt = "beginning"
-			operator, _ := buildTestManager(t, cfg)
+			temp, err := os.CreateTemp(tempDir, "")
+			require.NoError(t, err)
 
-			operator.readerFactory.readerConfig.fingerprintSize = tc.fingerprintSize
-
-			// Create a new file
-			temp := openTemp(t, tempDir)
-			writeString(t, temp, string(tokenWithLength(tc.fileSize)))
+			_, err = temp.WriteString(string(tokenWithLength(tc.fileSize)))
+			require.NoError(t, err)
 
 			// Validate that the file is actually the expected size after writing
 			info, err := temp.Stat()
 			require.NoError(t, err)
 			require.Equal(t, tc.fileSize, int(info.Size()))
 
-			fp, err := operator.readerFactory.newFingerprint(temp)
+			fp, err := New(temp, tc.fingerprintSize)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expectedLen, len(fp.FirstBytes))
@@ -146,8 +137,8 @@ func TestFingerprintCopy(t *testing.T) {
 		"",
 		"hello",
 		"asdfsfaddsfas",
-		string(tokenWithLength(MinFingerprintSize)),
-		string(tokenWithLength(DefaultFingerprintSize)),
+		string(tokenWithLength(MinSize)),
+		string(tokenWithLength(DefaultSize)),
 		string(tokenWithLength(1234)),
 	}
 
@@ -174,43 +165,23 @@ func TestFingerprintCopy(t *testing.T) {
 }
 
 func TestFingerprintStartsWith(t *testing.T) {
-	cases := []struct {
-		name string
-		a    string
-		b    string
-	}{
-		{
-			name: "same",
-			a:    "hello",
-			b:    "hello",
-		},
-		{
-			name: "aStartsWithB",
-			a:    "helloworld",
-			b:    "hello",
-		},
-		{
-			name: "bStartsWithA",
-			a:    "hello",
-			b:    "helloworld",
-		},
-		{
-			name: "neither",
-			a:    "hello",
-			b:    "world",
-		},
-	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			fa := &Fingerprint{FirstBytes: []byte(tc.a)}
-			fb := &Fingerprint{FirstBytes: []byte(tc.b)}
+	empty := &Fingerprint{FirstBytes: []byte("")}
+	hello := &Fingerprint{FirstBytes: []byte("hello")}
+	world := &Fingerprint{FirstBytes: []byte("world")}
+	helloworld := &Fingerprint{FirstBytes: []byte("helloworld")}
 
-			require.Equal(t, strings.HasPrefix(tc.a, tc.b), fa.StartsWith(fb))
-			require.Equal(t, strings.HasPrefix(tc.b, tc.a), fb.StartsWith(fa))
-		})
-	}
+	// Empty never matches
+	require.False(t, hello.StartsWith(empty))
+	require.False(t, empty.StartsWith(hello))
+
+	require.True(t, hello.StartsWith(hello))
+	require.False(t, hello.StartsWith(helloworld))
+
+	require.True(t, helloworld.StartsWith(hello))
+	require.True(t, helloworld.StartsWith(helloworld))
+	require.False(t, helloworld.StartsWith(world))
+
 }
 
 // Generates a file filled with many random bytes, then
@@ -222,15 +193,10 @@ func TestFingerprintStartsWith(t *testing.T) {
 // a possible state of the same file at a previous time.
 func TestFingerprintStartsWith_FromFile(t *testing.T) {
 	r := rand.New(rand.NewSource(112358))
+	fingerprintSize := 10
+	fileLength := 12 * fingerprintSize
 
 	tempDir := t.TempDir()
-	cfg := NewConfig().includeDir(tempDir)
-	cfg.StartAt = "beginning"
-	operator, _ := buildTestManager(t, cfg)
-
-	operator.readerFactory.readerConfig.fingerprintSize *= 10
-
-	fileLength := 12 * operator.readerFactory.readerConfig.fingerprintSize
 
 	// Make a []byte we can write one at a time
 	content := make([]byte, fileLength)
@@ -253,7 +219,7 @@ func TestFingerprintStartsWith_FromFile(t *testing.T) {
 	_, err = fullFile.Write(content)
 	require.NoError(t, err)
 
-	fff, err := operator.readerFactory.newFingerprint(fullFile)
+	fff, err := New(fullFile, fingerprintSize)
 	require.NoError(t, err)
 
 	partialFile, err := os.CreateTemp(tempDir, "")
@@ -271,11 +237,18 @@ func TestFingerprintStartsWith_FromFile(t *testing.T) {
 		_, err = partialFile.Write(content[i:i])
 		require.NoError(t, err)
 
-		pff, err := operator.readerFactory.newFingerprint(partialFile)
+		pff, err := New(partialFile, fingerprintSize)
 		require.NoError(t, err)
 
 		require.True(t, fff.StartsWith(pff))
 	}
 }
 
-// TODO TestConfig (config_test.go) - sets defaults, errors appropriately, etc
+func tokenWithLength(length int) []byte {
+	charset := "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return b
+}

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/pipeline"
 )
@@ -33,7 +34,7 @@ type Reader struct {
 	encoding      helper.Encoding
 	processFunc   EmitFunc
 
-	Fingerprint    *Fingerprint
+	Fingerprint    *fingerprint.Fingerprint
 	Offset         int64
 	generation     int
 	file           *os.File

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/pipeline"
 )
@@ -24,7 +25,7 @@ type readerFactory struct {
 	headerSettings  *headerSettings
 }
 
-func (f *readerFactory) newReader(file *os.File, fp *Fingerprint) (*Reader, error) {
+func (f *readerFactory) newReader(file *os.File, fp *fingerprint.Fingerprint) (*Reader, error) {
 	return f.newReaderBuilder().
 		withFile(file).
 		withFingerprint(fp).
@@ -47,14 +48,14 @@ func (f *readerFactory) unsafeReader() (*Reader, error) {
 	return f.newReaderBuilder().build()
 }
 
-func (f *readerFactory) newFingerprint(file *os.File) (*Fingerprint, error) {
-	return NewFingerprint(file, f.readerConfig.fingerprintSize)
+func (f *readerFactory) newFingerprint(file *os.File) (*fingerprint.Fingerprint, error) {
+	return fingerprint.New(file, f.readerConfig.fingerprintSize)
 }
 
 type readerBuilder struct {
 	*readerFactory
 	file             *os.File
-	fp               *Fingerprint
+	fp               *fingerprint.Fingerprint
 	offset           int64
 	splitFunc        bufio.SplitFunc
 	headerFinalized  bool
@@ -75,7 +76,7 @@ func (b *readerBuilder) withFile(f *os.File) *readerBuilder {
 	return b
 }
 
-func (b *readerBuilder) withFingerprint(fp *Fingerprint) *readerBuilder {
+func (b *readerBuilder) withFingerprint(fp *fingerprint.Fingerprint) *readerBuilder {
 	b.fp = fp
 	return b
 }

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex"
@@ -201,7 +202,7 @@ func testReaderFactory(t *testing.T) (*readerFactory, chan *emitParams) {
 	return &readerFactory{
 		SugaredLogger: testutil.Logger(t),
 		readerConfig: &readerConfig{
-			fingerprintSize: DefaultFingerprintSize,
+			fingerprintSize: fingerprint.DefaultSize,
 			maxLogSize:      defaultMaxLogSize,
 			emit:            testEmitFunc(emitChan),
 		},
@@ -244,16 +245,16 @@ func TestMapCopy(t *testing.T) {
 
 func TestEncodingDecode(t *testing.T) {
 	testFile := openTemp(t, t.TempDir())
-	testToken := tokenWithLength(2 * DefaultFingerprintSize)
+	testToken := tokenWithLength(2 * fingerprint.DefaultSize)
 	_, err := testFile.Write(testToken)
 	require.NoError(t, err)
-	fp, err := NewFingerprint(testFile, DefaultFingerprintSize)
+	fp, err := fingerprint.New(testFile, fingerprint.DefaultSize)
 	require.NoError(t, err)
 
 	f := readerFactory{
 		SugaredLogger: testutil.Logger(t),
 		readerConfig: &readerConfig{
-			fingerprintSize: DefaultFingerprintSize,
+			fingerprintSize: fingerprint.DefaultSize,
 			maxLogSize:      defaultMaxLogSize,
 		},
 		splitterFactory: newMultilineSplitterFactory(helper.NewSplitterConfig()),
@@ -266,8 +267,8 @@ func TestEncodingDecode(t *testing.T) {
 	r.HeaderFinalized = true
 	r.FileAttributes.HeaderAttributes = map[string]any{"foo": "bar"}
 
-	assert.Equal(t, testToken[:DefaultFingerprintSize], r.Fingerprint.FirstBytes)
-	assert.Equal(t, int64(2*DefaultFingerprintSize), r.Offset)
+	assert.Equal(t, testToken[:fingerprint.DefaultSize], r.Fingerprint.FirstBytes)
+	assert.Equal(t, int64(2*fingerprint.DefaultSize), r.Offset)
 
 	// Encode
 	var buf bytes.Buffer
@@ -281,8 +282,8 @@ func TestEncodingDecode(t *testing.T) {
 	require.NoError(t, dec.Decode(decodedReader))
 
 	// Assert decoded reader has values persisted
-	assert.Equal(t, testToken[:DefaultFingerprintSize], decodedReader.Fingerprint.FirstBytes)
-	assert.Equal(t, int64(2*DefaultFingerprintSize), decodedReader.Offset)
+	assert.Equal(t, testToken[:fingerprint.DefaultSize], decodedReader.Fingerprint.FirstBytes)
+	assert.Equal(t, int64(2*fingerprint.DefaultSize), decodedReader.Offset)
 	assert.True(t, decodedReader.HeaderFinalized)
 	assert.Equal(t, map[string]any{"foo": "bar"}, decodedReader.FileAttributes.HeaderAttributes)
 


### PR DESCRIPTION
Incremental refactoring of the fileconsumer package creates an `internal/fingerprint` package.