### PR TITLE
[pkg/ottl] Add support for optional parameters

### DIFF
--- a/.chloggen/ottl-named-arguments.yaml
+++ b/.chloggen/ottl-named-arguments.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow named arguments in function invocations
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [20879]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Arguments can now be specified by a snake-cased version of their name in the function's
+  `Arguments` struct. Named arguments can be specified in any order, but must be specified
+  after arguments without a name.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/ottl-optional-parameters.yaml
+++ b/.chloggen/ottl-optional-parameters.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for optional parameters
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [20879]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The new `ottl.Optional` type can now be used in a function's `Arguments` struct
+  to indicate that a parameter is optional.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/ottl/README.md
+++ b/pkg/ottl/README.md
@@ -90,6 +90,18 @@ For slice parameters, the following types are supported:
 - `uint8`. Byte slice literals are parsed as byte slices by the OTTL.
 - `Getter`
 
+To make a parameter optional, use the `Optional` type, which takes a type argument for the underlying
+parameter type. For example, an optional string parameter would be specified as `Optional[string]`.
+All optional parameters must be specified after all required parameters.
+
+#### Arguments in invocations
+
+Function arguments must be passed in the order defined in the `Arguments` struct for the function unless they are named, in which case the arguments can come in any order. All named arguments must come after all arguments without
+names. Argument names are snake-cased versions of the argument's field name in the function's `Arguments` struct.
+
+When passing optional arguments, all optional arguments preceding a given optional argument must be specified if
+the arguments are not named. Passing a named argument allows skipping the preceding optional arguments.
+
 ### Values
 
 Values are passed as function parameters or are used in a Boolean Expression. Values can take the form of:

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
@@ -73,6 +74,11 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			&functionGetterArguments{},
 			functionWithFunctionGetter,
 		),
+		createFactory[any](
+			"testing_optional_args",
+			&optionalArgsArguments{},
+			functionWithOptionalArgs,
+		),
 	)
 
 	p, _ := NewParser(
@@ -90,16 +96,18 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			name: "unknown function",
 			inv: editor{
 				Function:  "unknownfunc",
-				Arguments: []value{},
+				Arguments: []argument{},
 			},
 		},
 		{
 			name: "Invalid Function Name",
 			inv: editor{
 				Function: "testing_functiongetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						String: (ottltest.Strp("SHA256")),
+						Value: value{
+							String: (ottltest.Strp("SHA256")),
+						},
 					},
 				},
 			},
@@ -108,9 +116,11 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			name: "not accessor",
 			inv: editor{
 				Function: "testing_getsetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						String: ottltest.Strp("not path"),
+						Value: value{
+							String: ottltest.Strp("not path"),
+						},
 					},
 				},
 			},
@@ -119,11 +129,13 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			name: "not reader (invalid function)",
 			inv: editor{
 				Function: "testing_getter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Converter: &converter{
-								Function: "Unknownfunc",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Converter: &converter{
+									Function: "Unknownfunc",
+								},
 							},
 						},
 					},
@@ -134,20 +146,24 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			name: "not enough args",
 			inv: editor{
 				Function: "testing_multiple_args",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
 									},
 								},
 							},
 						},
 					},
 					{
-						String: ottltest.Strp("test"),
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
 					},
 				},
 			},
@@ -156,72 +172,28 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			name: "too many args",
 			inv: editor{
 				Function: "testing_multiple_args",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
 									},
 								},
 							},
 						},
 					},
 					{
-						String: ottltest.Strp("test"),
-					},
-					{
-						String: ottltest.Strp("test"),
-					},
-				},
-			},
-		},
-		{
-			name: "not enough args with telemetrySettings",
-			inv: editor{
-				Function: "testing_telemetry_settings_first",
-				Arguments: []value{
-					{
-						String: ottltest.Strp("test"),
-					},
-					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("test"),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "too many args with telemetrySettings",
-			inv: editor{
-				Function: "testing_telemetry_settings_first",
-				Arguments: []value{
-					{
-						String: ottltest.Strp("test"),
-					},
-					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("test"),
-								},
-							},
+						Value: value{
+							String: ottltest.Strp("test"),
 						},
 					},
 					{
-						Literal: &mathExprLiteral{
-							Int: ottltest.Intp(10),
-						},
-					},
-					{
-						Literal: &mathExprLiteral{
-							Int: ottltest.Intp(10),
+						Value: value{
+							String: ottltest.Strp("test"),
 						},
 					},
 				},
@@ -231,10 +203,12 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			name: "not matching arg type",
 			inv: editor{
 				Function: "testing_string",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Int: ottltest.Intp(10),
+						Value: value{
+							Literal: &mathExprLiteral{
+								Int: ottltest.Intp(10),
+							},
 						},
 					},
 				},
@@ -244,15 +218,21 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			name: "not matching arg type when byte slice",
 			inv: editor{
 				Function: "testing_byte_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						String: ottltest.Strp("test"),
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
 					},
 					{
-						String: ottltest.Strp("test"),
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
 					},
 					{
-						String: ottltest.Strp("test"),
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
 					},
 				},
 			},
@@ -261,16 +241,18 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			name: "mismatching slice element type",
 			inv: editor{
 				Function: "testing_string_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("test"),
-								},
-								{
-									Literal: &mathExprLiteral{
-										Int: ottltest.Intp(10),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										String: ottltest.Strp("test"),
+									},
+									{
+										Literal: &mathExprLiteral{
+											Int: ottltest.Intp(10),
+										},
 									},
 								},
 							},
@@ -283,9 +265,92 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			name: "mismatching slice argument type",
 			inv: editor{
 				Function: "testing_string_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						String: ottltest.Strp("test"),
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "named parameters used before unnamed parameters",
+			inv: editor{
+				Function: "testing_optional_args",
+				Arguments: []argument{
+					{
+						Name: "get_setter_arg",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
+					},
+					{
+						Name: "optional_arg",
+						Value: value{
+							String: ottltest.Strp("test_optional"),
+						},
+					},
+					{
+						Name: "optional_float_arg",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Float: ottltest.Floatp(1.1),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nonexistent named parameter used",
+			inv: editor{
+				Function: "testing_optional_args",
+				Arguments: []argument{
+					{
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
+					},
+					{
+						Name: "no_such_name",
+						Value: value{
+							String: ottltest.Strp("test_optional"),
+						},
+					},
+					{
+						Name: "optional_float_arg",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Float: ottltest.Floatp(1.1),
+							},
+						},
 					},
 				},
 			},
@@ -300,9 +365,11 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			name: "Enum not found",
 			inv: editor{
 				Function: "testing_enum",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Enum: (*EnumSymbol)(ottltest.Strp("SYMBOL_NOT_FOUND")),
+						Value: value{
+							Enum: (*EnumSymbol)(ottltest.Strp("SYMBOL_NOT_FOUND")),
+						},
 					},
 				},
 			},
@@ -311,9 +378,11 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 			name: "Unknown Function",
 			inv: editor{
 				Function: "testing_functiongetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						FunctionName: (ottltest.Strp("SHA256")),
+						Value: value{
+							FunctionName: (ottltest.Strp("SHA256")),
+						},
 					},
 				},
 			},
