### PR TITLE
[chore] validate .chloggen entries in chores so no invalid changelog entries get committed

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   changelog:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,7 +23,6 @@ concurrency:
 jobs:
   changelog:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
 
     steps:
       - uses: actions/checkout@v3
@@ -44,6 +43,7 @@ jobs:
           key: changelog-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Ensure no changes to the CHANGELOG
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: |
           if [[ $(git diff --name-only $(git merge-base origin/main ${{ github.event.pull_request.head.sha }}) ${{ github.event.pull_request.head.sha }} ./CHANGELOG.md) ]]
           then
@@ -57,6 +57,7 @@ jobs:
           fi
 
       - name: Ensure ./.chloggen/*.yaml addition(s)
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: |
           if [[ 1 -gt $(git diff --diff-filter=A --name-only $(git merge-base origin/main ${{ github.event.pull_request.head.sha }}) ${{ github.event.pull_request.head.sha }} ./.chloggen | grep -c \\.yaml) ]]
           then


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector/pull/8089 for origin.

When creating a chore PR, we don't check chloggen entries at all. If a chore introduces a changelog entry, we should validate it.