### PR TITLE
[pkg/ottl]: Add a new Function Getter to the OTTL package, to allow passing Converters as literal parameters

### DIFF
--- a/.chloggen/function-getter.yaml
+++ b/.chloggen/function-getter.yaml
@@ -1,0 +1,23 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a new Function Getter to the OTTL package, to allow passing Converters as literal parameters.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [22961]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Currently OTTL provides no way to use any defined Converter within another Editor/Converter.
+  Although Converters can be passed as a parameter, they are always executed and the result is what is actually passed as the parameter.
+  This allows OTTL to pass Converters themselves as a parameter so they can be executed within the function.

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -272,19 +272,9 @@ func (g StandardFunctionGetter[K]) Get(_ context.Context, iArgs Arguments) (Expr
 	}
 	for i := 0; i < fArgsVal.NumField(); i++ {
 		field := iArgsVal.Field(i)
-		fieldTag := fArgsVal.Type().Field(i).Tag.Get("ottlarg")
-		if fieldTag == "" {
-			return Expr[K]{}, fmt.Errorf("no `ottlarg` struct tag on Arguments field %q", fArgsVal.Type().Field(i).Name)
-		}
-		argNum, err := strconv.Atoi(fieldTag)
+		_, err := checkForArgErrors(i, fArgsVal)
 		if err != nil {
-			return Expr[K]{}, fmt.Errorf("ottlarg struct tag on field %q is not a valid integer: %w", fArgsVal.Type().Field(i).Name, err)
-		}
-		if argNum < 0 || argNum >= iArgsVal.NumField() {
-			return Expr[K]{}, fmt.Errorf("ottlarg struct tag on field %q has value %d, but must be between 0 and %d", fArgsVal.Type().Field(i).Name, argNum, iArgsVal.NumField())
-		}
-		if field.Type() != fArgsVal.Field(i).Type() {
-			return Expr[K]{}, fmt.Errorf("incorrect type for argument %d. Expected: %v Received: %v", i, fArgsVal.Field(i).Type(), field.Type())
+			return Expr[K]{}, err
 		}
 		fArgsVal.Field(i).Set(field)
 	}
@@ -449,7 +439,7 @@ func (g StandardFloatLikeGetter[K]) Get(ctx context.Context, tCtx K) (*float64, 
 	return &result, nil
 }
 
-// IntLikeGetter is a Getter that returns an int by converting the underlying value to an int if necessary.
+// IntLikeGetter is a Getter that returns an int by converting the underlying value to an int if necessary
 type IntLikeGetter[K any] interface {
 	// Get retrieves an int value.
 	// Unlike `IntGetter`, the expectation is that the underlying value is converted to an int if possible.

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -683,6 +683,23 @@ func Test_FunctionGetter(t *testing.T) {
 			&stringGetterArguments{},
 			functionWithStringGetter,
 		),
+		createFactory[any](
+			"test_arg_mismatch",
+			&multipleArgsArguments{},
+			functionWithStringGetter,
+		),
+		createFactory[any](
+			"no_struct_tag",
+			&noStructTagFunctionArguments{},
+			functionWithStringGetter,
+		),
+		NewFactory(
+			"cannot_create_function",
+			&stringGetterArguments{},
+			func(FunctionContext, Arguments) (ExprFunc[any], error) {
+				return functionWithErr()
+			},
+		),
 	)
 	type EditorArguments struct {
 		Replacement StringGetter[any]
@@ -721,6 +738,42 @@ func Test_FunctionGetter(t *testing.T) {
 			want:             "anything",
 			valid:            false,
 			expectedErrorMsg: "undefined function",
+		},
+		{
+			name: "function arg mismatch",
+			getter: StandardStringGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return nil, nil
+				},
+			},
+			function:         StandardFunctionGetter[any]{fCtx: FunctionContext{Set: componenttest.NewNopTelemetrySettings()}, fact: functions["test_arg_mismatch"]},
+			want:             "anything",
+			valid:            false,
+			expectedErrorMsg: "incorrect number of arguments. Expected: 4 Received: 1",
+		},
+		{
+			name: "Invalid Arguments struct tag",
+			getter: StandardStringGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return nil, nil
+				},
+			},
+			function:         StandardFunctionGetter[any]{fCtx: FunctionContext{Set: componenttest.NewNopTelemetrySettings()}, fact: functions["no_struct_tag"]},
+			want:             "anything",
+			valid:            false,
+			expectedErrorMsg: "no `ottlarg` struct tag on Arguments field \"StringArg\"",
+		},
+		{
+			name: "Cannot create function",
+			getter: StandardStringGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return nil, nil
+				},
+			},
+			function:         StandardFunctionGetter[any]{fCtx: FunctionContext{Set: componenttest.NewNopTelemetrySettings()}, fact: functions["cannot_create_function"]},
+			want:             "anything",
+			valid:            false,
+			expectedErrorMsg: "couldn't create function: error",
 		},
 	}
 

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -676,6 +676,41 @@ func Test_StandardStringGetter(t *testing.T) {
 	}
 }
 
