### PR TITLE
[GH-24564] tailsamplingprocessor added invert_match rule for numeric …

### DIFF
--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Added invert_match rule for numeric matcher, to support exclusion decision"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24563]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -139,6 +139,8 @@ type NumericAttributeCfg struct {
 	MinValue int64 `mapstructure:"min_value"`
 	// MaxValue is the maximum value of the attribute to be considered a match.
 	MaxValue int64 `mapstructure:"max_value"`
+	// If invertMatch is true it means that we will do the vice versa decision.
+	InvertMatch bool `mapstructure:"invert_match"`
 }
 
 // ProbabilisticCfg holds the configurable settings to create a probabilistic

--- a/processor/tailsamplingprocessor/config.go
+++ b/processor/tailsamplingprocessor/config.go
@@ -139,7 +139,9 @@ type NumericAttributeCfg struct {
 	MinValue int64 `mapstructure:"min_value"`
 	// MaxValue is the maximum value of the attribute to be considered a match.
 	MaxValue int64 `mapstructure:"max_value"`
-	// If invertMatch is true it means that we will do the vice versa decision.
+	// InvertMatch indicates that values must not match against attribute values.
+	// If InvertMatch is true and Values is equal to '123', all other values will be sampled except '123'.
+	// Also, if the specified Key does not match any resource or span attributes, data will be sampled.
 	InvertMatch bool `mapstructure:"invert_match"`
 }
 

--- a/processor/tailsamplingprocessor/internal/sampling/composite_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite_test.go
@@ -59,8 +59,8 @@ func newTraceWithKV(traceID pcommon.TraceID, key string, val int64) *TraceData {
 func TestCompositeEvaluatorNotSampled(t *testing.T) {
 
 	// Create 2 policies which do not match any trace
-	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100)
-	n2 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 200, 300)
+	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100, false)
+	n2 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 200, 300, false)
 	c := NewComposite(zap.NewNop(), 1000, []SubPolicyEvalParams{{n1, 100}, {n2, 100}}, FakeTimeProvider{})
 
 	trace := createTrace()
@@ -77,7 +77,7 @@ func TestCompositeEvaluatorNotSampled(t *testing.T) {
 func TestCompositeEvaluatorSampled(t *testing.T) {
 
 	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
-	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100)
+	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	c := NewComposite(zap.NewNop(), 1000, []SubPolicyEvalParams{{n1, 100}, {n2, 100}}, FakeTimeProvider{})
 
@@ -96,7 +96,7 @@ func TestCompositeEvaluator_OverflowAlwaysSampled(t *testing.T) {
 	timeProvider := &FakeTimeProvider{second: 0}
 
 	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
-	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100)
+	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	c := NewComposite(zap.NewNop(), 3, []SubPolicyEvalParams{{n1, 1}, {n2, 1}}, timeProvider)
 
@@ -130,7 +130,7 @@ func TestCompositeEvaluator_OverflowAlwaysSampled(t *testing.T) {
 func TestCompositeEvaluatorSampled_AlwaysSampled(t *testing.T) {
 
 	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
-	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100)
+	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	c := NewComposite(zap.NewNop(), 10, []SubPolicyEvalParams{{n1, 20}, {n2, 20}}, FakeTimeProvider{})
 
@@ -208,7 +208,7 @@ func TestCompositeEvaluatorThrottling(t *testing.T) {
 
 func TestCompositeEvaluator2SubpolicyThrottling(t *testing.T) {
 
-	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100)
+	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	timeProvider := &FakeTimeProvider{second: 0}
 	const totalSPS = 10

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
@@ -47,9 +47,6 @@ func (naf *numericAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID
 
 			}
 		}
-		if !naf.invertMatch {
-			return false
-		}
-		return true
+		return naf.invertMatch
 	}), nil
 }

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter.go
@@ -16,18 +16,20 @@ type numericAttributeFilter struct {
 	key                string
 	minValue, maxValue int64
 	logger             *zap.Logger
+	invertMatch        bool
 }
 
 var _ PolicyEvaluator = (*numericAttributeFilter)(nil)
 
 // NewNumericAttributeFilter creates a policy evaluator that samples all traces with
 // the given attribute in the given numeric range.
