### PR TITLE
[chore] [receiver/sqlquery] fix flaky tests by increasing timeouts

### DIFF
--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -72,7 +72,7 @@ func TestPostgresIntegrationLogsTrackingWithoutStorage(t *testing.T) {
 		func() bool {
 			return consumer.LogRecordCount() > 0
 		},
-		3*time.Second,
+		1*time.Minute,
 		1*time.Second,
 		"failed to receive more than 0 logs",
 	)
@@ -107,7 +107,7 @@ func TestPostgresIntegrationLogsTrackingWithoutStorage(t *testing.T) {
 		func() bool {
 			return consumer.LogRecordCount() > 0
 		},
-		3*time.Second,
+		1*time.Minute,
 		1*time.Second,
 		"failed to receive more than 0 logs",
 	)
@@ -161,7 +161,7 @@ func TestPostgresIntegrationLogsTrackingWithStorage(t *testing.T) {
 		func() bool {
 			return consumer.LogRecordCount() > 0
 		},
-		3*time.Second,
+		1*time.Minute,
 		1*time.Second,
 		"failed to receive more than 0 logs",
 	)
@@ -195,7 +195,7 @@ func TestPostgresIntegrationLogsTrackingWithStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for some logs to come in.
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// stop the SQL Query receiver
 	err = receiver.Shutdown(context.Background())
@@ -233,7 +233,7 @@ func TestPostgresIntegrationLogsTrackingWithStorage(t *testing.T) {
 		func() bool {
 			return consumer.LogRecordCount() > 0
 		},
-		3*time.Second,
+		1*time.Minute,
 		1*time.Second,
 		"failed to receive more than 0 logs",
 	)


### PR DESCRIPTION
Fixes #23568

The flaky tests are:

- `TestPostgresIntegrationLogsTrackingWithoutStorage`
- `TestPostgresIntegrationLogsTrackingWithStorage`

I cannot use the `scraperint` package for these tests, because those tests have a nonstandard flow:

- start the receiver
- gather some metrics
- shut down the receiver
- change something (add logs to the database in the container)
- start the receiver again
- gather some metrics
- shut down the receiver

The metrics collection timeout on the tests was low - 3 seconds. I have increased the timeout to 1 minute.