### PR TITLE
[chore] add codeowner for githubgen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,7 @@
 * @open-telemetry/collector-contrib-approvers
 
 cmd/configschema/                                        @open-telemetry/collector-contrib-approvers @mx-psi @dmitryax @pmcollins
+cmd/githubgen/                                           @open-telemetry/collector-contrib-approvers @atoulme
 cmd/mdatagen/                                            @open-telemetry/collector-contrib-approvers @dmitryax
 cmd/opampsupervisor/                                     @open-telemetry/collector-contrib-approvers @evan-bradley @atoulme @tigrannajaryan
 cmd/otelcontribcol/                                      @open-telemetry/collector-contrib-approvers

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -19,6 +19,7 @@ body:
       # Do not manually edit it.
       # Start Collector components list
       - cmd/configschema
+      - cmd/githubgen
       - cmd/mdatagen
       - cmd/opampsupervisor
       - cmd/otelcontribcol

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -13,6 +13,7 @@ body:
       # Do not manually edit it.
       # Start Collector components list
       - cmd/configschema
+      - cmd/githubgen
       - cmd/mdatagen
       - cmd/opampsupervisor
       - cmd/otelcontribcol

--- a/.github/ISSUE_TEMPLATE/other.yaml
+++ b/.github/ISSUE_TEMPLATE/other.yaml
@@ -13,6 +13,7 @@ body:
       # Do not manually edit it.
       # Start Collector components list
       - cmd/configschema
+      - cmd/githubgen
       - cmd/mdatagen
       - cmd/opampsupervisor
       - cmd/otelcontribcol

--- a/cmd/githubgen/metadata.yaml
+++ b/cmd/githubgen/metadata.yaml
@@ -1,0 +1,6 @@
+type: githubgen
+
+status:
+  class: cmd
+  codeowners:
+    active: [atoulme]


### PR DESCRIPTION
Adds the codeowner for githubgen, updating the metadata.yaml and CODEOWNERS file simultaneously.