### PR TITLE
[processor/resourcedetection] Fix system detector not setting attributes

### DIFF
--- a/.chloggen/res-attr-dont-drop-system-attributes.yaml
+++ b/.chloggen/res-attr-dont-drop-system-attributes.yaml
@@ -1,0 +1,15 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/resourcedetection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not drop all system attributes if `host.id` cannot be fetched.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24669]

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -34,10 +34,10 @@ var _ internal.Detector = (*Detector)(nil)
 
 // Detector is a system metadata detector
 type Detector struct {
-	provider        system.Provider
-	logger          *zap.Logger
-	hostnameSources []string
-	rb              *metadata.ResourceBuilder
+	provider system.Provider
+	logger   *zap.Logger
+	cfg      Config
+	rb       *metadata.ResourceBuilder
 }
 
 // NewDetector creates a new system metadata detector
@@ -48,10 +48,10 @@ func NewDetector(p processor.CreateSettings, dcfg internal.DetectorConfig) (inte
 	}
 
 	return &Detector{
-		provider:        system.NewProvider(),
-		logger:          p.Logger,
-		hostnameSources: cfg.HostnameSources,
-		rb:              metadata.NewResourceBuilder(cfg.ResourceAttributes),
+		provider: system.NewProvider(),
+		logger:   p.Logger,
+		cfg:      cfg,
+		rb:       metadata.NewResourceBuilder(cfg.ResourceAttributes),
 	}, nil
 }
 
@@ -64,23 +64,24 @@ func (d *Detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 		return pcommon.NewResource(), "", fmt.Errorf("failed getting OS type: %w", err)
 	}
 
-	hostID, err := d.provider.HostID(ctx)
-	if err != nil {
-		return pcommon.NewResource(), "", fmt.Errorf("failed getting host ID: %w", err)
-	}
-
 	hostArch, err := d.provider.HostArch()
 	if err != nil {
 		return pcommon.NewResource(), "", fmt.Errorf("failed getting host architecture: %w", err)
 	}
 
-	for _, source := range d.hostnameSources {
+	for _, source := range d.cfg.HostnameSources {
 		getHostFromSource := hostnameSourcesMap[source]
 		hostname, err = getHostFromSource(d)
 		if err == nil {
 			d.rb.SetHostName(hostname)
 			d.rb.SetOsType(osType)
-			d.rb.SetHostID(hostID)
+			if d.cfg.ResourceAttributes.HostID.Enabled {
+				if hostID, hostIDErr := d.provider.HostID(ctx); hostIDErr == nil {
+					d.rb.SetHostID(hostID)
+				} else {
+					d.logger.Warn("failed to get host ID", zap.Error(hostIDErr))
+				}
+			}
 			d.rb.SetHostArch(hostArch)
 			return d.rb.Emit(), conventions.SchemaURL, nil
 		}


### PR DESCRIPTION
Do not drop all system attributes if `host.id` cannot be fetched. This is a fix that restores the behavior closer to how it used to be before https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/24239.

This probably should be applied to all other attributes going forward: if any of the system attributes cannot be fetched, we should still try to set others. But that will be a significant change in the processor behavior, so it should be handled not as a hotfix.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24669