### PR TITLE
[exporter/googlemanagedprometheus] support resource filters

### DIFF
--- a/.chloggen/gmp-resource-filters.yaml
+++ b/.chloggen/gmp-resource-filters.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlemanagedprometheusexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: GMP exporter supports filtering resource attributes to metric labels.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [21654]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/googlemanagedprometheusexporter/README.md
+++ b/exporter/googlemanagedprometheusexporter/README.md
@@ -24,6 +24,12 @@ The following configuration options are supported:
 - `user_agent` (optional): Override the user agent string sent on requests to Cloud Monitoring (currently only applies to metrics). Specify `{{version}}` to include the application version number. Defaults to `opentelemetry-collector-contrib {{version}}`.
 - `metric`(optional): Configuration for sending metrics to Cloud Monitoring.
   - `endpoint` (optional): Endpoint where metric data is going to be sent to. Replaces `endpoint`.
+  - `extra_metrics_config` (optional): Enable or disable additional metrics.
+    - `enable_target_info` (default=`true`): Add `target_info` metric based on resource.
+    - `enable_scope_info` (default=`true`): Add `otel_scope_info` metric and `scope_name`/`scope_version` attributes to all other metrics.
+  - `resource_filters` (optional): Provides a list of filters to match resource attributes which will be included in metric labels.
+    - `prefix` (optional): Match resource attribute keys by prefix.
+    - `regex` (optional): Match resource attribute keys by regex.
 - `use_insecure` (optional): If true, use gRPC as their communication transport. Only has effect if Endpoint is not "".
 - `retry_on_failure` (optional): Configuration for how to handle retries when sending data to Google Cloud fails.
   - `enabled` (default = false)

--- a/exporter/googlemanagedprometheusexporter/config.go
+++ b/exporter/googlemanagedprometheusexporter/config.go
@@ -32,9 +32,10 @@ type GMPConfig struct {
 type MetricConfig struct {
 	// Prefix configures the prefix of metrics sent to GoogleManagedPrometheus.  Defaults to prometheus.googleapis.com.
 	// Changing this prefix is not recommended, as it may cause metrics to not be queryable with promql in the Cloud Monitoring UI.
-	Prefix             string                 `mapstructure:"prefix"`
-	ClientConfig       collector.ClientConfig `mapstructure:",squash"`
-	ExtraMetricsConfig ExtraMetricsConfig     `mapstructure:"extra_metrics_config"`
+	Prefix             string                     `mapstructure:"prefix"`
+	ClientConfig       collector.ClientConfig     `mapstructure:",squash"`
+	ExtraMetricsConfig ExtraMetricsConfig         `mapstructure:"extra_metrics_config"`
+	ResourceFilters    []collector.ResourceFilter `mapstructure:"resource_filters"`
 }
 
 // ExtraMetricsConfig controls the inclusion of additional metrics.
@@ -64,6 +65,7 @@ func (c *GMPConfig) toCollectorConfig() collector.Config {
 	cfg.ProjectID = c.ProjectID
 	cfg.UserAgent = c.UserAgent
 	cfg.MetricConfig.ClientConfig = c.MetricConfig.ClientConfig
+	cfg.MetricConfig.ResourceFilters = c.MetricConfig.ResourceFilters
 
 	// add target_info and scope_info metrics
 	extraMetricsFuncs := make([]func(m pmetric.Metrics), 0)


### PR DESCRIPTION
**Description:**
Fixes #21654 
Allows GMP exporter to use the same `resource_filters` option as supported by the main GCP exporter.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21654

**Testing:** Downstream unit/integration tests

**Documentation:** added to readme. (this also adds missing documentation to readme on flags added in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/24372)