### PR TITLE
[chore] add new make target for updating code-owners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,9 @@ mdatagen-test:
 gengithub:
 	$(GOCMD) run cmd/githubgen/main.go .
 
+.PHONY: update-codeowners
+update-codeowners: gengithub generate
+
 FILENAME?=$(shell git branch --show-current)
 .PHONY: chlog-new
 chlog-new: $(CHLOGGEN)


### PR DESCRIPTION
**Description:** 
Adds a new make target to update the codeowners file and regenerate component READMEs in 1 step.