### PR TITLE
[processor/resourcedetection] fix when panic when AKS detector is used

### DIFF
--- a/.chloggen/resourcedetection-aks-panic.yaml
+++ b/.chloggen/resourcedetection-aks-panic.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/resourcedetection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: make sure to use a aks config struct instead of nil to avoid collector panic
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24549]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/resourcedetectionprocessor/config.go
+++ b/processor/resourcedetectionprocessor/config.go
@@ -116,6 +116,8 @@ func (d *DetectorConfig) GetConfigFromType(detectorType internal.DetectorType) i
 		return d.LambdaConfig
 	case azure.TypeStr:
 		return d.AzureConfig
+	case aks.TypeStr:
+		return d.AksConfig
 	case consul.TypeStr:
 		return d.ConsulConfig
 	case docker.TypeStr:

--- a/processor/resourcedetectionprocessor/testdata/config.yaml
+++ b/processor/resourcedetectionprocessor/testdata/config.yaml
@@ -9,6 +9,11 @@ resourcedetection/openshift:
     tls:
       insecure: true
 
+resourcedetection/aks:
+  detectors: [ env, aks ]
+  timeout: 2s
+  override: false
+
 resourcedetection/gcp:
   detectors: [env, gcp]
   timeout: 2s


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Address the following panic when AKS detector is used.
This issue was introduced by this change https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/04327f5deaebd5f8abea3b313dd2f45ccef5bf7e

````
panic: interface conversion: internal.DetectorConfig is nil, not aks.Config

goroutine 1 [running]:
github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/azure/aks.NewDetector({{{0xc0023d5638, 0x11}, {0x0, 0x0}}, {0xc002568fc0, {0x6877700, 0xc0024f1580},            {0x68a1850, 0xc00251b590}, 0x0, ...}, ...}, ...)
        github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor@v0.81.0/internal/azure/aks/aks.go:34 +0x10a
github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal.(*ResourceProviderFactory).getDetectors(0xc00082ffe0, {{{0xc0023d5638, 0x11}, {0x0, 0x0}}, {0xc002568fc0,       {0x6877700, 0xc0024f1580}, {0x68a1850, 0xc00251b590}, ...}, ...}, ...)
        github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor@v0.81.0/internal/resourcedetection.go:73 +0x182
github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal.(*ResourceProviderFactory).CreateResourceProvider(0xc001dbfeb8?, {{{0xc0023d5638, 0x11}, {0x0, 0x0}},           {0xc002568fc0, {0x6877700, 0xc0024f1580}, {0x68a1850, 0xc00251b590}, ...}, ...}, ...)
        github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor@v0.81.0/internal/resourcedetection.go:49 +0x9d

````

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Manual validation
**Documentation:** <Describe the documentation added.>