### PR TITLE
[exporter/googlemanagedprometheus] Add target and scope info metrics by default

### DIFF
--- a/.chloggen/gmp-exporter-add-target-metrics.yaml
+++ b/.chloggen/gmp-exporter-add-target-metrics.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlemanagedprometheusexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: GMP exporter now automatically adds target_info and otel_scope_info metrics.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24372]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/googlemanagedprometheusexporter/config.go
+++ b/exporter/googlemanagedprometheusexporter/config.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus"
-
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
@@ -33,8 +32,17 @@ type GMPConfig struct {
 type MetricConfig struct {
 	// Prefix configures the prefix of metrics sent to GoogleManagedPrometheus.  Defaults to prometheus.googleapis.com.
 	// Changing this prefix is not recommended, as it may cause metrics to not be queryable with promql in the Cloud Monitoring UI.
-	Prefix       string                 `mapstructure:"prefix"`
-	ClientConfig collector.ClientConfig `mapstructure:",squash"`
+	Prefix             string                 `mapstructure:"prefix"`
+	ClientConfig       collector.ClientConfig `mapstructure:",squash"`
+	ExtraMetricsConfig ExtraMetricsConfig     `mapstructure:"extra_metrics_config"`
+}
+
+// ExtraMetricsConfig controls the inclusion of additional metrics.
+type ExtraMetricsConfig struct {
+	// Add `target_info` metric based on the resource. On by default.
+	EnableTargetInfo bool `mapstructure:"enable_target_info"`
+	// Add `otel_scope_info` metric and `scope_name`/`scope_version` attributes to all other metrics. On by default.
+	EnableScopeInfo bool `mapstructure:"enable_scope_info"`
 }
 
 func (c *GMPConfig) toCollectorConfig() collector.Config {
@@ -56,10 +64,19 @@ func (c *GMPConfig) toCollectorConfig() collector.Config {
 	cfg.ProjectID = c.ProjectID
 	cfg.UserAgent = c.UserAgent
 	cfg.MetricConfig.ClientConfig = c.MetricConfig.ClientConfig
+
 	// add target_info and scope_info metrics
+	extraMetricsFuncs := make([]func(m pmetric.Metrics), 0)
+	if c.MetricConfig.ExtraMetricsConfig.EnableTargetInfo {
+		extraMetricsFuncs = append(extraMetricsFuncs, googlemanagedprometheus.AddTargetInfoMetric)
+	}
+	if c.MetricConfig.ExtraMetricsConfig.EnableScopeInfo {
+		extraMetricsFuncs = append(extraMetricsFuncs, googlemanagedprometheus.AddScopeInfoMetric)
+	}
 	cfg.MetricConfig.ExtraMetrics = func(m pmetric.Metrics) pmetric.ResourceMetricsSlice {
-		googlemanagedprometheus.AddScopeInfoMetric(m)
-		googlemanagedprometheus.AddTargetInfoMetric(m)
+		for _, extraMetricsFunc := range extraMetricsFuncs {
+			extraMetricsFunc(m)
+		}
 		return m.ResourceMetrics()
 	}
 	return cfg

--- a/exporter/googlemanagedprometheusexporter/config.go
+++ b/exporter/googlemanagedprometheusexporter/config.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus"
+
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
 // Config defines configuration for Google Cloud Managed Service for Prometheus exporter.
@@ -54,6 +56,12 @@ func (c *GMPConfig) toCollectorConfig() collector.Config {
 	cfg.ProjectID = c.ProjectID
 	cfg.UserAgent = c.UserAgent
 	cfg.MetricConfig.ClientConfig = c.MetricConfig.ClientConfig
+	// add target_info and scope_info metrics
+	cfg.MetricConfig.ExtraMetrics = func(m pmetric.Metrics) pmetric.ResourceMetricsSlice {
+		googlemanagedprometheus.AddScopeInfoMetric(m)
+		googlemanagedprometheus.AddTargetInfoMetric(m)
+		return m.ResourceMetrics()
+	}
 	return cfg
 }
 

--- a/exporter/googlemanagedprometheusexporter/config_test.go
+++ b/exporter/googlemanagedprometheusexporter/config_test.go
@@ -9,12 +9,13 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter/internal/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/otelcol/otelcoltest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter/internal/metadata"
 )
 
 func TestLoadConfig(t *testing.T) {

--- a/exporter/googlemanagedprometheusexporter/config_test.go
+++ b/exporter/googlemanagedprometheusexporter/config_test.go
@@ -9,13 +9,12 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter/internal/metadata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/otelcol/otelcoltest"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter/internal/metadata"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -43,6 +42,12 @@ func TestLoadConfig(t *testing.T) {
 			GMPConfig: GMPConfig{
 				ProjectID: "my-project",
 				UserAgent: "opentelemetry-collector-contrib {{version}}",
+				MetricConfig: MetricConfig{
+					ExtraMetricsConfig: ExtraMetricsConfig{
+						EnableTargetInfo: true,
+						EnableScopeInfo:  true,
+					},
+				},
 			},
 			RetrySettings: exporterhelper.RetrySettings{
 				Enabled:             true,

--- a/exporter/googlemanagedprometheusexporter/factory.go
+++ b/exporter/googlemanagedprometheusexporter/factory.go
@@ -10,11 +10,10 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter/internal/metadata"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter/internal/metadata"
 )
 
 const (
@@ -38,6 +37,14 @@ func createDefaultConfig() component.Config {
 		TimeoutSettings: exporterhelper.TimeoutSettings{Timeout: defaultTimeout},
 		RetrySettings:   retrySettings,
 		QueueSettings:   exporterhelper.NewDefaultQueueSettings(),
+		GMPConfig: GMPConfig{
+			MetricConfig: MetricConfig{
+				ExtraMetricsConfig: ExtraMetricsConfig{
+					EnableTargetInfo: true,
+					EnableScopeInfo:  true,
+				},
+			},
+		},
 	}
 }
 

--- a/exporter/googlemanagedprometheusexporter/factory.go
+++ b/exporter/googlemanagedprometheusexporter/factory.go
@@ -10,10 +10,11 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter/internal/metadata"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter/internal/metadata"
 )
 
 const (

--- a/exporter/googlemanagedprometheusexporter/go.mod
+++ b/exporter/googlemanagedprometheusexporter/go.mod
@@ -10,6 +10,7 @@ require (
 	go.opentelemetry.io/collector v0.81.0
 	go.opentelemetry.io/collector/component v0.81.0
 	go.opentelemetry.io/collector/exporter v0.81.0
+	go.opentelemetry.io/collector/pdata v1.0.0-rcv0013
 )
 
 require (
@@ -78,7 +79,6 @@ require (
 	go.opentelemetry.io/collector/consumer v0.81.0 // indirect
 	go.opentelemetry.io/collector/extension v0.81.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0013 // indirect
-	go.opentelemetry.io/collector/pdata v1.0.0-rcv0013 // indirect
 	go.opentelemetry.io/collector/processor v0.81.0 // indirect
 	go.opentelemetry.io/collector/receiver v0.81.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.81.0 // indirect


### PR DESCRIPTION
**Description:**
This enabled `target_info` and `otel_scope_info` metrics by default in the GMP exporter, to be compatible with the prometheus spec.

**Link to tracking Issue:** https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/543

**Testing:** Downstream unit + integration tests

**Documentation:** Downstream + specification