### PR TITLE
[cmd/telemetrygen] Change span kind from an attribute to top level info

### DIFF
--- a/.chloggen/issue-24286-telemetrygen-span-kind-attribute.yaml
+++ b/.chloggen/issue-24286-telemetrygen-span-kind-attribute.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/telemetrygen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Move the span attribute span.kind to the native Kind which is a top level trace information
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24286]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:


### PR DESCRIPTION
**Description:** Remove the span attribute `span.kind` and instead set the `Kind` (which is a top level span information) directly using `trace.WithSpanKind`.

**Link to tracking Issue:** #24286 

**Testing:** Added a rudimentary test to ensure that `Kind` is not `Internal` which is the default when not specified.

**Documentation:** None. This is probably the original intention.