### PR TITLE
[connector/spanmetrics] disable exemplars by default

### DIFF
--- a/.chloggen/spanmetricsconnector-disabled.yaml
+++ b/.chloggen/spanmetricsconnector-disabled.yaml
@@ -18,4 +18,4 @@ issues: [23872]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: "Previously spanmetricsconnector would attach every single span as an exemplar to the histogram. |
-  While now exemplars are disabled. To enable them set `exemplar.enabled=true`"
+  Exemplars are now disabled by default. To enable them set `exemplars.enabled=true`"

--- a/.chloggen/spanmetricsconnector-disabled.yaml
+++ b/.chloggen/spanmetricsconnector-disabled.yaml
@@ -17,5 +17,6 @@ issues: [23872]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: "Previously spanmetricsconnector would attach every single span as an exemplar to the histogram. |
-  Exemplars are now disabled by default. To enable them set `exemplars.enabled=true`"
+subtext: | 
+  Previously spanmetricsconnector would attach every single span as an exemplar to the histogram.
+  Exemplars are now disabled by default. To enable them set `exemplars::enabled=true`

--- a/.chloggen/spanmetricsconnector-disabled.yaml
+++ b/.chloggen/spanmetricsconnector-disabled.yaml
@@ -1,0 +1,21 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Histograms will not have exemplars by default"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23872]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "Previously spanmetricsconnector would attach every single span as an exemplar to the histogram. |
+  While now exemplars are disabled. To enable them set `exemplar.enabled=true`"

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -98,7 +98,9 @@ The following settings can be optionally configured:
   One of either `AGGREGATION_TEMPORALITY_CUMULATIVE` or `AGGREGATION_TEMPORALITY_DELTA`.
 - `namespace`: Defines the namespace of the generated metrics. If `namespace` provided, generated metric name will be added `namespace.` prefix.
 - `metrics_flush_interval` (default: `15s`): Defines the flush interval of the generated metrics.
-  
+- `exemplars`:  Use to configure how to attach exemplars to histograms
+  - `enabled` (default: `false`): enabling will add spans as Exemplars.
+
 ## Examples
 
 The following is a simple example usage of the `spanmetrics` connector.
@@ -123,6 +125,8 @@ connectors:
       - name: http.method
         default: GET
       - name: http.status_code
+    exemplars:
+      enabled: false
     exclude_dimensions: ['status.code']
     dimensions_cache_size: 1000
     aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"    

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -126,7 +126,7 @@ connectors:
         default: GET
       - name: http.status_code
     exemplars:
