### PR TITLE
[receiver/statsd] fix linting changes

### DIFF
--- a/receiver/statsdreceiver/config.go
+++ b/receiver/statsdreceiver/config.go
@@ -39,9 +39,12 @@ func (c *Config) Validate() error {
 		}
 
 		switch eachMap.StatsdType {
-		case protocol.TimingTypeName, protocol.TimingAltTypeName, protocol.HistogramTypeName, protocol.CounterTypeName, protocol.GaugeTypeName:
+		case protocol.TimingTypeName, protocol.TimingAltTypeName, protocol.HistogramTypeName:
+			// do nothing
+		case protocol.CounterTypeName, protocol.GaugeTypeName:
+			fallthrough
 		default:
-			errs = multierr.Append(errs, fmt.Errorf("statsd_type is not a supported mapping: %s", eachMap.StatsdType))
+			errs = multierr.Append(errs, fmt.Errorf("statsd_type is not a supported mapping for histogram and timing metrics: %s", eachMap.StatsdType))
 		}
 
 		if eachMap.ObserverType == "" {
@@ -50,9 +53,12 @@ func (c *Config) Validate() error {
 		}
 
 		switch eachMap.ObserverType {
-		case protocol.GaugeObserver, protocol.SummaryObserver, protocol.HistogramObserver, protocol.DisableObserver:
+		case protocol.GaugeObserver, protocol.SummaryObserver, protocol.HistogramObserver:
+			// do nothing
+		case protocol.DisableObserver:
+			fallthrough
 		default:
-			errs = multierr.Append(errs, fmt.Errorf("observer_type is not supported: %s", eachMap.ObserverType))
+			errs = multierr.Append(errs, fmt.Errorf("observer_type is not supported for histogram and timing metrics: %s", eachMap.ObserverType))
 		}
 
 		if eachMap.ObserverType == protocol.HistogramObserver {

--- a/receiver/statsdreceiver/config_test.go
+++ b/receiver/statsdreceiver/config_test.go
@@ -84,8 +84,8 @@ func TestValidate(t *testing.T) {
 	const (
 		negativeAggregationIntervalErr = "aggregation_interval must be a positive duration"
 		noObjectNameErr                = "must specify object id for all TimerHistogramMappings"
-		statsdTypeNotSupportErr        = "statsd_type is not a supported mapping: %s"
-		observerTypeNotSupportErr      = "observer_type is not supported: %s"
+		statsdTypeNotSupportErr        = "statsd_type is not a supported mapping for histogram and timing metrics: %s"
+		observerTypeNotSupportErr      = "observer_type is not supported for histogram and timing metrics: %s"
 	)
 
 	tests := []test{


### PR DESCRIPTION
There were changes in behaviour introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/24046 which needed to be fixed to maintain current receiver behaviour.
