### PR TITLE
Add ottl len converter

### DIFF
--- a/.chloggen/add-ottl-len-converter.yaml
+++ b/.chloggen/add-ottl-len-converter.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add new `len` converter that computes the length of strings
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23847]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/add-ottl-len-converter.yaml
+++ b/.chloggen/add-ottl-len-converter.yaml
@@ -9,7 +9,7 @@ change_type: enhancement
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add new `Len` converter that computes the length of strings and slices
+note: Add new `Len` converter that computes the length of strings, slices, and maps.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [23847]

--- a/.chloggen/add-ottl-len-converter.yaml
+++ b/.chloggen/add-ottl-len-converter.yaml
@@ -9,7 +9,7 @@ change_type: enhancement
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add new `len` converter that computes the length of strings
+note: Add new `Len` converter that computes the length of strings and slices
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [23847]

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -463,9 +463,9 @@ Examples:
 
 `Len(target)`
 
-The `Len` Converter returns the length of the target string or slice.
+The `Len` Converter returns the int64 length of the target string or slice.
 
-`target` is either a `string`, slice, `pcommmon.ValueTypeStr`, or `pcommon.Value` with type `pcommon.ValueTypeStr`, or `pcommon.Slice`.
+`target` is either a `string`, `slice`, `map`, `pcommon.Slice`, `pcommon.Map`, or `pcommon.Value` with type `pcommon.ValueTypeStr`, `pcommon.ValueTypeSlice`, or `pcommon.ValueTypeMap`.
 
 If the `target` is not an acceptable type, the `Len` Converter will return an error.
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -463,11 +463,11 @@ Examples:
 
 `Len(target)`
 
-The `Len` Converter returns the length of the target string.
+The `Len` Converter returns the length of the target string or slice.
 
-`target` is a `string`.
+`target` is either a `string`, slice, `pcommmon.ValueTypeStr`, or `pcommon.Value` with type `pcommon.ValueTypeStr`, or `pcommon.Slice`.
 
-If the `target` is not a string or does not exist, the `Len` Converter will return an error.
+If the `target` is not an acceptable type, the `Len` Converter will return an error.
 
 Examples:
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -459,6 +459,20 @@ Examples:
 
 - `IsString(attributes["maybe a string"])`
 
+### Len
+
+`Len(target)`
+
+The `Len` Converter returns the length of the target string.
+
+`target` is a `string`.
+
+If the `target` is not a string or does not exist, the `Len` Converter will return an error.
+
+Examples:
+
+- `Len(body)`
+
 ### Log
 
 `Log(value)`

