### PR TITLE
[chore] update codeowners to match the CODEOWNERS file

### DIFF
--- a/connector/exceptionsconnector/README.md
+++ b/connector/exceptionsconnector/README.md
@@ -5,6 +5,7 @@
 | ------------- |-----------|
 | Distributions | [contrib] |
 | Issues        | ![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aconnector%2Fexceptions%20&label=open&color=orange&logo=opentelemetry) ![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aconnector%2Fexceptions%20&label=closed&color=blue&logo=opentelemetry) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@jpkrohling](https://www.github.com/jpkrohling) |
 
 [development]: https://github.com/open-telemetry/opentelemetry-collector#development
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/connector/exceptionsconnector/metadata.yaml
+++ b/connector/exceptionsconnector/metadata.yaml
@@ -5,3 +5,5 @@ status:
   stability:
     development: [traces_to_metrics, traces_to_logs]
   distributions: [contrib]
+  codeowners:
+    active: [jpkrohling]

--- a/examples/demo/metadata.yaml
+++ b/examples/demo/metadata.yaml
@@ -1,0 +1,5 @@
+type: demo
+
+status:
+  codeowners:
+    active: [open-telemetry/collector-approvers]

--- a/exporter/datasetexporter/README.md
+++ b/exporter/datasetexporter/README.md
@@ -6,7 +6,7 @@
 | Stability     | [alpha]: logs, traces   |
 | Distributions | [contrib] |
 | Issues        | ![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aexporter%2Fdataset%20&label=open&color=orange&logo=opentelemetry) ![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aexporter%2Fdataset%20&label=closed&color=blue&logo=opentelemetry) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@atoulme](https://www.github.com/atoulme), [@martin-majlis-s1](https://www.github.com/martin-majlis-s1), [@zdaratom](https://www.github.com/zdaratom) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@atoulme](https://www.github.com/atoulme), [@martin-majlis-s1](https://www.github.com/martin-majlis-s1), [@zdaratom](https://www.github.com/zdaratom), [@tomaz-s1](https://www.github.com/tomaz-s1) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/exporter/datasetexporter/metadata.yaml
+++ b/exporter/datasetexporter/metadata.yaml
@@ -6,4 +6,4 @@ status:
     alpha: [logs, traces]
   distributions: [contrib]
   codeowners:
-    active: [atoulme, martin-majlis-s1, zdaratom]
+    active: [atoulme, martin-majlis-s1, zdaratom, tomaz-s1]

--- a/exporter/opensearchexporter/metadata.yaml
+++ b/exporter/opensearchexporter/metadata.yaml
@@ -1,0 +1,6 @@
+type: opensearch
+
+status:
+  class: exporter
+  codeowners:
+    active: [Aneurysm9, MitchellGale, MaxKsyunz, YANG-DB]

--- a/internal/tools/metadata.yaml
+++ b/internal/tools/metadata.yaml
@@ -1,3 +1,3 @@
 status:
   codeowners:
-    active: [Aneurysm9, mxiamxia]
+    active: []


### PR DESCRIPTION
**Description:**
Follow up of #24404, some changes occurred in the last week or I had misses in translating the CODEOWNERS file over.

Those minute changes fix that and prepare for the script to generate `.github/CODEOWNERS`.