### PR TITLE
[chore] remove components from unmaintained list

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -23,6 +23,4 @@ internal/common
 ## DEPRECATED components
 
 ## UNMAINTAINED components
-exporter/carbonexporter/
-receiver/carbonreceiver/
 receiver/wavefrontreceiver/


### PR DESCRIPTION
Carbon components are now maintained again with #23676 
This PR removes them from the unmaintained components list.