@@ -351,14 +420,8 @@ func Test_NewFunctionCall(t *testing.T) {
 		{
 			name: "no arguments",
 			inv: editor{
-				Function: "testing_noop",
-				Arguments: []value{
-					{
-						List: &list{
-							Values: []value{},
-						},
-					},
-				},
+				Function:  "testing_noop",
+				Arguments: []argument{},
 			},
 			want: nil,
 		},
@@ -366,10 +429,12 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "empty slice arg",
 			inv: editor{
 				Function: "testing_string_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{},
+						Value: value{
+							List: &list{
+								Values: []value{},
+							},
 						},
 					},
 				},
@@ -380,18 +445,20 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "string slice arg",
 			inv: editor{
 				Function: "testing_string_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("test"),
-								},
-								{
-									String: ottltest.Strp("test"),
-								},
-								{
-									String: ottltest.Strp("test"),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										String: ottltest.Strp("test"),
+									},
+									{
+										String: ottltest.Strp("test"),
+									},
+									{
+										String: ottltest.Strp("test"),
+									},
 								},
 							},
 						},
@@ -404,23 +471,25 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "float slice arg",
 			inv: editor{
 				Function: "testing_float_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									Literal: &mathExprLiteral{
-										Float: ottltest.Floatp(1.1),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										Literal: &mathExprLiteral{
+											Float: ottltest.Floatp(1.1),
+										},
 									},
