### PR TITLE
[extension/filestorage] Sanitize names containing slash

### DIFF
--- a/extension/storage/filestorage/extension.go
+++ b/extension/storage/filestorage/extension.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
@@ -44,10 +45,11 @@ func (lfs *localFileStorage) Shutdown(context.Context) error {
 // GetClient returns a storage client for an individual component
 func (lfs *localFileStorage) GetClient(_ context.Context, kind component.Kind, ent component.ID, name string) (storage.Client, error) {
 	var rawName string
+	entName := strings.ReplaceAll(ent.Name(), "/", "_")
 	if name == "" {
-		rawName = fmt.Sprintf("%s_%s_%s", kindString(kind), ent.Type(), ent.Name())
+		rawName = fmt.Sprintf("%s_%s_%s", kindString(kind), ent.Type(), entName)
 	} else {
-		rawName = fmt.Sprintf("%s_%s_%s_%s", kindString(kind), ent.Type(), ent.Name(), name)
+		rawName = fmt.Sprintf("%s_%s_%s_%s", kindString(kind), ent.Type(), entName, name)
 	}
 	// TODO sanitize rawName
 	absoluteName := filepath.Join(lfs.cfg.Directory, rawName)

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -35,6 +35,7 @@ func TestExtensionIntegrity(t *testing.T) {
 		{kind: component.KindExporter, name: newTestEntity("exporter_two")},
 		{kind: component.KindExtension, name: newTestEntity("extension_one")},
 		{kind: component.KindExtension, name: newTestEntity("extension_two")},
+		{kind: component.KindExtension, name: newTestEntity("extension/three")},
 	}
 
 	// Make a client for each component


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Handled use case: when receivers, processors, or exporters have names with more than one slash in them, they need to be replaced with underscores otherwise the storage will look for a non-existent directory

**Testing:** <Describe what testing was performed and which tests were added.>
Added a test case in the corresponding test file: extension/storage/filestorage/extension_test.go