### PR TITLE
[chore] Pin github.com/DataDog/datadog-agent/pkg/trace dependancy

### DIFF
--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -1112,3 +1112,6 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/obse
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8stest => ../../internal/k8stest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling => ../../extension/jaegerremotesampling
+
+// Pin to a specific commit to adopt to a breaking change until next release
+replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.3 => github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.3.0.20230720220350-143f7b52181b

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -1126,3 +1126,6 @@ replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristre
 
 // ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules
 replace cloud.google.com/go => cloud.google.com/go v0.110.2
+
+// Pin to a specific commit to adopt to a breaking change until next release
+replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.3 => github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.3.0.20230720220350-143f7b52181b

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -267,3 +267,6 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8ste
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver => ../../receiver/dockerstatsreceiver
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker => ../../internal/docker
+
+// Pin to a specific commit to adopt to a breaking change until next release
+replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.3 => github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.3.0.20230720220350-143f7b52181b

--- a/processor/datadogprocessor/go.mod
+++ b/processor/datadogprocessor/go.mod
@@ -96,3 +96,6 @@ retract (
 	v0.76.2
 	v0.76.1
 )
+
+// Pin to a specific commit to adopt to a breaking change until next release
+replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.3 => github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.3.0.20230720220350-143f7b52181b

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -338,3 +338,6 @@ retract (
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../pkg/pdatatest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil => ../pkg/pdatautil
+
+// Pin to a specific commit to adopt to a breaking change until next release
+replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.3 => github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.3.0.20230720220350-143f7b52181b


### PR DESCRIPTION
Pin the datadog agent to a specific commit to adopt to a breaking change until the next release. Unblocks `make update-otel`