-      enabled: false
+      enabled: true
     exclude_dimensions: ['status.code']
     dimensions_cache_size: 1000
     aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"    

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -55,6 +55,9 @@ type Config struct {
 
 	// Namespace is the namespace of the metrics emitted by the connector.
 	Namespace string `mapstructure:"namespace"`
+
+	// ExemplarConfig defines the configuration for exemplars.
+	ExemplarConfig ExemplarConfig `mapstructure:"exemplar"`
 }
 
 type HistogramConfig struct {
@@ -62,6 +65,10 @@ type HistogramConfig struct {
 	Unit        metrics.Unit                `mapstructure:"unit"`
 	Exponential *ExponentialHistogramConfig `mapstructure:"exponential"`
 	Explicit    *ExplicitHistogramConfig    `mapstructure:"explicit"`
+}
+
+type ExemplarConfig struct {
+	Enabled bool `mapstructure:"enabled"`
 }
 
 type ExponentialHistogramConfig struct {

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -56,8 +56,8 @@ type Config struct {
 	// Namespace is the namespace of the metrics emitted by the connector.
 	Namespace string `mapstructure:"namespace"`
 
-	// ExemplarConfig defines the configuration for exemplars.
-	ExemplarConfig ExemplarConfig `mapstructure:"exemplar"`
+	// Exemplars defines the configuration for exemplars.
+	Exemplars ExemplarsConfig `mapstructure:"exemplars"`
 }
 
 type HistogramConfig struct {
@@ -67,7 +67,7 @@ type HistogramConfig struct {
 	Explicit    *ExplicitHistogramConfig    `mapstructure:"explicit"`
 }
 
-type ExemplarConfig struct {
+type ExemplarsConfig struct {
 	Enabled bool `mapstructure:"enabled"`
 }
 

--- a/connector/spanmetricsconnector/config_test.go
+++ b/connector/spanmetricsconnector/config_test.go
@@ -49,6 +49,9 @@ func TestLoadConfig(t *testing.T) {
 				},
 				DimensionsCacheSize:  1500,
 				MetricsFlushInterval: 30 * time.Second,
+				ExemplarConfig: ExemplarConfig{
+					Enabled: true,
+				},
 				Histogram: HistogramConfig{
 					Unit: metrics.Seconds,
 					Explicit: &ExplicitHistogramConfig{
@@ -59,8 +62,7 @@ func TestLoadConfig(t *testing.T) {
 						},
 					},
 				},
-			},
-		},
+			}},
 		{
 			id: component.NewIDWithName(metadata.Type, "exponential_histogram"),
 			expected: &Config{

--- a/connector/spanmetricsconnector/config_test.go
+++ b/connector/spanmetricsconnector/config_test.go
@@ -49,7 +49,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				DimensionsCacheSize:  1500,
 				MetricsFlushInterval: 30 * time.Second,
-				ExemplarConfig: ExemplarConfig{
+				Exemplars: ExemplarsConfig{
 					Enabled: true,
 				},
 				Histogram: HistogramConfig{
@@ -84,6 +84,16 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id:           component.NewIDWithName(metadata.Type, "invalid_histogram_unit"),
 			errorMessage: "unknown Unit \"h\"",
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "exemplars_enabled"),
+			expected: &Config{
+				AggregationTemporality: "AGGREGATION_TEMPORALITY_CUMULATIVE",
+				DimensionsCacheSize:    defaultDimensionsCacheSize,
+				MetricsFlushInterval:   15 * time.Second,
+				Histogram:              HistogramConfig{Disable: false, Unit: defaultUnit},
+				Exemplars:              ExemplarsConfig{Enabled: true},
+			},
 		},
 	}
 

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -327,7 +327,7 @@ func (p *connectorImp) aggregateMetrics(traces ptrace.Traces) {
 }
 
 func (p *connectorImp) addExemplar(span ptrace.Span, duration float64, h metrics.Histogram) {
-	if !p.config.ExemplarConfig.Enabled {
+	if !p.config.Exemplars.Enabled {
 		return
 	}
 	if span.TraceID().IsEmpty() {

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -314,10 +314,9 @@ func (p *connectorImp) aggregateMetrics(traces ptrace.Traces) {
 				if !p.config.Histogram.Disable {
 					// aggregate histogram metrics
 					h := histograms.GetOrCreate(key, attributes)
+					p.addExemplar(span, duration, h)
 					h.Observe(duration)
-					if !span.TraceID().IsEmpty() {
-						h.AddExemplar(span.TraceID(), span.SpanID(), duration)
-					}
+
 				}
 				// aggregate sums metrics
 				s := sums.GetOrCreate(key, attributes)
@@ -325,6 +324,17 @@ func (p *connectorImp) aggregateMetrics(traces ptrace.Traces) {
 			}
 		}
 	}
+}
+
+func (p *connectorImp) addExemplar(span ptrace.Span, duration float64, h metrics.Histogram) {
+	if !p.config.ExemplarConfig.Enabled {
+		return
+	}
+	if span.TraceID().IsEmpty() {
+		return
+	}
+
+	h.AddExemplar(span.TraceID(), span.SpanID(), duration)
 }
 
 type resourceKey [16]byte

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -398,14 +398,14 @@ func initSpan(span span, s ptrace.Span) {
 	s.SetSpanID(pcommon.SpanID(span.spanID))
 }
 
-func disabledExemplarConfig() ExemplarConfig {
-	return ExemplarConfig{
+func disabledExemplarsConfig() ExemplarsConfig {
+	return ExemplarsConfig{
 		Enabled: false,
 	}
 }
 
-func enabledExemplarConfig() ExemplarConfig {
-	return ExemplarConfig{
+func enabledExemplarsConfig() ExemplarsConfig {
+	return ExemplarsConfig{
 		Enabled: true,
 	}
 }
@@ -583,7 +583,7 @@ func TestConcurrentShutdown(t *testing.T) {
 	ticker := mockClock.NewTicker(time.Nanosecond)
 
 	// Test
-	p := newConnectorImp(t, new(consumertest.MetricsSink), nil, explicitHistogramsConfig, disabledExemplarConfig, cumulative, logger, ticker)
+	p := newConnectorImp(t, new(consumertest.MetricsSink), nil, explicitHistogramsConfig, disabledExemplarsConfig, cumulative, logger, ticker)
 	err := p.Start(ctx, componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -651,7 +651,7 @@ func TestConsumeMetricsErrors(t *testing.T) {
 
 	mockClock := clock.NewMock(time.Now())
 	ticker := mockClock.NewTicker(time.Nanosecond)
-	p := newConnectorImp(t, mcon, nil, explicitHistogramsConfig, disabledExemplarConfig, cumulative, logger, ticker)
+	p := newConnectorImp(t, mcon, nil, explicitHistogramsConfig, disabledExemplarsConfig, cumulative, logger, ticker)
 
 	ctx := metadata.NewIncomingContext(context.Background(), nil)
 	err := p.Start(ctx, componenttest.NewNopHost())
@@ -688,7 +688,7 @@ func TestConsumeTraces(t *testing.T) {
 		name                   string
 		aggregationTemporality string
 		histogramConfig        func() HistogramConfig
-		exemplarConfig         func() ExemplarConfig
+		exemplarConfig         func() ExemplarsConfig
 		verifier               func(t testing.TB, input pmetric.Metrics) bool
 		traces                 []ptrace.Traces
 	}{
@@ -697,7 +697,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test histogram metrics are disabled",
 			aggregationTemporality: cumulative,
 			histogramConfig:        disabledHistogramsConfig,
-			exemplarConfig:         disabledExemplarConfig,
+			exemplarConfig:         disabledExemplarsConfig,
 			verifier:               verifyDisabledHistogram,
 			traces:                 []ptrace.Traces{buildSampleTrace()},
 		},
@@ -706,7 +706,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test single consumption, three spans (Cumulative), using exp. histogram",
 			aggregationTemporality: cumulative,
 			histogramConfig:        exponentialHistogramsConfig,
-			exemplarConfig:         disabledExemplarConfig,
+			exemplarConfig:         disabledExemplarsConfig,
 			verifier:               verifyConsumeMetricsInputCumulative,
 			traces:                 []ptrace.Traces{buildSampleTrace()},
 		},
@@ -714,7 +714,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test single consumption, three spans (Delta), using exp. histogram",
 			aggregationTemporality: delta,
 			histogramConfig:        exponentialHistogramsConfig,
-			exemplarConfig:         disabledExemplarConfig,
+			exemplarConfig:         disabledExemplarsConfig,
 			verifier:               verifyConsumeMetricsInputDelta,
 			traces:                 []ptrace.Traces{buildSampleTrace()},
 		},
@@ -723,7 +723,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test two consumptions (Cumulative), using exp. histogram",
 			aggregationTemporality: cumulative,
 			histogramConfig:        exponentialHistogramsConfig,
-			exemplarConfig:         disabledExemplarConfig,
+			exemplarConfig:         disabledExemplarsConfig,
 			verifier:               verifyMultipleCumulativeConsumptions(),
 			traces:                 []ptrace.Traces{buildSampleTrace(), buildSampleTrace()},
 		},
@@ -732,7 +732,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test two consumptions (Delta), using exp. histogram",
 			aggregationTemporality: delta,
 			histogramConfig:        exponentialHistogramsConfig,
-			exemplarConfig:         disabledExemplarConfig,
+			exemplarConfig:         disabledExemplarsConfig,
 			verifier:               verifyConsumeMetricsInputDelta,
 			traces:                 []ptrace.Traces{buildSampleTrace(), buildSampleTrace()},
 		},
@@ -741,7 +741,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test bad consumptions (Delta), using exp. histogram",
 			aggregationTemporality: cumulative,
 			histogramConfig:        exponentialHistogramsConfig,
-			exemplarConfig:         disabledExemplarConfig,
+			exemplarConfig:         disabledExemplarsConfig,
 			verifier:               verifyBadMetricsOkay,
 			traces:                 []ptrace.Traces{buildBadSampleTrace()},
 		},
@@ -751,7 +751,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test single consumption, three spans (Cumulative).",
 			aggregationTemporality: cumulative,
 			histogramConfig:        explicitHistogramsConfig,
-			exemplarConfig:         disabledExemplarConfig,
+			exemplarConfig:         disabledExemplarsConfig,
 			verifier:               verifyConsumeMetricsInputCumulative,
 			traces:                 []ptrace.Traces{buildSampleTrace()},
 		},
@@ -759,7 +759,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test single consumption, three spans (Delta).",
 			aggregationTemporality: delta,
 			histogramConfig:        explicitHistogramsConfig,
-			exemplarConfig:         disabledExemplarConfig,
+			exemplarConfig:         disabledExemplarsConfig,
 			verifier:               verifyConsumeMetricsInputDelta,
 			traces:                 []ptrace.Traces{buildSampleTrace()},
 		},
@@ -768,7 +768,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test two consumptions (Cumulative).",
 			aggregationTemporality: cumulative,
 			histogramConfig:        explicitHistogramsConfig,
-			exemplarConfig:         disabledExemplarConfig,
+			exemplarConfig:         disabledExemplarsConfig,
 			verifier:               verifyMultipleCumulativeConsumptions(),
 			traces:                 []ptrace.Traces{buildSampleTrace(), buildSampleTrace()},
 		},
@@ -777,7 +777,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test two consumptions (Delta).",
 			aggregationTemporality: delta,
 			histogramConfig:        explicitHistogramsConfig,
-			exemplarConfig:         disabledExemplarConfig,
+			exemplarConfig:         disabledExemplarsConfig,
 			verifier:               verifyConsumeMetricsInputDelta,
 			traces:                 []ptrace.Traces{buildSampleTrace(), buildSampleTrace()},
 		},
