### PR TITLE
[splunkhecreceiver] aligns success response body w/ splunk enterprise

### DIFF
--- a/.chloggen/splunkhecreceiver-align-success-response.yaml
+++ b/.chloggen/splunkhecreceiver-align-success-response.yaml
@@ -1,0 +1,19 @@
+# use this changelog template to create an entry for the release notes. if
+# your changes don't affect end-users (e.g. test fixes or tooling updates),
+# title your pull request with "[chore]" or use the "skip changelog" label
+
+# choose one: breaking, deprecation, new_component, enhancement, or bug_fix
+change_type: bug_fix
+
+# name of the component or a single word describing the area of concern
+component: splunkhecreceiver
+
+# brief description of the proposed changes
+note: aligns success resp body w/ splunk enterprise
+
+# tracking issues related to the changes (or a pr number if none exist)
+issues: [19219]
+
+# (optional) additional information to render under the primary note provided above;
+# these lines will be padded with two spaces and inserted directly into the document
+subtext: changes resp from plaintext "ok" to json {"text"："success", "code"：0}

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -31,7 +31,7 @@ import (
 const (
 	defaultServerTimeout = 20 * time.Second
 
-	responseOK                        = "OK"
+	responseOK                        = `{"text": "Success", "code": 0}`
 	responseHecHealthy                = `{"text": "HEC is healthy", "code": 17}`
 	responseInvalidMethod             = `Only "POST" method is supported`
 	responseInvalidEncoding           = `"Content-Encoding" must be "gzip" or empty`
@@ -376,8 +376,7 @@ func (r *splunkReceiver) consumeMetrics(ctx context.Context, events []*splunk.Ev
 		r.failRequest(ctx, resp, http.StatusInternalServerError, errInternalServerError, len(events), decodeErr)
 	} else {
 		resp.WriteHeader(http.StatusOK)
-		_, err := resp.Write(okRespBody)
-		if err != nil {
+		if _, err := resp.Write(okRespBody); err != nil {
 			r.failRequest(ctx, resp, http.StatusInternalServerError, errInternalServerError, len(events), err)
 		}
 	}

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -1221,7 +1221,7 @@ func Test_splunkhecReceiver_rawReqHasmetadataInResource(t *testing.T) {
 			resp := w.Result()
 			assert.NoError(t, err)
 
-			assertResponse(t, resp.StatusCode, "OK")
+			assertResponse(t, resp.StatusCode, responseOK)
 			tt.assertResource(t, sink.AllLogs())
 		})
 	}


### PR DESCRIPTION
**Description:** Changed `200` response body from plaintext to JSON object: `"OK"` → `{"text": "Success", "code": 0}`.

**Testing:** Updated existing unit tests to reflect the new response body. Everything passes as expected.

**Documentation:** https://docs.splunk.com/Documentation/Splunk/9.0.4/RESTREF/RESTinput

**Link to Tracking Issue:** #19219