### PR TITLE
[fileconsumer] Generlize emit function

### DIFF
--- a/.chloggen/fileconsumer-emitfunc-generalize.yaml
+++ b/.chloggen/fileconsumer-emitfunc-generalize.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate fileconsumer.EmitFunc in favor of fileconsumer.emit.Callback
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24036]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/stanza/fileconsumer/attributes.go
+++ b/pkg/stanza/fileconsumer/attributes.go
@@ -4,14 +4,10 @@
 package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
 
 import (
-	"path/filepath"
-	"runtime"
-
-	"go.uber.org/multierr"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/util"
 )
 
+// Deprecated: [v0.82.0] This will be removed in a future release, tentatively v0.84.0.
 type FileAttributes struct {
 	Name             string `json:"-"`
 	Path             string `json:"-"`
@@ -21,28 +17,8 @@ type FileAttributes struct {
 }
 
 // HeaderAttributesCopy gives a copy of the HeaderAttributes, in order to restrict mutation of the HeaderAttributes.
+//
+// Deprecated: [v0.82.0] This will be removed in a future release, tentatively v0.84.0.
 func (f *FileAttributes) HeaderAttributesCopy() map[string]any {
 	return util.MapCopy(f.HeaderAttributes)
-}
-
-// resolveFileAttributes resolves file attributes
-// and sets it to empty string in case of error
-func resolveFileAttributes(path string) (*FileAttributes, error) {
-	resolved := ""
-	var symErr error
-	// Dirty solution, waiting for this permanent fix https://github.com/golang/go/issues/39786
-	// EvalSymlinks on windows is partially working depending on the way you use Symlinks and Junctions
-	if runtime.GOOS != "windows" {
-		resolved, symErr = filepath.EvalSymlinks(path)
-	} else {
-		resolved = path
-	}
-	abs, absErr := filepath.Abs(resolved)
-
-	return &FileAttributes{
-		Path:         path,
-		Name:         filepath.Base(path),
-		PathResolved: abs,
-		NameResolved: filepath.Base(abs),
-	}, multierr.Combine(symErr, absErr)
 }

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
@@ -72,7 +73,7 @@ type Config struct {
 }
 
 // Build will build a file input operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger, emit EmitFunc) (*Manager, error) {
+func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback) (*Manager, error) {
 	if err := c.validate(); err != nil {
 		return nil, err
 	}
@@ -87,7 +88,7 @@ func (c Config) Build(logger *zap.SugaredLogger, emit EmitFunc) (*Manager, error
 }
 
 // BuildWithSplitFunc will build a file input operator with customized splitFunc function
-func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit EmitFunc, splitFunc bufio.SplitFunc) (*Manager, error) {
+func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit emit.Callback, splitFunc bufio.SplitFunc) (*Manager, error) {
 	if err := c.validate(); err != nil {
 		return nil, err
 	}
@@ -105,7 +106,7 @@ func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit EmitFunc, spl
 	return c.buildManager(logger, emit, factory)
 }
 