+func Test_StandardFunctionGetter(t *testing.T) {
+	tests := []struct {
+		name             string
+		getter           StandardFunctionGetter[any]
+		want             ExprFunc[any]
+		valid            bool
+		expectedErrorMsg string
+	}{
+		{
+			name: "function type",
+			getter: StandardFunctionGetter[any]{
+				Getter: func(ctx context.Context, tCtx any) (interface{}, error) {
+					return "str", nil
+				},
+			},
+			want:  func(context.Context, any) (interface{}, error) { return "str", nil },
+			valid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			function, err := tt.getter.Get(context.Background(), nil)
+			funcVal, err := function(context.Background(), nil)
+			if tt.valid {
+				assert.NoError(t, err)
+				assert.Equal(t, "str", funcVal)
+			} else {
+				assert.IsType(t, TypeError(""), err)
+				assert.EqualError(t, err, tt.expectedErrorMsg)
+			}
+		})
+	}
+}
+
 // nolint:errorlint
 func Test_StandardStringGetter_WrappedError(t *testing.T) {
 	getter := StandardStringGetter[interface{}]{

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -706,7 +706,7 @@ func Test_FunctionGetter(t *testing.T) {
 		Function    FunctionGetter[any]
 	}
 	type FuncArgs struct {
-		Input StringGetter[any]
+		Input StringGetter[any] `ottlarg:"0"`
 	}
 	tests := []struct {
 		name             string
@@ -783,7 +783,7 @@ func Test_FunctionGetter(t *testing.T) {
 				Replacement: tt.getter,
 				Function:    tt.function,
 			}
-			fn, err := editorArgs.Function.Get(context.Background(), &FuncArgs{Input: editorArgs.Replacement})
+			fn, err := editorArgs.Function.Get(&FuncArgs{Input: editorArgs.Replacement})
 			if tt.valid {
 				var result interface{}
 				result, err = fn.Eval(context.Background(), nil)

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -86,7 +86,7 @@ func (p *Parser[K]) buildArgs(ed editor, argsVal reflect.Value) error {
 			case argVal.FunctionName != nil:
 				name = *argVal.FunctionName
 			default:
-				return errors.New("invalid function name given")
+				return fmt.Errorf("invalid function name given")
 			}
 			f, ok := p.functions[name]
 			if !ok {

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -47,8 +47,8 @@ func (p *Parser[K]) newFunctionCall(ed editor) (Expr[K], error) {
 	return Expr[K]{exprFunc: fn}, err
 }
 
-func checkForArgErrors(index int, argsVal reflect.Value) (int, error) {
-	argsType := argsVal.Type()
+func getArgumentIndex(index int, args reflect.Value) (int, error) {
+	argsType := args.Type()
 	fieldTag, ok := argsType.Field(index).Tag.Lookup("ottlarg")
 	if !ok {
 		return 0, fmt.Errorf("no `ottlarg` struct tag on Arguments field %q", argsType.Field(index).Name)
@@ -57,8 +57,8 @@ func checkForArgErrors(index int, argsVal reflect.Value) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("ottlarg struct tag on field %q is not a valid integer: %w", argsType.Field(index).Name, err)
 	}
-	if argNum < 0 || argNum >= argsVal.NumField() {
-		return 0, fmt.Errorf("ottlarg struct tag on field %q has value %d, but must be between 0 and %d", argsType.Field(index).Name, argNum, argsVal.NumField())
+	if argNum < 0 || argNum >= args.NumField() {
+		return 0, fmt.Errorf("ottlarg struct tag on field %q has value %d, but must be between 0 and %d", argsType.Field(index).Name, argNum, args.NumField())
 	}
 	return argNum, nil
 }
@@ -71,7 +71,7 @@ func (p *Parser[K]) buildArgs(ed editor, argsVal reflect.Value) error {
 	for i := 0; i < argsVal.NumField(); i++ {
 		field := argsVal.Field(i)
 		fieldType := field.Type()
-		argNum, err := checkForArgErrors(i, argsVal)
+		argNum, err := getArgumentIndex(i, argsVal)
 		if err != nil {
 			return err
 		}

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -192,6 +192,12 @@ func (p *Parser[K]) buildArg(argVal value, argType reflect.Type) (any, error) {
 			return nil, err
 		}
 		return arg, nil
+	case strings.HasPrefix(name, "FunctionGetter"):
+		arg, err := p.newGetter(argVal)
+		if err != nil {
+			return nil, err
+		}
+		return StandardFunctionGetter[K]{Getter: arg.Get}, nil
 	case strings.HasPrefix(name, "StringGetter"):
 		arg, err := p.newGetter(argVal)
 		if err != nil {

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -93,6 +93,11 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			&functionGetterArguments{},
 			functionWithFunctionGetter,
 		),
+		createFactory[any](
+			"testing_functiongetter",
+			&functionGetterArguments{},
+			functionWithFunctionGetter,
+		),
 	)
 
 	p, _ := NewParser(
@@ -111,6 +116,17 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			inv: editor{
 				Function:  "unknownfunc",
 				Arguments: []value{},
+			},
+		},
+		{
+			name: "Invalid Function Name",
+			inv: editor{
+				Function: "testing_functiongetter",
+				Arguments: []value{
+					{
+						String: (ottltest.Strp("SHA256")),
+					},
+				},
 			},
 		},
 		{
@@ -956,12 +972,24 @@ func Test_NewFunctionCall(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "functiongetter arg",
+			name: "functiongetter arg (Uppercase)",
 			inv: editor{
 				Function: "testing_functiongetter",
 				Arguments: []value{
 					{
 						FunctionName: (ottltest.Strp("SHA256")),
+					},
+				},
+			},
+			want: "hashstring",
+		},
+		{
+			name: "functiongetter arg",
+			inv: editor{
+				Function: "testing_functiongetter",
+				Arguments: []value{
+					{
+						FunctionName: (ottltest.Strp("Sha256")),
 					},
 				},
 			},
@@ -1178,6 +1206,12 @@ func functionWithNoArguments() (ExprFunc[any], error) {
 	return func(context.Context, any) (any, error) {
 		return nil, nil
 	}, nil
+}
+
+func functionWithErr() (ExprFunc[any], error) {
+	return func(context.Context, any) (any, error) {
+		return nil, nil
+	}, fmt.Errorf("error")
 }
 
 type stringSliceArguments struct {
@@ -1631,6 +1665,11 @@ func defaultFunctionsForTests() map[string]Factory[any] {
 		),
 		createFactory[any](
 			"SHA256",
+			&stringGetterArguments{},
+			functionWithStringGetter,
+		),
+		createFactory[any](
+			"Sha256",
 			&stringGetterArguments{},
 			functionWithStringGetter,
 		),

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -322,7 +322,7 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 				Function: "testing_functiongetter",
 				Arguments: []value{
 					{
-						Enum: (*EnumSymbol)(ottltest.Strp("SHA256")),
+						FunctionName: (ottltest.Strp("SHA256")),
 					},
 				},
 			},
@@ -961,7 +961,7 @@ func Test_NewFunctionCall(t *testing.T) {
 				Function: "testing_functiongetter",
 				Arguments: []value{
 					{
-						Enum: (*EnumSymbol)(ottltest.Strp("SHA256")),
+						FunctionName: (ottltest.Strp("SHA256")),
 					},
 				},
 			},

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -88,6 +88,11 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			&outOfBoundsStructTagFunctionArguments{},
 			functionThatHasAnError,
 		),
+		createFactory(
+			"testing_unknown_function",
+			&functionGetterArguments{},
+			functionWithFunctionGetter,
+		),
 	)
 
 	p, _ := NewParser(
@@ -307,6 +312,17 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 				Arguments: []value{
 					{
 						Enum: (*EnumSymbol)(ottltest.Strp("SYMBOL_NOT_FOUND")),
+					},
+				},
+			},
+		},
+		{
+			name: "Unknown Function",
+			inv: editor{
+				Function: "testing_functiongetter",
+				Arguments: []value{
+					{
+						Enum: (*EnumSymbol)(ottltest.Strp("SHA256")),
 					},
 				},
 			},
@@ -940,6 +956,18 @@ func Test_NewFunctionCall(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "functiongetter arg",
+			inv: editor{
+				Function: "testing_functiongetter",
+				Arguments: []value{
+					{
+						Enum: (*EnumSymbol)(ottltest.Strp("SHA256")),
+					},
+				},
+			},
+			want: "hashstring",
+		},
+		{
 			name: "stringlikegetter arg",
 			inv: editor{
 				Function: "testing_stringlikegetter",
@@ -1312,6 +1340,16 @@ func functionWithStringGetter(StringGetter[interface{}]) (ExprFunc[interface{}],
 	}, nil
 }
 
+type functionGetterArguments struct {
+	FunctionGetterArg FunctionGetter[any] `ottlarg:"0"`
+}
+
+func functionWithFunctionGetter(FunctionGetter[interface{}]) (ExprFunc[interface{}], error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		return "hashstring", nil
+	}, nil
+}
+
 type stringLikeGetterArguments struct {
 	StringLikeGetterArg StringLikeGetter[any] `ottlarg:"0"`
 }
@@ -1583,6 +1621,16 @@ func defaultFunctionsForTests() map[string]Factory[any] {
 		),
 		createFactory[any](
 			"testing_stringgetter",
+			&stringGetterArguments{},
+			functionWithStringGetter,
+		),
+		createFactory[any](
+			"testing_functiongetter",
+			&functionGetterArguments{},
+			functionWithFunctionGetter,
+		),
+		createFactory[any](
+			"SHA256",
 			&stringGetterArguments{},
 			functionWithStringGetter,
 		),

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -225,7 +225,7 @@ type value struct {
 	Bytes          *byteSlice       `parser:"| @Bytes"`
 	String         *string          `parser:"| @String"`
 	Bool           *boolean         `parser:"| @Boolean"`
-	Enum           *EnumSymbol      `parser:"| @Uppercase"`
+	Enum           *EnumSymbol      `parser:"| @Uppercase (?! Lowercase)"`
 	FunctionName   *string          `parser:"| @(Uppercase(Uppercase | Lowercase)*)"`
 	List           *list            `parser:"| @@)"`
 }

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -226,6 +226,7 @@ type value struct {
 	String         *string          `parser:"| @String"`
 	Bool           *boolean         `parser:"| @Boolean"`
 	Enum           *EnumSymbol      `parser:"| @Uppercase"`
+	FunctionName   *string          `parser:"| @(Uppercase(Uppercase | Lowercase)*)"`
 	List           *list            `parser:"| @@)"`
 }
 

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -141,17 +141,6 @@ func (p *Parser[K]) ParseStatement(statement string) (*Statement[K], error) {
 	}, nil
 }
 
-func (p *Parser[K]) ConverterGetter(statement string) (Getter[K], error) {
-	parsed, err := parseStatement(statement)
-	if err != nil {
-		if parsed.Converter != nil {
-			return p.newGetterFromConverter(*parsed.Converter)
-		}
-		return nil, err
-	}
-	return p.newGetterFromConverter(*parsed.Converter)
-}
-
 var parser = newParser[parsedStatement]()
 
 func parseStatement(raw string) (*parsedStatement, error) {
@@ -162,9 +151,6 @@ func parseStatement(raw string) (*parsedStatement, error) {
 	}
 	err = parsed.checkForCustomError()
 	if err != nil {
-		if parsed.Converter != nil {
-			return parsed, err
-		}
 		return nil, err
 	}
 

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -141,6 +141,17 @@ func (p *Parser[K]) ParseStatement(statement string) (*Statement[K], error) {
 	}, nil
 }
 
+func (p *Parser[K]) ConverterGetter(statement string) (Getter[K], error) {
+	parsed, err := parseStatement(statement)
+	if err != nil {
+		if parsed.Converter != nil {
+			return p.newGetterFromConverter(*parsed.Converter)
+		}
+		return nil, err
+	}
+	return p.newGetterFromConverter(*parsed.Converter)
+}
+
 var parser = newParser[parsedStatement]()
 
 func parseStatement(raw string) (*parsedStatement, error) {
@@ -151,6 +162,9 @@ func parseStatement(raw string) (*parsedStatement, error) {
 	}
 	err = parsed.checkForCustomError()
 	if err != nil {
+		if parsed.Converter != nil {
+			return parsed, err
+		}
 		return nil, err
 	}
 

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -154,6 +154,118 @@ func Test_parse(t *testing.T) {
 			},
 		},
 		{
+			name:      "Converter parameters (All Uppercase)",
+			statement: `replace_pattern(attributes["message"], "device=*", attributes["device_name"], SHA256)`,
+			expected: &parsedStatement{
+				Editor: editor{
+					Function: "replace_pattern",
+					Arguments: []value{
+						{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "attributes",
+											Keys: []Key{
+												{
+													String: ottltest.Strp("message"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							String: ottltest.Strp("device=*"),
+						},
+						{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "attributes",
+											Keys: []Key{
+												{
+													String: ottltest.Strp("device_name"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Enum: (*EnumSymbol)(ottltest.Strp("SHA256")),
+						},
+					},
+				},
+				WhereClause: nil,
+			},
+		},
+		{
+			name:      "Converter parameters",
+			statement: `replace_pattern(attributes["message"], Sha256)`,
+			expected: &parsedStatement{
+				Editor: editor{
+					Function: "replace_pattern",
+					Arguments: []value{
+						{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "attributes",
+											Keys: []Key{
+												{
+													String: ottltest.Strp("message"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							FunctionName: (ottltest.Strp("Sha256")),
+						},
+					},
+				},
+				WhereClause: nil,
+			},
+		},
+		{
+			name:      "Converter parameters (One Uppercase symbol)",
+			statement: `replace_pattern(attributes["message"], S)`,
+			expected: &parsedStatement{
+				Editor: editor{
+					Function: "replace_pattern",
+					Arguments: []value{
+						{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "attributes",
+											Keys: []Key{
+												{
+													String: ottltest.Strp("message"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						{
+							Enum: (*EnumSymbol)(ottltest.Strp("S")),
+						},
+					},
+				},
+				WhereClause: nil,
+			},
+		},
+		{
 			name:      "complex path",
 			statement: `set(foo.bar["x"]["y"].z, Test()[0]["pass"])`,
 			expected: &parsedStatement{


### PR DESCRIPTION
**Description:** Add a new Function Getter to the OTTL package, to allow passing Converters as literal parameters

**Link to tracking Issue:** [<Issue number if applicable>](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22961)

**Testing:** Added a unit test and also tested the following configuration

```
replace_pattern(attributes["message"], "device=*", attributes["device_name"], SHA256)
```

A tentative example of how the literal function gets invoked is
```
type ReplacePatternArguments[K any] struct {
	Target       ottl.GetSetter[K]      `ottlarg:"0"`
	RegexPattern string                 `ottlarg:"1"`
	Replacement  ottl.StringGetter[K]   `ottlarg:"2"`
	Function     ottl.FunctionGetter[K] `ottlarg:"3"`
}

func replacePattern[K any](target ottl.GetSetter[K], regexPattern string, replacement ottl.StringGetter[K], fn ottl.Expr[K]) (ottl.ExprFunc[K], error) {
	compiledPattern, err := regexp.Compile(regexPattern)
	if err != nil {
		return nil, fmt.Errorf("the regex pattern supplied to replace_pattern is not a valid pattern: %w", err)
	}
	return func(ctx context.Context, tCtx K) (interface{}, error) {
		originalVal, err := target.Get(ctx, tCtx)
		if err != nil {
			return nil, err
		}
		replacementVal, err := fn.Eval(ctx, tCtx)
		if err != nil {
			return nil, err
		}
          .......
          updatedStr := compiledPattern.ReplaceAllString(originalValStr, replacementValHash.(string))
}
```