### PR TITLE
[chore][fileconsumer] Establish internal util package

### DIFF
--- a/pkg/stanza/fileconsumer/attributes.go
+++ b/pkg/stanza/fileconsumer/attributes.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 
 	"go.uber.org/multierr"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/util"
 )
 
 type FileAttributes struct {
@@ -20,7 +22,7 @@ type FileAttributes struct {
 
 // HeaderAttributesCopy gives a copy of the HeaderAttributes, in order to restrict mutation of the HeaderAttributes.
 func (f *FileAttributes) HeaderAttributesCopy() map[string]any {
-	return mapCopy(f.HeaderAttributes)
+	return util.MapCopy(f.HeaderAttributes)
 }
 
 // resolveFileAttributes resolves file attributes

--- a/pkg/stanza/fileconsumer/internal/util/util.go
+++ b/pkg/stanza/fileconsumer/internal/util/util.go
@@ -1,0 +1,20 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/util"
+
+// MapCopy deep copies the provided attributes map.
+func MapCopy(m map[string]any) map[string]any {
+	newMap := make(map[string]any, len(m))
+	for k, v := range m {
+		switch typedVal := v.(type) {
+		case map[string]any:
+			newMap[k] = MapCopy(typedVal)
+		default:
+			// Assume any other values are safe to directly copy.
+			// Struct types and slice types shouldn't appear in attribute maps from pipelines
+			newMap[k] = v
+		}
+	}
+	return newMap
+}

--- a/pkg/stanza/fileconsumer/internal/util/util_test.go
+++ b/pkg/stanza/fileconsumer/internal/util/util_test.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapCopy(t *testing.T) {
+	initMap := map[string]any{
+		"mapVal": map[string]any{
+			"nestedVal": "value1",
+		},
+		"intVal": 1,
+		"strVal": "OrigStr",
+	}
+
+	copyMap := MapCopy(initMap)
+	// Mutate values on the copied map
+	copyMap["mapVal"].(map[string]any)["nestedVal"] = "overwrittenValue"
+	copyMap["intVal"] = 2
+	copyMap["strVal"] = "CopyString"
+
+	// Assert that the original map should have the same values
+	assert.Equal(t, "value1", initMap["mapVal"].(map[string]any)["nestedVal"])
+	assert.Equal(t, 1, initMap["intVal"])
+	assert.Equal(t, "OrigStr", initMap["strVal"])
+}

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -201,19 +201,3 @@ func min0(a, b int) int {
 	}
 	return b
 }
-
-// mapCopy deep copies the provided attributes map.
-func mapCopy(m map[string]any) map[string]any {
-	newMap := make(map[string]any, len(m))
-	for k, v := range m {
-		switch typedVal := v.(type) {
-		case map[string]any:
-			newMap[k] = mapCopy(typedVal)
-		default:
-			// Assume any other values are safe to directly copy.
-			// Struct types and slice types shouldn't appear in attribute maps from pipelines
-			newMap[k] = v
-		}
-	}
-	return newMap
-}

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/util"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/pipeline"
 )
@@ -39,7 +40,7 @@ func (f *readerFactory) copy(old *Reader, newFile *os.File) (*Reader, error) {
 		withFingerprint(old.Fingerprint.Copy()).
 		withOffset(old.Offset).
 		withSplitterFunc(old.lineSplitFunc).
-		withHeaderAttributes(mapCopy(old.FileAttributes.HeaderAttributes)).
+		withHeaderAttributes(util.MapCopy(old.FileAttributes.HeaderAttributes)).
 		withHeaderFinalized(old.HeaderFinalized).
 		build()
 }

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -222,27 +222,6 @@ func readToken(t *testing.T, c chan *emitParams) []byte {
 	return nil
 }
 
-func TestMapCopy(t *testing.T) {
-	initMap := map[string]any{
-		"mapVal": map[string]any{
-			"nestedVal": "value1",
-		},
-		"intVal": 1,
-		"strVal": "OrigStr",
-	}
-
-	copyMap := mapCopy(initMap)
-	// Mutate values on the copied map
-	copyMap["mapVal"].(map[string]any)["nestedVal"] = "overwrittenValue"
-	copyMap["intVal"] = 2
-	copyMap["strVal"] = "CopyString"
-
-	// Assert that the original map should have the same values
-	assert.Equal(t, "value1", initMap["mapVal"].(map[string]any)["nestedVal"])
-	assert.Equal(t, 1, initMap["intVal"])
-	assert.Equal(t, "OrigStr", initMap["strVal"])
-}
-
 func TestEncodingDecode(t *testing.T) {
 	testFile := openTemp(t, t.TempDir())
 	testToken := tokenWithLength(2 * fingerprint.DefaultSize)


### PR DESCRIPTION
Subset of #24036 

The `MapCopy` function is currently only used in `fileconsumer`, but will soon be used in multiple subpackages.