--- a/pkg/ottl/ottlfuncs/func_len.go
+++ b/pkg/ottl/ottlfuncs/func_len.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type LenArguments[K any] struct {
+	Target ottl.StringGetter[K] `ottlarg:"0"`
+}
+
+func NewLenFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("Len", &LenArguments[K]{}, createLenFunction[K])
+}
+
+func createLenFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*LenArguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("LenFactory args must be of type *LenArguments[K]")
+	}
+
+	return strLen(args.Target), nil
+}
+
+func strLen[K any](target ottl.StringGetter[K]) ottl.ExprFunc[K] {
+	return func(ctx context.Context, tCtx K) (interface{}, error) {
+		val, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		return int64(len(val)), nil
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_len.go
+++ b/pkg/ottl/ottlfuncs/func_len.go
@@ -62,7 +62,7 @@ func computeLen[K any](target ottl.Getter[K]) ottl.ExprFunc[K] {
 
 		v := reflect.ValueOf(val)
 		switch v.Kind() {
-                case reflect.String, reflect.Map, reflect.Slice:
+		case reflect.String, reflect.Map, reflect.Slice:
 			return int64(v.Len()), nil
 		}
 

--- a/pkg/ottl/ottlfuncs/func_len.go
+++ b/pkg/ottl/ottlfuncs/func_len.go
@@ -58,16 +58,11 @@ func computeLen[K any](target ottl.Getter[K]) ottl.ExprFunc[K] {
 			return int64(valType.Len()), nil
 		case pcommon.Slice:
 			return int64(valType.Len()), nil
-
 		}
 
 		v := reflect.ValueOf(val)
 		switch v.Kind() {
-		case reflect.Map:
-			fallthrough
-		case reflect.Slice:
-			fallthrough
-		case reflect.String:
+                case reflect.String, reflect.Map, reflect.Slice:
 			return int64(v.Len()), nil
 		}
 

--- a/pkg/ottl/ottlfuncs/func_len.go
+++ b/pkg/ottl/ottlfuncs/func_len.go
@@ -6,12 +6,15 @@ package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-c
 import (
 	"context"
 	"fmt"
+	"reflect"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
 type LenArguments[K any] struct {
-	Target ottl.StringGetter[K] `ottlarg:"0"`
+	Target ottl.Getter[K] `ottlarg:"0"`
 }
 
 func NewLenFactory[K any]() ottl.Factory[K] {
@@ -25,15 +28,32 @@ func createLenFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ott
 		return nil, fmt.Errorf("LenFactory args must be of type *LenArguments[K]")
 	}
 
-	return strLen(args.Target), nil
+	return computeLen(args.Target), nil
 }
 
-func strLen[K any](target ottl.StringGetter[K]) ottl.ExprFunc[K] {
+func computeLen[K any](target ottl.Getter[K]) ottl.ExprFunc[K] {
 	return func(ctx context.Context, tCtx K) (interface{}, error) {
 		val, err := target.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
-		return int64(len(val)), nil
+
+		v := reflect.ValueOf(val)
+		if v.Kind() == reflect.String {
+			return int64(len(v.String())), nil
+		} else if v.Kind() == reflect.Slice {
+			return int64(v.Len()), nil
+		}
+
+		if pcommonVal, ok := val.(pcommon.Value); ok {
+			if pcommonVal.Type() == pcommon.ValueTypeStr {
+				return int64(len(pcommonVal.Str())), nil
+			}
+		}
+		if pcommonSlice, ok := val.(pcommon.Slice); ok {
+			return int64(pcommonSlice.Len()), nil
+		}
+
+		return nil, fmt.Errorf("target arg must be of type string, []any, or pcommon.Slice")
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_len_test.go
+++ b/pkg/ottl/ottlfuncs/func_len_test.go
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_Len(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    interface{}
+		expected int
+	}{
+		{
+			name:     "string",
+			value:    "a string",
+			expected: 8,
+		},
+		{
+			name:     "ValueTypeString",
+			value:    pcommon.NewValueStr("a string"),
+			expected: 8,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc := strLen[any](&ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, interface{}) (interface{}, error) {
+					return tt.value, nil
+				},
+			})
+			result, err := exprFunc(context.Background(), nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// nolint:errorlint
+func Test_Len_Error(t *testing.T) {
+	exprFunc := strLen[any](&ottl.StandardStringGetter[any]{
+		Getter: func(context.Context, interface{}) (interface{}, error) {
+			return nil, ottl.TypeError("")
+		},
+	})
+	result, err := exprFunc(context.Background(), nil)
+	assert.Equal(t, nil, result)
+	assert.Error(t, err)
+	_, ok := err.(ottl.TypeError)
+	assert.False(t, ok)
+}

--- a/pkg/ottl/ottlfuncs/func_len_test.go
+++ b/pkg/ottl/ottlfuncs/func_len_test.go
@@ -14,10 +14,16 @@ import (
 )
 
 func Test_Len(t *testing.T) {
+	pcommonSlice := pcommon.NewSlice()
+	err := pcommonSlice.FromRaw(make([]any, 5))
+	if err != nil {
+		t.Error(err)
+	}
+
 	tests := []struct {
 		name     string
 		value    interface{}
-		expected int
+		expected int64
 	}{
 		{
 			name:     "string",
@@ -29,11 +35,26 @@ func Test_Len(t *testing.T) {
 			value:    pcommon.NewValueStr("a string"),
 			expected: 8,
 		},
+		{
+			name:     "string slice",
+			value:    make([]string, 5),
+			expected: 5,
+		},
+		{
+			name:     "int slice",
+			value:    make([]int, 5),
+			expected: 5,
+		},
+		{
+			name:     "pcommon slice",
+			value:    pcommonSlice,
+			expected: 5,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exprFunc := strLen[any](&ottl.StandardStringGetter[any]{
-				Getter: func(context.Context, interface{}) (interface{}, error) {
+			exprFunc := computeLen[any](&ottl.StandardGetSetter[any]{
+				Getter: func(context context.Context, tCtx any) (interface{}, error) {
 					return tt.value, nil
 				},
 			})
@@ -46,9 +67,9 @@ func Test_Len(t *testing.T) {
 
 // nolint:errorlint
 func Test_Len_Error(t *testing.T) {
-	exprFunc := strLen[any](&ottl.StandardStringGetter[any]{
+	exprFunc := computeLen[any](&ottl.StandardGetSetter[any]{
 		Getter: func(context.Context, interface{}) (interface{}, error) {
-			return nil, ottl.TypeError("")
+			return 24, nil
 		},
 	})
 	result, err := exprFunc(context.Background(), nil)

--- a/pkg/ottl/ottlfuncs/func_len_test.go
+++ b/pkg/ottl/ottlfuncs/func_len_test.go
@@ -5,6 +5,7 @@ package ottlfuncs
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,24 @@ func Test_Len(t *testing.T) {
 		t.Error(err)
 	}
 
+	pcommonMap := pcommon.NewMap()
+	err = pcommonMap.FromRaw(dummyMap(5))
+	if err != nil {
+		t.Error(err)
+	}
+
+	pcommonValueSlice := pcommon.NewValueSlice()
+	err = pcommonValueSlice.FromRaw(make([]any, 5))
+	if err != nil {
+		t.Error(err)
+	}
+
+	pcommonValueMap := pcommon.NewValueMap()
+	err = pcommonValueMap.FromRaw(dummyMap(5))
+	if err != nil {
+		t.Error(err)
+	}
+
 	tests := []struct {
 		name     string
 		value    interface{}
@@ -31,9 +50,9 @@ func Test_Len(t *testing.T) {
 			expected: 8,
 		},
 		{
-			name:     "ValueTypeString",
-			value:    pcommon.NewValueStr("a string"),
-			expected: 8,
+			name:     "map",
+			value:    dummyMap(5),
+			expected: 5,
 		},
 		{
 			name:     "string slice",
@@ -46,8 +65,28 @@ func Test_Len(t *testing.T) {
 			expected: 5,
 		},
 		{
+			name:     "pcommon map",
+			value:    pcommonMap,
+			expected: 5,
+		},
+		{
 			name:     "pcommon slice",
 			value:    pcommonSlice,
+			expected: 5,
+		},
+		{
+			name:     "pcommon value string",
+			value:    pcommon.NewValueStr("a string"),
+			expected: 8,
+		},
+		{
+			name:     "pcommon value slice",
+			value:    pcommonValueSlice,
+			expected: 5,
+		},
+		{
+			name:     "pcommon value map",
+			value:    pcommonValueMap,
 			expected: 5,
 		},
 	}
@@ -63,6 +102,14 @@ func Test_Len(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func dummyMap(size int) map[string]any {
+	m := make(map[string]any, size)
+	for i := 0; i < size; i++ {
+		m[strconv.Itoa(i)] = i
+	}
+	return m
 }
 
 // nolint:errorlint

--- a/pkg/ottl/ottlfuncs/func_len_test.go
+++ b/pkg/ottl/ottlfuncs/func_len_test.go
@@ -120,7 +120,7 @@ func Test_Len_Error(t *testing.T) {
 		},
 	})
 	result, err := exprFunc(context.Background(), nil)
-	assert.Equal(t, nil, result)
+	assert.Nil(t, result)
 	assert.Error(t, err)
 	_, ok := err.(ottl.TypeError)
 	assert.False(t, ok)

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -42,6 +42,7 @@ func converters[K any]() []ottl.Factory[K] {
 		NewIsMapFactory[K](),
 		NewIsMatchFactory[K](),
 		NewIsStringFactory[K](),
+		NewLenFactory[K](),
 		NewLogFactory[K](),
 		NewParseJSONFactory[K](),
 		NewSHA1Factory[K](),


### PR DESCRIPTION
**Description:** 

Add ottl `Len` converter to make `Substring` useful for truncating. E.g.:
```
    log_statements:
      - context: log
        statements:
        - set(body, Substring(body, 0, 10)) where Len(body) >= 10
```

**Link to tracking Issue:**  Resolves #23847.

**Testing:** Unit tests, local verification with running collector.

**Documentation:** Added documentation to `pkg/ottl/ottlfuncs/README.md`.

This PR is the result of [conversation](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/23880#issuecomment-1642294029) on #23880.