### PR TITLE
[processor/resourcedetection] Fix heroku config interface

### DIFF
--- a/.chloggen/resource-detection-processor-fix-heroku-attr.yaml
+++ b/.chloggen/resource-detection-processor-fix-heroku-attr.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/resourcedetection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix Heroku config option for the `service.name` and `service.version` attributes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24355]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `service.name` and `service.version` attributes were mistakenly controlled by `heroku.app.name` and
+  `heroku.release.version` options under `resource_attributes` configuration introduced in 0.81.0. 
+  This PR fixes the issue by using the correct config options named the same as the attributes.

--- a/processor/resourcedetectionprocessor/internal/heroku/heroku.go
+++ b/processor/resourcedetectionprocessor/internal/heroku/heroku.go
@@ -63,7 +63,7 @@ func (d *detector) Detect(_ context.Context) (resource pcommon.Resource, schemaU
 			attrs.PutStr(herokuAppID, v)
 		}
 	}
-	if d.resourceAttributes.HerokuAppName.Enabled {
+	if d.resourceAttributes.ServiceName.Enabled {
 		if v, ok := os.LookupEnv("HEROKU_APP_NAME"); ok {
 			attrs.PutStr(conventions.AttributeServiceName, v)
 		}
@@ -73,7 +73,7 @@ func (d *detector) Detect(_ context.Context) (resource pcommon.Resource, schemaU
 			attrs.PutStr(herokuReleaseCreationTimestamp, v)
 		}
 	}
-	if d.resourceAttributes.HerokuReleaseVersion.Enabled {
+	if d.resourceAttributes.ServiceVersion.Enabled {
 		if v, ok := os.LookupEnv("HEROKU_RELEASE_VERSION"); ok {
 			attrs.PutStr(conventions.AttributeServiceVersion, v)
 		}

--- a/processor/resourcedetectionprocessor/internal/heroku/internal/metadata/generated_config.go
+++ b/processor/resourcedetectionprocessor/internal/heroku/internal/metadata/generated_config.go
@@ -11,12 +11,12 @@ type ResourceAttributeConfig struct {
 type ResourceAttributesConfig struct {
 	CloudProvider                  ResourceAttributeConfig `mapstructure:"cloud.provider"`
 	HerokuAppID                    ResourceAttributeConfig `mapstructure:"heroku.app.id"`
-	HerokuAppName                  ResourceAttributeConfig `mapstructure:"heroku.app.name"`
 	HerokuDynoID                   ResourceAttributeConfig `mapstructure:"heroku.dyno.id"`
 	HerokuReleaseCommit            ResourceAttributeConfig `mapstructure:"heroku.release.commit"`
 	HerokuReleaseCreationTimestamp ResourceAttributeConfig `mapstructure:"heroku.release.creation_timestamp"`
-	HerokuReleaseVersion           ResourceAttributeConfig `mapstructure:"heroku.release.version"`
 	ServiceInstanceID              ResourceAttributeConfig `mapstructure:"service.instance.id"`
+	ServiceName                    ResourceAttributeConfig `mapstructure:"service.name"`
+	ServiceVersion                 ResourceAttributeConfig `mapstructure:"service.version"`
 }
 
 func DefaultResourceAttributesConfig() ResourceAttributesConfig {
@@ -25,9 +25,6 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 			Enabled: true,
 		},
 		HerokuAppID: ResourceAttributeConfig{
-			Enabled: true,
-		},
-		HerokuAppName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 		HerokuDynoID: ResourceAttributeConfig{
@@ -39,10 +36,13 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 		HerokuReleaseCreationTimestamp: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		HerokuReleaseVersion: ResourceAttributeConfig{
+		ServiceInstanceID: ResourceAttributeConfig{
 			Enabled: true,
 		},
-		ServiceInstanceID: ResourceAttributeConfig{
+		ServiceName: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		ServiceVersion: ResourceAttributeConfig{
 			Enabled: true,
 		},
 	}

--- a/processor/resourcedetectionprocessor/internal/heroku/internal/metadata/generated_config_test.go
+++ b/processor/resourcedetectionprocessor/internal/heroku/internal/metadata/generated_config_test.go
@@ -27,12 +27,12 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				CloudProvider:                  ResourceAttributeConfig{Enabled: true},
 				HerokuAppID:                    ResourceAttributeConfig{Enabled: true},
-				HerokuAppName:                  ResourceAttributeConfig{Enabled: true},
 				HerokuDynoID:                   ResourceAttributeConfig{Enabled: true},
 				HerokuReleaseCommit:            ResourceAttributeConfig{Enabled: true},
 				HerokuReleaseCreationTimestamp: ResourceAttributeConfig{Enabled: true},
-				HerokuReleaseVersion:           ResourceAttributeConfig{Enabled: true},
 				ServiceInstanceID:              ResourceAttributeConfig{Enabled: true},
+				ServiceName:                    ResourceAttributeConfig{Enabled: true},
+				ServiceVersion:                 ResourceAttributeConfig{Enabled: true},
 			},
 		},
 		{
@@ -40,12 +40,12 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				CloudProvider:                  ResourceAttributeConfig{Enabled: false},
 				HerokuAppID:                    ResourceAttributeConfig{Enabled: false},
-				HerokuAppName:                  ResourceAttributeConfig{Enabled: false},
 				HerokuDynoID:                   ResourceAttributeConfig{Enabled: false},
 				HerokuReleaseCommit:            ResourceAttributeConfig{Enabled: false},
 				HerokuReleaseCreationTimestamp: ResourceAttributeConfig{Enabled: false},
-				HerokuReleaseVersion:           ResourceAttributeConfig{Enabled: false},
 				ServiceInstanceID:              ResourceAttributeConfig{Enabled: false},
+				ServiceName:                    ResourceAttributeConfig{Enabled: false},
+				ServiceVersion:                 ResourceAttributeConfig{Enabled: false},
 			},
 		},
 	}

--- a/processor/resourcedetectionprocessor/internal/heroku/internal/metadata/testdata/config.yaml
+++ b/processor/resourcedetectionprocessor/internal/heroku/internal/metadata/testdata/config.yaml
@@ -5,17 +5,17 @@ all_set:
       enabled: true
     heroku.app.id:
       enabled: true
-    heroku.app.name:
-      enabled: true
     heroku.dyno.id:
       enabled: true
     heroku.release.commit:
       enabled: true
     heroku.release.creation_timestamp:
       enabled: true
-    heroku.release.version:
-      enabled: true
     service.instance.id:
+      enabled: true
+    service.name:
+      enabled: true
+    service.version:
       enabled: true
 none_set:
   resource_attributes:
@@ -23,15 +23,15 @@ none_set:
       enabled: false
     heroku.app.id:
       enabled: false
-    heroku.app.name:
-      enabled: false
     heroku.dyno.id:
       enabled: false
     heroku.release.commit:
       enabled: false
     heroku.release.creation_timestamp:
       enabled: false
-    heroku.release.version:
-      enabled: false
     service.instance.id:
+      enabled: false
+    service.name:
+      enabled: false
+    service.version:
       enabled: false

--- a/processor/resourcedetectionprocessor/internal/heroku/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/heroku/metadata.yaml
@@ -11,10 +11,6 @@ resource_attributes:
     description: The heroku.app.id
     enabled: true
     type: string
-  heroku.app.name:
-    description: The heroku.app.name
-    enabled: true
-    type: string
   heroku.dyno.id:
     description: The heroku.dyno.id
     enabled: true
@@ -27,11 +23,15 @@ resource_attributes:
     description: The heroku.release.creation_timestamp
     enabled: true
     type: string
-  heroku.release.version:
-    description: The heroku.release.version
-    enabled: true
-    type: string
   service.instance.id:
     description: The service.instance.id
     type: string
     enabled: true
+  service.name:
+    description: Heroku app name recorded as service.name.
+    enabled: true
+    type: string
+  service.version:
+    description: Heroku relese version set as service.version.
+    enabled: true
+    type: string


### PR DESCRIPTION
Fix Heroku config option for the `service.name` and `service.version` attributes. `service.name` and `service.version` attributes were mistakenly controlled by `heroku.app.name` and `heroku.release.version` options under `resource_attributes` configuration introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/23253. This PR fixes the issue by using the correct config options named the same as the attributes.