### PR TITLE
[datadog receiver] Exit function on failed payload decode

### DIFF
--- a/.chloggen/msg_fix-npe-datadog-receiver.yaml
+++ b/.chloggen/msg_fix-npe-datadog-receiver.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed NPE on failed to decode message path
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24562]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -91,6 +91,7 @@ func (ddr *datadogReceiver) handleTraces(w http.ResponseWriter, req *http.Reques
 	if err != nil {
 		http.Error(w, "Unable to unmarshal reqs", http.StatusInternalServerError)
 		ddr.params.Logger.Error("Unable to unmarshal reqs")
+		return
 	}
 
 	otelTraces := toTraces(ddTraces, req)

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -89,7 +89,7 @@ func (ddr *datadogReceiver) handleTraces(w http.ResponseWriter, req *http.Reques
 
 	ddTraces, err = handlePayload(req)
 	if err != nil {
-		http.Error(w, "Unable to unmarshal reqs", http.StatusInternalServerError)
+		http.Error(w, "Unable to unmarshal reqs", http.StatusBadRequest)
 		ddr.params.Logger.Error("Unable to unmarshal reqs")
 		return
 	}

--- a/receiver/datadogreceiver/receiver_test.go
+++ b/receiver/datadogreceiver/receiver_test.go
@@ -5,12 +5,18 @@ package datadogreceiver
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/multierr"
 )
 
 func TestDatadogReceiver_Lifecycle(t *testing.T) {
@@ -24,4 +30,58 @@ func TestDatadogReceiver_Lifecycle(t *testing.T) {
 
 	err = ddr.Shutdown(context.Background())
 	assert.NoError(t, err, "Server should stop")
+}
+
+func TestDatadogServer(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	dd, err := newDataDogReceiver(
+		cfg,
+		consumertest.NewNop(),
+		receivertest.NewNopCreateSettings(),
+	)
+	require.NoError(t, err, "Must not error when creating receiver")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	require.NoError(t, dd.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, dd.Shutdown(ctx), "Must not error shutting down")
+	})
+
+	for _, tc := range []struct {
+		name string
+		op   io.Reader
+
+		expectCode    int
+		expectContent string
+	}{
+		{
+			name:          "invalid data",
+			op:            strings.NewReader("{"),
+			expectCode:    http.StatusBadRequest,
+			expectContent: "Unable to unmarshal reqs\n",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest(
+				http.MethodPost,
+				fmt.Sprintf("http://%s/v0.7/traces", cfg.Endpoint),
+				tc.op,
+			)
+			require.NoError(t, err, "Must not error when creating request")
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err, "Must not error performing request")
+
+			actual, err := io.ReadAll(resp.Body)
+			require.NoError(t, multierr.Combine(err, resp.Body.Close()), "Must not error when reading body")
+
+			assert.Equal(t, tc.expectContent, string(actual))
+			assert.Equal(t, tc.expectCode, resp.StatusCode, "Must match the expected status code")
+		})
+	}
 }


### PR DESCRIPTION
**Description:** 

Exit on error to avoid NPE

**Link to tracking Issue:**

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24562

**Testing:**

I would like to fix up how the component does tests in future PR.

**Documentation:**

N/A