-func (c Config) buildManager(logger *zap.SugaredLogger, emit EmitFunc, factory splitterFactory) (*Manager, error) {
+func (c Config) buildManager(logger *zap.SugaredLogger, emit emit.Callback, factory splitterFactory) (*Manager, error) {
 	if emit == nil {
 		return nil, fmt.Errorf("must provide emit function")
 	}
@@ -138,9 +139,13 @@ func (c Config) buildManager(logger *zap.SugaredLogger, emit EmitFunc, factory s
 		readerFactory: readerFactory{
 			SugaredLogger: logger.With("component", "fileconsumer"),
 			readerConfig: &readerConfig{
-				fingerprintSize: int(c.FingerprintSize),
-				maxLogSize:      int(c.MaxLogSize),
-				emit:            emit,
+				fingerprintSize:         int(c.FingerprintSize),
+				maxLogSize:              int(c.MaxLogSize),
+				emit:                    emit,
+				includeFileName:         c.IncludeFileName,
+				includeFilePath:         c.IncludeFilePath,
+				includeFileNameResolved: c.IncludeFileNameResolved,
+				includeFilePathResolved: c.IncludeFilePathResolved,
 			},
 			fromBeginning:   startAtBeginning,
 			splitterFactory: factory,

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -636,7 +636,7 @@ func TestBuild(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			nopEmit := func(_ context.Context, _ *FileAttributes, _ []byte) {}
+			nopEmit := func(_ context.Context, _ []byte, _ map[string]any) {}
 
 			input, err := cfg.Build(testutil.Logger(t), nopEmit)
 			tc.errorRequirement(t, err)
@@ -708,7 +708,7 @@ func TestBuildWithSplitFunc(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			nopEmit := func(_ context.Context, _ *FileAttributes, _ []byte) {}
+			nopEmit := func(_ context.Context, _ []byte, _ map[string]any) {}
 			splitNone := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 				if !atEOF {
 					return 0, nil, nil
@@ -809,7 +809,7 @@ func TestBuildWithHeader(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			nopEmit := func(_ context.Context, _ *FileAttributes, _ []byte) {}
+			nopEmit := func(_ context.Context, _ []byte, _ map[string]any) {}
 
 			input, err := cfg.Build(testutil.Logger(t), nopEmit)
 			tc.errorRequirement(t, err)

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -4,7 +4,6 @@
 package fileconsumer
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -636,9 +635,7 @@ func TestBuild(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			nopEmit := func(_ context.Context, _ []byte, _ map[string]any) {}
-
-			input, err := cfg.Build(testutil.Logger(t), nopEmit)
+			input, err := cfg.Build(testutil.Logger(t), nopEmitFunc)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return
@@ -708,7 +705,6 @@ func TestBuildWithSplitFunc(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			nopEmit := func(_ context.Context, _ []byte, _ map[string]any) {}
 			splitNone := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 				if !atEOF {
 					return 0, nil, nil
@@ -719,7 +715,7 @@ func TestBuildWithSplitFunc(t *testing.T) {
 				return len(data), data, nil
 			}
 
-			input, err := cfg.BuildWithSplitFunc(testutil.Logger(t), nopEmit, splitNone)
+			input, err := cfg.BuildWithSplitFunc(testutil.Logger(t), nopEmitFunc, splitNone)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return
@@ -809,9 +805,7 @@ func TestBuildWithHeader(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			nopEmit := func(_ context.Context, _ []byte, _ map[string]any) {}
-
-			input, err := cfg.Build(testutil.Logger(t), nopEmit)
+			input, err := cfg.Build(testutil.Logger(t), nopEmitFunc)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return

--- a/pkg/stanza/fileconsumer/emit/emit.go
+++ b/pkg/stanza/fileconsumer/emit/emit.go
@@ -7,4 +7,4 @@ import (
 	"context"
 )
 
-type Callback func(ctx context.Context, token []byte, attrs map[string]any)
+type Callback func(ctx context.Context, token []byte, attrs map[string]any) error

--- a/pkg/stanza/fileconsumer/emit/emit.go
+++ b/pkg/stanza/fileconsumer/emit/emit.go
@@ -1,0 +1,10 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package emit // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
+
+import (
+	"context"
+)
+
+type Callback func(ctx context.Context, token []byte, attrs map[string]any)

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -18,6 +18,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
+const (
+	logFileName         = "log.file.name"
+	logFilePath         = "log.file.path"
+	logFileNameResolved = "log.file.name_resolved"
+	logFilePathResolved = "log.file.path_resolved"
+)
+
+// Deprecated: [v0.82.0] Use emit.Callback instead. This will be removed in a future release, tentatively v0.84.0.
 type EmitFunc func(ctx context.Context, attrs *FileAttributes, token []byte)
 
 type Manager struct {
@@ -369,6 +377,21 @@ func (m *Manager) loadLastPollFiles(ctx context.Context) error {
 		if err = dec.Decode(unsafeReader); err != nil {
 			return err
 		}
+
+		// Migrate readers that used FileAttributes.HeaderAttributes
+		// This block can be removed in a future release, tentatively v0.90.0
+		if ha, ok := unsafeReader.FileAttributes["HeaderAttributes"]; ok {
+			switch hat := ha.(type) {
+			case map[string]any:
+				for k, v := range hat {
+					unsafeReader.FileAttributes[k] = v
+				}
+				delete(unsafeReader.FileAttributes, "HeaderAttributes")
+			default:
+				m.Errorw("migrate header attributes: unexpected format")
+			}
+		}
+
 		m.knownFiles = append(m.knownFiles, unsafeReader)
 	}
 

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -54,6 +54,8 @@ func TestAddFileFields(t *testing.T) {
 	cfg.StartAt = "beginning"
 	cfg.IncludeFileName = true
 	cfg.IncludeFilePath = true
+	cfg.IncludeFileNameResolved = false
+	cfg.IncludeFilePathResolved = false
 	operator, emitCalls := buildTestManager(t, cfg)
 
 	// Create a file, then start
@@ -66,8 +68,10 @@ func TestAddFileFields(t *testing.T) {
 	}()
 
 	emitCall := waitForEmit(t, emitCalls)
-	require.Equal(t, filepath.Base(temp.Name()), emitCall.attrs.Name)
-	require.Equal(t, temp.Name(), emitCall.attrs.Path)
+	require.Equal(t, filepath.Base(temp.Name()), emitCall.attrs[logFileName])
+	require.Equal(t, temp.Name(), emitCall.attrs[logFilePath])
+	require.Nil(t, emitCall.attrs[logFileNameResolved])
+	require.Nil(t, emitCall.attrs[logFilePathResolved])
 }
 
 // AddFileResolvedFields tests that the `log.file.name_resolved` and `log.file.path_resolved` fields are included
@@ -116,10 +120,10 @@ func TestAddFileResolvedFields(t *testing.T) {
 	}()
 
 	emitCall := waitForEmit(t, emitCalls)
-	require.Equal(t, filepath.Base(symLinkPath), emitCall.attrs.Name)
-	require.Equal(t, symLinkPath, emitCall.attrs.Path)
-	require.Equal(t, filepath.Base(resolved), emitCall.attrs.NameResolved)
-	require.Equal(t, resolved, emitCall.attrs.PathResolved)
+	require.Equal(t, filepath.Base(symLinkPath), emitCall.attrs[logFileName])
+	require.Equal(t, symLinkPath, emitCall.attrs[logFilePath])
+	require.Equal(t, filepath.Base(resolved), emitCall.attrs[logFileNameResolved])
+	require.Equal(t, resolved, emitCall.attrs[logFilePathResolved])
 }
 
 // AddFileResolvedFields tests that the `log.file.name_resolved` and `log.file.path_resolved` fields are included
@@ -186,10 +190,10 @@ func TestAddFileResolvedFieldsWithChangeOfSymlinkTarget(t *testing.T) {
 	}()
 
 	emitCall := waitForEmit(t, emitCalls)
-	require.Equal(t, filepath.Base(symLinkPath), emitCall.attrs.Name)
-	require.Equal(t, symLinkPath, emitCall.attrs.Path)
-	require.Equal(t, filepath.Base(resolved1), emitCall.attrs.NameResolved)
-	require.Equal(t, resolved1, emitCall.attrs.PathResolved)
+	require.Equal(t, filepath.Base(symLinkPath), emitCall.attrs[logFileName])
+	require.Equal(t, symLinkPath, emitCall.attrs[logFilePath])
+	require.Equal(t, filepath.Base(resolved1), emitCall.attrs[logFileNameResolved])
+	require.Equal(t, resolved1, emitCall.attrs[logFilePathResolved])
 
 	// Change middleSymLink to point to file2
 	err = os.Remove(middleSymLinkPath)
@@ -201,10 +205,10 @@ func TestAddFileResolvedFieldsWithChangeOfSymlinkTarget(t *testing.T) {
 	writeString(t, file2, "testlog2\n")
 
 	emitCall = waitForEmit(t, emitCalls)
-	require.Equal(t, filepath.Base(symLinkPath), emitCall.attrs.Name)
-	require.Equal(t, symLinkPath, emitCall.attrs.Path)
-	require.Equal(t, filepath.Base(resolved2), emitCall.attrs.NameResolved)
-	require.Equal(t, resolved2, emitCall.attrs.PathResolved)
+	require.Equal(t, filepath.Base(symLinkPath), emitCall.attrs[logFileName])
+	require.Equal(t, symLinkPath, emitCall.attrs[logFilePath])
+	require.Equal(t, filepath.Base(resolved2), emitCall.attrs[logFileNameResolved])
+	require.Equal(t, resolved2, emitCall.attrs[logFilePathResolved])
 }
 
 func TestFileFieldsUpdatedAfterRestart(t *testing.T) {
@@ -227,8 +231,10 @@ func TestFileFieldsUpdatedAfterRestart(t *testing.T) {
 
 	emitCall1 := waitForEmit(t, emitCalls1)
 	assert.Equal(t, []byte("testlog1"), emitCall1.token)
-	assert.Equal(t, filepath.Base(temp.Name()), emitCall1.attrs.Name)
-	assert.Equal(t, temp.Name(), emitCall1.attrs.Path)
+	assert.Equal(t, filepath.Base(temp.Name()), emitCall1.attrs[logFileName])
+	assert.Equal(t, temp.Name(), emitCall1.attrs[logFilePath])
+	assert.Nil(t, emitCall1.attrs[logFileNameResolved])
+	assert.Nil(t, emitCall1.attrs[logFilePathResolved])
 
 	require.NoError(t, op1.Stop())
 	temp.Close() // On windows, we must close the file before renaming it
@@ -245,8 +251,10 @@ func TestFileFieldsUpdatedAfterRestart(t *testing.T) {
 
 	emitCall2 := waitForEmit(t, emitCalls2)
 	assert.Equal(t, []byte("testlog2"), emitCall2.token)
-	assert.Equal(t, filepath.Base(newPath), emitCall2.attrs.Name)
-	assert.Equal(t, newPath, emitCall2.attrs.Path)
+	assert.Equal(t, filepath.Base(newPath), emitCall2.attrs[logFileName])
+	assert.Equal(t, newPath, emitCall2.attrs[logFilePath])
+	assert.Nil(t, emitCall2.attrs[logFileNameResolved])
+	assert.Nil(t, emitCall2.attrs[logFilePathResolved])
 
 	require.NoError(t, op2.Stop())
 }
@@ -1457,9 +1465,10 @@ func TestReadExistingLogsWithHeader(t *testing.T) {
 		require.NoError(t, operator.Stop())
 	}()
 
-	waitForTokenHeaderAttributes(t, emitCalls, []byte("testlog"), map[string]any{
+	waitForTokenWithAttributes(t, emitCalls, []byte("testlog"), map[string]any{
 		"header_key":   "headerField",
 		"header_value": "headerValue",
+		logFileName:    filepath.Base(temp.Name()),
 	})
 }
 
@@ -1555,9 +1564,10 @@ func TestHeaderPersistance(t *testing.T) {
 	persister := testutil.NewUnscopedMockPersister()
 	require.NoError(t, op1.Start(persister))
 
-	waitForTokenHeaderAttributes(t, emitCalls1, []byte("log line"), map[string]any{
+	waitForTokenWithAttributes(t, emitCalls1, []byte("log line"), map[string]any{
 		"header_key":   "headerField",
 		"header_value": "headerValue",
+		logFileName:    filepath.Base(temp.Name()),
 	})
 
 	require.NoError(t, op1.Stop())
@@ -1568,13 +1578,13 @@ func TestHeaderPersistance(t *testing.T) {
 
 	require.NoError(t, op2.Start(persister))
 
-	waitForTokenHeaderAttributes(t, emitCalls2, []byte("log line 2"), map[string]any{
+	waitForTokenWithAttributes(t, emitCalls2, []byte("log line 2"), map[string]any{
 		"header_key":   "headerField",
 		"header_value": "headerValue",
+		logFileName:    filepath.Base(temp.Name()),
 	})
 
 	require.NoError(t, op2.Stop())
-
 }
 
 func TestHeaderPersistanceInHeader(t *testing.T) {
@@ -1613,9 +1623,10 @@ func TestHeaderPersistanceInHeader(t *testing.T) {
 
 	require.NoError(t, op2.Start(persister))
 
-	waitForTokenHeaderAttributes(t, emitCalls, []byte("log line"), map[string]any{
+	waitForTokenWithAttributes(t, emitCalls, []byte("log line"), map[string]any{
 		"header_value_1": "headerValue1",
 		"header_value_2": "headerValue2",
+		logFileName:      filepath.Base(temp.Name()),
 	})
 
 	require.NoError(t, op2.Stop())

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/scanner"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -19,9 +20,13 @@ import (
 )
 
 type readerConfig struct {
-	fingerprintSize int
-	maxLogSize      int
-	emit            EmitFunc
+	fingerprintSize         int
+	maxLogSize              int
+	emit                    emit.Callback
+	includeFileName         bool
+	includeFilePath         bool
+	includeFileNameResolved bool
+	includeFilePathResolved bool
 }
 
 // Reader manages a single file
@@ -33,13 +38,13 @@ type Reader struct {
 	lineSplitFunc bufio.SplitFunc
 	splitFunc     bufio.SplitFunc
 	encoding      helper.Encoding
-	processFunc   EmitFunc
+	processFunc   emit.Callback
 
 	Fingerprint    *fingerprint.Fingerprint
 	Offset         int64
 	generation     int
 	file           *os.File
-	FileAttributes *FileAttributes
+	FileAttributes map[string]any
 	eof            bool
 
 	HeaderFinalized bool
@@ -92,7 +97,7 @@ func (r *Reader) ReadToEnd(ctx context.Context) {
 		if err != nil {
 			r.Errorw("decode: %w", zap.Error(err))
 		} else {
-			r.processFunc(ctx, r.FileAttributes, token)
+			r.processFunc(ctx, token, r.FileAttributes)
 		}
 
 		if r.recreateScanner {
@@ -116,7 +121,7 @@ func (r *Reader) ReadToEnd(ctx context.Context) {
 // consumeHeaderLine checks if the given token is a line of the header, and consumes it if it is.
 // The return value dictates whether the given line was a header line or not.
 // If false is returned, the full header can be assumed to be read.
-func (r *Reader) consumeHeaderLine(ctx context.Context, _ *FileAttributes, token []byte) {
+func (r *Reader) consumeHeaderLine(ctx context.Context, token []byte, _ map[string]any) {
 	if !r.headerSettings.matchRegex.Match(token) {
 		// Finalize and cleanup the pipeline
 		r.HeaderFinalized = true
@@ -154,7 +159,7 @@ func (r *Reader) consumeHeaderLine(ctx context.Context, _ *FileAttributes, token
 
 	// Copy resultant attributes over current set of attributes (upsert)
 	for k, v := range ent.Attributes {
-		r.FileAttributes.HeaderAttributes[k] = v
+		r.FileAttributes[k] = v
 	}
 }
 

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -7,6 +7,8 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 
 	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
@@ -40,7 +42,7 @@ func (f *readerFactory) copy(old *Reader, newFile *os.File) (*Reader, error) {
 		withFingerprint(old.Fingerprint.Copy()).
 		withOffset(old.Offset).
 		withSplitterFunc(old.lineSplitFunc).
-		withHeaderAttributes(util.MapCopy(old.FileAttributes.HeaderAttributes)).
+		withFileAttributes(util.MapCopy(old.FileAttributes)).
 		withHeaderFinalized(old.HeaderFinalized).
 		build()
 }
@@ -55,16 +57,16 @@ func (f *readerFactory) newFingerprint(file *os.File) (*fingerprint.Fingerprint,
 
 type readerBuilder struct {
 	*readerFactory
-	file             *os.File
-	fp               *fingerprint.Fingerprint
-	offset           int64
-	splitFunc        bufio.SplitFunc
-	headerFinalized  bool
-	headerAttributes map[string]any
+	file            *os.File
+	fp              *fingerprint.Fingerprint
+	offset          int64
+	splitFunc       bufio.SplitFunc
+	headerFinalized bool
+	fileAttributes  map[string]any
 }
 
 func (f *readerFactory) newReaderBuilder() *readerBuilder {
-	return &readerBuilder{readerFactory: f, headerAttributes: map[string]any{}}
+	return &readerBuilder{readerFactory: f, fileAttributes: map[string]any{}}
 }
 
 func (b *readerBuilder) withSplitterFunc(s bufio.SplitFunc) *readerBuilder {
@@ -92,8 +94,8 @@ func (b *readerBuilder) withHeaderFinalized(finalized bool) *readerBuilder {
 	return b
 }
 
-func (b *readerBuilder) withHeaderAttributes(attrs map[string]any) *readerBuilder {
-	b.headerAttributes = attrs
+func (b *readerBuilder) withFileAttributes(attrs map[string]any) *readerBuilder {
+	b.fileAttributes = attrs
 	return b
 }
 
@@ -103,6 +105,7 @@ func (b *readerBuilder) build() (r *Reader, err error) {
 		Offset:          b.offset,
 		headerSettings:  b.headerSettings,
 		HeaderFinalized: b.headerFinalized,
+		FileAttributes:  b.fileAttributes,
 	}
 
 	if b.splitFunc != nil {
@@ -110,74 +113,99 @@ func (b *readerBuilder) build() (r *Reader, err error) {
 	} else {
 		r.lineSplitFunc, err = b.splitterFactory.Build(b.readerConfig.maxLogSize)
 		if err != nil {
-			return
-		}
-	}
-
-	enc, err := b.encodingConfig.Build()
-	if err != nil {
-		return
-	}
-	r.encoding = enc
-
-	if b.file != nil {
-		r.file = b.file
-		r.SugaredLogger = b.SugaredLogger.With("path", b.file.Name())
-		r.FileAttributes, err = resolveFileAttributes(b.file.Name())
-		if err != nil {
-			b.Errorf("resolve attributes: %w", err)
-		}
-
-		// unsafeReader has the file set to nil, so don't try emending its offset.
-		if !b.fromBeginning {
-			if err = r.offsetToEnd(); err != nil {
-				return nil, err
-			}
-		}
-	} else {
-		r.SugaredLogger = b.SugaredLogger.With("path", "uninitialized")
-		r.FileAttributes = &FileAttributes{}
-	}
-
-	if b.fp != nil {
-		r.Fingerprint = b.fp
-	} else if b.file != nil {
-		r.Fingerprint, err = b.readerFactory.newFingerprint(r.file)
-		if err != nil {
 			return nil, err
 		}
 	}
 
-	r.FileAttributes.HeaderAttributes = b.headerAttributes
+	r.encoding, err = b.encodingConfig.Build()
+	if err != nil {
+		return nil, err
+	}
 
 	if b.headerSettings == nil || b.headerFinalized {
 		r.splitFunc = r.lineSplitFunc
 		r.processFunc = b.readerConfig.emit
+	} else {
+		// We are reading the header. Use the header split func
+		r.splitFunc = b.headerSettings.splitFunc
+		r.processFunc = r.consumeHeaderLine
+
+		// Create the header pipeline
+		r.headerPipelineOutput = newHeaderPipelineOutput(b.SugaredLogger)
+		r.headerPipeline, err = pipeline.Config{
+			Operators:     b.headerSettings.config.MetadataOperators,
+			DefaultOutput: r.headerPipelineOutput,
+		}.Build(b.SugaredLogger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build pipeline: %w", err)
+		}
+		if err = r.headerPipeline.Start(storage.NewNopClient()); err != nil {
+			return nil, fmt.Errorf("failed to start header pipeline: %w", err)
+		}
+	}
+
+	if b.file == nil {
+		r.SugaredLogger = b.SugaredLogger.With("path", "uninitialized")
 		return r, nil
 	}
 
-	// We are reading the header so we should start with the header split func
-	r.splitFunc = b.headerSettings.splitFunc
+	r.file = b.file
+	r.SugaredLogger = b.SugaredLogger.With("path", b.file.Name())
+	r.FileAttributes = b.fileAttributes
 
-	outOp := newHeaderPipelineOutput(b.SugaredLogger)
-	p, err := pipeline.Config{
-		Operators:     b.headerSettings.config.MetadataOperators,
-		DefaultOutput: outOp,
-	}.Build(b.SugaredLogger)
+	// Resolve file name and path attributes
+	resolved := b.file.Name()
 
+	// Dirty solution, waiting for this permanent fix https://github.com/golang/go/issues/39786
+	// EvalSymlinks on windows is partially working depending on the way you use Symlinks and Junctions
+	if runtime.GOOS != "windows" {
+		resolved, err = filepath.EvalSymlinks(b.file.Name())
+		if err != nil {
+			b.Errorf("resolve symlinks: %w", err)
+		}
+	}
+	abs, err := filepath.Abs(resolved)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build pipeline: %w", err)
+		b.Errorf("resolve abs: %w", err)
 	}
 
-	if err := p.Start(storage.NewNopClient()); err != nil {
-		return nil, fmt.Errorf("failed to start header pipeline: %w", err)
+	if b.readerConfig.includeFileName {
+		r.FileAttributes[logFileName] = filepath.Base(b.file.Name())
+	} else if r.FileAttributes[logFileName] != nil {
+		delete(r.FileAttributes, logFileName)
+	}
+	if b.readerConfig.includeFilePath {
+		r.FileAttributes[logFilePath] = b.file.Name()
+	} else if r.FileAttributes[logFilePath] != nil {
+		delete(r.FileAttributes, logFilePath)
+	}
+	if b.readerConfig.includeFileNameResolved {
+		r.FileAttributes[logFileNameResolved] = filepath.Base(abs)
+	} else if r.FileAttributes[logFileNameResolved] != nil {
+		delete(r.FileAttributes, logFileNameResolved)
+	}
+	if b.readerConfig.includeFilePathResolved {
+		r.FileAttributes[logFilePathResolved] = abs
+	} else if r.FileAttributes[logFilePathResolved] != nil {
+		delete(r.FileAttributes, logFilePathResolved)
 	}
 
-	r.headerPipeline = p
-	r.headerPipelineOutput = outOp
+	if !b.fromBeginning {
+		if err = r.offsetToEnd(); err != nil {
+			return nil, err
+		}
+	}
 
-	// Set initial emit func to header function
-	r.processFunc = r.consumeHeaderLine
+	if b.fp != nil {
+		r.Fingerprint = b.fp
+		return r, nil
+	}
+
+	fp, err := b.readerFactory.newFingerprint(r.file)
+	if err != nil {
+		return nil, err
+	}
+	r.Fingerprint = fp
 
 	return r, nil
 }

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -244,7 +244,7 @@ func TestEncodingDecode(t *testing.T) {
 
 	// Just faking out these properties
 	r.HeaderFinalized = true
-	r.FileAttributes.HeaderAttributes = map[string]any{"foo": "bar"}
+	r.FileAttributes = map[string]any{"foo": "bar"}
 
 	assert.Equal(t, testToken[:fingerprint.DefaultSize], r.Fingerprint.FirstBytes)
 	assert.Equal(t, int64(2*fingerprint.DefaultSize), r.Offset)
@@ -264,11 +264,11 @@ func TestEncodingDecode(t *testing.T) {
 	assert.Equal(t, testToken[:fingerprint.DefaultSize], decodedReader.Fingerprint.FirstBytes)
 	assert.Equal(t, int64(2*fingerprint.DefaultSize), decodedReader.Offset)
 	assert.True(t, decodedReader.HeaderFinalized)
-	assert.Equal(t, map[string]any{"foo": "bar"}, decodedReader.FileAttributes.HeaderAttributes)
+	assert.Equal(t, map[string]any{"foo": "bar"}, decodedReader.FileAttributes)
 
 	// These fields are intentionally excluded, as they may have changed
-	assert.Empty(t, decodedReader.FileAttributes.Name)
-	assert.Empty(t, decodedReader.FileAttributes.Path)
-	assert.Empty(t, decodedReader.FileAttributes.NameResolved)
-	assert.Empty(t, decodedReader.FileAttributes.PathResolved)
+	assert.Empty(t, decodedReader.FileAttributes[logFileName])
+	assert.Empty(t, decodedReader.FileAttributes[logFilePath])
+	assert.Empty(t, decodedReader.FileAttributes[logFileNameResolved])
+	assert.Empty(t, decodedReader.FileAttributes[logFilePathResolved])
 }

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -17,14 +17,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
-func testEmitFunc(emitChan chan *emitParams) EmitFunc {
-	return func(_ context.Context, attrs *FileAttributes, token []byte) {
+func testEmitFunc(emitChan chan *emitParams) emit.Callback {
+	return func(_ context.Context, token []byte, attrs map[string]any) {
 		copied := make([]byte, len(token))
 		copy(copied, token)
 		emitChan <- &emitParams{attrs, copied}
@@ -54,14 +55,14 @@ func (c *Config) withHeader(headerMatchPattern, extractRegex string) *Config {
 	return c
 }
 
-func emitOnChan(received chan []byte) EmitFunc {
-	return func(_ context.Context, _ *FileAttributes, token []byte) {
+func emitOnChan(received chan []byte) emit.Callback {
+	return func(_ context.Context, token []byte, _ map[string]any) {
 		received <- token
 	}
 }
 
 type emitParams struct {
-	attrs *FileAttributes
+	attrs map[string]any
 	token []byte
 }
 
@@ -174,11 +175,11 @@ func waitForToken(t *testing.T, c chan *emitParams, expected []byte) {
 	}
 }
 
-func waitForTokenHeaderAttributes(t *testing.T, c chan *emitParams, expected []byte, headerAttributes map[string]any) {
+func waitForTokenWithAttributes(t *testing.T, c chan *emitParams, expected []byte, attrs map[string]any) {
 	select {
 	case call := <-c:
 		require.Equal(t, expected, call.token)
-		require.Equal(t, headerAttributes, call.attrs.HeaderAttributes)
+		require.Equal(t, attrs, call.attrs)
 	case <-time.After(3 * time.Second):
 		require.FailNow(t, fmt.Sprintf("Timed out waiting for token: %s", expected))
 	}

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -24,11 +24,16 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
+func nopEmitFunc(_ context.Context, _ []byte, _ map[string]any) error {
+	return nil
+}
+
 func testEmitFunc(emitChan chan *emitParams) emit.Callback {
-	return func(_ context.Context, token []byte, attrs map[string]any) {
+	return func(_ context.Context, token []byte, attrs map[string]any) error {
 		copied := make([]byte, len(token))
 		copy(copied, token)
 		emitChan <- &emitParams{attrs, copied}
+		return nil
 	}
 }
 
@@ -56,8 +61,9 @@ func (c *Config) withHeader(headerMatchPattern, extractRegex string) *Config {
 }
 
 func emitOnChan(received chan []byte) emit.Callback {
-	return func(_ context.Context, token []byte, _ map[string]any) {
+	return func(_ context.Context, token []byte, _ map[string]any) error {
 		received <- token
+		return nil
 	}
 }
 

--- a/pkg/stanza/operator/input/file/config.go
+++ b/pkg/stanza/operator/input/file/config.go
@@ -43,25 +43,6 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		return nil, err
 	}
 
-	var preEmitOptions []preEmitOption
-
-	if fileconsumer.AllowHeaderMetadataParsing.IsEnabled() {
-		preEmitOptions = append(preEmitOptions, setHeaderMetadata)
-	}
-
-	if c.IncludeFileName {
-		preEmitOptions = append(preEmitOptions, setFileName)
-	}
-	if c.IncludeFilePath {
-		preEmitOptions = append(preEmitOptions, setFilePath)
-	}
-	if c.IncludeFileNameResolved {
-		preEmitOptions = append(preEmitOptions, setFileNameResolved)
-	}
-	if c.IncludeFilePathResolved {
-		preEmitOptions = append(preEmitOptions, setFilePathResolved)
-	}
-
 	var toBody toBodyFunc = func(token []byte) interface{} {
 		return string(token)
 	}
@@ -74,9 +55,8 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 	}
 
 	input := &Input{
-		InputOperator:  inputOperator,
-		toBody:         toBody,
-		preEmitOptions: preEmitOptions,
+		InputOperator: inputOperator,
+		toBody:        toBody,
 	}
 
 	input.fileConsumer, err = c.Config.Build(logger, input.emit)

--- a/pkg/stanza/operator/input/file/config_test.go
+++ b/pkg/stanza/operator/input/file/config_test.go
@@ -5,8 +5,6 @@ package file
 
 import (
 	"path/filepath"
-	"reflect"
-	"runtime"
 	"testing"
 	"time"
 
@@ -456,74 +454,6 @@ func TestBuild(t *testing.T) {
 			require.NoError,
 			func(t *testing.T, f *Input) {
 				require.Equal(t, f.OutputOperators[0], fakeOutput)
-				expectOptions := []preEmitOption{setFileName}
-				requireSamePreEmitOptions(t, expectOptions, f.preEmitOptions)
-			},
-		},
-		{
-			"IncludeFilePath",
-			func(f *Config) {
-				f.IncludeFilePath = true
-			},
-			require.NoError,
-			func(t *testing.T, f *Input) {
-				require.Equal(t, f.OutputOperators[0], fakeOutput)
-				expectOptions := []preEmitOption{setFileName, setFilePath}
-				requireSamePreEmitOptions(t, expectOptions, f.preEmitOptions)
-			},
-		},
-		{
-			"IncludeFileNameResolved",
-			func(f *Config) {
-				f.IncludeFileNameResolved = true
-			},
-			require.NoError,
-			func(t *testing.T, f *Input) {
-				require.Equal(t, f.OutputOperators[0], fakeOutput)
-				expectOptions := []preEmitOption{setFileName, setFileNameResolved}
-				requireSamePreEmitOptions(t, expectOptions, f.preEmitOptions)
-			},
-		},
-		{
-			"IncludeFilePathResolved",
-			func(f *Config) {
-				f.IncludeFilePathResolved = true
-			},
-			require.NoError,
-			func(t *testing.T, f *Input) {
-				require.Equal(t, f.OutputOperators[0], fakeOutput)
-				expectOptions := []preEmitOption{setFileName, setFilePathResolved}
-				requireSamePreEmitOptions(t, expectOptions, f.preEmitOptions)
-			},
-		},
-		{
-			"IncludeResolvedAttrs",
-			func(f *Config) {
-				f.IncludeFileName = false
-				f.IncludeFilePath = false
-				f.IncludeFilePathResolved = true
-				f.IncludeFileNameResolved = true
-			},
-			require.NoError,
-			func(t *testing.T, f *Input) {
-				require.Equal(t, f.OutputOperators[0], fakeOutput)
-				expectOptions := []preEmitOption{setFileNameResolved, setFilePathResolved}
-				requireSamePreEmitOptions(t, expectOptions, f.preEmitOptions)
-			},
-		},
-		{
-			"IncludeAllFileAttrs",
-			func(f *Config) {
-				f.IncludeFileName = true
-				f.IncludeFilePath = true
-				f.IncludeFilePathResolved = true
-				f.IncludeFileNameResolved = true
-			},
-			require.NoError,
-			func(t *testing.T, f *Input) {
-				require.Equal(t, f.OutputOperators[0], fakeOutput)
-				expectOptions := []preEmitOption{setFileName, setFilePath, setFileNameResolved, setFilePathResolved}
-				requireSamePreEmitOptions(t, expectOptions, f.preEmitOptions)
 			},
 		},
 		{
@@ -648,16 +578,5 @@ func TestBuild(t *testing.T) {
 			fileInput := op.(*Input)
 			tc.validate(t, fileInput)
 		})
-	}
-}
-
-func requireSamePreEmitOptions(t *testing.T, expect, actual []preEmitOption) {
-	// Comparing functions is not directly possible
-	require.Equal(t, len(expect), len(actual))
-	for i := range expect {
-		// Credit https://github.com/stretchr/testify/issues/182#issuecomment-495359313
-		expectFuncName := runtime.FuncForPC(reflect.ValueOf(expect[i]).Pointer()).Name()
-		actualFuncName := runtime.FuncForPC(reflect.ValueOf(actual[i]).Pointer()).Name()
-		require.Equal(t, expectFuncName, actualFuncName)
 	}
 }

--- a/pkg/stanza/operator/input/file/file.go
+++ b/pkg/stanza/operator/input/file/file.go
@@ -20,8 +20,7 @@ type Input struct {
 
 	fileConsumer *fileconsumer.Manager
 
-	toBody         toBodyFunc
-	preEmitOptions []preEmitOption
+	toBody toBodyFunc
 }
 
 // Start will start the file monitoring process
@@ -34,7 +33,7 @@ func (f *Input) Stop() error {
 	return f.fileConsumer.Stop()
 }
 
-func (f *Input) emit(ctx context.Context, attrs *fileconsumer.FileAttributes, token []byte) {
+func (f *Input) emit(ctx context.Context, token []byte, attrs map[string]any) {
 	if len(token) == 0 {
 		return
 	}
@@ -45,33 +44,10 @@ func (f *Input) emit(ctx context.Context, attrs *fileconsumer.FileAttributes, to
 		return
 	}
 
-	for _, option := range f.preEmitOptions {
-		if err := option(attrs, ent); err != nil {
-			f.Errorf("preemit: %w", err)
+	for k, v := range attrs {
+		if err := ent.Set(entry.NewAttributeField(k), v); err != nil {
+			f.Errorf("set attribute: %w", err)
 		}
 	}
-
 	f.Write(ctx, ent)
-}
-
-type preEmitOption func(*fileconsumer.FileAttributes, *entry.Entry) error
-
-func setHeaderMetadata(attrs *fileconsumer.FileAttributes, ent *entry.Entry) error {
-	return ent.Set(entry.NewAttributeField(), attrs.HeaderAttributesCopy())
-}
-
-func setFileName(attrs *fileconsumer.FileAttributes, ent *entry.Entry) error {
-	return ent.Set(entry.NewAttributeField("log.file.name"), attrs.Name)
-}
-
-func setFilePath(attrs *fileconsumer.FileAttributes, ent *entry.Entry) error {
-	return ent.Set(entry.NewAttributeField("log.file.path"), attrs.Path)
-}
-
-func setFileNameResolved(attrs *fileconsumer.FileAttributes, ent *entry.Entry) error {
-	return ent.Set(entry.NewAttributeField("log.file.name_resolved"), attrs.NameResolved)
-}
-
-func setFilePathResolved(attrs *fileconsumer.FileAttributes, ent *entry.Entry) error {
-	return ent.Set(entry.NewAttributeField("log.file.path_resolved"), attrs.PathResolved)
 }

--- a/pkg/stanza/operator/input/file/file.go
+++ b/pkg/stanza/operator/input/file/file.go
@@ -5,6 +5,7 @@ package file // import "github.com/open-telemetry/opentelemetry-collector-contri
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
@@ -33,15 +34,14 @@ func (f *Input) Stop() error {
 	return f.fileConsumer.Stop()
 }
 
-func (f *Input) emit(ctx context.Context, token []byte, attrs map[string]any) {
+func (f *Input) emit(ctx context.Context, token []byte, attrs map[string]any) error {
 	if len(token) == 0 {
-		return
+		return nil
 	}
 
 	ent, err := f.NewEntry(f.toBody(token))
 	if err != nil {
-		f.Errorf("create entry: %w", err)
-		return
+		return fmt.Errorf("create entry: %w", err)
 	}
 
 	for k, v := range attrs {
@@ -50,4 +50,5 @@ func (f *Input) emit(ctx context.Context, token []byte, attrs map[string]any) {
 		}
 	}
 	f.Write(ctx, ent)
+	return nil
 }

--- a/receiver/otlpjsonfilereceiver/file.go
+++ b/receiver/otlpjsonfilereceiver/file.go
@@ -73,7 +73,7 @@ func createLogsReceiver(_ context.Context, settings rcvr.CreateSettings, configu
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) {
+	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartLogsOp(ctx)
 		var l plog.Logs
 		l, err = logsUnmarshaler.UnmarshalLogs(token)
@@ -85,6 +85,7 @@ func createLogsReceiver(_ context.Context, settings rcvr.CreateSettings, configu
 			}
 			obsrecv.EndLogsOp(ctx, metadata.Type, l.LogRecordCount(), err)
 		}
+		return nil
 	})
 	if err != nil {
 		return nil, err
@@ -104,7 +105,7 @@ func createMetricsReceiver(_ context.Context, settings rcvr.CreateSettings, conf
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) {
+	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartMetricsOp(ctx)
 		var m pmetric.Metrics
 		m, err = metricsUnmarshaler.UnmarshalMetrics(token)
@@ -116,6 +117,7 @@ func createMetricsReceiver(_ context.Context, settings rcvr.CreateSettings, conf
 			}
 			obsrecv.EndMetricsOp(ctx, metadata.Type, m.MetricCount(), err)
 		}
+		return nil
 	})
 	if err != nil {
 		return nil, err
@@ -135,7 +137,7 @@ func createTracesReceiver(_ context.Context, settings rcvr.CreateSettings, confi
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) {
+	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartTracesOp(ctx)
 		var t ptrace.Traces
 		t, err = tracesUnmarshaler.UnmarshalTraces(token)
@@ -147,6 +149,7 @@ func createTracesReceiver(_ context.Context, settings rcvr.CreateSettings, confi
 			}
 			obsrecv.EndTracesOp(ctx, metadata.Type, t.SpanCount(), err)
 		}
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/receiver/otlpjsonfilereceiver/file.go
+++ b/receiver/otlpjsonfilereceiver/file.go
@@ -73,7 +73,7 @@ func createLogsReceiver(_ context.Context, settings rcvr.CreateSettings, configu
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, attrs *fileconsumer.FileAttributes, token []byte) {
+	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) {
 		ctx = obsrecv.StartLogsOp(ctx)
 		var l plog.Logs
 		l, err = logsUnmarshaler.UnmarshalLogs(token)
@@ -104,7 +104,7 @@ func createMetricsReceiver(_ context.Context, settings rcvr.CreateSettings, conf
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, attrs *fileconsumer.FileAttributes, token []byte) {
+	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) {
 		ctx = obsrecv.StartMetricsOp(ctx)
 		var m pmetric.Metrics
 		m, err = metricsUnmarshaler.UnmarshalMetrics(token)
@@ -135,7 +135,7 @@ func createTracesReceiver(_ context.Context, settings rcvr.CreateSettings, confi
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, attrs *fileconsumer.FileAttributes, token []byte) {
+	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) {
 		ctx = obsrecv.StartTracesOp(ctx)
 		var t ptrace.Traces
 		t, err = tracesUnmarshaler.UnmarshalTraces(token)


### PR DESCRIPTION
This is part of an effort to make `fileconsumer.Reader` more testable. I'd eventually like to move that struct into its own internal package. However, there is a dependency on the `EmitFunc` which is part of the `fileconsumer` package. Therefore, the `EmitFunc` will need to move into a separate package from `fileconsumer`.

Since this will be a breaking change (Go API only), I would like to take the opportunity to replace the emit function altogether with something more generic. The current `EmitFunc` includes a `FileAttributes` struct, the purpose of which is to pass along attributes describing the file from which a log is read. The `FileAttributes` struct may in turn contain a `HeaderAttributes` struct describing elements parsed from the header of a file.

If the emit function instead passes along all these attributes as a `map[string]any`, the `Reader` struct will be simpler and more testable, and dependencies between packages will be simpler as well. This PR is a proposal to make this change. 

There are a few complicating factors here.

1. The package checkpoints files by encoding and storing `Reader`'s. This in turn means that the `FileAttributes` struct is encoded as well. However, only the `HeaderAttributes` struct is included in this encoded representation. The idea here was that these attributes need to be attached to any log read from the file, even if we are resuming after a restart or upgrade. Conversely, the other fields (file name/path, etc) are omitted from the encoding because the file may have moved. Since this PR _would_ encode these values, we need to be sure to overwrite them when we reconstruct the `Reader`. This is accomplished in the reader factory by resolving the fields _after_ copying the previously known values. A new test verified that these fields are updated appropriately.
2. Since existing users may have encoded representations of the `Reader` from before this change, we need to handle this during decoding. This is handled in a single block of code which can be removed in a future version. I've tested this manually.
3. The `file_input` operator used the `FileAttributes` struct in a specific way, but this is made redundant by the approach described in 1.


Benchmarks for this change show no notable impact:

```
--- main ---
BenchmarkFileInput/Single-10         	 1280559	       953.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkFileInput/Glob-10           	  342447	      3574 ns/op	       2 B/op	       0 allocs/op
BenchmarkFileInput/MultiGlob-10      	  347842	      3513 ns/op	       2 B/op	       0 allocs/op
BenchmarkFileInput/MaxConcurrent-10  	  339127	      3615 ns/op	       4 B/op	       0 allocs/op
BenchmarkFileInput/FngrPrntLarge-10  	 1266826	       955.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkFileInput/FngrPrntSmall-10  	 1260673	       964.4 ns/op	       0 B/op	       0 allocs/op

--- pr ---
BenchmarkFileInput/Single-10         	 1298505	       943.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkFileInput/Glob-10           	  351753	      3495 ns/op	       2 B/op	       0 allocs/op
BenchmarkFileInput/MultiGlob-10      	  348549	      3511 ns/op	       2 B/op	       0 allocs/op
BenchmarkFileInput/MaxConcurrent-10  	  353061	      3470 ns/op	       4 B/op	       0 allocs/op
BenchmarkFileInput/FngrPrntLarge-10  	 1270884	       948.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkFileInput/FngrPrntSmall-10  	 1279246	       941.2 ns/op	       0 B/op	       0 allocs/op
```