-								},
-								{
-									Literal: &mathExprLiteral{
-										Float: ottltest.Floatp(1.2),
+									{
+										Literal: &mathExprLiteral{
+											Float: ottltest.Floatp(1.2),
+										},
 									},
-								},
-								{
-									Literal: &mathExprLiteral{
-										Float: ottltest.Floatp(1.3),
+									{
+										Literal: &mathExprLiteral{
+											Float: ottltest.Floatp(1.3),
+										},
 									},
 								},
 							},
@@ -434,23 +503,25 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "int slice arg",
 			inv: editor{
 				Function: "testing_int_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									Literal: &mathExprLiteral{
-										Int: ottltest.Intp(1),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										Literal: &mathExprLiteral{
+											Int: ottltest.Intp(1),
+										},
 									},
-								},
-								{
-									Literal: &mathExprLiteral{
-										Int: ottltest.Intp(1),
+									{
+										Literal: &mathExprLiteral{
+											Int: ottltest.Intp(1),
+										},
 									},
-								},
-								{
-									Literal: &mathExprLiteral{
-										Int: ottltest.Intp(1),
+									{
+										Literal: &mathExprLiteral{
+											Int: ottltest.Intp(1),
+										},
 									},
 								},
 							},
@@ -464,72 +535,74 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "getter slice arg",
 			inv: editor{
 				Function: "testing_getter_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									Literal: &mathExprLiteral{
-										Path: &Path{
-											Fields: []Field{
-												{
-													Name: "name",
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										Literal: &mathExprLiteral{
+											Path: &Path{
+												Fields: []Field{
+													{
+														Name: "name",
+													},
 												},
 											},
 										},
 									},
-								},
-								{
-									String: ottltest.Strp("test"),
-								},
-								{
-									Literal: &mathExprLiteral{
-										Int: ottltest.Intp(1),
+									{
+										String: ottltest.Strp("test"),
 									},
-								},
-								{
-									Literal: &mathExprLiteral{
-										Float: ottltest.Floatp(1.1),
+									{
+										Literal: &mathExprLiteral{
+											Int: ottltest.Intp(1),
+										},
 									},
-								},
-								{
-									Bool: (*boolean)(ottltest.Boolp(true)),
-								},
-								{
-									Enum: (*EnumSymbol)(ottltest.Strp("TEST_ENUM")),
-								},
-								{
-									List: &list{
-										Values: []value{
-											{
-												String: ottltest.Strp("test"),
-											},
-											{
-												String: ottltest.Strp("test"),
+									{
+										Literal: &mathExprLiteral{
+											Float: ottltest.Floatp(1.1),
+										},
+									},
+									{
+										Bool: (*boolean)(ottltest.Boolp(true)),
+									},
+									{
+										Enum: (*EnumSymbol)(ottltest.Strp("TEST_ENUM")),
+									},
+									{
+										List: &list{
+											Values: []value{
+												{
+													String: ottltest.Strp("test"),
+												},
+												{
+													String: ottltest.Strp("test"),
+												},
 											},
 										},
 									},
-								},
-								{
-									List: &list{
-										Values: []value{
-											{
-												String: ottltest.Strp("test"),
-											},
-											{
-												List: &list{
-													Values: []value{
-														{
-															String: ottltest.Strp("test"),
-														},
-														{
-															List: &list{
-																Values: []value{
-																	{
-																		String: ottltest.Strp("test"),
-																	},
-																	{
-																		String: ottltest.Strp("test"),
+									{
+										List: &list{
+											Values: []value{
+												{
+													String: ottltest.Strp("test"),
+												},
+												{
+													List: &list{
+														Values: []value{
+															{
+																String: ottltest.Strp("test"),
+															},
+															{
+																List: &list{
+																	Values: []value{
+																		{
+																			String: ottltest.Strp("test"),
+																		},
+																		{
+																			String: ottltest.Strp("test"),
+																		},
 																	},
 																},
 															},
@@ -539,18 +612,20 @@ func Test_NewFunctionCall(t *testing.T) {
 											},
 										},
 									},
-								},
-								{
-									Literal: &mathExprLiteral{
-										Converter: &converter{
-											Function: "testing_getter",
-											Arguments: []value{
-												{
-													Literal: &mathExprLiteral{
-														Path: &Path{
-															Fields: []Field{
-																{
-																	Name: "name",
+									{
+										Literal: &mathExprLiteral{
+											Converter: &converter{
+												Function: "testing_getter",
+												Arguments: []argument{
+													{
+														Value: value{
+															Literal: &mathExprLiteral{
+																Path: &Path{
+																	Fields: []Field{
+																		{
+																			Name: "name",
+																		},
+																	},
 																},
 															},
 														},
@@ -571,15 +646,17 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "stringgetter slice arg",
 			inv: editor{
 				Function: "testing_stringgetter_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("test"),
-								},
-								{
-									String: ottltest.Strp("also test"),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										String: ottltest.Strp("test"),
+									},
+									{
+										String: ottltest.Strp("also test"),
+									},
 								},
 							},
 						},
@@ -592,12 +669,14 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "durationgetter slice arg",
 			inv: editor{
 				Function: "testing_durationgetter_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("test"),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										String: ottltest.Strp("test"),
+									},
 								},
 							},
 						},
@@ -609,12 +688,14 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "timegetter slice arg",
 			inv: editor{
 				Function: "testing_timegetter_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("test"),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										String: ottltest.Strp("test"),
+									},
 								},
 							},
 						},
@@ -626,16 +707,18 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "floatgetter slice arg",
 			inv: editor{
 				Function: "testing_floatgetter_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("1.1"),
-								},
-								{
-									Literal: &mathExprLiteral{
-										Float: ottltest.Floatp(1),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										String: ottltest.Strp("1.1"),
+									},
+									{
+										Literal: &mathExprLiteral{
+											Float: ottltest.Floatp(1),
+										},
 									},
 								},
 							},
@@ -649,18 +732,20 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "intgetter slice arg",
 			inv: editor{
 				Function: "testing_intgetter_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									Literal: &mathExprLiteral{
-										Int: ottltest.Intp(1),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										Literal: &mathExprLiteral{
+											Int: ottltest.Intp(1),
+										},
 									},
-								},
-								{
-									Literal: &mathExprLiteral{
-										Int: ottltest.Intp(2),
+									{
+										Literal: &mathExprLiteral{
+											Int: ottltest.Intp(2),
+										},
 									},
 								},
 							},
@@ -674,27 +759,29 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "pmapgetter slice arg",
 			inv: editor{
 				Function: "testing_pmapgetter_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									Literal: &mathExprLiteral{
-										Path: &Path{
-											Fields: []Field{
-												{
-													Name: "name",
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										Literal: &mathExprLiteral{
+											Path: &Path{
+												Fields: []Field{
+													{
+														Name: "name",
+													},
 												},
 											},
 										},
 									},
-								},
-								{
-									Literal: &mathExprLiteral{
-										Path: &Path{
-											Fields: []Field{
-												{
-													Name: "name",
+									{
+										Literal: &mathExprLiteral{
+											Path: &Path{
+												Fields: []Field{
+													{
+														Name: "name",
+													},
 												},
 											},
 										},
@@ -711,16 +798,18 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "stringlikegetter slice arg",
 			inv: editor{
 				Function: "testing_stringlikegetter_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("test"),
-								},
-								{
-									Literal: &mathExprLiteral{
-										Int: ottltest.Intp(1),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										String: ottltest.Strp("test"),
+									},
+									{
+										Literal: &mathExprLiteral{
+											Int: ottltest.Intp(1),
+										},
 									},
 								},
 							},
@@ -734,16 +823,18 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "floatlikegetter slice arg",
 			inv: editor{
 				Function: "testing_floatlikegetter_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("1.1"),
-								},
-								{
-									Literal: &mathExprLiteral{
-										Float: ottltest.Floatp(1.1),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										String: ottltest.Strp("1.1"),
+									},
+									{
+										Literal: &mathExprLiteral{
+											Float: ottltest.Floatp(1.1),
+										},
 									},
 								},
 							},
@@ -757,16 +848,18 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "intlikegetter slice arg",
 			inv: editor{
 				Function: "testing_intlikegetter_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("1"),
-								},
-								{
-									Literal: &mathExprLiteral{
-										Float: ottltest.Floatp(1.1),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										String: ottltest.Strp("1"),
+									},
+									{
+										Literal: &mathExprLiteral{
+											Float: ottltest.Floatp(1.1),
+										},
 									},
 								},
 							},
@@ -780,13 +873,15 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "setter arg",
 			inv: editor{
 				Function: "testing_setter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
 									},
 								},
 							},
@@ -800,13 +895,15 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "getsetter arg",
 			inv: editor{
 				Function: "testing_getsetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
 									},
 								},
 							},
@@ -820,13 +917,15 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "getter arg",
 			inv: editor{
 				Function: "testing_getter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
 									},
 								},
 							},
@@ -840,9 +939,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "getter arg with nil literal",
 			inv: editor{
 				Function: "testing_getter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						IsNil: (*isNil)(ottltest.Boolp(true)),
+						Value: value{
+							IsNil: (*isNil)(ottltest.Boolp(true)),
+						},
 					},
 				},
 			},
@@ -852,51 +953,55 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "getter arg with list",
 			inv: editor{
 				Function: "testing_getter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						List: &list{
-							Values: []value{
-								{
-									String: ottltest.Strp("test"),
-								},
-								{
-									Literal: &mathExprLiteral{
-										Int: ottltest.Intp(1),
+						Value: value{
+							List: &list{
+								Values: []value{
+									{
+										String: ottltest.Strp("test"),
 									},
-								},
-								{
-									Literal: &mathExprLiteral{
-										Float: ottltest.Floatp(1.1),
+									{
+										Literal: &mathExprLiteral{
+											Int: ottltest.Intp(1),
+										},
 									},
-								},
-								{
-									Bool: (*boolean)(ottltest.Boolp(true)),
-								},
-								{
-									Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
-								},
-								{
-									Literal: &mathExprLiteral{
-										Path: &Path{
-											Fields: []Field{
-												{
-													Name: "name",
+									{
+										Literal: &mathExprLiteral{
+											Float: ottltest.Floatp(1.1),
+										},
+									},
+									{
+										Bool: (*boolean)(ottltest.Boolp(true)),
+									},
+									{
+										Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+									},
+									{
+										Literal: &mathExprLiteral{
+											Path: &Path{
+												Fields: []Field{
+													{
+														Name: "name",
+													},
 												},
 											},
 										},
 									},
-								},
-								{
-									Literal: &mathExprLiteral{
-										Converter: &converter{
-											Function: "testing_getter",
-											Arguments: []value{
-												{
-													Literal: &mathExprLiteral{
-														Path: &Path{
-															Fields: []Field{
-																{
-																	Name: "name",
+									{
+										Literal: &mathExprLiteral{
+											Converter: &converter{
+												Function: "testing_getter",
+												Arguments: []argument{
+													{
+														Value: value{
+															Literal: &mathExprLiteral{
+																Path: &Path{
+																	Fields: []Field{
+																		{
+																			Name: "name",
+																		},
+																	},
 																},
 															},
 														},
@@ -917,9 +1022,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "stringgetter arg",
 			inv: editor{
 				Function: "testing_stringgetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						String: ottltest.Strp("test"),
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
 					},
 				},
 			},
@@ -929,9 +1036,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "durationgetter arg",
 			inv: editor{
 				Function: "testing_durationgetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						String: ottltest.Strp("test"),
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
 					},
 				},
 			},
@@ -940,9 +1049,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "timegetter arg",
 			inv: editor{
 				Function: "testing_timegetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						String: ottltest.Strp("test"),
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
 					},
 				},
 			},
@@ -951,9 +1062,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "functiongetter arg (Uppercase)",
 			inv: editor{
 				Function: "testing_functiongetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						FunctionName: (ottltest.Strp("SHA256")),
+						Value: value{
+							FunctionName: (ottltest.Strp("SHA256")),
+						},
 					},
 				},
 			},
@@ -963,9 +1076,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "functiongetter arg",
 			inv: editor{
 				Function: "testing_functiongetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						FunctionName: (ottltest.Strp("Sha256")),
+						Value: value{
+							FunctionName: (ottltest.Strp("Sha256")),
+						},
 					},
 				},
 			},
@@ -975,9 +1090,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "stringlikegetter arg",
 			inv: editor{
 				Function: "testing_stringlikegetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Bool: (*boolean)(ottltest.Boolp(false)),
+						Value: value{
+							Bool: (*boolean)(ottltest.Boolp(false)),
+						},
 					},
 				},
 			},
@@ -987,9 +1104,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "floatgetter arg",
 			inv: editor{
 				Function: "testing_floatgetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						String: ottltest.Strp("1.1"),
+						Value: value{
+							String: ottltest.Strp("1.1"),
+						},
 					},
 				},
 			},
@@ -999,9 +1118,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "floatlikegetter arg",
 			inv: editor{
 				Function: "testing_floatlikegetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Bool: (*boolean)(ottltest.Boolp(false)),
+						Value: value{
+							Bool: (*boolean)(ottltest.Boolp(false)),
+						},
 					},
 				},
 			},
@@ -1011,10 +1132,12 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "intgetter arg",
 			inv: editor{
 				Function: "testing_intgetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Int: ottltest.Intp(1),
+						Value: value{
+							Literal: &mathExprLiteral{
+								Int: ottltest.Intp(1),
+							},
 						},
 					},
 				},
@@ -1025,10 +1148,12 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "intlikegetter arg",
 			inv: editor{
 				Function: "testing_intgetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Float: ottltest.Floatp(1.1),
+						Value: value{
+							Literal: &mathExprLiteral{
+								Float: ottltest.Floatp(1.1),
+							},
 						},
 					},
 				},
@@ -1039,13 +1164,15 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "pmapgetter arg",
 			inv: editor{
 				Function: "testing_pmapgetter",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
 									},
 								},
 							},
@@ -1059,9 +1186,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "string arg",
 			inv: editor{
 				Function: "testing_string",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						String: ottltest.Strp("test"),
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
 					},
 				},
 			},
@@ -1071,10 +1200,12 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "float arg",
 			inv: editor{
 				Function: "testing_float",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Float: ottltest.Floatp(1.1),
+						Value: value{
+							Literal: &mathExprLiteral{
+								Float: ottltest.Floatp(1.1),
+							},
 						},
 					},
 				},
@@ -1085,10 +1216,12 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "int arg",
 			inv: editor{
 				Function: "testing_int",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Int: ottltest.Intp(1),
+						Value: value{
+							Literal: &mathExprLiteral{
+								Int: ottltest.Intp(1),
+							},
 						},
 					},
 				},
@@ -1099,9 +1232,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "bool arg",
 			inv: editor{
 				Function: "testing_bool",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Bool: (*boolean)(ottltest.Boolp(true)),
+						Value: value{
+							Bool: (*boolean)(ottltest.Boolp(true)),
+						},
 					},
 				},
 			},
@@ -1111,9 +1246,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "byteSlice arg",
 			inv: editor{
 				Function: "testing_byte_slice",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+						Value: value{
+							Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+						},
 					},
 				},
 			},
@@ -1123,29 +1260,117 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "multiple args",
 			inv: editor{
 				Function: "testing_multiple_args",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Literal: &mathExprLiteral{
-							Path: &Path{
-								Fields: []Field{
-									{
-										Name: "name",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
 									},
 								},
 							},
 						},
 					},
 					{
-						String: ottltest.Strp("test"),
-					},
-					{
-						Literal: &mathExprLiteral{
-							Float: ottltest.Floatp(1.1),
+						Value: value{
+							String: ottltest.Strp("test"),
 						},
 					},
 					{
-						Literal: &mathExprLiteral{
-							Int: ottltest.Intp(1),
+						Value: value{
+							Literal: &mathExprLiteral{
+								Float: ottltest.Floatp(1.1),
+							},
+						},
+					},
+					{
+						Value: value{
+							Literal: &mathExprLiteral{
+								Int: ottltest.Intp(1),
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "optional args",
+			inv: editor{
+				Function: "testing_optional_args",
+				Arguments: []argument{
+					{
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
+					},
+					{
+						Value: value{
+							String: ottltest.Strp("test_optional"),
+						},
+					},
+					{
+						Value: value{
+							Literal: &mathExprLiteral{
+								Float: ottltest.Floatp(1.1),
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "optional named args",
+			inv: editor{
+				Function: "testing_optional_args",
+				Arguments: []argument{
+					{
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &Path{
+									Fields: []Field{
+										{
+											Name: "name",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Value: value{
+							String: ottltest.Strp("test"),
+						},
+					},
+					{
+						Name: "optional_arg",
+						Value: value{
+							String: ottltest.Strp("test_optional"),
+						},
+					},
+					{
+						Name: "optional_float_arg",
+						Value: value{
+							Literal: &mathExprLiteral{
+								Float: ottltest.Floatp(1.1),
+							},
 						},
 					},
 				},
@@ -1156,9 +1381,11 @@ func Test_NewFunctionCall(t *testing.T) {
 			name: "Enum arg",
 			inv: editor{
 				Function: "testing_enum",
-				Arguments: []value{
+				Arguments: []argument{
 					{
-						Enum: (*EnumSymbol)(ottltest.Strp("TEST_ENUM")),
+						Value: value{
+							Enum: (*EnumSymbol)(ottltest.Strp("TEST_ENUM")),
+						},
 					},
 				},
 			},
@@ -1176,6 +1403,94 @@ func Test_NewFunctionCall(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_ArgumentsNotMutated(t *testing.T) {
+	args := optionalArgsArguments{}
+	fact := createFactory[any](
+		"testing_optional_args",
+		&args,
+		functionWithOptionalArgs,
+	)
+	p, _ := NewParser(
+		CreateFactoryMap[any](fact),
+		testParsePath,
+		componenttest.NewNopTelemetrySettings(),
+		WithEnumParser[any](testParseEnum),
+	)
+
+	invWithOptArg := editor{
+		Function: "testing_optional_args",
+		Arguments: []argument{
+			{
+				Value: value{
+					Literal: &mathExprLiteral{
+						Path: &Path{
+							Fields: []Field{
+								{
+									Name: "name",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Value: value{
+					String: ottltest.Strp("test"),
+				},
+			},
+			{
+				Value: value{
+					String: ottltest.Strp("test_optional"),
+				},
+			},
+			{
+				Value: value{
+					Literal: &mathExprLiteral{
+						Float: ottltest.Floatp(1.1),
+					},
+				},
+			},
+		},
+	}
+
+	invWithoutOptArg := editor{
+		Function: "testing_optional_args",
+		Arguments: []argument{
+			{
+				Value: value{
+					Literal: &mathExprLiteral{
+						Path: &Path{
+							Fields: []Field{
+								{
+									Name: "name",
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				Value: value{
+					String: ottltest.Strp("test"),
+				},
+			},
+		},
+	}
+
+	fn, err := p.newFunctionCall(invWithOptArg)
+	require.NoError(t, err)
+	res, _ := fn.Eval(context.Background(), nil)
+	require.Equal(t, 4, res)
+
+	fn, err = p.newFunctionCall(invWithoutOptArg)
+	require.NoError(t, err)
+	res, _ = fn.Eval(context.Background(), nil)
+	require.Equal(t, 2, res)
+
+	assert.Zero(t, args.OptionalArg)
+	assert.Zero(t, args.OptionalFloatArg)
 }
 
 func functionWithNoArguments() (ExprFunc[any], error) {
@@ -1513,6 +1828,28 @@ func functionWithMultipleArgs(GetSetter[interface{}], string, float64, int64) (E
 	}, nil
 }
 
+type optionalArgsArguments struct {
+	GetSetterArg     GetSetter[any]              `ottlarg:"0"`
+	StringArg        string                      `ottlarg:"1"`
+	OptionalArg      Optional[StringGetter[any]] `ottlarg:"2"`
+	OptionalFloatArg Optional[float64]           `ottlarg:"3"`
+}
+
+func functionWithOptionalArgs(_ GetSetter[interface{}], _ string, stringOpt Optional[StringGetter[any]], floatOpt Optional[float64]) (ExprFunc[interface{}], error) {
+	return func(context.Context, interface{}) (interface{}, error) {
+		argCount := 2
+
+		if !stringOpt.IsEmpty() {
+			argCount++
+		}
+		if !floatOpt.IsEmpty() {
+			argCount++
+		}
+
+		return argCount, nil
+	}, nil
+}
+
 type errorFunctionArguments struct{}
 
 func functionThatHasAnError() (ExprFunc[interface{}], error) {
@@ -1743,6 +2080,11 @@ func defaultFunctionsForTests() map[string]Factory[any] {
 			"testing_multiple_args",
 			&multipleArgsArguments{},
 			functionWithMultipleArgs,
+		),
+		createFactory[any](
+			"testing_optional_args",
+			&optionalArgsArguments{},
+			functionWithOptionalArgs,
 		),
 		createFactory[any](
 			"testing_enum",

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -189,14 +189,15 @@ func (c *comparison) checkForCustomError() error {
 
 // editor represents the function call of a statement.
 type editor struct {
-	Function  string  `parser:"@(Lowercase(Uppercase | Lowercase)*)"`
-	Arguments []value `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
+	Function  string     `parser:"@(Lowercase(Uppercase | Lowercase)*)"`
+	Arguments []argument `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
 	// If keys are matched return an error
 	Keys []Key `parser:"( @@ )*"`
 }
 
 func (i *editor) checkForCustomError() error {
 	var err error
+
 	for _, arg := range i.Arguments {
 		err = arg.checkForCustomError()
 		if err != nil {
@@ -211,9 +212,18 @@ func (i *editor) checkForCustomError() error {
 
 // converter represents a converter function call.
 type converter struct {
-	Function  string  `parser:"@(Uppercase(Uppercase | Lowercase)*)"`
-	Arguments []value `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
-	Keys      []Key   `parser:"( @@ )*"`
+	Function  string     `parser:"@(Uppercase(Uppercase | Lowercase)*)"`
+	Arguments []argument `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
+	Keys      []Key      `parser:"( @@ )*"`
+}
+
+type argument struct {
+	Name  string `parser:"(@(Lowercase(Uppercase | Lowercase)*) Equal)?"`
+	Value value  `parser:"@@"`
+}
+
+func (a *argument) checkForCustomError() error {
+	return a.Value.checkForCustomError()
 }
 
 // value represents a part of a parsed statement which is resolved to a value of some sort. This can be a telemetry path
@@ -424,6 +434,7 @@ func buildLexer() *lexer.StatefulDefinition {
 		{Name: `Float`, Pattern: `[-+]?\d*\.\d+([eE][-+]?\d+)?`},
 		{Name: `Int`, Pattern: `[-+]?\d+`},
 		{Name: `String`, Pattern: `"(\\"|[^"])*"`},
+		{Name: `Equal`, Pattern: `=[^=]`},
 		{Name: `OpNot`, Pattern: `\b(not)\b`},
 		{Name: `OpOr`, Pattern: `\b(or)\b`},
 		{Name: `OpAnd`, Pattern: `\b(and)\b`},

--- a/pkg/ottl/math_test.go
+++ b/pkg/ottl/math_test.go
@@ -276,12 +276,16 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Time",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("2023-04-12"),
+										Value: value{
+											String: ottltest.Strp("2023-04-12"),
+										},
 									},
 									{
-										String: ottltest.Strp("%Y-%m-%d"),
+										Value: value{
+											String: ottltest.Strp("%Y-%m-%d"),
+										},
 									},
 								},
 							},
@@ -296,12 +300,16 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Time",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("2023-04-12"),
+												Value: value{
+													String: ottltest.Strp("2023-04-12"),
+												},
 											},
 											{
-												String: ottltest.Strp("%Y-%m-%d"),
+												Value: value{
+													String: ottltest.Strp("%Y-%m-%d"),
+												},
 											},
 										},
 									},
@@ -321,9 +329,11 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Duration",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("100h100m100s100ns"),
+										Value: value{
+											String: ottltest.Strp("100h100m100s100ns"),
+										},
 									},
 								},
 							},
@@ -338,9 +348,11 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Duration",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("1h1m1s1ns"),
+												Value: value{
+													String: ottltest.Strp("1h1m1s1ns"),
+												},
 											},
 										},
 									},
@@ -360,12 +372,16 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Time",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("2023-04-12"),
+										Value: value{
+											String: ottltest.Strp("2023-04-12"),
+										},
 									},
 									{
-										String: ottltest.Strp("%Y-%m-%d"),
+										Value: value{
+											String: ottltest.Strp("%Y-%m-%d"),
+										},
 									},
 								},
 							},
@@ -395,9 +411,11 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Duration",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("1h1m1s1ns"),
+										Value: value{
+											String: ottltest.Strp("1h1m1s1ns"),
+										},
 									},
 								},
 							},
@@ -427,12 +445,16 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Time",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("2023-04-12"),
+										Value: value{
+											String: ottltest.Strp("2023-04-12"),
+										},
 									},
 									{
-										String: ottltest.Strp("%Y-%m-%d"),
+										Value: value{
+											String: ottltest.Strp("%Y-%m-%d"),
+										},
 									},
 								},
 							},
@@ -447,12 +469,16 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Time",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("2022-05-11"),
+												Value: value{
+													String: ottltest.Strp("2022-05-11"),
+												},
 											},
 											{
-												String: ottltest.Strp("%Y-%m-%d"),
+												Value: value{
+													String: ottltest.Strp("%Y-%m-%d"),
+												},
 											},
 										},
 									},
@@ -472,9 +498,11 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Duration",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("2h"),
+										Value: value{
+											String: ottltest.Strp("2h"),
+										},
 									},
 								},
 							},
@@ -489,12 +517,16 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Time",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("2000-10-30"),
+												Value: value{
+													String: ottltest.Strp("2000-10-30"),
+												},
 											},
 											{
-												String: ottltest.Strp("%Y-%m-%d"),
+												Value: value{
+													String: ottltest.Strp("%Y-%m-%d"),
+												},
 											},
 										},
 									},
@@ -604,12 +636,16 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Time",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("2023-04-12"),
+										Value: value{
+											String: ottltest.Strp("2023-04-12"),
+										},
 									},
 									{
-										String: ottltest.Strp("%Y-%m-%d"),
+										Value: value{
+											String: ottltest.Strp("%Y-%m-%d"),
+										},
 									},
 								},
 							},
@@ -624,12 +660,16 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Time",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("2023-04-12"),
+												Value: value{
+													String: ottltest.Strp("2023-04-12"),
+												},
 											},
 											{
-												String: ottltest.Strp("%Y-%m-%d"),
+												Value: value{
+													String: ottltest.Strp("%Y-%m-%d"),
+												},
 											},
 										},
 									},
@@ -649,12 +689,16 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Time",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("1986-10-30T00:17:33"),
+										Value: value{
+											String: ottltest.Strp("1986-10-30T00:17:33"),
+										},
 									},
 									{
-										String: ottltest.Strp("%Y-%m-%dT%H:%M:%S"),
+										Value: value{
+											String: ottltest.Strp("%Y-%m-%dT%H:%M:%S"),
+										},
 									},
 								},
 							},
@@ -669,12 +713,16 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Time",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("1986-11-01"),
+												Value: value{
+													String: ottltest.Strp("1986-11-01"),
+												},
 											},
 											{
-												String: ottltest.Strp("%Y-%m-%d"),
+												Value: value{
+													String: ottltest.Strp("%Y-%m-%d"),
+												},
 											},
 										},
 									},
@@ -694,9 +742,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Duration",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("10h"),
+										Value: value{
+											String: ottltest.Strp("10h"),
+										},
 									},
 								},
 							},
@@ -711,12 +761,16 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Time",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("01-01-2000"),
+												Value: value{
+													String: ottltest.Strp("01-01-2000"),
+												},
 											},
 											{
-												String: ottltest.Strp("%m-%d-%Y"),
+												Value: value{
+													String: ottltest.Strp("%m-%d-%Y"),
+												},
 											},
 										},
 									},
@@ -736,12 +790,16 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Time",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("Feb 15, 2023"),
+										Value: value{
+											String: ottltest.Strp("Feb 15, 2023"),
+										},
 									},
 									{
-										String: ottltest.Strp("%b %d, %Y"),
+										Value: value{
+											String: ottltest.Strp("%b %d, %Y"),
+										},
 									},
 								},
 							},
@@ -756,9 +814,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Duration",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("10h"),
+												Value: value{
+													String: ottltest.Strp("10h"),
+												},
 											},
 										},
 									},
