### PR TITLE
[chore] ignore pmetric.MetricTypeEmpty for exhaustive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,6 +125,7 @@ linters-settings:
 
   exhaustive:
     explicit-exhaustive-switch: true
+    ignore-enum-members: "pmetric.MetricTypeEmpty"
 
 linters:
   enable:


### PR DESCRIPTION
**Description:** 
related #23266

The `pmetric.MetricTypeEmpty` always has no meaning for  the components, for example

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c55822fe72d57a2e61b6611ce1f7e9ee926ace21/processor/metricstransformprocessor/metrics_transform_processor_otlp.go#L503-L517

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/c55822fe72d57a2e61b6611ce1f7e9ee926ace21/processor/metricstransformprocessor/metrics_transform_processor_otlp.go#L463-L501

so we could optimize the check logic of exhaustive to ignore the type `pmetric.MetricTypeEmpty` to avoid solving many meaningless failed check like

```
metrics_transform_processor_otlp.go:505:2: missing cases in switch of type pmetric.MetricType: pmetric.MetricTypeEmpty (exhaustive)
``` 