### PR TITLE
[receiver/jaeger] Removing remote sampling configuration code

### DIFF
--- a/.chloggen/disable_jaeger_receiver_remote_sampling.yaml
+++ b/.chloggen/disable_jaeger_receiver_remote_sampling.yaml
@@ -17,7 +17,7 @@ issues: [24186]
 # Use pipe (|) for multiline entries.
 subtext: > 
   The jaeger receiver will fail to start if remote_sampling config is specified in it. 
-  The `receiver.jaeger.DisableRemoteSampling` feature gate can be disabled to let the receiver start and treat 
+  The `receiver.jaeger.DisableRemoteSampling` feature gate can be set to let the receiver start and treat 
   remote_sampling config as no-op. In a future version this feature gate will be removed and the receiver will always 
   fail when remote_sampling config is specified.
 

--- a/.chloggen/disable_jaeger_receiver_remote_sampling.yaml
+++ b/.chloggen/disable_jaeger_receiver_remote_sampling.yaml
@@ -10,7 +10,7 @@ component: jaegerreceiver
 note: Deprecate remote_sampling config in the jaeger receiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [22853]
+issues: [24186]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/disable_jaeger_receiver_remote_sampling.yaml
+++ b/.chloggen/disable_jaeger_receiver_remote_sampling.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: jaegerreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate remote_sampling config in the jaeger receiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22853]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: > 
+  The jaeger receiver will fail to start if remote_sampling config is specified in it. 
+  The `receiver.jaeger.DisableRemoteSampling` feature gate can be disabled to let the receiver start and treat 
+  remote_sampling config as no-op. In a future version this feature gate will be removed and the receiver will always 
+  fail when remote_sampling config is specified.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/extension/jaegerremotesampling/factory.go
+++ b/extension/jaegerremotesampling/factory.go
@@ -15,7 +15,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling/internal/metadata"
 )
 
