### PR TITLE
[cmd/mdatagen] Add unit test for metric collisions.

### DIFF
--- a/cmd/mdatagen/validate_test.go
+++ b/cmd/mdatagen/validate_test.go
@@ -110,10 +110,6 @@ func TestMetricCollision(t *testing.T) {
 	allMetrics := map[string][]string{}
 	err := filepath.Walk("../../receiver", func(path string, info fs.FileInfo, err error) error {
 		if info.Name() == "metadata.yaml" {
-			// TODO: Remove once https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/24011 is merged.
-			if path == "../../receiver/googlecloudspannerreceiver/internal/metadataconfig/metadata.yaml" {
-				return nil
-			}
 			md, err := loadMetadata(path)
 			assert.NoError(t, err)
 			if len(md.Metrics) > 0 {

--- a/cmd/mdatagen/validate_test.go
+++ b/cmd/mdatagen/validate_test.go
@@ -134,8 +134,8 @@ func TestMetricCollision(t *testing.T) {
 			if metricName == "container.cpu.utilization" || metricName == "container.memory.rss" {
 				continue
 			}
-			val, ok := seen[metricName]
-			assert.False(t, ok, fmt.Sprintf("Collision for metric %v in receivers %v and %v \n", metricName, receiver, val))
+			val, exists := seen[metricName]
+			assert.False(t, exists, fmt.Sprintf("Collision for metric %v in receivers %v and %v \n", metricName, receiver, val))
 			seen[metricName] = receiver
 		}
 	}


### PR DESCRIPTION
**Description:**
This PR adds a unit test to check for metric collisions in receivers which have metrics defined.

**Link to tracking Issue:**
#23375