@@ -786,7 +786,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test bad consumptions (Delta).",
 			aggregationTemporality: cumulative,
 			histogramConfig:        explicitHistogramsConfig,
-			exemplarConfig:         disabledExemplarConfig,
+			exemplarConfig:         disabledExemplarsConfig,
 			verifier:               verifyBadMetricsOkay,
 			traces:                 []ptrace.Traces{buildBadSampleTrace()},
 		},
@@ -795,7 +795,7 @@ func TestConsumeTraces(t *testing.T) {
 			name:                   "Test Exemplars are enabled",
 			aggregationTemporality: cumulative,
 			histogramConfig:        explicitHistogramsConfig,
-			exemplarConfig:         enabledExemplarConfig,
+			exemplarConfig:         enabledExemplarsConfig,
 			verifier:               verifyExemplarsExist,
 			traces:                 []ptrace.Traces{buildSampleTrace()},
 		},
@@ -846,7 +846,7 @@ func TestMetricKeyCache(t *testing.T) {
 	mcon := &mocks.MetricsConsumer{}
 	mcon.On("ConsumeMetrics", mock.Anything, mock.Anything).Return(nil)
 
-	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarConfig, cumulative, zaptest.NewLogger(t), nil)
+	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, cumulative, zaptest.NewLogger(t), nil)
 	traces := buildSampleTrace()
 
 	// Test
