### PR TITLE
[fileconsumer] Prepare Finder for move to internal

### DIFF
--- a/.chloggen/fileconsumer-internal-finder-prep.yaml
+++ b/.chloggen/fileconsumer-internal-finder-prep.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate filconsumer.Finder and related sortation structs and functions
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24013]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -55,7 +55,7 @@ func NewConfig() *Config {
 
 // Config is the configuration of a file input operator
 type Config struct {
-	Finder                  `mapstructure:",squash"`
+	MatchingCriteria        `mapstructure:",squash"`
 	IncludeFileName         bool                  `mapstructure:"include_file_name,omitempty"`
 	IncludeFilePath         bool                  `mapstructure:"include_file_path,omitempty"`
 	IncludeFileNameResolved bool                  `mapstructure:"include_file_name_resolved,omitempty"`
@@ -156,7 +156,7 @@ func (c Config) buildManager(logger *zap.SugaredLogger, emit EmitFunc, factory s
 			encodingConfig:  c.Splitter.EncodingConfig,
 			headerSettings:  hs,
 		},
-		finder:          c.Finder,
+		finder:          c.MatchingCriteria,
 		roller:          newRoller(),
 		pollInterval:    c.PollInterval,
 		maxBatchFiles:   c.MaxConcurrentFiles / 2,

--- a/pkg/stanza/fileconsumer/file_sort.go
+++ b/pkg/stanza/fileconsumer/file_sort.go
@@ -26,16 +26,6 @@ type sortRule interface {
 	sort(re *regexp.Regexp, files []string) ([]string, error)
 }
 
-type BaseSortRule struct {
-	RegexKey  string `mapstructure:"regex_key,omitempty"`
-	Ascending bool   `mapstructure:"ascending,omitempty"`
-	SortType  string `mapstructure:"sort_type,omitempty"`
-}
-
-type SortRuleImpl struct {
-	sortRule
-}
-
 func (sr *SortRuleImpl) Unmarshal(component *confmap.Conf) error {
 	if !component.IsSet("sort_type") {
 		return fmt.Errorf("missing required field 'sort_type'")
@@ -76,10 +66,6 @@ func (sr *SortRuleImpl) Unmarshal(component *confmap.Conf) error {
 	return nil
 }
 
-type NumericSortRule struct {
-	BaseSortRule `mapstructure:",squash"`
-}
-
 func (f NumericSortRule) validate() error {
 	if f.RegexKey == "" {
 		return fmt.Errorf("regex key must be specified for numeric sort")
@@ -87,21 +73,11 @@ func (f NumericSortRule) validate() error {
 	return nil
 }
 
-type AlphabeticalSortRule struct {
-	BaseSortRule `mapstructure:",squash"`
-}
-
 func (f AlphabeticalSortRule) validate() error {
 	if f.RegexKey == "" {
 		return fmt.Errorf("regex key must be specified for alphabetical sort")
 	}
 	return nil
-}
-
-type TimestampSortRule struct {
-	BaseSortRule `mapstructure:",squash"`
-	Layout       string `mapstructure:"layout,omitempty"`
-	Location     string `mapstructure:"location,omitempty"`
 }
 
 func (f TimestampSortRule) validate() error {

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -677,8 +677,8 @@ func TestMultiFileSort(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	cfg.Finder.OrderingCriteria.Regex = `.*(?P<value>\d)`
-	cfg.Finder.OrderingCriteria.SortBy = []SortRuleImpl{
+	cfg.MatchingCriteria.OrderingCriteria.Regex = `.*(?P<value>\d)`
+	cfg.MatchingCriteria.OrderingCriteria.SortBy = []SortRuleImpl{
 		{
 			NumericSortRule{
 				BaseSortRule: BaseSortRule{

--- a/pkg/stanza/fileconsumer/finder.go
+++ b/pkg/stanza/fileconsumer/finder.go
@@ -10,23 +10,49 @@ import (
 	"go.uber.org/multierr"
 )
 
-type Finder struct {
+type MatchingCriteria struct {
 	Include          []string         `mapstructure:"include,omitempty"`
 	Exclude          []string         `mapstructure:"exclude,omitempty"`
 	OrderingCriteria OrderingCriteria `mapstructure:"ordering_criteria,omitempty"`
 }
 
 type OrderingCriteria struct {
-	// TODO(#23787): Add Grouping Capability
-	// TODO(#23788): Add Support for multiple current files
-
 	Regex  string         `mapstructure:"regex,omitempty"`
 	SortBy []SortRuleImpl `mapstructure:"sort_by,omitempty"`
 }
 
+type NumericSortRule struct {
+	BaseSortRule `mapstructure:",squash"`
+}
+
+type AlphabeticalSortRule struct {
+	BaseSortRule `mapstructure:",squash"`
+}
+
+type TimestampSortRule struct {
+	BaseSortRule `mapstructure:",squash"`
+	Layout       string `mapstructure:"layout,omitempty"`
+	Location     string `mapstructure:"location,omitempty"`
+}
+
+// Deprecated: [v0.82.0] This will be made internal in a future release, tentatively v0.83.0.
+type BaseSortRule struct {
+	RegexKey  string `mapstructure:"regex_key,omitempty"`
+	Ascending bool   `mapstructure:"ascending,omitempty"`
+	SortType  string `mapstructure:"sort_type,omitempty"`
+}
+
+// Deprecated: [v0.82.0] This will be made internal in a future release, tentatively v0.83.0.
+type SortRuleImpl struct {
+	sortRule
+}
+
+// Deprecated: [v0.82.0] Use MatchingCriteria instead. This will be removed in v0.83.0.
+type Finder = MatchingCriteria
+
 // FindFiles gets a list of paths given an array of glob patterns to include and exclude
 //
-// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.82.0.
+// Deprecated: [v0.80.0] This will be made internal in a future release, tentatively v0.83.0.
 func (f Finder) FindFiles() ([]string, error) {
 	all := make([]string, 0, len(f.Include))
 	for _, include := range f.Include {
@@ -54,6 +80,8 @@ func (f Finder) FindFiles() ([]string, error) {
 
 // FindCurrent gets the current file to read from a list of files if ordering_criteria is configured
 // otherwise it returns the list of files.
+//
+// Deprecated: [v0.82.0] This will be made internal in a future release, tentatively v0.83.0.
 func (f Finder) FindCurrent(files []string) ([]string, error) {
 	if len(f.OrderingCriteria.SortBy) == 0 || files == nil || len(files) == 0 {
 		return files, nil

--- a/receiver/otlpjsonfilereceiver/file_test.go
+++ b/receiver/otlpjsonfilereceiver/file_test.go
@@ -125,7 +125,7 @@ func testdataConfigYamlAsMap() *Config {
 			FingerprintSize:         1000,
 			MaxLogSize:              1024 * 1024,
 			MaxConcurrentFiles:      1024,
-			Finder: fileconsumer.Finder{
+			MatchingCriteria: fileconsumer.MatchingCriteria{
 				Include: []string{"/var/log/*.log"},
 				Exclude: []string{"/var/log/example.log"},
 			},


### PR DESCRIPTION
The `Finder` struct currently serves as both a config struct and a functional element of the fileconsumer package. I would like to move the functional element into an internal package.

This PR defines a more limited API for the configuration of finding and selecting files. Everything else is deprecated so that a future PR can move these to an internal package.