-// NewFactory creates a factory for the OIDC Authenticator extension.
+// NewFactory creates a factory for the jaeger remote sampling extension.
 func NewFactory() extension.Factory {
 	return extension.NewFactory(
 		metadata.Type,

--- a/extension/oauth2clientauthextension/factory.go
+++ b/extension/oauth2clientauthextension/factory.go
@@ -13,7 +13,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension/internal/metadata"
 )
 
-// NewFactory creates a factory for the OIDC Authenticator extension.
+// NewFactory creates a factory for the oauth2 client Authenticator extension.
 func NewFactory() extension.Factory {
 	return extension.NewFactory(
 		metadata.Type,

--- a/receiver/jaegerreceiver/config.go
+++ b/receiver/jaegerreceiver/config.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -25,14 +24,6 @@ const (
 	defaultServerWorkers    = 10
 	defaultSocketBufferSize = 0
 )
-
-// RemoteSamplingConfig defines config key for remote sampling fetch endpoint
-type RemoteSamplingConfig struct {
-	HostEndpoint                  string        `mapstructure:"host_endpoint"`
-	StrategyFile                  string        `mapstructure:"strategy_file"`
-	StrategyFileReloadInterval    time.Duration `mapstructure:"strategy_file_reload_interval"`
-	configgrpc.GRPCClientSettings `mapstructure:",squash"`
-}
 
 // Protocols is the configuration for the supported protocols.
 type Protocols struct {
@@ -68,8 +59,7 @@ func DefaultServerConfigUDP() ServerConfigUDP {
 
 // Config defines configuration for Jaeger receiver.
 type Config struct {
-	Protocols      `mapstructure:"protocols"`
-	RemoteSampling *RemoteSamplingConfig `mapstructure:"remote_sampling"`
+	Protocols `mapstructure:"protocols"`
 }
 
 var _ component.Config = (*Config)(nil)
@@ -105,20 +95,6 @@ func (cfg *Config) Validate() error {
 	if cfg.ThriftCompact != nil {
 		if err := checkPortFromEndpoint(cfg.ThriftCompact.Endpoint); err != nil {
 			return fmt.Errorf("invalid port number for the Thrift UDP Compact endpoint: %w", err)
-		}
-	}
-
-	if cfg.RemoteSampling != nil {
-		if err := checkPortFromEndpoint(cfg.RemoteSampling.HostEndpoint); err != nil {
-			return fmt.Errorf("invalid port number for the Remote Sampling endpoint: %w", err)
-		}
-
-		if len(cfg.RemoteSampling.StrategyFile) != 0 && cfg.GRPC == nil {
-			return fmt.Errorf("strategy file requires the gRPC protocol to be enabled")
-		}
-
-		if cfg.RemoteSampling.StrategyFileReloadInterval < 0 {
-			return fmt.Errorf("strategy file reload interval should be great or equal zero")
 		}
 	}
 

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -6,7 +6,6 @@ package jaegerreceiver
 import (
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,14 +60,6 @@ func TestLoadConfig(t *testing.T) {
 							SocketBufferSize: 0,
 						},
 					},
-				},
-				RemoteSampling: &RemoteSamplingConfig{
-					HostEndpoint: "0.0.0.0:5778",
-					GRPCClientSettings: configgrpc.GRPCClientSettings{
-						Endpoint: "jaeger-collector:1234",
-					},
-					StrategyFile:               "/etc/strategies.json",
-					StrategyFileReloadInterval: time.Second * 10,
 				},
 			},
 		},
@@ -208,15 +199,6 @@ func TestInvalidConfig(t *testing.T) {
 			err: "receiver creation with no port number for Thrift UDP - Binary must fail",
 		},
 		{
-			desc: "remote-sampling-http-no-port",
-			apply: func(cfg *Config) {
-				cfg.RemoteSampling = &RemoteSamplingConfig{
-					HostEndpoint: "localhost:",
-				}
-			},
-			err: "receiver creation with no port number for the remote sampling HTTP endpoint must fail",
-		},
-		{
 			desc: "grpc-invalid-host",
 			apply: func(cfg *Config) {
 				cfg.GRPC = &configgrpc.GRPCServerSettings{
@@ -251,29 +233,8 @@ func TestInvalidConfig(t *testing.T) {
 				cfg.ThriftCompact = &ProtocolUDP{
 					Endpoint: defaultThriftCompactBindEndpoint,
 				}
-				cfg.RemoteSampling = &RemoteSamplingConfig{
-					HostEndpoint: "localhost:5778",
-					StrategyFile: "strategies.json",
-				}
 			},
-			err: "receiver creation without gRPC and with remote sampling config",
-		},
-		{
-			desc: "reload-interval-outside-of-range",
-			apply: func(cfg *Config) {
-				cfg.Protocols.GRPC = &configgrpc.GRPCServerSettings{
-					NetAddr: confignet.NetAddr{
-						Endpoint:  "1234",
-						Transport: "tcp",
-					},
-				}
-				cfg.RemoteSampling = &RemoteSamplingConfig{
-					HostEndpoint:               "localhost:5778",
-					StrategyFile:               "strategies.json",
-					StrategyFileReloadInterval: -time.Second,
-				}
-			},
-			err: "strategy file reload interval should be great zero",
+			err: "receiver creation without gRPC",
 		},
 	}
 	for _, tC := range testCases {

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -226,16 +226,6 @@ func TestInvalidConfig(t *testing.T) {
 			},
 			err: "receiver creation with too large port number must fail",
 		},
-		{
-			desc: "port-outside-of-range",
-			apply: func(cfg *Config) {
-				cfg.Protocols = Protocols{}
-				cfg.ThriftCompact = &ProtocolUDP{
-					Endpoint: defaultThriftCompactBindEndpoint,
-				}
-			},
-			err: "receiver creation without gRPC",
-		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {

--- a/receiver/jaegerreceiver/go.mod
+++ b/receiver/jaegerreceiver/go.mod
@@ -17,6 +17,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.83.0
 	go.opentelemetry.io/collector/confmap v0.83.0
 	go.opentelemetry.io/collector/consumer v0.83.0
+	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0014
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0014
 	go.opentelemetry.io/collector/receiver v0.83.0
 	go.opentelemetry.io/collector/semconv v0.83.0
@@ -60,7 +61,6 @@ require (
 	go.opentelemetry.io/collector/exporter v0.83.0 // indirect
 	go.opentelemetry.io/collector/extension v0.83.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.83.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0014 // indirect
 	go.opentelemetry.io/collector/processor v0.83.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.42.1-0.20230612162650-64be7e574a17 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0 // indirect

--- a/receiver/jaegerreceiver/testdata/config.yaml
+++ b/receiver/jaegerreceiver/testdata/config.yaml
@@ -20,11 +20,6 @@ jaeger/customname:
       max_packet_size: 65_536
       workers: 5
       socket_buffer_size: 0
-  remote_sampling:
-    host_endpoint: "0.0.0.0:5778"
-    endpoint: "jaeger-collector:1234"
-    strategy_file: "/etc/strategies.json"
-    strategy_file_reload_interval: 10s
 # The following demonstrates how to enable protocols with defaults.
 jaeger/defaults:
   protocols:


### PR DESCRIPTION
Most remote sampling code is already removed from the jaeger receiver via #6633, but the configuration is still there. It is unused and should be removed.

The only reason I can think of for retaining it is so that old configuration files don't stop the Collector from running. However, given that this is a no-op, I think it would be better to have an error and let the customers reconfigure their collectors. Here, I'm assuming that configuring a struct which doesn't exist will indeed raise an error.

There is no changelog entry since the change is mostly an implementation detail.