### PR TITLE
[chore] [processor/tailsampling] Clarify ordering relative to context-dependent processors (#23870)

### DIFF
--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -33,11 +33,10 @@ Each association is specified as a list of sources of associations. A source is 
 In order to get an association applied, all the sources specified need to match.
 
 Each sources rule is specified as a pair of `from` (representing the rule type) and `name` (representing the attribute name if `from` is set to `resource_attribute`).
-Following rule types are available:
+The following rule types are available:
 
-**from: "connection"** - takes the IP attribute from connection context (if available)
-**from: "resource_attribute"** - allows to specify the attribute name to lookup up in the list of attributes of the received Resource.
-                                 Semantic convention should be used for naming.
+  - `connection`: Takes the IP attribute from connection context (if available). In this case the processor must appear before any batching or tail sampling, which remove this information.
+  - `resource_attribute`: Allows specifying the attribute name to lookup in the list of attributes of the received Resource. Semantic convention should be used for naming.
 
 Pod association configuration.
 

--- a/processor/tailsamplingprocessor/README.md
+++ b/processor/tailsamplingprocessor/README.md
@@ -17,6 +17,8 @@
 
 The tail sampling processor samples traces based on a set of defined policies. All spans for a given trace MUST be received by the same collector instance for effective sampling decisions.
 
+This processor must be placed in pipelines after any processors that rely on context, e.g. `k8sattributes`. It reassembles spans into new batches, causing them to lose their original context.
+
 Please refer to [config.go](./config.go) for the config spec.
 
 The following configuration options are required:


### PR DESCRIPTION
**Description:** Makes clear that `tail_sampling` must be placed after `k8sattributes` and other processors that clobber context. Please see issue below for why this is an easy trap to fall into.

**Link to tracking Issue:** #23870