@@ -878,7 +878,7 @@ func BenchmarkConnectorConsumeTraces(b *testing.B) {
 	mcon := &mocks.MetricsConsumer{}
 	mcon.On("ConsumeMetrics", mock.Anything, mock.Anything).Return(nil)
 
-	conn := newConnectorImp(nil, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarConfig, cumulative, zaptest.NewLogger(b), nil)
+	conn := newConnectorImp(nil, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, cumulative, zaptest.NewLogger(b), nil)
 
 	traces := buildSampleTrace()
 
@@ -893,7 +893,7 @@ func TestExcludeDimensionsConsumeTraces(t *testing.T) {
 	mcon := &mocks.MetricsConsumer{}
 	mcon.On("ConsumeMetrics", mock.Anything, mock.Anything).Return(nil)
 	excludeDimensions := []string{"span.kind", "span.name", "totallyWrongNameDoesNotAffectAnything"}
-	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarConfig, cumulative, zaptest.NewLogger(t), nil, excludeDimensions...)
+	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, cumulative, zaptest.NewLogger(t), nil, excludeDimensions...)
 	traces := buildSampleTrace()
 
 	// Test
@@ -942,12 +942,12 @@ func TestExcludeDimensionsConsumeTraces(t *testing.T) {
 
 }
 
