### PR TITLE
update branch and token for benchmarks

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -131,7 +131,7 @@ jobs:
         with:
           tool: 'customSmallerIsBetter'
           output-file-path: output.json
-          gh-pages-branch: gh-pages
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-pages-branch: benchmarks
+          github-token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
           benchmark-data-dir-path: "docs/benchmarks/loadtests"
           auto-push: true


### PR DESCRIPTION
**Description:** 
This PR updates the branch and token used to write the benchmark results. It pairs with and is dependent on: https://github.com/open-telemetry/community/issues/1577.