### PR TITLE
Remove units from the prometheus conversion that aren't UCUM

### DIFF
--- a/.chloggen/prometheus_translation_ucum.yaml
+++ b/.chloggen/prometheus_translation_ucum.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'breaking'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove invalid unit translations from the prometheus exporters
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24647]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/translator/prometheus/normalize_name.go
+++ b/pkg/translator/prometheus/normalize_name.go
@@ -37,11 +37,6 @@ var unitMap = map[string]string{
 	"MBy":  "megabytes",
 	"GBy":  "gigabytes",
 	"TBy":  "terabytes",
-	"B":    "bytes",
-	"KB":   "kilobytes",
-	"MB":   "megabytes",
-	"GB":   "gigabytes",
-	"TB":   "terabytes",
 
 	// SI
 	"m": "meters",
@@ -56,7 +51,6 @@ var unitMap = map[string]string{
 	"Hz":  "hertz",
 	"1":   "",
 	"%":   "percent",
-	"$":   "dollars",
 }
 
 // The map that translates the "per" unit

--- a/pkg/translator/prometheus/normalize_name_test.go
+++ b/pkg/translator/prometheus/normalize_name_test.go
@@ -88,13 +88,6 @@ func TestPercent(t *testing.T) {
 
 }
 
-func TestDollar(t *testing.T) {
-
-	require.Equal(t, "crypto_bitcoin_value_dollars", normalizeName(createGauge("crypto.bitcoin.value", "$"), ""))
-	require.Equal(t, "crypto_bitcoin_value_dollars", normalizeName(createGauge("crypto.bitcoin.value.dollars", "$"), ""))
-
-}
-
 func TestEmpty(t *testing.T) {
 
 	require.Equal(t, "test_metric_no_unit", normalizeName(createGauge("test.metric.no_unit", ""), ""))


### PR DESCRIPTION
**Description:**

Discovered during https://github.com/open-telemetry/opentelemetry-go/pull/4374#pullrequestreview-1548606912.

`B` means `bel` in UCUM, so MB is `megabel`, for example.  `$` is also not UCUM.

https://ucum.org/ucum#section-Alphabetic-Index-By-Symbol