### PR TITLE
[exporter/awsemfexporter] Propagate RetainInitialValueOfDeltaMetric to translateOTelToGroupedMetric

### DIFF
--- a/.chloggen/awsemfexporter-publish-initial-metrics.yaml
+++ b/.chloggen/awsemfexporter-publish-initial-metrics.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsemfexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add retain_initial_value_of_delta_metric to translateOTelToGroupedMetric, allowing the initial set of metrics to be published
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24051]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -103,6 +103,7 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm pmetric.ResourceMetri
 	var instrumentationScopeName string
 	cWNamespace := getNamespace(rm, config.Namespace)
 	logGroup, logStream, patternReplaceSucceeded := getLogInfo(rm, cWNamespace, config)
+	deltaInitialValue := config.RetainInitialValueOfDeltaMetric
 
 	ilms := rm.ScopeMetrics()
 	var metricReceiver string
@@ -120,11 +121,12 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm pmetric.ResourceMetri
 			metric := metrics.At(k)
 			metadata := cWMetricMetadata{
 				groupedMetricMetadata: groupedMetricMetadata{
-					namespace:      cWNamespace,
-					timestampMs:    timestamp,
-					logGroup:       logGroup,
-					logStream:      logStream,
-					metricDataType: metric.Type(),
+					namespace:                  cWNamespace,
+					timestampMs:                timestamp,
+					logGroup:                   logGroup,
+					logStream:                  logStream,
+					metricDataType:             metric.Type(),
+					retainInitialValueForDelta: deltaInitialValue,
 				},
 				instrumentationScopeName: instrumentationScopeName,
 				receiver:                 metricReceiver,


### PR DESCRIPTION
**Description:**

The config option `retain_initial_value_of_delta_metric` does not seem to be used in `translateOTelToGroupedMetric`, which prevents the initial value of a basic counter from being published during a Lambda cold boot.

Please see the minimum project required to replicate the issue [here](https://github.com/jameshi16/delta-initial-value-minimum-project).

**Link to tracking Issue:** The main issue related to this PR can be found [here](https://github.com/aws-observability/aws-otel-lambda/issues/634).

It seems like I had a predecessor fixing this issue (see #17988), but his changes does not work for my use case.

**Testing:** An additional test ensures that if `retain_initial_value_of_delta_metric` is set, it will be propagated to the `cWMetricMetadata`.

**Documentation:** None