### PR TITLE
[chore] [processor/resourcedetection] Create ResourceBuilder on start

### DIFF
--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	ec2provider "github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders/aws/ec2"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2/internal/metadata"
 )
 
 var errUnavailable = errors.New("ec2metadata unavailable")
@@ -172,11 +173,10 @@ func TestDetector_Detect(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resourceAttributes := CreateDefaultConfig().ResourceAttributes
 			d := &Detector{
-				metadataProvider:   tt.fields.metadataProvider,
-				logger:             zap.NewNop(),
-				resourceAttributes: resourceAttributes,
+				metadataProvider: tt.fields.metadataProvider,
+				logger:           zap.NewNop(),
+				rb:               metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig()),
 			}
 			got, _, err := d.Detect(tt.args.ctx)
 

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
@@ -120,8 +120,7 @@ func Test_ecsDetectV4(t *testing.T) {
 	attr.PutEmptySlice("aws.log.stream.names").AppendEmpty().SetStr("stream")
 	attr.PutEmptySlice("aws.log.stream.arns").AppendEmpty().SetStr("arn:aws:logs:us-east-1:123456789123:log-group:group:log-stream:stream")
 
-	resourceAttributes := CreateDefaultConfig().ResourceAttributes
-	d := Detector{provider: &mockMetaDataProvider{isV4: true}, resourceAttributes: resourceAttributes}
+	d := Detector{provider: &mockMetaDataProvider{isV4: true}, rb: metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())}
 	got, _, err := d.Detect(context.TODO())
 
 	assert.Nil(t, err)
@@ -144,8 +143,7 @@ func Test_ecsDetectV3(t *testing.T) {
 	attr.PutStr("cloud.availability_zone", "us-west-2a")
 	attr.PutStr("cloud.account.id", "123456789123")
 
-	resourceAttributes := CreateDefaultConfig().ResourceAttributes
-	d := Detector{provider: &mockMetaDataProvider{isV4: false}, resourceAttributes: resourceAttributes}
+	d := Detector{provider: &mockMetaDataProvider{isV4: false}, rb: metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())}
 	got, _, err := d.Detect(context.TODO())
 
 	assert.Nil(t, err)

--- a/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/eks/detector_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/processor/processortest"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/eks/internal/metadata"
 )
 
 type MockDetectorUtils struct {
@@ -38,8 +40,7 @@ func TestEKS(t *testing.T) {
 	t.Setenv("KUBERNETES_SERVICE_HOST", "localhost")
 	detectorUtils.On("getConfigMap", authConfigmapNS, authConfigmapName).Return(map[string]string{"cluster.name": "my-cluster"}, nil)
 	// Call EKS Resource detector to detect resources
-	resourceAttributes := CreateDefaultConfig().ResourceAttributes
-	eksResourceDetector := &detector{utils: detectorUtils, err: nil, resourceAttributes: resourceAttributes}
+	eksResourceDetector := &detector{utils: detectorUtils, err: nil, rb: metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())}
 	res, _, err := eksResourceDetector.Detect(ctx)
 	require.NoError(t, err)
 

--- a/processor/resourcedetectionprocessor/internal/aws/lambda/lambda_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/lambda/lambda_test.go
@@ -11,15 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/processor/processortest"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
-	"go.uber.org/zap"
 )
