### PR TITLE
[exporter/datadog] Run source providers in parallel

### DIFF
--- a/.chloggen/mx-psi_parallel-source-resolution.yaml
+++ b/.chloggen/mx-psi_parallel-source-resolution.yaml
@@ -18,4 +18,4 @@ issues: [24234]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  All source providers now run in all environments so you may see more spurious logs from downstream dependencies when using the Datadog exporter.
+  All source providers now run in all environments so you may see more spurious logs from downstream dependencies when using the Datadog exporter. These logs should be safe to ignore.

--- a/.chloggen/mx-psi_parallel-source-resolution.yaml
+++ b/.chloggen/mx-psi_parallel-source-resolution.yaml
@@ -1,0 +1,21 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Source resolution logic now runs all source providers in parallel to improve start times."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24234]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  All source providers now run in all environments so you may see more spurious logs from downstream dependencies when using the Datadog exporter.

--- a/exporter/datadogexporter/internal/hostmetadata/provider/provider.go
+++ b/exporter/datadogexporter/internal/hostmetadata/provider/provider.go
@@ -55,6 +55,7 @@ func (p *chainProvider) Source(ctx context.Context) (source.Source, error) {
 	for i, ch := range replies {
 		reply := <-ch
 		if reply.err != nil {
+			// Provider was unavailable, error was logged on goroutine
 			continue
 		}
 

--- a/exporter/datadogexporter/internal/hostmetadata/provider/provider.go
+++ b/exporter/datadogexporter/internal/hostmetadata/provider/provider.go
@@ -54,12 +54,14 @@ func (p *chainProvider) Source(ctx context.Context) (source.Source, error) {
 	// Check provider responses in order to ensure priority
 	for i, ch := range replies {
 		reply := <-ch
-		if reply.err == nil {
-			p.logger.Info("Resolved source",
-				zap.String("provider", p.priorityList[i]), zap.Any("source", reply.src),
-			)
-			return reply.src, nil
+		if reply.err != nil {
+			continue
 		}
+
+		p.logger.Info("Resolved source",
+			zap.String("provider", p.priorityList[i]), zap.Any("source", reply.src),
+		)
+		return reply.src, nil
 	}
 
 	return source.Source{}, fmt.Errorf("no source provider was available")

--- a/exporter/datadogexporter/internal/hostmetadata/provider/provider_test.go
+++ b/exporter/datadogexporter/internal/hostmetadata/provider/provider_test.go
@@ -1,0 +1,132 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package provider // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/hostmetadata/provider"
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zaptest"
+)
+
+var _ source.Provider = (*HostProvider)(nil)
+
+type HostProvider string
+
+func (p HostProvider) Source(context.Context) (source.Source, error) {
+	return source.Source{Kind: source.HostnameKind, Identifier: string(p)}, nil
+}
+
+var _ source.Provider = (*ErrorSourceProvider)(nil)
+
+type ErrorSourceProvider string
+
+func (p ErrorSourceProvider) Source(context.Context) (source.Source, error) {
+	return source.Source{}, errors.New(string(p))
+}
+
+var _ source.Provider = (*delayedProvider)(nil)
+
+type delayedProvider struct {
+	provider source.Provider
+	delay    time.Duration
+}
+
+func (p *delayedProvider) Source(ctx context.Context) (source.Source, error) {
+	time.Sleep(p.delay)
+	return p.provider.Source(ctx)
+}
+
+func withDelay(provider source.Provider, delay time.Duration) source.Provider {
+	return &delayedProvider{provider, delay}
+}
+
+func TestChain(t *testing.T) {
+	tests := []struct {
+		name         string
+		providers    map[string]source.Provider
+		priorityList []string
+
+		buildErr string
+
+		hostname string
+		queryErr string
+	}{
+		{
+			name: "missing provider in priority list",
+			providers: map[string]source.Provider{
+				"p1": HostProvider("p1SourceName"),
+				"p2": ErrorSourceProvider("errP2"),
+			},
+			priorityList: []string{"p1", "p2", "p3"},
+
+			buildErr: "\"p3\" source is not available in providers",
+		},
+		{
+			name: "all providers fail",
+			providers: map[string]source.Provider{
+				"p1": ErrorSourceProvider("errP1"),
+				"p2": ErrorSourceProvider("errP2"),
+				"p3": HostProvider("p3SourceName"),
+			},
+			priorityList: []string{"p1", "p2"},
+
+			queryErr: "no source provider was available",
+		},
+		{
+			name: "no providers fail",
+			providers: map[string]source.Provider{
+				"p1": HostProvider("p1SourceName"),
+				"p2": HostProvider("p2SourceName"),
+				"p3": HostProvider("p3SourceName"),
+			},
+			priorityList: []string{"p1", "p2", "p3"},
+
+			hostname: "p1SourceName",
+		},
+		{
+			name: "some providers fail",
+			providers: map[string]source.Provider{
+				"p1": ErrorSourceProvider("p1Err"),
+				"p2": HostProvider("p2SourceName"),
+				"p3": ErrorSourceProvider("p3Err"),
+			},
+			priorityList: []string{"p1", "p2", "p3"},
+
+			hostname: "p2SourceName",
+		},
+		{
+			name: "p2 takes longer than p3",
+			providers: map[string]source.Provider{
+				"p1": ErrorSourceProvider("p1Err"),
+				"p2": withDelay(HostProvider("p2SourceName"), 50*time.Millisecond),
+				"p3": HostProvider("p3SourceName"),
+			},
+			priorityList: []string{"p1", "p2", "p3"},
+
+			hostname: "p2SourceName",
+		},
+	}
+
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			provider, err := Chain(zaptest.NewLogger(t), testInstance.providers, testInstance.priorityList)
+			if err != nil || testInstance.buildErr != "" {
+				assert.EqualError(t, err, testInstance.buildErr)
+				return
+			}
+
+			src, err := provider.Source(context.Background())
+			if err != nil || testInstance.queryErr != "" {
+				assert.EqualError(t, err, testInstance.queryErr)
+			} else {
+				assert.Equal(t, testInstance.hostname, src.Identifier)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description:** 

Make Datadog exporter source providers run in parallel to reduce start times. With the new `Chain` implementation, we start checking all sources in parallel instead of waiting for the previous one to fail. This makes the Datadog exporter call all cloud provider endpoints in all cloud providers, so it may increase spurious logs such as those reported in #24072.

**Link to tracking Issue:** Updates #16442 (at least it should substantially improve start time in some environments)

**Testing:** Added unit test

**Documentation:** Performance improvement, no new docs needed