@@ -778,12 +838,16 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Time",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("02/04/2023"),
+										Value: value{
+											String: ottltest.Strp("02/04/2023"),
+										},
 									},
 									{
-										String: ottltest.Strp("%m/%d/%Y"),
+										Value: value{
+											String: ottltest.Strp("%m/%d/%Y"),
+										},
 									},
 								},
 							},
@@ -798,9 +862,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Duration",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("1h2m3s"),
+												Value: value{
+													String: ottltest.Strp("1h2m3s"),
+												},
 											},
 										},
 									},
@@ -820,12 +886,16 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Time",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("Mar 14 2023 17:02:59"),
+										Value: value{
+											String: ottltest.Strp("Mar 14 2023 17:02:59"),
+										},
 									},
 									{
-										String: ottltest.Strp("%b %d %Y %H:%M:%S"),
+										Value: value{
+											String: ottltest.Strp("%b %d %Y %H:%M:%S"),
+										},
 									},
 								},
 							},
@@ -840,9 +910,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Duration",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("11h2m58s"),
+												Value: value{
+													String: ottltest.Strp("11h2m58s"),
+												},
 											},
 										},
 									},
@@ -862,12 +934,16 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Time",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("Monday, May 01, 2023"),
+										Value: value{
+											String: ottltest.Strp("Monday, May 01, 2023"),
+										},
 									},
 									{
-										String: ottltest.Strp("%A, %B %d, %Y"),
+										Value: value{
+											String: ottltest.Strp("%A, %B %d, %Y"),
+										},
 									},
 								},
 							},
