### PR TITLE
[chronyreceiver] Remove hard dependency on explicit timeout

### DIFF
--- a/receiver/chronyreceiver/config_test.go
+++ b/receiver/chronyreceiver/config_test.go
@@ -52,48 +52,54 @@ func TestValidate(t *testing.T) {
 		{
 			scenario: "Valid udp configuration",
 			conf: Config{
-				Endpoint: "udp://localhost:323",
-				Timeout:  10 * time.Second,
+				Endpoint:                  "udp://localhost:323",
+				Timeout:                   10 * time.Second,
+				ScraperControllerSettings: scraperhelper.NewDefaultScraperControllerSettings(metadata.Type),
 			},
 			err: nil,
 		},
 		{
 			scenario: "Invalid udp hostname",
 			conf: Config{
-				Endpoint: "udp://:323",
-				Timeout:  10 * time.Second,
+				Endpoint:                  "udp://:323",
+				Timeout:                   10 * time.Second,
+				ScraperControllerSettings: scraperhelper.NewDefaultScraperControllerSettings(metadata.Type),
 			},
 			err: chrony.ErrInvalidNetwork,
 		},
 		{
 			scenario: "Invalid udp port",
 			conf: Config{
-				Endpoint: "udp://localhost",
-				Timeout:  10 * time.Second,
+				Endpoint:                  "udp://localhost",
+				Timeout:                   10 * time.Second,
+				ScraperControllerSettings: scraperhelper.NewDefaultScraperControllerSettings(metadata.Type),
 			},
 			err: chrony.ErrInvalidNetwork,
 		},
 		{
 			scenario: "Valid unix path",
 			conf: Config{
-				Endpoint: fmt.Sprintf("unix://%s", t.TempDir()),
-				Timeout:  10 * time.Second,
+				Endpoint:                  fmt.Sprintf("unix://%s", t.TempDir()),
+				Timeout:                   10 * time.Second,
+				ScraperControllerSettings: scraperhelper.NewDefaultScraperControllerSettings(metadata.Type),
 			},
 			err: nil,
 		},
 		{
 			scenario: "Invalid unix path",
 			conf: Config{
-				Endpoint: "unix:///no/dir/to/socket",
-				Timeout:  10 * time.Second,
+				Endpoint:                  "unix:///no/dir/to/socket",
+				Timeout:                   10 * time.Second,
+				ScraperControllerSettings: scraperhelper.NewDefaultScraperControllerSettings(metadata.Type),
 			},
 			err: os.ErrNotExist,
 		},
 		{
 			scenario: "Invalid timeout set",
 			conf: Config{
-				Endpoint: "unix://no/dir/to/socket",
-				Timeout:  0,
+				Endpoint:                  "unix://no/dir/to/socket",
+				Timeout:                   0,
+				ScraperControllerSettings: scraperhelper.NewDefaultScraperControllerSettings(metadata.Type),
 			},
 			err: errInvalidValue,
 		},

--- a/receiver/chronyreceiver/scraper.go
+++ b/receiver/chronyreceiver/scraper.go
@@ -35,7 +35,7 @@ func (cs *chronyScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		return pmetric.Metrics{}, err
 	}
 
-	now := pcommon.NewTimestampFromTime(clock.FromContext(ctx).Now())
+	now := pcommon.NewTimestampFromTime(clock.Now(ctx))
 
 	cs.mb.RecordNtpStratumDataPoint(now, int64(data.Stratum))
 	cs.mb.RecordNtpTimeCorrectionDataPoint(


### PR DESCRIPTION
**Description:** 

With the upcoming changes in https://github.com/open-telemetry/opentelemetry-collector/pull/7951 where it includes timeout as an explicit field, chrony receiver is no longer required to explicitly call it.

**Link to tracking Issue:**

NA

**Testing:** 

Updated tests where required

**Documentation:** 

Documentation remains the same.