-func NewNumericAttributeFilter(settings component.TelemetrySettings, key string, minValue, maxValue int64) PolicyEvaluator {
+func NewNumericAttributeFilter(settings component.TelemetrySettings, key string, minValue, maxValue int64, invertMatch bool) PolicyEvaluator {
 	return &numericAttributeFilter{
-		key:      key,
-		minValue: minValue,
-		maxValue: maxValue,
-		logger:   settings.Logger,
+		key:         key,
+		minValue:    minValue,
+		maxValue:    maxValue,
+		logger:      settings.Logger,
+		invertMatch: invertMatch,
 	}
 }
 
@@ -41,9 +43,13 @@ func (naf *numericAttributeFilter) Evaluate(_ context.Context, _ pcommon.TraceID
 		if v, ok := span.Attributes().Get(naf.key); ok {
 			value := v.Int()
 			if value >= naf.minValue && value <= naf.maxValue {
-				return true
+				return !(naf.invertMatch)
+
 			}
 		}
-		return false
+		if !naf.invertMatch {
+			return false
+		}
+		return true
 	}), nil
 }

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
@@ -34,12 +34,12 @@ func TestNumericTagFilter(t *testing.T) {
 			Decision: NotSampled,
 		},
 		{
-			Desc:     "span attribute with lower limit",
+			Desc:     "span attribute at the lower limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MinInt32),
 			Decision: Sampled,
 		},
 		{
-			Desc:     "span attribute with upper limit",
+			Desc:     "span attribute at the upper limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32),
 			Decision: Sampled,
 		},
@@ -84,12 +84,12 @@ func TestNumericTagFilterInverted(t *testing.T) {
 			Decision: Sampled,
 		},
 		{
-			Desc:     "span attribute with lower limit",
+			Desc:     "span attribute at the lower limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MinInt32),
 			Decision: NotSampled,
 		},
 		{
-			Desc:     "span attribute with upper limit",
+			Desc:     "span attribute at the upper limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32),
 			Decision: NotSampled,
 		},

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -225,7 +225,6 @@ func (tsp *tailSamplingSpanProcessor) makeDecision(id pcommon.TraceID, trace *sa
 		stats.Record(
 			p.ctx,
 			statDecisionLatencyMicroSec.M(int64(time.Since(policyEvaluateStartTime)/time.Microsecond)))
-
 		if err != nil {
 			samplingDecision[sampling.Error] = true
 			trace.Decisions[i] = sampling.NotSampled

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -127,7 +127,7 @@ func getSharedPolicyEvaluator(settings component.TelemetrySettings, cfg *sharedP
 		return sampling.NewLatency(settings, lfCfg.ThresholdMs), nil
 	case NumericAttribute:
 		nafCfg := cfg.NumericAttributeCfg
-		return sampling.NewNumericAttributeFilter(settings, nafCfg.Key, nafCfg.MinValue, nafCfg.MaxValue), nil
+		return sampling.NewNumericAttributeFilter(settings, nafCfg.Key, nafCfg.MinValue, nafCfg.MaxValue, nafCfg.InvertMatch), nil
 	case Probabilistic:
 		pCfg := cfg.ProbabilisticCfg
 		return sampling.NewProbabilisticSampler(settings, pCfg.HashSalt, pCfg.SamplingPercentage), nil


### PR DESCRIPTION


**Description:** <Describe what has changed.>
Added invert_match rule for numeric matcher, to support exclusion decision

**Link to tracking Issue:** 
[GH-24563]

**Testing:**
Added tests

**Documentation:**
Updated Readme