### PR TITLE
Allow access to the metrics slice in the OTTL metric context

### DIFF
--- a/.chloggen/feat_ottl_metrics-context-slice.yaml
+++ b/.chloggen/feat_ottl_metrics-context-slice.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow access to the metrics slice in the metric context
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24446]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This is only a breaking change for users using OTTL in custom components. For all Contrib components this is an enhancement.

--- a/connector/countconnector/connector.go
+++ b/connector/countconnector/connector.go
@@ -101,7 +101,7 @@ func (c *count) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 
 			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
 				metric := scopeMetrics.Metrics().At(k)
-				mCtx := ottlmetric.NewTransformContext(metric, scopeMetrics.Scope(), resourceMetric.Resource())
+				mCtx := ottlmetric.NewTransformContext(metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetric.Resource())
 				errors = multierr.Append(errors, metricsCounter.update(ctx, pcommon.NewMap(), mCtx))
 
 				switch metric.Type() {

--- a/internal/filter/filtermetric/filtermetric_test.go
+++ b/internal/filter/filtermetric/filtermetric_test.go
@@ -83,7 +83,7 @@ func TestMatcherMatches(t *testing.T) {
 			assert.NotNil(t, matcher)
 			assert.NoError(t, err)
 
-			matches, err := matcher.Eval(context.Background(), ottlmetric.NewTransformContext(test.metric, pcommon.NewInstrumentationScope(), pcommon.NewResource()))
+			matches, err := matcher.Eval(context.Background(), ottlmetric.NewTransformContext(test.metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource()))
 			assert.NoError(t, err)
 			assert.Equal(t, test.shouldMatch, matches)
 		})
@@ -188,7 +188,7 @@ func Test_NewSkipExpr_With_Bridge(t *testing.T) {
 
 			scope := pcommon.NewInstrumentationScope()
 
-			tCtx := ottlmetric.NewTransformContext(metric, scope, resource)
+			tCtx := ottlmetric.NewTransformContext(metric, pmetric.NewMetricSlice(), scope, resource)
 
 			boolExpr, err := NewSkipExpr(tt.include, tt.exclude)
 			require.NoError(t, err)

--- a/internal/filter/filterottl/functions_test.go
+++ b/internal/filter/filterottl/functions_test.go
@@ -126,7 +126,7 @@ func Test_HasAttrKeyOnDatapoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := hasAttributeKeyOnDatapoint(tt.key)
 			assert.NoError(t, err)
-			result, err := exprFunc(context.Background(), ottlmetric.NewTransformContext(tt.input(), pcommon.NewInstrumentationScope(), pcommon.NewResource()))
+			result, err := exprFunc(context.Background(), ottlmetric.NewTransformContext(tt.input(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource()))
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -351,7 +351,7 @@ func Test_HasAttrOnDatapoint(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc, err := hasAttributeOnDatapoint(tt.key, tt.expectedVal)
 			assert.NoError(t, err)
-			result, err := exprFunc(context.Background(), ottlmetric.NewTransformContext(tt.input(), pcommon.NewInstrumentationScope(), pcommon.NewResource()))
+			result, err := exprFunc(context.Background(), ottlmetric.NewTransformContext(tt.input(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource()))
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -21,6 +21,7 @@ var _ internal.MetricContext = TransformContext{}
 
 type TransformContext struct {
 	metric               pmetric.Metric
+	metrics              pmetric.MetricSlice
 	instrumentationScope pcommon.InstrumentationScope
 	resource             pcommon.Resource
 	cache                pcommon.Map
@@ -28,9 +29,10 @@ type TransformContext struct {
 
 type Option func(*ottl.Parser[TransformContext])
 
-func NewTransformContext(metric pmetric.Metric, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource) TransformContext {
+func NewTransformContext(metric pmetric.Metric, metrics pmetric.MetricSlice, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource) TransformContext {
 	return TransformContext{
 		metric:               metric,
+		metrics:              metrics,
 		instrumentationScope: instrumentationScope,
 		resource:             resource,
 		cache:                pcommon.NewMap(),
@@ -39,6 +41,10 @@ func NewTransformContext(metric pmetric.Metric, instrumentationScope pcommon.Ins
 
 func (tCtx TransformContext) GetMetric() pmetric.Metric {
 	return tCtx.metric
+}
+
+func (tCtx TransformContext) GetMetrics() pmetric.MetricSlice {
+	return tCtx.metrics
 }
 
 func (tCtx TransformContext) GetInstrumentationScope() pcommon.InstrumentationScope {

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -165,7 +165,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			metric := createMetricTelemetry()
 
-			ctx := NewTransformContext(metric, pcommon.NewInstrumentationScope(), pcommon.NewResource())
+			ctx := NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
 			got, err := accessor.Get(context.Background(), ctx)
 			assert.Nil(t, err)

--- a/processor/attributesprocessor/attributes_metric.go
+++ b/processor/attributesprocessor/attributes_metric.go
@@ -44,7 +44,7 @@ func (a *metricAttributesProcessor) processMetrics(ctx context.Context, md pmetr
 			for k := 0; k < metrics.Len(); k++ {
 				m := metrics.At(k)
 				if a.skipExpr != nil {
-					skip, err := a.skipExpr.Eval(ctx, ottlmetric.NewTransformContext(m, scope, resource))
+					skip, err := a.skipExpr.Eval(ctx, ottlmetric.NewTransformContext(m, metrics, scope, resource))
 					if err != nil {
 						return md, err
 					}

--- a/processor/filterprocessor/metrics.go
+++ b/processor/filterprocessor/metrics.go
@@ -124,7 +124,7 @@ func (fmp *filterMetricProcessor) processMetrics(ctx context.Context, md pmetric
 			scope := smetrics.Scope()
 			smetrics.Metrics().RemoveIf(func(metric pmetric.Metric) bool {
 				if fmp.skipMetricExpr != nil {
-					skip, err := fmp.skipMetricExpr.Eval(ctx, ottlmetric.NewTransformContext(metric, scope, resource))
+					skip, err := fmp.skipMetricExpr.Eval(ctx, ottlmetric.NewTransformContext(metric, smetrics.Metrics(), scope, resource))
 					if err != nil {
 						errors = multierr.Append(errors, err)
 					}

--- a/processor/transformprocessor/internal/common/metrics.go
+++ b/processor/transformprocessor/internal/common/metrics.go
@@ -37,7 +37,7 @@ func (m metricStatements) ConsumeMetrics(ctx context.Context, md pmetric.Metrics
 			smetrics := rmetrics.ScopeMetrics().At(j)
 			metrics := smetrics.Metrics()
 			for k := 0; k < metrics.Len(); k++ {
-				tCtx := ottlmetric.NewTransformContext(metrics.At(k), smetrics.Scope(), rmetrics.Resource())
+				tCtx := ottlmetric.NewTransformContext(metrics.At(k), smetrics.Metrics(), smetrics.Scope(), rmetrics.Resource())
 				err := m.Execute(ctx, tCtx)
 				if err != nil {
 					return err


### PR DESCRIPTION
**Description:**
Allow OTTL functions to access the MetricsSlice in the metric context. This makes it possible for functions to create new metrics without having to use the datapoint context.


**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24446

**Testing:**
Tested this change with a new function in #24368 
