### PR TITLE
[processor/resourcedetection] Fix docker detector

### DIFF
--- a/.chloggen/resource-detection-processor-fix-docker-detector.yaml
+++ b/.chloggen/resource-detection-processor-fix-docker-detector.yaml
@@ -1,0 +1,15 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/resourcedetection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix docker detector not setting any attributes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24280]

--- a/processor/resourcedetectionprocessor/internal/docker/docker.go
+++ b/processor/resourcedetectionprocessor/internal/docker/docker.go
@@ -32,13 +32,17 @@ type Detector struct {
 }
 
 // NewDetector creates a new system metadata detector
-func NewDetector(p processor.CreateSettings, _ internal.DetectorConfig) (internal.Detector, error) {
+func NewDetector(p processor.CreateSettings, cfg internal.DetectorConfig) (internal.Detector, error) {
 	dockerProvider, err := docker.NewProvider()
 	if err != nil {
 		return nil, fmt.Errorf("failed creating detector: %w", err)
 	}
 
-	return &Detector{provider: dockerProvider, logger: p.Logger}, nil
+	return &Detector{
+		provider:           dockerProvider,
+		logger:             p.Logger,
+		resourceAttributes: cfg.(Config).ResourceAttributes,
+	}, nil
 }
 
 // Detect detects system metadata and returns a resource with the available ones

--- a/processor/resourcedetectionprocessor/internal/docker/docker_test.go
+++ b/processor/resourcedetectionprocessor/internal/docker/docker_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/processor/processortest"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders/docker"
 )
@@ -37,8 +37,9 @@ func TestDetect(t *testing.T) {
 	md.On("Hostname").Return("hostname", nil)
 	md.On("OSType").Return("darwin", nil)
 
-	dcfg := CreateDefaultConfig()
-	detector := &Detector{provider: md, logger: zap.NewNop(), resourceAttributes: dcfg.ResourceAttributes}
+	detector, err := NewDetector(processortest.NewNopCreateSettings(), CreateDefaultConfig())
+	require.NoError(t, err)
+	detector.(*Detector).provider = md
 	res, schemaURL, err := detector.Detect(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, conventions.SchemaURL, schemaURL)


### PR DESCRIPTION
After migrating the detection processor to the new config interface, the docker detector stopped setting any attributes

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24280