-func newConnectorImp(t *testing.T, mcon consumer.Metrics, defaultNullValue *string, histogramConfig func() HistogramConfig, exemplarConfig func() ExemplarConfig, temporality string, logger *zap.Logger, ticker *clock.Ticker, excludedDimensions ...string) *connectorImp {
+func newConnectorImp(t *testing.T, mcon consumer.Metrics, defaultNullValue *string, histogramConfig func() HistogramConfig, exemplarsConfig func() ExemplarsConfig, temporality string, logger *zap.Logger, ticker *clock.Ticker, excludedDimensions ...string) *connectorImp {
 
 	cfg := &Config{
 		AggregationTemporality: temporality,
 		Histogram:              histogramConfig(),
-		ExemplarConfig:         exemplarConfig(),
+		Exemplars:              exemplarsConfig(),
 		ExcludeDimensions:      excludedDimensions,
 		DimensionsCacheSize:    DimensionsCacheSize,
 		Dimensions: []Dimension{
@@ -1077,7 +1077,7 @@ func TestConnectorConsumeTracesEvictedCacheKey(t *testing.T) {
 	ticker := mockClock.NewTicker(time.Nanosecond)
 
 	// Note: default dimension key cache size is 2.
-	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarConfig, cumulative, zaptest.NewLogger(t), ticker)
+	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, cumulative, zaptest.NewLogger(t), ticker)
 
 	ctx := metadata.NewIncomingContext(context.Background(), nil)
 	err := p.Start(ctx, componenttest.NewNopHost())

--- a/connector/spanmetricsconnector/testdata/config.yaml
+++ b/connector/spanmetricsconnector/testdata/config.yaml
@@ -12,7 +12,7 @@ spanmetrics/full:
     unit: "s"
     explicit:
       buckets: [ 10ms, 100ms, 250ms ]
-  exemplar:
+  exemplars:
     enabled: true
   dimensions_cache_size: 1500
 
@@ -57,11 +57,7 @@ spanmetrics/invalid_histogram_unit:
   histogram:
     unit: "h"
 
-# exemplars disabled 
-spanmetrics/exemplars_disabled:
+# exemplars enabled 
+spanmetrics/exemplars_enabled:
   exemplars:
     enabled: true
-  histogram:
-    exponential:
-      max_size: 10
-

--- a/connector/spanmetricsconnector/testdata/config.yaml
+++ b/connector/spanmetricsconnector/testdata/config.yaml
@@ -12,7 +12,8 @@ spanmetrics/full:
     unit: "s"
     explicit:
       buckets: [ 10ms, 100ms, 250ms ]
-
+  exemplar:
+    enabled: true
   dimensions_cache_size: 1500
 
   # Additional list of dimensions on top of:
@@ -55,3 +56,12 @@ spanmetrics/exponential_and_explicit_histogram:
 spanmetrics/invalid_histogram_unit:
   histogram:
     unit: "h"
+
+# exemplars disabled 
+spanmetrics/exemplars_disabled:
+  exemplars:
+    enabled: true
+  histogram:
+    exponential:
+      max_size: 10
+


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Breaking change! Allows enabling / disabling Exemplars.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23872
**Testing:** <Describe what testing was performed and which tests were added.>

- Added unit test
**Documentation:** <Describe the documentation added.>
- Added docs