### PR TITLE
Update Kafka exporter and receiver docs

### DIFF
--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -57,14 +57,15 @@ The following settings can be optionally configured:
   - `kerberos`
     - `service_name`: Kerberos service name
     - `realm`: Kerberos realm
-    - `use_keytab`:  Use of keytab instead of password, if this is true, keytab file will be used instead of password
+    - `use_keytab`: Use of keytab instead of password, if this is true, keytab file will be used instead of password
     - `username`: The Kerberos username used for authenticate with KDC
     - `password`: The Kerberos password used for authenticate with KDC
     - `config_file`: Path to Kerberos configuration. i.e /etc/krb5.conf
     - `keytab_file`: Path to keytab file. i.e /etc/security/kafka.keytab
 - `metadata`
-  - `full` (default = true): Whether to maintain a full set of metadata. 
-                                    When disabled the client does not make the initial request to broker at the startup.
+  - `full` (default = true): Whether to maintain a full set of metadata. When
+    disabled, the client does not make the initial request to broker at the
+    startup.
   - `retry`
     - `max` (default = 3): The number of retries to get metadata
     - `backoff` (default = 250ms): How long to wait between metadata retries

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -46,6 +46,12 @@ The following settings can be optionally configured:
   - `plain_text`
     - `username`: The username to use.
     - `password`: The password to use
+  - `sasl`
+    - `username`: The username to use.
+    - `password`: The password to use
+    - `mechanism`: The sasl mechanism to use (SCRAM-SHA-256, SCRAM-SHA-512, AWS_MSK_IAM or PLAIN)
+    - `aws_msk.region`: AWS Region in case of AWS_MSK_IAM mechanism
+    - `aws_msk.broker_addr`: MSK Broker address in case of AWS_MSK_IAM mechanism
   - `tls`
     - `ca_file`: path to the CA cert. For a client this verifies the server certificate. Should
       only be used if `insecure` is set to true.
@@ -67,7 +73,7 @@ The following settings can be optionally configured:
     - `keytab_file`: Path to keytab file. i.e /etc/security/kafka.keytab
 - `metadata`
   - `full` (default = true): Whether to maintain a full set of metadata. When
-    disabled the client does not make the initial request to broker at the
+    disabled, the client does not make the initial request to broker at the
     startup.
   - `retry`
     - `max` (default = 3): The number of retries to get metadata


### PR DESCRIPTION
Minor updates to make the documentation for Kafka receiver in line with the Kafka exporter. I am not adding a changelog entry since technically this is not a new feature, but rather an undocumented existing feature in the receiver.