-
-func TestNewDetector(t *testing.T) {
-	dcfg := CreateDefaultConfig()
-	detector, err := NewDetector(processortest.NewNopCreateSettings(), dcfg)
-	assert.NoError(t, err)
-	assert.NotNil(t, detector)
-}
 
 // Tests Lambda resource detector running in Lambda environment
 func TestLambda(t *testing.T) {
@@ -29,8 +21,8 @@ func TestLambda(t *testing.T) {
 	t.Setenv(awsLambdaFunctionNameEnvVar, functionName)
 
 	// Call Lambda Resource detector to detect resources
-	resourceAttributes := CreateDefaultConfig().ResourceAttributes
-	lambdaDetector := &detector{logger: zap.NewNop(), resourceAttributes: resourceAttributes}
+	lambdaDetector, err := NewDetector(processortest.NewNopCreateSettings(), CreateDefaultConfig())
+	require.NoError(t, err)
 	res, _, err := lambdaDetector.Detect(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -45,8 +37,8 @@ func TestLambda(t *testing.T) {
 // Tests Lambda resource detector not running in Lambda environment
 func TestNotLambda(t *testing.T) {
 	ctx := context.Background()
-	resourceAttributes := CreateDefaultConfig().ResourceAttributes
-	lambdaDetector := &detector{logger: zap.NewNop(), resourceAttributes: resourceAttributes}
+	lambdaDetector, err := NewDetector(processortest.NewNopCreateSettings(), CreateDefaultConfig())
+	require.NoError(t, err)
 	res, _, err := lambdaDetector.Detect(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, res)

--- a/processor/resourcedetectionprocessor/internal/consul/consul_test.go
+++ b/processor/resourcedetectionprocessor/internal/consul/consul_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders/consul"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/consul/internal/metadata"
 )
 
 var _ consul.Provider = (*mockMetadata)(nil)
@@ -39,11 +40,10 @@ func TestDetect(t *testing.T) {
 		},
 		nil,
 	)
-	dcfg := CreateDefaultConfig()
 	detector := &Detector{
-		provider:           md,
-		logger:             zap.NewNop(),
-		resourceAttributes: dcfg.ResourceAttributes,
+		provider: md,
+		logger:   zap.NewNop(),
+		rb:       metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig()),
 	}
 	res, schemaURL, err := detector.Detect(context.Background())
 	require.NoError(t, err)

--- a/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
+++ b/processor/resourcedetectionprocessor/internal/gcp/gcp_test.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+	localMetadata "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/gcp/internal/metadata"
 )
 
 func TestDetect(t *testing.T) {
@@ -227,11 +228,10 @@ func TestDetect(t *testing.T) {
 }
 
 func newTestDetector(gcpDetector *fakeGCPDetector) *detector {
-	resourceAttributes := CreateDefaultConfig().ResourceAttributes
 	return &detector{
-		logger:             zap.NewNop(),
-		detector:           gcpDetector,
-		resourceAttributes: resourceAttributes,
+		logger:   zap.NewNop(),
+		detector: gcpDetector,
+		rb:       localMetadata.NewResourceBuilder(localMetadata.DefaultResourceAttributesConfig()),
 	}
 }
 

--- a/processor/resourcedetectionprocessor/internal/heroku/heroku_test.go
+++ b/processor/resourcedetectionprocessor/internal/heroku/heroku_test.go
@@ -16,13 +16,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
 )
 
-func TestNewDetector(t *testing.T) {
-	dcfg := CreateDefaultConfig()
-	d, err := NewDetector(processortest.NewNopCreateSettings(), dcfg)
-	assert.NotNil(t, d)
-	assert.NoError(t, err)
-}
-
 func TestDetectTrue(t *testing.T) {
 	t.Setenv("HEROKU_DYNO_ID", "foo")
 	t.Setenv("HEROKU_APP_ID", "appid")
@@ -31,8 +24,8 @@ func TestDetectTrue(t *testing.T) {
 	t.Setenv("HEROKU_RELEASE_VERSION", "v1")
 	t.Setenv("HEROKU_SLUG_COMMIT", "23456")
 
-	resourceAttributes := CreateDefaultConfig().ResourceAttributes
-	detector := &detector{resourceAttributes: resourceAttributes}
+	detector, err := NewDetector(processortest.NewNopCreateSettings(), CreateDefaultConfig())
+	require.NoError(t, err)
 	res, schemaURL, err := detector.Detect(context.Background())
 	assert.Equal(t, conventions.SchemaURL, schemaURL)
 	require.NoError(t, err)
@@ -54,8 +47,8 @@ func TestDetectTruePartial(t *testing.T) {
 	t.Setenv("HEROKU_APP_NAME", "appname")
 	t.Setenv("HEROKU_RELEASE_VERSION", "v1")
 
-	resourceAttributes := CreateDefaultConfig().ResourceAttributes
-	detector := &detector{resourceAttributes: resourceAttributes}
+	detector, err := NewDetector(processortest.NewNopCreateSettings(), CreateDefaultConfig())
+	require.NoError(t, err)
 	res, schemaURL, err := detector.Detect(context.Background())
 	assert.Equal(t, conventions.SchemaURL, schemaURL)
 	require.NoError(t, err)

--- a/processor/resourcedetectionprocessor/internal/openshift/openshift_test.go
+++ b/processor/resourcedetectionprocessor/internal/openshift/openshift_test.go
@@ -15,6 +15,7 @@ import (
 
 	ocp "github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders/openshift"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/openshift/internal/metadata"
 )
 
 type providerResponse struct {
@@ -53,7 +54,6 @@ func (m *mockProvider) Infrastructure(context.Context) (*ocp.InfrastructureAPIRe
 }
 
 func newTestDetector(t *testing.T, res *providerResponse, ocpCVErr, k8sCVErr, infraErr error) internal.Detector {
-	resourceAttributes := CreateDefaultConfig().ResourceAttributes
 	return &detector{
 		logger: zaptest.NewLogger(t),
 		provider: &mockProvider{
@@ -62,7 +62,7 @@ func newTestDetector(t *testing.T, res *providerResponse, ocpCVErr, k8sCVErr, in
 			k8sCVErr: k8sCVErr,
 			infraErr: infraErr,
 		},
-		resourceAttributes: resourceAttributes,
+		rb: metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig()),
 	}
 }
 

--- a/processor/resourcedetectionprocessor/internal/system/system_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/system_test.go
@@ -102,8 +102,8 @@ func TestDetectFQDNAvailable(t *testing.T) {
 	md.On("HostID").Return("2", nil)
 	md.On("HostArch").Return("amd64", nil)
 
-	resourceAttributes := allEnabledConfig()
-	detector := &Detector{provider: md, logger: zap.NewNop(), hostnameSources: []string{"dns"}, resourceAttributes: resourceAttributes}
+	detector := &Detector{provider: md, logger: zap.NewNop(), hostnameSources: []string{"dns"},
+		rb: metadata.NewResourceBuilder(allEnabledConfig())}
 	res, schemaURL, err := detector.Detect(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, conventions.SchemaURL, schemaURL)
@@ -128,8 +128,8 @@ func TestFallbackHostname(t *testing.T) {
 	mdHostname.On("HostID").Return("3", nil)
 	mdHostname.On("HostArch").Return("amd64", nil)
 
-	resourceAttributes := CreateDefaultConfig().ResourceAttributes
-	detector := &Detector{provider: mdHostname, logger: zap.NewNop(), hostnameSources: []string{"dns", "os"}, resourceAttributes: resourceAttributes}
+	detector := &Detector{provider: mdHostname, logger: zap.NewNop(), hostnameSources: []string{"dns", "os"},
+		rb: metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())}
 	res, schemaURL, err := detector.Detect(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, conventions.SchemaURL, schemaURL)
@@ -151,8 +151,8 @@ func TestEnableHostID(t *testing.T) {
 	mdHostname.On("HostID").Return("3", nil)
 	mdHostname.On("HostArch").Return("amd64", nil)
 
-	resourceAttributes := allEnabledConfig()
-	detector := &Detector{provider: mdHostname, logger: zap.NewNop(), hostnameSources: []string{"dns", "os"}, resourceAttributes: resourceAttributes}
+	detector := &Detector{provider: mdHostname, logger: zap.NewNop(), hostnameSources: []string{"dns", "os"},
+		rb: metadata.NewResourceBuilder(allEnabledConfig())}
 	res, schemaURL, err := detector.Detect(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, conventions.SchemaURL, schemaURL)
@@ -175,8 +175,8 @@ func TestUseHostname(t *testing.T) {
 	mdHostname.On("HostID").Return("1", nil)
 	mdHostname.On("HostArch").Return("amd64", nil)
 
-	resourceAttributes := allEnabledConfig()
-	detector := &Detector{provider: mdHostname, logger: zap.NewNop(), hostnameSources: []string{"os"}, resourceAttributes: resourceAttributes}
+	detector := &Detector{provider: mdHostname, logger: zap.NewNop(), hostnameSources: []string{"os"},
+		rb: metadata.NewResourceBuilder(allEnabledConfig())}
 	res, schemaURL, err := detector.Detect(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, conventions.SchemaURL, schemaURL)
@@ -201,8 +201,8 @@ func TestDetectError(t *testing.T) {
 	mdFQDN.On("HostID").Return("", errors.New("err"))
 	mdFQDN.On("HostArch").Return("amd64", nil)
 
-	resourceAttributes := allEnabledConfig()
-	detector := &Detector{provider: mdFQDN, logger: zap.NewNop(), hostnameSources: []string{"dns"}, resourceAttributes: resourceAttributes}
+	detector := &Detector{provider: mdFQDN, logger: zap.NewNop(), hostnameSources: []string{"dns"},
+		rb: metadata.NewResourceBuilder(allEnabledConfig())}
 	res, schemaURL, err := detector.Detect(context.Background())
 	assert.Error(t, err)
 	assert.Equal(t, "", schemaURL)
@@ -215,7 +215,8 @@ func TestDetectError(t *testing.T) {
 	mdHostname.On("HostID").Return("", errors.New("err"))
 	mdHostname.On("HostArch").Return("amd64", nil)
 
-	detector = &Detector{provider: mdHostname, logger: zap.NewNop(), hostnameSources: []string{"os"}, resourceAttributes: resourceAttributes}
+	detector = &Detector{provider: mdHostname, logger: zap.NewNop(), hostnameSources: []string{"os"},
+		rb: metadata.NewResourceBuilder(allEnabledConfig())}
 	res, schemaURL, err = detector.Detect(context.Background())
 	assert.Error(t, err)
 	assert.Equal(t, "", schemaURL)
@@ -228,7 +229,8 @@ func TestDetectError(t *testing.T) {
 	mdOSType.On("HostID").Return("", errors.New("err"))
 	mdOSType.On("HostArch").Return("amd64", nil)
 
-	detector = &Detector{provider: mdOSType, logger: zap.NewNop(), hostnameSources: []string{"dns"}, resourceAttributes: resourceAttributes}
+	detector = &Detector{provider: mdOSType, logger: zap.NewNop(), hostnameSources: []string{"dns"},
+		rb: metadata.NewResourceBuilder(allEnabledConfig())}
 	res, schemaURL, err = detector.Detect(context.Background())
 	assert.Error(t, err)
 	assert.Equal(t, "", schemaURL)


### PR DESCRIPTION
Create ResourceBuilder during the initialization state, not in the Detect call. We want to make sure that ResourceBuilder is initialized only once so we can introduce the same warnings as MetricsBuilder has. Detect is currently called only once as well, but it's better not to depend on such behavior, so it can be changed independently in the future if needed.
