### PR TITLE
[cmd/mdatagen] fix component validation for connectors

### DIFF
--- a/.chloggen/mdatagen-component-validation.yaml
+++ b/.chloggen/mdatagen-component-validation.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Updates mdatagen to enumerate all connector options during component validation. It would previously error on some valid options.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24003]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/mdatagen/validate.go
+++ b/cmd/mdatagen/validate.go
@@ -77,7 +77,19 @@ func (s *Status) validateStability() error {
 			errs = multierr.Append(errs, fmt.Errorf("missing component for stability: %v", stability))
 		}
 		for _, c := range component {
-			if c != "metrics" && c != "traces" && c != "logs" && c != "traces_to_metrics" && c != "metrics_to_metrics" && c != "logs_to_metrics" && c != "extension" {
+			if c != "metrics" &&
+				c != "traces" &&
+				c != "logs" &&
+				c != "traces_to_traces" &&
+				c != "traces_to_metrics" &&
+				c != "traces_to_logs" &&
+				c != "metrics_to_traces" &&
+				c != "metrics_to_metrics" &&
+				c != "metrics_to_logs" &&
+				c != "logs_to_traces" &&
+				c != "logs_to_metrics" &&
+				c != "logs_to_logs" &&
+				c != "extension" {
 				errs = multierr.Append(errs, fmt.Errorf("invalid component: %v", c))
 			}
 		}


### PR DESCRIPTION
**Description:** 
I was dusting off my routing connector PR and noticed that mdatagen was updated to validate components (#23783), but did not list all valid connector options. This PR updates mdatagen to enumerate all connector options during component validation.
