### PR TITLE
[exporter/awsxray] Fix X-Ray metadata unmarshal.

### DIFF
--- a/.chloggen/fix-xray-metadata-unmarshal.yaml
+++ b/.chloggen/fix-xray-metadata-unmarshal.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Restore the AWS X-Ray metadata structure when exporting.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23610]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -534,6 +534,33 @@ func TestSpanWithAttributesAllIndexed(t *testing.T) {
 	assert.Equal(t, "val2", segment.Annotations["attr2_2"])
 }
 
+func TestSpanWithAttributesSegmentMetadata(t *testing.T) {
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]interface{})
+	attributes["attr1@1"] = "val1"
+	attributes[awsxray.AWSXraySegmentMetadataAttributePrefix+"default"] = "{\"custom_key\": \"custom_value\"}"
+	attributes[awsxray.AWSXraySegmentMetadataAttributePrefix+"http"] = "{\"connection\":{\"reused\":false,\"was_idle\":false}}"
+	attributes[awsxray.AWSXraySegmentMetadataAttributePrefix+"non-xray-sdk"] = "retain-value"
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, 0, len(segment.Annotations))
+	assert.Equal(t, 2, len(segment.Metadata))
+	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
+	assert.Equal(t, "custom_value", segment.Metadata["default"]["custom_key"])
+	assert.Equal(t, "retain-value", segment.Metadata["default"][awsxray.AWSXraySegmentMetadataAttributePrefix+"non-xray-sdk"])
+	assert.Nil(t, segment.Metadata["default"][awsxray.AWSXraySegmentMetadataAttributePrefix+"default"])
+	assert.Nil(t, segment.Metadata["default"][awsxray.AWSXraySegmentMetadataAttributePrefix+"http"])
+	assert.Equal(t, map[string]interface{}{
+		"reused":   false,
+		"was_idle": false,
+	}, segment.Metadata["http"]["connection"])
+}
+
 func TestResourceAttributesCanBeIndexed(t *testing.T) {
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()


### PR DESCRIPTION
**Description:** The X-Ray receiver [marshals the metadata](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/awsxrayreceiver/internal/translator/metadata.go#L16) from the X-Ray SDK, but the exporter doesn't unmarshal the metadata, which results in squashed and incorrectly nested metadata.

```
"metadata": {
    "default": {
        "aws.xray.metadata.http": "{\"connection\":{\"reused\":false,\"was_idle\":false}}"
    }
},
```
instead of 
```
"metadata": {
    "http": {
        "connection": {
            "was_idle": false,
            "reused": false
        }
    }
},
```

Changes the exporter translator to check for the metadata attribute prefix and attempt to unmarshal those.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23610

**Testing:** Added unit test. Ran the change with the collector and verified in the AWS X-Ray console. 