### PR TITLE
[chore] Add "Sponsor Needed" as default label of new component

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_component.yaml
+++ b/.github/ISSUE_TEMPLATE/new_component.yaml
@@ -1,7 +1,7 @@
 name: New component proposal
 description: Suggest a new component for the project
 title: "New component: "
-labels: ["new component", "needs triage"]
+labels: ["Sponsor Needed", "needs triage"]
 body:
   - type: textarea
     attributes:


### PR DESCRIPTION
Removes the "new component" label, which doesn't exist.