### PR TITLE
[processor/tailsampling] Tailsampling evaluation data race

### DIFF
--- a/.chloggen/tailsampling-evaluation-data-race.yaml
+++ b/.chloggen/tailsampling-evaluation-data-race.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix data race when accessing spans during policies evaluation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24283]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter.go
@@ -33,8 +33,8 @@ func NewBooleanAttributeFilter(settings component.TelemetrySettings, key string,
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 func (baf *booleanAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *TraceData) (Decision, error) {
 	trace.Lock()
+	defer trace.Unlock()
 	batches := trace.ReceivedBatches
-	trace.Unlock()
 
 	return hasResourceOrSpanWithCondition(
 		batches,

--- a/processor/tailsamplingprocessor/internal/sampling/latency.go
+++ b/processor/tailsamplingprocessor/internal/sampling/latency.go
@@ -32,8 +32,8 @@ func (l *latency) Evaluate(_ context.Context, _ pcommon.TraceID, traceData *Trac
 	l.logger.Debug("Evaluating spans in latency filter")
 
 	traceData.Lock()
+	defer traceData.Unlock()
 	batches := traceData.ReceivedBatches
-	traceData.Unlock()
 
 	var minTime pcommon.Timestamp
 	var maxTime pcommon.Timestamp

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
@@ -34,8 +34,8 @@ func NewNumericAttributeFilter(settings component.TelemetrySettings, key string,
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 func (naf *numericAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *TraceData) (Decision, error) {
 	trace.Lock()
+	defer trace.Unlock()
 	batches := trace.ReceivedBatches
-	trace.Unlock()
 
 	return hasSpanWithCondition(batches, func(span ptrace.Span) bool {
 		if v, ok := span.Attributes().Get(naf.key); ok {

--- a/processor/tailsamplingprocessor/internal/sampling/ottl.go
+++ b/processor/tailsamplingprocessor/internal/sampling/ottl.go
@@ -63,8 +63,8 @@ func (ocf *ottlConditionFilter) Evaluate(ctx context.Context, traceID pcommon.Tr
 	}
 
 	trace.Lock()
+	defer trace.Unlock()
 	batches := trace.ReceivedBatches
-	trace.Unlock()
 
 	for i := 0; i < batches.ResourceSpans().Len(); i++ {
 		rs := batches.ResourceSpans().At(i)

--- a/processor/tailsamplingprocessor/internal/sampling/status_code.go
+++ b/processor/tailsamplingprocessor/internal/sampling/status_code.go
@@ -54,8 +54,8 @@ func (r *statusCodeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace 
 	r.logger.Debug("Evaluating spans in status code filter")
 
 	trace.Lock()
+	defer trace.Unlock()
 	batches := trace.ReceivedBatches
-	trace.Unlock()
 
 	return hasSpanWithCondition(batches, func(span ptrace.Span) bool {
 		for _, statusCode := range r.statusCodes {

--- a/processor/tailsamplingprocessor/internal/sampling/string_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/string_tag_filter.go
@@ -94,8 +94,8 @@ func NewStringAttributeFilter(settings component.TelemetrySettings, key string, 
 func (saf *stringAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *TraceData) (Decision, error) {
 	saf.logger.Debug("Evaluting spans in string-tag filter")
 	trace.Lock()
+	defer trace.Unlock()
 	batches := trace.ReceivedBatches
-	trace.Unlock()
 
 	if saf.invertMatch {
 		// Invert Match returns true by default, except when key and value are matched

--- a/processor/tailsamplingprocessor/internal/sampling/trace_state_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/trace_state_filter.go
@@ -45,8 +45,8 @@ func NewTraceStateFilter(settings component.TelemetrySettings, key string, value
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 func (tsf *traceStateFilter) Evaluate(_ context.Context, _ pcommon.TraceID, trace *TraceData) (Decision, error) {
 	trace.Lock()
+	defer trace.Unlock()
 	batches := trace.ReceivedBatches
-	trace.Unlock()
 
 	return hasSpanWithCondition(batches, func(span ptrace.Span) bool {
 		traceState, err := tracesdk.ParseTraceState(span.TraceState().AsRaw())

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -30,6 +30,27 @@ const (
 )
 
 var testPolicy = []PolicyCfg{{sharedPolicyCfg: sharedPolicyCfg{Name: "test-policy", Type: AlwaysSample}}}
+var testLatencyPolicy = []PolicyCfg{
+	{
+		sharedPolicyCfg: sharedPolicyCfg{
+			Name:       "test-policy",
+			Type:       Latency,
+			LatencyCfg: LatencyCfg{ThresholdMs: 1},
+		},
+	},
+}
+
+type TestPolicyEvaluator struct {
+	Started       chan struct{}
+	CouldContinue chan struct{}
+	pe            sampling.PolicyEvaluator
+}
+
+func (t *TestPolicyEvaluator) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *sampling.TraceData) (sampling.Decision, error) {
+	close(t.Started)
+	<-t.CouldContinue
+	return t.pe.Evaluate(ctx, traceID, trace)
+}
 
 func TestSequentialTraceArrival(t *testing.T) {
 	traceIds, batches := generateIdsAndBatches(128)
@@ -99,6 +120,51 @@ func TestConcurrentTraceArrival(t *testing.T) {
 		v := d.(*sampling.TraceData)
 		require.Equal(t, int64(i+1)*2, v.SpanCount.Load(), "Incorrect number of spans for entry %d", i)
 	}
+}
+
+func TestConcurrentArrivalAndEvaluation(t *testing.T) {
+	traceIds, batches := generateIdsAndBatches(1)
+	evalStarted := make(chan struct{})
+	continueEvaluation := make(chan struct{})
+
+	var wg sync.WaitGroup
+	cfg := Config{
+		DecisionWait:            defaultTestDecisionWait,
+		NumTraces:               uint64(2 * len(traceIds)),
+		ExpectedNewTracesPerSec: 64,
+		PolicyCfgs:              testLatencyPolicy,
+	}
+	sp, _ := newTracesProcessor(context.Background(), componenttest.NewNopTelemetrySettings(), consumertest.NewNop(), cfg)
+	tsp := sp.(*tailSamplingSpanProcessor)
+	tsp.tickerFrequency = 1 * time.Millisecond
+	require.NoError(t, tsp.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, tsp.Shutdown(context.Background()))
+	}()
+
+	tpe := &TestPolicyEvaluator{
+		Started:       evalStarted,
+		CouldContinue: continueEvaluation,
+		pe:            tsp.policies[0].evaluator,
+	}
+	tsp.policies[0].evaluator = tpe
+
+	for _, batch := range batches {
+		wg.Add(1)
+		go func(td ptrace.Traces) {
+			for i := 0; i < 10; i++ {
+				require.NoError(t, tsp.ConsumeTraces(context.Background(), td))
+			}
+			<-evalStarted
+			close(continueEvaluation)
+			for i := 0; i < 10; i++ {
+				require.NoError(t, tsp.ConsumeTraces(context.Background(), td))
+			}
+			wg.Done()
+		}(batch)
+	}
+
+	wg.Wait()
 }
 
 func TestSequentialTraceMapSize(t *testing.T) {


### PR DESCRIPTION
**Description:**
This PR contains a fix for a race condition that occurs during policies evaluation in the tail sampling processor. Data race occurs because of concurrent read/write to ptrace.Traces underlying slice (*[]*v1.ResourceSpans).So one of the possible solution is to extend mutex lock to whole Evaluate method.

**Link to tracking Issue:** #24283 

**Testing:** 
Added new ConcurrentArrivalAndEvaluation unit test for data race case.

**Documentation:** <Describe the documentation added.>