### PR TITLE
Revert "[chore] give go cache download 5 minutes timeout (#24178)"

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -47,7 +47,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-mod-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,7 +29,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |
@@ -83,7 +82,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |
@@ -144,7 +142,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |
@@ -167,7 +164,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |
@@ -240,7 +236,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |
@@ -317,7 +312,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |
@@ -338,7 +332,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |
@@ -364,7 +357,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |
@@ -428,7 +420,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |
@@ -563,7 +554,6 @@ jobs:
           mkdir bin/ dist/
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,7 +35,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,7 +20,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |
@@ -57,7 +56,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -31,7 +31,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |
@@ -69,7 +68,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -30,7 +30,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -25,7 +25,6 @@ jobs:
           cache: false
       - name: Cache Go
         id: go-cache
-        timeout-minutes: 5
         uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
This reverts commit 6bc44a80c2498cf473afcc5a3988abf4e9f9ebea.

Linked to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24251