@@ -882,9 +958,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Duration",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("100ns"),
+												Value: value{
+													String: ottltest.Strp("100ns"),
+												},
 											},
 										},
 									},
@@ -904,9 +982,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Duration",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("100h100m100s100ns"),
+										Value: value{
+											String: ottltest.Strp("100h100m100s100ns"),
+										},
 									},
 								},
 							},
@@ -921,9 +1001,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Duration",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("1h1m1s1ns"),
+												Value: value{
+													String: ottltest.Strp("1h1m1s1ns"),
+												},
 											},
 										},
 									},
@@ -943,9 +1025,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Duration",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("0h"),
+										Value: value{
+											String: ottltest.Strp("0h"),
+										},
 									},
 								},
 							},
@@ -960,9 +1044,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Duration",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("1000h"),
+												Value: value{
+													String: ottltest.Strp("1000h"),
+												},
 											},
 										},
 									},
@@ -982,9 +1068,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Duration",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("0h"),
+										Value: value{
+											String: ottltest.Strp("0h"),
+										},
 									},
 								},
 							},
@@ -999,9 +1087,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Duration",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("328m"),
+												Value: value{
+													String: ottltest.Strp("328m"),
+												},
 											},
 										},
 									},
@@ -1021,9 +1111,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 						Literal: &mathExprLiteral{
 							Converter: &converter{
 								Function: "Duration",
-								Arguments: []value{
+								Arguments: []argument{
 									{
-										String: ottltest.Strp("11h11ns"),
+										Value: value{
+											String: ottltest.Strp("11h11ns"),
+										},
 									},
 								},
 							},
@@ -1038,9 +1130,11 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Duration",
-										Arguments: []value{
+										Arguments: []argument{
 											{
-												String: ottltest.Strp("12m12s"),
+												Value: value{
+													String: ottltest.Strp("12m12s"),
+												},
 											},
 										},
 									},

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -168,7 +168,7 @@ func newParser[G any]() *participle.Parser[G] {
 		participle.UseLookahead(participle.MaxLookahead), // Allows negative lookahead to work properly in 'value' for 'mathExprLiteral'.
 	)
 	if err != nil {
-		panic("Unable to initialize parser; this is a programming error in the transformprocessor:" + err.Error())
+		panic("Unable to initialize parser; this is a programming error in OTTL:" + err.Error())
 	}
 	return parser
 }

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -35,9 +35,11 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							String: ottltest.Strp("foo"),
+							Value: value{
+								String: ottltest.Strp("foo"),
+							},
 						},
 					},
 				},
@@ -50,10 +52,12 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "met",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Float: ottltest.Floatp(1.2),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Float: ottltest.Floatp(1.2),
+								},
 							},
 						},
 					},
@@ -67,10 +71,12 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "fff",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Int: ottltest.Intp(12),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Int: ottltest.Intp(12),
+								},
 							},
 						},
 					},
@@ -84,24 +90,30 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							String: ottltest.Strp("foo"),
+							Value: value{
+								String: ottltest.Strp("foo"),
+							},
 						},
 						{
-							Literal: &mathExprLiteral{
-								Converter: &converter{
-									Function: "GetSomething",
-									Arguments: []value{
-										{
-											Literal: &mathExprLiteral{
-												Path: &Path{
-													Fields: []Field{
-														{
-															Name: "bear",
-														},
-														{
-															Name: "honey",
+							Value: value{
+								Literal: &mathExprLiteral{
+									Converter: &converter{
+										Function: "GetSomething",
+										Arguments: []argument{
+											{
+												Value: value{
+													Literal: &mathExprLiteral{
+														Path: &Path{
+															Fields: []Field{
+																{
+																	Name: "bear",
+																},
+																{
+																	Name: "honey",
+																},
+															},
 														},
 													},
 												},
@@ -122,31 +134,35 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "foo",
-										},
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("bar"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "foo",
+											},
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("bar"),
+													},
 												},
 											},
-										},
-										{
-											Name: "cat",
+											{
+												Name: "cat",
+											},
 										},
 									},
 								},
 							},
 						},
 						{
-							String: ottltest.Strp("dog"),
+							Value: value{
+								String: ottltest.Strp("dog"),
+							},
 						},
 					},
 				},
@@ -159,16 +175,18 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "replace_pattern",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("message"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("message"),
+													},
 												},
 											},
 										},
@@ -177,17 +195,21 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							String: ottltest.Strp("device=*"),
+							Value: value{
+								String: ottltest.Strp("device=*"),
+							},
 						},
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("device_name"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("device_name"),
+													},
 												},
 											},
 										},
@@ -196,7 +218,9 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							Enum: (*EnumSymbol)(ottltest.Strp("SHA256")),
+							Value: value{
+								Enum: (*EnumSymbol)(ottltest.Strp("SHA256")),
+							},
 						},
 					},
 				},
@@ -209,16 +233,18 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "replace_pattern",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("message"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("message"),
+													},
 												},
 											},
 										},
@@ -227,7 +253,9 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							FunctionName: (ottltest.Strp("Sha256")),
+							Value: value{
+								FunctionName: (ottltest.Strp("Sha256")),
+							},
 						},
 					},
 				},
@@ -240,16 +268,18 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "replace_pattern",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("message"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("message"),
+													},
 												},
 											},
 										},
@@ -258,7 +288,9 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							Enum: (*EnumSymbol)(ottltest.Strp("S")),
+							Value: value{
+								Enum: (*EnumSymbol)(ottltest.Strp("S")),
+							},
 						},
 					},
 				},
@@ -271,42 +303,46 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "foo",
-										},
-										{
-											Name: "bar",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("x"),
-												},
-												{
-													String: ottltest.Strp("y"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "foo",
+											},
+											{
+												Name: "bar",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("x"),
+													},
+													{
+														String: ottltest.Strp("y"),
+													},
 												},
 											},
-										},
-										{
-											Name: "z",
+											{
+												Name: "z",
+											},
 										},
 									},
 								},
 							},
 						},
 						{
-							Literal: &mathExprLiteral{
-								Converter: &converter{
-									Function: "Test",
-									Keys: []Key{
-										{
-											Int: ottltest.Intp(0),
-										},
-										{
-											String: ottltest.Strp("pass"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Converter: &converter{
+										Function: "Test",
+										Keys: []Key{
+											{
+												Int: ottltest.Intp(0),
+											},
+											{
+												String: ottltest.Strp("pass"),
+											},
 										},
 									},
 								},
@@ -323,31 +359,35 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "foo",
-										},
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("bar"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "foo",
+											},
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("bar"),
+													},
 												},
 											},
-										},
-										{
-											Name: "cat",
+											{
+												Name: "cat",
+											},
 										},
 									},
 								},
 							},
 						},
 						{
-							String: ottltest.Strp("dog"),
+							Value: value{
+								String: ottltest.Strp("dog"),
+							},
 						},
 					},
 				},
@@ -382,31 +422,35 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "foo",
-										},
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("bar"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "foo",
+											},
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("bar"),
+													},
 												},
 											},
-										},
-										{
-											Name: "cat",
+											{
+												Name: "cat",
+											},
 										},
 									},
 								},
 							},
 						},
 						{
-							String: ottltest.Strp("dog"),
+							Value: value{
+								String: ottltest.Strp("dog"),
+							},
 						},
 					},
 				},
@@ -441,31 +485,35 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "foo",
-										},
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("bar"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "foo",
+											},
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("bar"),
+													},
 												},
 											},
-										},
-										{
-											Name: "cat",
+											{
+												Name: "cat",
+											},
 										},
 									},
 								},
 							},
 						},
 						{
-							String: ottltest.Strp("dog"),
+							Value: value{
+								String: ottltest.Strp("dog"),
+							},
 						},
 					},
 				},
@@ -500,9 +548,11 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							String: ottltest.Strp("fo\"o"),
+							Value: value{
+								String: ottltest.Strp("fo\"o"),
+							},
 						},
 					},
 				},
@@ -515,12 +565,16 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "convert_gauge_to_sum",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							String: ottltest.Strp("cumulative"),
+							Value: value{
+								String: ottltest.Strp("cumulative"),
+							},
 						},
 						{
-							Bool: (*boolean)(ottltest.Boolp(false)),
+							Value: value{
+								Bool: (*boolean)(ottltest.Boolp(false)),
+							},
 						},
 					},
 				},
@@ -533,12 +587,16 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "convert_gauge_to_sum",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							String: ottltest.Strp("cumulative"),
+							Value: value{
+								String: ottltest.Strp("cumulative"),
+							},
 						},
 						{
-							Bool: (*boolean)(ottltest.Boolp(true)),
+							Value: value{
+								Bool: (*boolean)(ottltest.Boolp(true)),
+							},
 						},
 					},
 				},
@@ -551,16 +609,18 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("bytes"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("bytes"),
+													},
 												},
 											},
 										},
@@ -569,7 +629,9 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+							Value: value{
+								Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+							},
 						},
 					},
 				},
@@ -582,16 +644,18 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("test"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("test"),
+													},
 												},
 											},
 										},
@@ -600,7 +664,9 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							IsNil: (*isNil)(ottltest.Boolp(true)),
+							Value: value{
+								IsNil: (*isNil)(ottltest.Boolp(true)),
+							},
 						},
 					},
 				},
@@ -613,16 +679,18 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("test"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("test"),
+													},
 												},
 											},
 										},
@@ -631,7 +699,9 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							Enum: (*EnumSymbol)(ottltest.Strp("TEST_ENUM")),
+							Value: value{
+								Enum: (*EnumSymbol)(ottltest.Strp("TEST_ENUM")),
+							},
 						},
 					},
 				},
@@ -644,16 +714,18 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("test"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("test"),
+													},
 												},
 											},
 										},
@@ -662,8 +734,10 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							List: &list{
-								Values: nil,
+							Value: value{
+								List: &list{
+									Values: nil,
+								},
 							},
 						},
 					},
@@ -677,16 +751,18 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("test"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("test"),
+													},
 												},
 											},
 										},
@@ -695,10 +771,12 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("value0"),
+							Value: value{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("value0"),
+										},
 									},
 								},
 							},
@@ -714,16 +792,18 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("test"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("test"),
+													},
 												},
 											},
 										},
@@ -732,13 +812,15 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("value1"),
-									},
-									{
-										String: ottltest.Strp("value2"),
+							Value: value{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("value1"),
+										},
+										{
+											String: ottltest.Strp("value2"),
+										},
 									},
 								},
 							},
@@ -754,16 +836,18 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("test"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("test"),
+													},
 												},
 											},
 										},
@@ -772,63 +856,69 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							List: &list{
-								Values: []value{
-									{
-										Literal: &mathExprLiteral{
-											Converter: &converter{
-												Function: "Concat",
-												Arguments: []value{
-													{
-														List: &list{
-															Values: []value{
-																{
-																	String: ottltest.Strp("a"),
-																},
-																{
-																	String: ottltest.Strp("b"),
+							Value: value{
+								List: &list{
+									Values: []value{
+										{
+											Literal: &mathExprLiteral{
+												Converter: &converter{
+													Function: "Concat",
+													Arguments: []argument{
+														{
+															Value: value{
+																List: &list{
+																	Values: []value{
+																		{
+																			String: ottltest.Strp("a"),
+																		},
+																		{
+																			String: ottltest.Strp("b"),
+																		},
+																	},
 																},
 															},
 														},
-													},
-													{
-														String: ottltest.Strp("+"),
-													},
-												},
-											},
-										},
-									},
-									{
-										List: &list{
-											Values: []value{
-												{
-													String: ottltest.Strp("1"),
-												},
-												{
-													Literal: &mathExprLiteral{
-														Int: ottltest.Intp(2),
-													},
-												},
-												{
-													Literal: &mathExprLiteral{
-														Float: ottltest.Floatp(3.0),
+														{
+															Value: value{
+																String: ottltest.Strp("+"),
+															},
+														},
 													},
 												},
 											},
 										},
-									},
-									{
-										IsNil: (*isNil)(ottltest.Boolp(true)),
-									},
-									{
-										Literal: &mathExprLiteral{
-											Path: &Path{
-												Fields: []Field{
+										{
+											List: &list{
+												Values: []value{
 													{
-														Name: "attributes",
-														Keys: []Key{
-															{
-																String: ottltest.Strp("test"),
+														String: ottltest.Strp("1"),
+													},
+													{
+														Literal: &mathExprLiteral{
+															Int: ottltest.Intp(2),
+														},
+													},
+													{
+														Literal: &mathExprLiteral{
+															Float: ottltest.Floatp(3.0),
+														},
+													},
+												},
+											},
+										},
+										{
+											IsNil: (*isNil)(ottltest.Boolp(true)),
+										},
+										{
+											Literal: &mathExprLiteral{
+												Path: &Path{
+													Fields: []Field{
+														{
+															Name: "attributes",
+															Keys: []Key{
+																{
+																	String: ottltest.Strp("test"),
+																},
 															},
 														},
 													},
@@ -850,16 +940,18 @@ func Test_parse(t *testing.T) {
 			expected: &parsedStatement{
 				Editor: editor{
 					Function: "set",
-					Arguments: []value{
+					Arguments: []argument{
 						{
-							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
-										{
-											Name: "attributes",
-											Keys: []Key{
-												{
-													String: ottltest.Strp("test"),
+							Value: value{
+								Literal: &mathExprLiteral{
+									Path: &Path{
+										Fields: []Field{
+											{
+												Name: "attributes",
+												Keys: []Key{
+													{
+														String: ottltest.Strp("test"),
+													},
 												},
 											},
 										},
@@ -868,21 +960,23 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							MathExpression: &mathExpression{
-								Left: &addSubTerm{
-									Left: &mathValue{
-										Literal: &mathExprLiteral{
-											Int: ottltest.Intp(1000),
+							Value: value{
+								MathExpression: &mathExpression{
+									Left: &addSubTerm{
+										Left: &mathValue{
+											Literal: &mathExprLiteral{
+												Int: ottltest.Intp(1000),
+											},
 										},
 									},
-								},
-								Right: []*opAddSubTerm{
-									{
-										Operator: SUB,
-										Term: &addSubTerm{
-											Left: &mathValue{
-												Literal: &mathExprLiteral{
-													Int: ottltest.Intp(600),
+									Right: []*opAddSubTerm{
+										{
+											Operator: SUB,
+											Term: &addSubTerm{
+												Left: &mathValue{
+													Literal: &mathExprLiteral{
+														Int: ottltest.Intp(600),
+													},
 												},
 											},
 										},
@@ -1027,20 +1121,24 @@ func setNameTest(b *booleanExpression) *parsedStatement {
 	return &parsedStatement{
 		Editor: editor{
 			Function: "set",
-			Arguments: []value{
+			Arguments: []argument{
 				{
-					Literal: &mathExprLiteral{
-						Path: &Path{
-							Fields: []Field{
-								{
-									Name: "name",
+					Value: value{
+						Literal: &mathExprLiteral{
+							Path: &Path{
+								Fields: []Field{
+									{
+										Name: "name",
+									},
 								},
 							},
 						},
 					},
 				},
 				{
-					String: ottltest.Strp("test"),
+					Value: value{
+						String: ottltest.Strp("test"),
+					},
 				},
 			},
 		},
@@ -1574,7 +1672,7 @@ func Test_parseStatement(t *testing.T) {
 		{`set() where true and 1 == int() `, true},
 		{`set() where false or 1 == int() `, true},
 		{`set(foo.attributes["bar"].cat, "dog")`, false},
-		{`set(foo.attributes["animal"], "dog") where animal == "cat"`, false},
+		{`set(set = foo.attributes["animal"], val = "dog") where animal == "cat"`, false},
 		{`test() where service == "pinger" or foo.attributes["endpoint"] == "/x/alive"`, false},
 		{`test() where service == "pinger" or foo.attributes["verb"] == "GET" and foo.attributes["endpoint"] == "/x/alive"`, false},
 		{`test() where animal > "cat"`, false},
@@ -1598,9 +1696,10 @@ func Test_parseStatement(t *testing.T) {
 	for _, tt := range tests {
 		name := pat.ReplaceAllString(tt.statement, "_")
 		t.Run(name, func(t *testing.T) {
-			_, err := parseStatement(tt.statement)
+			ast, err := parseStatement(tt.statement)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseStatement(%s) error = %v, wantErr %v", tt.statement, err, tt.wantErr)
+				t.Errorf("AST: %+v", ast)
 				return
 			}
 		})


### PR DESCRIPTION
**Description:**

Provides one possible path for allowing functions to define optional parameters in OTTL.

This uses Python-style keyword arguments, so function calls will look like `ConvertCase(attributes["source"], delimiter = ".")`. Proposed rules for arguments after this change:
1.  camelCase/snake_case versions of the struct field names for the parameter can be used in function calls to specify an argument.
2. All named arguments must come after unnamed arguments.
3. Unnamed arguments must be in function signature order, named arguments can be in any order.
4. Arguments can be passed in unnamed or named.

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20879