### PR TITLE
[cmd/mdatagen] Rename aggregation to aggregation_temporality for sum metrics

### DIFF
--- a/.chloggen/rename-agggregation-aggregation-temporality.yaml
+++ b/.chloggen/rename-agggregation-aggregation-temporality.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename the mdatagen sum field `aggregation` to `aggregation_temporality`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [16374]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -133,9 +133,9 @@ func Test_loadMetadata(t *testing.T) {
 						},
 						Unit: "s",
 						Sum: &sum{
-							MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeInt},
-							Aggregated:      Aggregated{Aggregation: pmetric.AggregationTemporalityCumulative},
-							Mono:            Mono{Monotonic: true},
+							MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeInt},
+							AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityCumulative},
+							Mono:                   Mono{Monotonic: true},
 						},
 						Attributes: []attributeName{"string_attr", "overridden_int_attr", "enum_attr", "slice_attr", "map_attr"},
 					},
@@ -160,9 +160,9 @@ func Test_loadMetadata(t *testing.T) {
 						},
 						Unit: "s",
 						Sum: &sum{
-							MetricValueType: MetricValueType{pmetric.NumberDataPointValueTypeDouble},
-							Aggregated:      Aggregated{Aggregation: pmetric.AggregationTemporalityDelta},
-							Mono:            Mono{Monotonic: false},
+							MetricValueType:        MetricValueType{pmetric.NumberDataPointValueTypeDouble},
+							AggregationTemporality: AggregationTemporality{Aggregation: pmetric.AggregationTemporalityDelta},
+							Mono:                   Mono{Monotonic: false},
 						},
 					},
 				},
@@ -202,12 +202,12 @@ func Test_loadMetadata(t *testing.T) {
 		{
 			name:    "testdata/no_aggregation.yaml",
 			want:    metadata{},
-			wantErr: "1 error(s) decoding:\n\n* error decoding 'metrics[default.metric]': 1 error(s) decoding:\n\n* error decoding 'sum': missing required field: `aggregation`",
+			wantErr: "1 error(s) decoding:\n\n* error decoding 'metrics[default.metric]': 1 error(s) decoding:\n\n* error decoding 'sum': missing required field: `aggregation_temporality`",
 		},
 		{
 			name:    "testdata/invalid_aggregation.yaml",
 			want:    metadata{},
-			wantErr: "1 error(s) decoding:\n\n* error decoding 'metrics[default.metric]': 1 error(s) decoding:\n\n* error decoding 'sum': 1 error(s) decoding:\n\n* error decoding 'aggregation': invalid aggregation: \"invalidaggregation\"",
+			wantErr: "1 error(s) decoding:\n\n* error decoding 'metrics[default.metric]': 1 error(s) decoding:\n\n* error decoding 'sum': 1 error(s) decoding:\n\n* error decoding 'aggregation_temporality': invalid aggregation: \"invalidaggregation\"",
 		},
 		{
 			name:    "testdata/invalid_type_attr.yaml",

--- a/cmd/mdatagen/metadata-sample.yaml
+++ b/cmd/mdatagen/metadata-sample.yaml
@@ -77,7 +77,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [string_attr, overridden_int_attr, enum_attr, slice_attr, map_attr]
     warnings:
       if_enabled_not_set: This metric will be disabled by default soon.
@@ -100,6 +100,6 @@ metrics:
     sum:
       value_type: double
       monotonic: false
-      aggregation: delta
+      aggregation_temporality: delta
     warnings:
       if_enabled: This metric is deprecated and will be removed soon.

--- a/cmd/mdatagen/metadata-schema.yaml
+++ b/cmd/mdatagen/metadata-schema.yaml
@@ -86,7 +86,7 @@ metrics:
       monotonic: bool
       # Required for sum metric: whether reported values incorporate previous measurements
       # (cumulative) or not (delta).
-      aggregation: <delta|cumulative>
+      aggregation_temporality: <delta|cumulative>
        # Optional: Indicates the type the metric needs to be parsed from. If set, the generated
        # functions will parse the value from string to value_type.
       input_type: string

--- a/cmd/mdatagen/metricdata.go
+++ b/cmd/mdatagen/metricdata.go
@@ -24,16 +24,15 @@ type MetricData interface {
 	HasMetricInputType() bool
 }
 
-// Aggregated defines a metric aggregation type.
-// TODO: Rename to AggregationTemporality
-type Aggregated struct {
+// AggregationTemporality defines a metric aggregation type.
+type AggregationTemporality struct {
 	// Aggregation describes if the aggregator reports delta changes
 	// since last report time, or cumulative changes since a fixed start time.
 	Aggregation pmetric.AggregationTemporality
 }
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
-func (agg *Aggregated) UnmarshalText(text []byte) error {
+func (agg *AggregationTemporality) UnmarshalText(text []byte) error {
 	switch vtStr := string(text); vtStr {
 	case "cumulative":
 		agg.Aggregation = pmetric.AggregationTemporalityCumulative
@@ -46,7 +45,7 @@ func (agg *Aggregated) UnmarshalText(text []byte) error {
 }
 
 // String returns string representation of the aggregation temporality.
-func (agg *Aggregated) String() string {
+func (agg *AggregationTemporality) String() string {
 	return agg.Aggregation.String()
 }
 
@@ -142,16 +141,16 @@ func (d gauge) HasAggregated() bool {
 }
 
 type sum struct {
-	Aggregated      `mapstructure:"aggregation"`
-	Mono            `mapstructure:",squash"`
-	MetricValueType `mapstructure:"value_type"`
-	MetricInputType `mapstructure:",squash"`
+	AggregationTemporality `mapstructure:"aggregation_temporality"`
+	Mono                   `mapstructure:",squash"`
+	MetricValueType        `mapstructure:"value_type"`
+	MetricInputType        `mapstructure:",squash"`
 }
 
 // Unmarshal is a custom unmarshaler for sum. Needed mostly to avoid MetricValueType.Unmarshal inheritance.
 func (d *sum) Unmarshal(parser *confmap.Conf) error {
-	if !parser.IsSet("aggregation") {
-		return errors.New("missing required field: `aggregation`")
+	if !parser.IsSet("aggregation_temporality") {
+		return errors.New("missing required field: `aggregation_temporality`")
 	}
 	if err := d.MetricValueType.Unmarshal(parser); err != nil {
 		return err

--- a/cmd/mdatagen/templates/documentation.md.tmpl
+++ b/cmd/mdatagen/templates/documentation.md.tmpl
@@ -15,7 +15,7 @@
 | Unit | Metric Type | Value Type |{{ if $metric.Data.HasAggregated }} Aggregation Temporality |{{ end }}{{ if $metric.Data.HasMonotonic }} Monotonic |{{ end }}
 | ---- | ----------- | ---------- |{{ if $metric.Data.HasAggregated }} ----------------------- |{{ end }}{{ if $metric.Data.HasMonotonic }} --------- |{{ end }}
 | {{ $metric.Unit }} | {{ $metric.Data.Type }} | {{ $metric.Data.MetricValueType }} |
-{{- if $metric.Data.HasAggregated }} {{ $metric.Data.Aggregated }} |{{ end }}
+{{- if $metric.Data.HasAggregated }} {{ $metric.Data.AggregationTemporality }} |{{ end }}
 {{- if $metric.Data.HasMonotonic }} {{ $metric.Data.Monotonic }} |{{ end }}
 
 {{- if $metric.Attributes }}

--- a/cmd/mdatagen/templates/metrics.go.tmpl
+++ b/cmd/mdatagen/templates/metrics.go.tmpl
@@ -68,7 +68,7 @@ func (m *metric{{ $name.Render }}) init() {
 	m.data.{{ $metric.Data.Type }}().SetIsMonotonic({{ $metric.Data.Monotonic }})
 	{{- end }}
 	{{- if $metric.Data.HasAggregated }}
-	m.data.{{ $metric.Data.Type }}().SetAggregationTemporality(pmetric.AggregationTemporality{{ $metric.Data.Aggregated }})
+	m.data.{{ $metric.Data.Type }}().SetAggregationTemporality(pmetric.AggregationTemporality{{ $metric.Data.AggregationTemporality }})
 	{{- end }}
 	{{- if $metric.Attributes }}
 	m.data.{{ $metric.Data.Type }}().DataPoints().EnsureCapacity(m.capacity)

--- a/cmd/mdatagen/templates/metrics_test.go.tmpl
+++ b/cmd/mdatagen/templates/metrics_test.go.tmpl
@@ -130,7 +130,7 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, {{ $metric.Data.Monotonic }}, ms.At(i).{{ $metric.Data.Type }}().IsMonotonic())
 					{{- end }}
 					{{- if $metric.Data.HasAggregated }}
-					assert.Equal(t, pmetric.AggregationTemporality{{ $metric.Data.Aggregated }}, ms.At(i).{{ $metric.Data.Type }}().AggregationTemporality())
+					assert.Equal(t, pmetric.AggregationTemporality{{ $metric.Data.AggregationTemporality }}, ms.At(i).{{ $metric.Data.Type }}().AggregationTemporality())
 					{{- end }}
 					dp := ms.At(i).{{ $metric.Data.Type }}().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())

--- a/cmd/mdatagen/testdata/invalid_aggregation.yaml
+++ b/cmd/mdatagen/testdata/invalid_aggregation.yaml
@@ -19,4 +19,4 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: invalidaggregation
+      aggregation_temporality: invalidaggregation

--- a/cmd/mdatagen/testdata/invalid_input_type.yaml
+++ b/cmd/mdatagen/testdata/invalid_input_type.yaml
@@ -15,6 +15,6 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       input_type: double
     attributes:

--- a/cmd/mdatagen/testdata/no_description_attr.yaml
+++ b/cmd/mdatagen/testdata/no_description_attr.yaml
@@ -27,7 +27,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [string_attr]
     warnings:
       if_enabled_not_set: This metric will be disabled by default soon.

--- a/cmd/mdatagen/testdata/no_enabled.yaml
+++ b/cmd/mdatagen/testdata/no_enabled.yaml
@@ -14,5 +14,5 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:

--- a/cmd/mdatagen/testdata/no_metric_description.yaml
+++ b/cmd/mdatagen/testdata/no_metric_description.yaml
@@ -19,4 +19,4 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative

--- a/cmd/mdatagen/testdata/no_metric_unit.yaml
+++ b/cmd/mdatagen/testdata/no_metric_unit.yaml
@@ -19,4 +19,4 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative

--- a/cmd/mdatagen/testdata/no_monotonic.yaml
+++ b/cmd/mdatagen/testdata/no_monotonic.yaml
@@ -19,4 +19,4 @@ metrics:
     unit: s
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative

--- a/cmd/mdatagen/testdata/no_value_type.yaml
+++ b/cmd/mdatagen/testdata/no_value_type.yaml
@@ -18,5 +18,5 @@ metrics:
     unit: s
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:

--- a/cmd/mdatagen/testdata/two_metric_types.yaml
+++ b/cmd/mdatagen/testdata/two_metric_types.yaml
@@ -17,5 +17,5 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:

--- a/cmd/mdatagen/testdata/unknown_metric_attribute.yaml
+++ b/cmd/mdatagen/testdata/unknown_metric_attribute.yaml
@@ -15,5 +15,5 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [missing]

--- a/cmd/mdatagen/testdata/unknown_value_type.yaml
+++ b/cmd/mdatagen/testdata/unknown_value_type.yaml
@@ -15,4 +15,4 @@ metrics:
     sum:
       value_type: unknown
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative

--- a/receiver/activedirectorydsreceiver/metadata.yaml
+++ b/receiver/activedirectorydsreceiver/metadata.yaml
@@ -65,7 +65,7 @@ metrics:
     unit: By
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [direction, network_data_type]
     enabled: true
@@ -74,7 +74,7 @@ metrics:
     unit: "{objects}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   active_directory.ds.replication.sync.request.count:
@@ -82,7 +82,7 @@ metrics:
     unit: "{requests}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [sync_result]
     enabled: true
@@ -91,7 +91,7 @@ metrics:
     unit: "{objects}/s"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: double
     attributes: [direction]
     enabled: true
@@ -100,7 +100,7 @@ metrics:
     unit: "{properties}/s"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: double
     attributes: [direction]
     enabled: true
@@ -109,7 +109,7 @@ metrics:
     unit: "{values}/s"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: double
     attributes: [direction, value_type]
     enabled: true
@@ -118,7 +118,7 @@ metrics:
     unit: "{operations}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   active_directory.ds.operation.rate:
@@ -126,7 +126,7 @@ metrics:
     unit: "{operations}/s"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: double
     attributes: [operation_type]
     enabled: true
@@ -141,7 +141,7 @@ metrics:
     unit: "{notifications}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   active_directory.ds.security_descriptor_propagations_event.queued:
@@ -149,7 +149,7 @@ metrics:
     unit: "{events}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   active_directory.ds.suboperation.rate:
@@ -157,7 +157,7 @@ metrics:
     unit: "{suboperations}/s"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: double
     attributes: [suboperation_type]
     enabled: true
@@ -166,7 +166,7 @@ metrics:
     unit: "{binds}/s"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: double
     attributes: [bind_type]
     enabled: true
@@ -175,7 +175,7 @@ metrics:
     unit: "{threads}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   active_directory.ds.ldap.client.session.count:
@@ -183,7 +183,7 @@ metrics:
     unit: "{sessions}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   active_directory.ds.ldap.bind.last_successful.time:
@@ -197,7 +197,7 @@ metrics:
     unit: "{binds}/s"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: double
     enabled: true
   active_directory.ds.ldap.search.rate:
@@ -205,6 +205,6 @@ metrics:
     unit: "{searches}/s"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: double
     enabled: true

--- a/receiver/aerospikereceiver/metadata.yaml
+++ b/receiver/aerospikereceiver/metadata.yaml
@@ -127,7 +127,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   aerospike.node.connection.open:
     enabled: true
     description: Current number of open connections to the node
@@ -138,7 +138,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   aerospike.node.query.tracked:
     enabled: true
     description: Number of queries tracked by the system.
@@ -148,7 +148,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   aerospike.namespace.memory.usage:
     enabled: true
     description: Memory currently used by each component of the namespace
@@ -159,7 +159,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   aerospike.namespace.memory.free:
     enabled: true
     description: Percentage of the namespace's memory which is still free
@@ -185,7 +185,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   aerospike.namespace.query.count:
     enabled: true
     description: Number of query operations performed on the namespace
@@ -196,7 +196,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   aerospike.namespace.geojson.region_query_cells:
     enabled: true
     description: Number of cell coverings for query region queried
@@ -206,7 +206,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   aerospike.namespace.geojson.region_query_false_positive:
     enabled: true
     description: Number of points outside the region.
@@ -216,7 +216,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   aerospike.namespace.geojson.region_query_points:
     enabled: true
     description: Number of points within the region.
@@ -226,7 +226,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   aerospike.namespace.geojson.region_query_requests:
     enabled: true
     description: Number of geojson queries on the system since the uptime of the node.
@@ -236,7 +236,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   aerospike.namespace.transaction.count:
     enabled: true
     description: Number of transactions performed on the namespace
@@ -247,4 +247,4 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -67,7 +67,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   apache.current_connections:
     enabled: true
@@ -77,7 +77,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   apache.workers:
     enabled: true
@@ -87,7 +87,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [workers_state]
   apache.requests:
     enabled: true
@@ -97,7 +97,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   apache.traffic:
     enabled: true
@@ -106,7 +106,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   apache.cpu.time:
     enabled: true
@@ -116,7 +116,7 @@ metrics:
       value_type: double
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [cpu_level, cpu_mode]
   apache.cpu.load:
     enabled: true
@@ -158,7 +158,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   apache.scoreboard:
     enabled: true
@@ -171,5 +171,5 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [scoreboard_state]

--- a/receiver/apachesparkreceiver/metadata.yaml
+++ b/receiver/apachesparkreceiver/metadata.yaml
@@ -125,7 +125,7 @@ metrics:
     enabled: true
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     unit: "{ status }"
     attributes:
@@ -134,7 +134,7 @@ metrics:
     description: Number of active tasks in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: "{ task }"
@@ -143,7 +143,7 @@ metrics:
     description: Number of tasks with a specific result in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ task }"
@@ -153,7 +153,7 @@ metrics:
     description: Amount of time spent by the executor in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: ms
@@ -162,7 +162,7 @@ metrics:
     description: CPU time spent by the executor in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: ns
@@ -171,7 +171,7 @@ metrics:
     description: The amount of data transmitted back to the driver by all the tasks in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: bytes
@@ -180,7 +180,7 @@ metrics:
     description: The amount of time the JVM spent on garbage collection in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: ms
@@ -189,7 +189,7 @@ metrics:
     description: The amount of memory moved to disk due to size constraints (spilled) in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: bytes
@@ -198,7 +198,7 @@ metrics:
     description: The amount of disk space used for storing portions of overly large data chunks that couldn't fit in memory in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: bytes
@@ -207,7 +207,7 @@ metrics:
     description: Peak memory used by internal data structures created during shuffles, aggregations and joins in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: bytes
@@ -216,7 +216,7 @@ metrics:
     description: Amount of data written and read at this stage.
     enabled: true
     sum: 
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: bytes
@@ -226,7 +226,7 @@ metrics:
     description: Number of records written and read in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ record }"
@@ -236,7 +236,7 @@ metrics:
     description: Number of blocks fetched in shuffle operations in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ block }"
@@ -246,7 +246,7 @@ metrics:
     description: Time spent in this stage waiting for remote shuffle blocks.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: ms
@@ -255,7 +255,7 @@ metrics:
     description: Amount of data read to disk in shuffle operations (sometimes required for large blocks, as opposed to the default behavior of reading into memory).
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: bytes
@@ -264,7 +264,7 @@ metrics:
     description: Amount of data read in shuffle operations in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: bytes
@@ -274,7 +274,7 @@ metrics:
     description: Amount of data written in shuffle operations in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: bytes
@@ -284,7 +284,7 @@ metrics:
     description: Number of records written or read in shuffle operations in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ record }"
@@ -294,7 +294,7 @@ metrics:
     description: Time spent blocking on writes to disk or buffer cache in this stage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: ns
@@ -304,7 +304,7 @@ metrics:
     description: Storage memory used by this executor.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: bytes
@@ -313,7 +313,7 @@ metrics:
     description: Disk space used by this executor for RDD storage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: bytes
@@ -322,7 +322,7 @@ metrics:
     description: Maximum number of tasks that can run concurrently in this executor.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: "{ task }"
@@ -331,7 +331,7 @@ metrics:
     description: Number of tasks currently running in this executor.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: "{ task }"
@@ -340,7 +340,7 @@ metrics:
     description: Number of tasks with a specific result in this executor.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ task }"
@@ -349,7 +349,7 @@ metrics:
     description: Elapsed time the JVM spent executing tasks in this executor.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: ms
@@ -358,7 +358,7 @@ metrics:
     description: Elapsed time the JVM spent in garbage collection in this executor.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: ms
@@ -367,7 +367,7 @@ metrics:
     description: Amount of data input for this executor.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: bytes
@@ -376,7 +376,7 @@ metrics:
     description: Amount of data written and read during shuffle operations for this executor.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: bytes
@@ -385,7 +385,7 @@ metrics:
     description: The executor's storage memory usage.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: bytes
@@ -395,7 +395,7 @@ metrics:
     description: Number of active tasks in this job.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: "{ task }"
@@ -404,7 +404,7 @@ metrics:
     description: Number of tasks with a specific result in this job.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ task }"
@@ -413,7 +413,7 @@ metrics:
     description: Number of active stages in this job.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: "{ task }"
@@ -422,7 +422,7 @@ metrics:
     description: Number of stages with a specific result in this job.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ task }"
@@ -432,7 +432,7 @@ metrics:
     description: Disk space used by the BlockManager.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: mb
@@ -441,7 +441,7 @@ metrics:
     description: Memory usage for the driver's BlockManager.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: mb
@@ -450,7 +450,7 @@ metrics:
     description: Number of file cache hits on the HiveExternalCatalog.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ hit }"
@@ -459,7 +459,7 @@ metrics:
     description: Number of files discovered while listing the partitions of a table in the Hive metastore
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ file }"
@@ -468,7 +468,7 @@ metrics:
     description: Number of calls to the underlying Hive Metastore client made by the Spark application.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ call }"
@@ -477,7 +477,7 @@ metrics:
     description: Number of parallel listing jobs initiated by the HiveExternalCatalog when listing partitions of a table.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ listing_job }"
@@ -486,7 +486,7 @@ metrics:
     description: Table partitions fetched by the HiveExternalCatalog.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ partition }"
@@ -495,7 +495,7 @@ metrics:
     description: Number of source code compilation operations performed by the CodeGenerator.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ compilation }"
@@ -511,7 +511,7 @@ metrics:
     description: Number of classes generated by the CodeGenerator.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ class }"
@@ -527,7 +527,7 @@ metrics:
     description: Number of methods generated by the CodeGenerator.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ method }"
@@ -543,7 +543,7 @@ metrics:
     description: Number of source code generation operations performed by the CodeGenerator.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ operation }"
@@ -559,7 +559,7 @@ metrics:
     description: Number of active jobs currently being processed by the DAGScheduler.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: "{ job }"
@@ -568,7 +568,7 @@ metrics:
     description: Number of jobs that have been submitted to the DAGScheduler.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ job }"
@@ -577,7 +577,7 @@ metrics:
     description: Number of failed stages run by the DAGScheduler.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ stage }"
@@ -586,7 +586,7 @@ metrics:
     description: Number of stages the DAGScheduler is either running or needs to run.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: "{ stage }"
@@ -595,7 +595,7 @@ metrics:
     description: Number of events that have been posted on the LiveListenerBus.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ event }"
@@ -611,7 +611,7 @@ metrics:
     description: Number of events that have been dropped by the LiveListenerBus.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ event }"
@@ -620,7 +620,7 @@ metrics:
     description: Number of events currently waiting to be processed by the LiveListenerBus.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: "{ event }"
@@ -629,7 +629,7 @@ metrics:
     description: Current CPU time taken by the Spark driver.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: ns
@@ -638,7 +638,7 @@ metrics:
     description: Amount of memory used by the driver's JVM.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: bytes
@@ -647,7 +647,7 @@ metrics:
     description: Amount of execution memory currently used by the driver.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: bytes
@@ -656,7 +656,7 @@ metrics:
     description: Amount of storage memory currently used by the driver.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: bytes
@@ -665,7 +665,7 @@ metrics:
     description: Amount of pool memory currently used by the driver.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: bytes
@@ -674,7 +674,7 @@ metrics:
     description: Number of garbage collection operations performed by the driver.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{ gc_operation }"
@@ -683,7 +683,7 @@ metrics:
     description: Total elapsed time during garbage collection operations performed by the driver.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: ms

--- a/receiver/bigipreceiver/metadata.yaml
+++ b/receiver/bigipreceiver/metadata.yaml
@@ -74,7 +74,7 @@ metrics:
     unit: "By"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [direction]
     enabled: true
@@ -83,7 +83,7 @@ metrics:
     unit: "{connections}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   bigip.virtual_server.request.count:
@@ -91,7 +91,7 @@ metrics:
     unit: "{requests}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   bigip.virtual_server.packet.count:
@@ -99,7 +99,7 @@ metrics:
     unit: "{packets}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [direction]
     enabled: true
@@ -122,7 +122,7 @@ metrics:
     unit: "By"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [direction]
     enabled: true
@@ -131,7 +131,7 @@ metrics:
     unit: "{connections}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   bigip.pool.request.count:
@@ -139,7 +139,7 @@ metrics:
     unit: "{requests}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   bigip.pool.packet.count:
@@ -147,7 +147,7 @@ metrics:
     unit: "{packets}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [direction]
     enabled: true
@@ -156,7 +156,7 @@ metrics:
     unit: "{members}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [active.status]
     enabled: true
@@ -179,7 +179,7 @@ metrics:
     unit: "By"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [direction]
     enabled: true
@@ -188,7 +188,7 @@ metrics:
     unit: "{connections}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   bigip.pool_member.request.count:
@@ -196,7 +196,7 @@ metrics:
     unit: "{requests}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   bigip.pool_member.packet.count:
@@ -204,7 +204,7 @@ metrics:
     unit: "{packets}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [direction]
     enabled: true
@@ -213,7 +213,7 @@ metrics:
     unit: "{sessions}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   bigip.pool_member.availability:
@@ -235,7 +235,7 @@ metrics:
     unit: "By"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [direction]
     enabled: true
@@ -244,7 +244,7 @@ metrics:
     unit: "{connections}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   bigip.node.request.count:
@@ -252,7 +252,7 @@ metrics:
     unit: "{requests}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   bigip.node.packet.count:
@@ -260,7 +260,7 @@ metrics:
     unit: "{packets}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [direction]
     enabled: true
@@ -269,7 +269,7 @@ metrics:
     unit: "{sessions}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   bigip.node.availability:

--- a/receiver/couchdbreceiver/metadata.yaml
+++ b/receiver/couchdbreceiver/metadata.yaml
@@ -45,7 +45,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   couchdb.httpd.requests:
     enabled: true
     description: The number of HTTP requests by method.
@@ -53,7 +53,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [ http.method ]
   couchdb.httpd.responses:
     enabled: true
@@ -62,7 +62,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [ http.status_code ]
   couchdb.httpd.views:
     enabled: true
@@ -71,7 +71,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [ view ]
   couchdb.database.open:
     enabled: true
@@ -80,7 +80,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   couchdb.file_descriptor.open:
     enabled: true
     description: The number of open file descriptors.
@@ -88,7 +88,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   couchdb.database.operations:
     enabled: true
     description: The number of database operations.
@@ -96,5 +96,5 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [ operation ]

--- a/receiver/dockerstatsreceiver/metadata.yaml
+++ b/receiver/dockerstatsreceiver/metadata.yaml
@@ -68,7 +68,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   container.cpu.usage.total:
     enabled: true
     description: "Total CPU time consumed."
@@ -76,7 +76,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   container.cpu.usage.kernelmode:
     enabled: true
     description: >-
@@ -86,7 +86,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   container.cpu.usage.usermode:
     enabled: true
     description: >-
@@ -96,7 +96,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   container.cpu.usage.percpu:
     enabled: false
     description: "Per-core CPU usage by the container (Only available with cgroups v1)."
@@ -104,7 +104,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - core
   container.cpu.throttling_data.periods:
@@ -114,7 +114,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   container.cpu.throttling_data.throttled_periods:
     enabled: false
     description: "Number of periods when the container hits its throttling limit."
@@ -122,7 +122,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   container.cpu.throttling_data.throttled_time:
     enabled: false
     description: "Aggregate time the container was throttled."
@@ -130,7 +130,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   container.cpu.utilization:
     enabled: false
     description: "Percent of CPU used by the container."
@@ -156,7 +156,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.usage.total:
     enabled: true
@@ -164,7 +164,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.usage.max:
     enabled: false
@@ -172,7 +172,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.percent:
     enabled: true
@@ -186,7 +186,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.rss:
     enabled: false
@@ -194,7 +194,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.rss_huge:
     enabled: false
@@ -202,7 +202,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.dirty:
     enabled: false
@@ -210,7 +210,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.writeback:
     enabled: false
@@ -218,7 +218,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.mapped_file:
     enabled: false
@@ -226,7 +226,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.pgpgin:
     enabled: false
@@ -235,7 +235,7 @@ metrics:
     unit: "{operations}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
   container.memory.pgpgout:
     enabled: false
@@ -244,7 +244,7 @@ metrics:
     unit: "{operations}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
   container.memory.pgfault:
     enabled: false
@@ -252,7 +252,7 @@ metrics:
     unit: "{faults}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
   container.memory.pgmajfault:
     enabled: false
@@ -260,7 +260,7 @@ metrics:
     unit: "{faults}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
   container.memory.inactive_anon:
     enabled: false
@@ -268,7 +268,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.active_anon:
     enabled: false
@@ -276,7 +276,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.inactive_file:
     enabled: false
@@ -285,7 +285,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.active_file:
     enabled: false
@@ -294,7 +294,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.unevictable:
     enabled: false
@@ -302,7 +302,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.hierarchical_memory_limit:
     enabled: false
@@ -310,7 +310,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.hierarchical_memsw_limit:
     enabled: false
@@ -318,7 +318,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.total_cache:
     enabled: true
@@ -326,7 +326,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.total_rss:
     enabled: false
@@ -334,7 +334,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.total_rss_huge:
     enabled: false
@@ -342,7 +342,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.total_dirty:
     enabled: false
@@ -350,7 +350,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.total_writeback:
     enabled: false
@@ -358,7 +358,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.total_mapped_file:
     enabled: false
@@ -366,7 +366,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.total_pgpgin:
     enabled: false
@@ -374,7 +374,7 @@ metrics:
     unit: "{operations}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
   container.memory.total_pgpgout:
     enabled: false
@@ -382,7 +382,7 @@ metrics:
     unit: "{operations}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
   container.memory.total_pgfault:
     enabled: false
@@ -390,7 +390,7 @@ metrics:
     unit: "{faults}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
   container.memory.total_pgmajfault:
     enabled: false
@@ -398,7 +398,7 @@ metrics:
     unit: "{faults}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
   container.memory.total_inactive_anon:
     enabled: false
@@ -406,7 +406,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.total_active_anon:
     enabled: false
@@ -414,7 +414,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.total_inactive_file:
     enabled: false
@@ -423,7 +423,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.total_active_file:
     enabled: false
@@ -432,7 +432,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.total_unevictable:
     enabled: false
@@ -440,7 +440,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.anon:
     enabled: false
@@ -449,7 +449,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   container.memory.file:
     enabled: true
@@ -458,7 +458,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
 
 
@@ -471,7 +471,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - device_major
       - device_minor
@@ -484,7 +484,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - device_major
       - device_minor
@@ -500,7 +500,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - device_major
       - device_minor
@@ -513,7 +513,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - device_major
       - device_minor
@@ -526,7 +526,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - device_major
       - device_minor
@@ -539,7 +539,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - device_major
       - device_minor
@@ -552,7 +552,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - device_major
       - device_minor
@@ -565,7 +565,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - device_major
       - device_minor
@@ -579,7 +579,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - interface
   container.network.io.usage.tx_bytes:
@@ -589,7 +589,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - interface
   container.network.io.usage.rx_dropped:
@@ -599,7 +599,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - interface
   container.network.io.usage.tx_dropped:
@@ -609,7 +609,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - interface
   container.network.io.usage.rx_errors:
@@ -619,7 +619,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - interface
   container.network.io.usage.tx_errors:
@@ -629,7 +629,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - interface
   container.network.io.usage.rx_packets:
@@ -639,7 +639,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - interface
   container.network.io.usage.tx_packets:
@@ -649,7 +649,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes:
       - interface
 
@@ -661,7 +661,7 @@ metrics:
     unit: "{pids}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
 
   container.pids.limit:
@@ -671,7 +671,7 @@ metrics:
     unit: "{pids}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
 
   # Base

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -203,7 +203,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [circuit_breaker_name]
     enabled: true
@@ -212,7 +212,7 @@ metrics:
     unit: 1
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [circuit_breaker_name]
     enabled: true
@@ -221,7 +221,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [cache_name]
     enabled: true
@@ -230,7 +230,7 @@ metrics:
     unit: "{evictions}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [cache_name]
     enabled: true
@@ -239,7 +239,7 @@ metrics:
     unit: "{count}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ query_cache_count_type ]
     enabled: true
@@ -248,7 +248,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: false
@@ -257,7 +257,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: []
     enabled: true
@@ -266,7 +266,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: []
     enabled: true
@@ -275,7 +275,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: []
     enabled: true
@@ -289,7 +289,7 @@ metrics:
     unit: KiBy
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -303,7 +303,7 @@ metrics:
     unit: KiBy
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -312,7 +312,7 @@ metrics:
     unit: By
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [direction]
     enabled: true
@@ -321,7 +321,7 @@ metrics:
     unit: "{connections}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: []
     enabled: true
@@ -330,7 +330,7 @@ metrics:
     unit: "{connections}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: []
     enabled: true
@@ -346,7 +346,7 @@ metrics:
     unit: "{operations}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [operation]
     enabled: true
@@ -355,7 +355,7 @@ metrics:
     unit: ms
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [operation]
     enabled: true
@@ -364,7 +364,7 @@ metrics:
     unit: "{operations}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [get_result]
     enabled: false
@@ -373,7 +373,7 @@ metrics:
     unit: ms
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [get_result]
     enabled: false
@@ -382,7 +382,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: []
     enabled: true
@@ -391,7 +391,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -400,7 +400,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -409,7 +409,7 @@ metrics:
     unit: "{operations}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -418,7 +418,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -427,7 +427,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -436,7 +436,7 @@ metrics:
     unit: "{threads}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [thread_pool_name, thread_state]
     enabled: true
@@ -445,7 +445,7 @@ metrics:
     unit: "{tasks}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [thread_pool_name]
     enabled: true
@@ -454,7 +454,7 @@ metrics:
     unit: "{tasks}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [thread_pool_name, task_state]
     enabled: true
@@ -463,7 +463,7 @@ metrics:
     unit: "{documents}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [document_state]
     enabled: true
@@ -472,7 +472,7 @@ metrics:
     unit: "{files}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: []
     enabled: true
@@ -490,7 +490,7 @@ metrics:
     unit: 1
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [collector_name]
     enabled: true
@@ -499,7 +499,7 @@ metrics:
     unit: ms
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [collector_name]
     enabled: true
@@ -572,7 +572,7 @@ metrics:
     unit: "{tasks}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -581,7 +581,7 @@ metrics:
     unit: "{fetches}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -591,7 +591,7 @@ metrics:
     unit: "{shards}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [shard_state]
     enabled: true
@@ -600,7 +600,7 @@ metrics:
     unit: "{nodes}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: []
     enabled: true
@@ -609,7 +609,7 @@ metrics:
     unit: "{nodes}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: []
     enabled: true
@@ -623,7 +623,7 @@ metrics:
     unit: "{status}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [health_status]
     enabled: true
@@ -667,7 +667,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [  indexing_pressure_stage ]
     enabled: true
@@ -676,7 +676,7 @@ metrics:
     unit: 1
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -685,7 +685,7 @@ metrics:
     unit: 1
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -701,7 +701,7 @@ metrics:
     unit: 1
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ cluster_state_queue_state ]
     enabled: true
@@ -710,7 +710,7 @@ metrics:
     unit: 1
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -719,7 +719,7 @@ metrics:
     unit: 1
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ cluster_published_difference_state ]
     enabled: true
@@ -728,7 +728,7 @@ metrics:
     unit: 1
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ cluster_state_update_state ]
     enabled: true
@@ -737,7 +737,7 @@ metrics:
     unit: ms
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ cluster_state_update_state, cluster_state_update_type ]
     enabled: true
@@ -746,7 +746,7 @@ metrics:
     unit: "{evictions}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [cache_name]
     enabled: false
@@ -755,7 +755,7 @@ metrics:
     unit: "{documents}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -764,7 +764,7 @@ metrics:
     unit: "{documents}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -773,7 +773,7 @@ metrics:
     unit: "{operation}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -782,7 +782,7 @@ metrics:
     unit: "{documents}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ingest_pipeline_name ]
     enabled: true
@@ -791,7 +791,7 @@ metrics:
     unit: "{operation}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ingest_pipeline_name ]
     enabled: true
@@ -800,7 +800,7 @@ metrics:
     unit: "{documents}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ingest_pipeline_name ]
     enabled: true
@@ -809,7 +809,7 @@ metrics:
     unit: "{compilations}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -818,7 +818,7 @@ metrics:
     unit: 1
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -827,7 +827,7 @@ metrics:
     unit: 1
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: true
@@ -836,7 +836,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [segments_memory_object_type]
     enabled: false
@@ -846,7 +846,7 @@ metrics:
     unit: "{operations}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [operation, index_aggregation_type]
     enabled: true
@@ -855,7 +855,7 @@ metrics:
     unit: ms
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [operation, index_aggregation_type]
     enabled: true
@@ -864,7 +864,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [index_aggregation_type]
     enabled: true
@@ -873,7 +873,7 @@ metrics:
     unit: By
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [index_aggregation_type]
     enabled: false
@@ -882,7 +882,7 @@ metrics:
     unit: "{documents}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [index_aggregation_type]
     enabled: false
@@ -891,7 +891,7 @@ metrics:
     unit: "{segments}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [index_aggregation_type]
     enabled: false
@@ -900,7 +900,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [index_aggregation_type]
     enabled: false
@@ -909,7 +909,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [index_aggregation_type, segments_memory_object_type]
     enabled: false
@@ -918,7 +918,7 @@ metrics:
     unit: "{operations}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [index_aggregation_type]
     enabled: false
@@ -927,7 +927,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [index_aggregation_type]
     enabled: false
@@ -936,7 +936,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [cache_name, index_aggregation_type]
     enabled: false
@@ -945,7 +945,7 @@ metrics:
     unit: 1
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [index_aggregation_type]
     enabled: false
@@ -954,7 +954,7 @@ metrics:
     unit: "{evictions}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [cache_name, index_aggregation_type]
     enabled: false
@@ -963,7 +963,7 @@ metrics:
     unit: "{documents}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [document_state, index_aggregation_type]
     enabled: false
@@ -979,7 +979,7 @@ metrics:
     unit: ms
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: false
@@ -988,7 +988,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [ ]
     enabled: false

--- a/receiver/expvarreceiver/metadata.yaml
+++ b/receiver/expvarreceiver/metadata.yaml
@@ -17,7 +17,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.sys:
     enabled: true
@@ -27,7 +27,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.lookups:
     enabled: false
@@ -37,7 +37,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.mallocs:
     enabled: true
@@ -47,7 +47,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.frees:
     enabled: true
@@ -57,7 +57,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.heap_alloc:
     enabled: true
@@ -67,7 +67,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.heap_sys:
     enabled: true
@@ -77,7 +77,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.heap_idle:
     enabled: true
@@ -87,7 +87,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.heap_inuse:
     enabled: true
@@ -97,7 +97,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.heap_released:
     enabled: true
@@ -107,7 +107,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.heap_objects:
     enabled: true
@@ -117,7 +117,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.stack_inuse:
     enabled: true
@@ -127,7 +127,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.stack_sys:
     enabled: true
@@ -137,7 +137,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.mspan_inuse:
     enabled: true
@@ -147,7 +147,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.mspan_sys:
     enabled: true
@@ -157,7 +157,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.mcache_inuse:
     enabled: true
@@ -167,7 +167,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.mcache_sys:
     enabled: true
@@ -177,7 +177,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.buck_hash_sys:
     enabled: true
@@ -187,7 +187,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.gc_sys:
     enabled: true
@@ -197,7 +197,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.other_sys:
     enabled: true
@@ -207,7 +207,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.next_gc:
     enabled: true
@@ -217,7 +217,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.pause_total:
     enabled: true
@@ -227,7 +227,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.last_pause:
     enabled: true
@@ -245,7 +245,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.num_forced_gc:
     enabled: true
@@ -255,7 +255,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   process.runtime.memstats.gc_cpu_fraction:
     enabled: true

--- a/receiver/filestatsreceiver/metadata.yaml
+++ b/receiver/filestatsreceiver/metadata.yaml
@@ -30,7 +30,7 @@ metrics:
     enabled: true
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     unit: "s"
   file.ctime:
@@ -38,7 +38,7 @@ metrics:
     enabled: false
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     unit: "s"
     attributes:
@@ -48,7 +48,7 @@ metrics:
     enabled: false
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     unit: "s"
   file.size:

--- a/receiver/flinkmetricsreceiver/metadata.yaml
+++ b/receiver/flinkmetricsreceiver/metadata.yaml
@@ -70,7 +70,7 @@ metrics:
     unit: ns
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -80,7 +80,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -90,7 +90,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -100,7 +100,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -110,7 +110,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -120,7 +120,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -130,7 +130,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -140,7 +140,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -150,7 +150,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -160,7 +160,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -170,7 +170,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -180,7 +180,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -190,7 +190,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -200,7 +200,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -210,7 +210,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -220,7 +220,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -230,7 +230,7 @@ metrics:
     unit: "{threads}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -240,7 +240,7 @@ metrics:
     unit: "{collections}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [ garbage_collector_name ]
@@ -250,7 +250,7 @@ metrics:
     unit: ms
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [ garbage_collector_name ]
@@ -260,7 +260,7 @@ metrics:
     unit: "{classes}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -270,7 +270,7 @@ metrics:
     unit: "{restarts}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -288,7 +288,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -298,7 +298,7 @@ metrics:
     unit: "{checkpoints}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [ checkpoint ]
@@ -308,7 +308,7 @@ metrics:
     unit: "{checkpoints}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -318,7 +318,7 @@ metrics:
     unit: "{records}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [ record ]
@@ -328,7 +328,7 @@ metrics:
     unit: "{records}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [ operator_name, record ]
@@ -338,7 +338,7 @@ metrics:
     unit: ms
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [ operator_name ]

--- a/receiver/haproxyreceiver/metadata.yaml
+++ b/receiver/haproxyreceiver/metadata.yaml
@@ -76,7 +76,7 @@ metrics:
     description: Cumulative number of connections (frontend). Corresponds to HAProxy's `conn_tot` metric.
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -85,7 +85,7 @@ metrics:
     description: Number of times a server was selected, either for new sessions or when re-dispatching. Corresponds to HAProxy's `lbtot` metric.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -94,7 +94,7 @@ metrics:
     description: Bytes in. Corresponds to HAProxy's `bin` metric.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -103,7 +103,7 @@ metrics:
     description: Bytes out. Corresponds to HAProxy's `bout` metric.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -112,7 +112,7 @@ metrics:
     description: Number of data transfers aborted by the client. Corresponds to HAProxy's `cli_abrt` metric
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -121,7 +121,7 @@ metrics:
     description: Number of bytes that bypassed the HTTP compressor (CPU/BW limit). Corresponds to HAProxy's `comp_byp` metric.
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -130,7 +130,7 @@ metrics:
     description: Number of HTTP response bytes fed to the compressor. Corresponds to HAProxy's `comp_in` metric.
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -139,7 +139,7 @@ metrics:
     description: Number of HTTP response bytes emitted by the compressor. Corresponds to HAProxy's `comp_out` metric.
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -148,7 +148,7 @@ metrics:
     description: Number of HTTP responses that were compressed. Corresponds to HAProxy's `comp_rsp` metric.
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -157,7 +157,7 @@ metrics:
     description: Requests denied because of security concerns. Corresponds to HAProxy's `dreq` metric
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -166,7 +166,7 @@ metrics:
     description: Responses denied because of security concerns. Corresponds to HAProxy's `dresp` metric
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -175,7 +175,7 @@ metrics:
     description:  Total downtime (in seconds). The value for the backend is the downtime for the whole backend, not the sum of the server downtime. Corresponds to HAProxy's `downtime` metric
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -184,7 +184,7 @@ metrics:
     description: Number of requests that encountered an error trying to connect to a backend server. The backend stat is the sum of the stat. Corresponds to HAProxy's `econ` metric
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -193,7 +193,7 @@ metrics:
     description: Cumulative number of request errors. Corresponds to HAProxy's `ereq` metric.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -202,7 +202,7 @@ metrics:
     description: Cumulative number of response errors. Corresponds to HAProxy's `eresp` metric, `srv_abrt` will be counted here also.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{errors}"
@@ -210,7 +210,7 @@ metrics:
     description: Number of failed checks. (Only counts checks failed when the server is up). Corresponds to HAProxy's `chkfail` metric.
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -219,7 +219,7 @@ metrics:
     description: Number of times a request was redispatched to another server. Corresponds to HAProxy's `wredis` metric.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -228,7 +228,7 @@ metrics:
     description: Total number of HTTP requests received. Corresponds to HAProxy's `req_tot`, `hrsp_1xx`, `hrsp_2xx`, `hrsp_3xx`, `hrsp_4xx`, `hrsp_5xx` and `hrsp_other` metrics.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -239,7 +239,7 @@ metrics:
     description: Number of times a connection to a server was retried. Corresponds to HAProxy's `wretr` metric.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -248,7 +248,7 @@ metrics:
     description: Cumulative number of sessions. Corresponds to HAProxy's `stot` metric.
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -257,7 +257,7 @@ metrics:
     description: Current queued requests. For the backend this reports the number queued without a server assigned. Corresponds to HAProxy's `qcur` metric.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -21,7 +21,7 @@ metrics:
     unit: s
     sum:
       value_type: double
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [cpu, state]
 
@@ -40,7 +40,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   system.cpu.logical.count:
     enabled: false
@@ -49,4 +49,4 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
@@ -21,7 +21,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [device, direction]
   system.disk.operations:
@@ -30,7 +30,7 @@ metrics:
     unit: "{operations}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [device, direction]
 
@@ -40,7 +40,7 @@ metrics:
     unit: s
     sum:
       value_type: double
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [device]
   system.disk.operation_time:
@@ -49,7 +49,7 @@ metrics:
     unit: s
     sum:
       value_type: double
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [device, direction]
   system.disk.weighted_io_time:
@@ -58,7 +58,7 @@ metrics:
     unit: s
     sum:
       value_type: double
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [device]
 
@@ -68,7 +68,7 @@ metrics:
     unit: "{operations}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: [device]
   system.disk.merged:
@@ -77,6 +77,6 @@ metrics:
     unit: "{operations}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [device, direction]

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
@@ -33,7 +33,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: [device, mode, mountpoint, type, state]
 
@@ -43,7 +43,7 @@ metrics:
     unit: "{inodes}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: [device, mode, mountpoint, type, state]
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -17,7 +17,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: [state]
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -27,7 +27,7 @@ metrics:
     unit: "{packets}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [device, direction]
   system.network.dropped:
@@ -36,7 +36,7 @@ metrics:
     unit: "{packets}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [device, direction]
   system.network.errors:
@@ -45,7 +45,7 @@ metrics:
     unit: "{errors}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [device, direction]
   system.network.io:
@@ -54,7 +54,7 @@ metrics:
     unit: "By"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [device, direction]
   system.network.connections:
@@ -63,7 +63,7 @@ metrics:
     unit: "{connections}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: [protocol, state]
   system.network.conntrack.count:
@@ -72,7 +72,7 @@ metrics:
     unit: "{entries}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   system.network.conntrack.max:
     enabled: false
@@ -80,5 +80,5 @@ metrics:
     unit: "{entries}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
@@ -31,7 +31,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: [device, state]
 
@@ -41,7 +41,7 @@ metrics:
     unit: "{operations}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [direction, type]
 
@@ -51,7 +51,7 @@ metrics:
     unit: "{faults}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [type]
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
@@ -17,7 +17,7 @@ metrics:
     unit: "{processes}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
 
   system.processes.count:
@@ -26,6 +26,6 @@ metrics:
     unit: "{processes}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: [status]

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -77,7 +77,7 @@ metrics:
     unit: s
     sum:
       value_type: double
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [state]
 
@@ -98,7 +98,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
 
   process.memory.virtual:
@@ -107,7 +107,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
 
   process.memory.utilization:
@@ -123,7 +123,7 @@ metrics:
     unit: By
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [direction]
 
@@ -134,7 +134,7 @@ metrics:
     unit: "{faults}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [paging_fault_type]
 
@@ -145,7 +145,7 @@ metrics:
     unit: "{signals}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
 
   process.threads:
@@ -154,7 +154,7 @@ metrics:
     unit: "{threads}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
 
   process.open_file_descriptors:
@@ -164,7 +164,7 @@ metrics:
     unit: '{count}'
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
 
   process.handles:
@@ -174,7 +174,7 @@ metrics:
     unit: '{count}'
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
   
   process.context_switches:
@@ -184,7 +184,7 @@ metrics:
     unit: '{count}'
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [context_switch_type]
 
@@ -194,6 +194,6 @@ metrics:
     unit: "{operations}"
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [direction]

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -34,7 +34,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     unit: 1
     attributes: [http.url, http.status_code, http.method, http.status_class]
@@ -50,7 +50,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     unit: "{error}"
     attributes: [http.url, error.message]

--- a/receiver/iisreceiver/metadata.yaml
+++ b/receiver/iisreceiver/metadata.yaml
@@ -43,7 +43,7 @@ metrics:
     unit: "{requests}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
     attributes: [ request ]
@@ -52,7 +52,7 @@ metrics:
     unit: "{requests}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   iis.request.queue.count:
@@ -60,7 +60,7 @@ metrics:
     unit: "{requests}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   iis.request.queue.age.max:
@@ -74,7 +74,7 @@ metrics:
     unit: "{files}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
     attributes: [ direction ]
@@ -83,7 +83,7 @@ metrics:
     unit: By
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   iis.network.io:
@@ -91,7 +91,7 @@ metrics:
     unit: By
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
     attributes: [ direction ]
@@ -100,7 +100,7 @@ metrics:
     unit: "{attempts}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   iis.connection.active:
@@ -108,7 +108,7 @@ metrics:
     unit: "{connections}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   iis.connection.anonymous:
@@ -116,7 +116,7 @@ metrics:
     unit: "{connections}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   iis.thread.active:
@@ -124,7 +124,7 @@ metrics:
     unit: "{threads}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   iis.uptime:

--- a/receiver/kafkametricsreceiver/metadata.yaml
+++ b/receiver/kafkametricsreceiver/metadata.yaml
@@ -28,7 +28,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   #  topics scraper
   kafka.topic.partitions:
     enabled: true
@@ -37,7 +37,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [topic]
   kafka.partition.current_offset:
     enabled: true
@@ -60,7 +60,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [topic, partition]
   kafka.partition.replicas_in_sync:
     enabled: true
@@ -69,7 +69,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [topic, partition]
   #  consumers scraper
   kafka.consumer_group.members:
@@ -79,7 +79,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [group]
   kafka.consumer_group.offset:
     enabled: true

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -95,7 +95,7 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   k8s.node.memory.available:
     enabled: true
@@ -167,7 +167,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: ["interface", "direction"]
   k8s.node.network.errors:
     enabled: true
@@ -176,7 +176,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: ["interface", "direction"]
   k8s.pod.cpu.utilization:
     enabled: true
@@ -192,7 +192,7 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [ ]
   k8s.pod.memory.available:
     enabled: true
@@ -264,7 +264,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: ["interface", "direction"]
   k8s.pod.network.errors:
     enabled: true
@@ -273,7 +273,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: ["interface", "direction"]
   container.cpu.utilization:
     enabled: true
@@ -289,7 +289,7 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [ ]
   container.memory.available:
     enabled: true

--- a/receiver/memcachedreceiver/metadata.yaml
+++ b/receiver/memcachedreceiver/metadata.yaml
@@ -58,7 +58,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   memcached.connections.total:
     enabled: true
@@ -67,7 +67,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   memcached.commands:
     enabled: true
@@ -76,7 +76,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [command]
   memcached.current_items:
     enabled: true
@@ -85,7 +85,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   memcached.evictions:
     enabled: true
@@ -94,7 +94,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   memcached.network:
     enabled: true
@@ -103,7 +103,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [direction]
   memcached.operations:
     enabled: true
@@ -112,7 +112,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [type,operation]
   memcached.operation_hit_ratio:
     enabled: true
@@ -128,7 +128,7 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [state]
   memcached.threads:
     enabled: true
@@ -137,5 +137,5 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -258,7 +258,7 @@ metrics:
     sum:
       value_type: double
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   mongodbatlas.process.connections:
     enabled: true
     description: Number of current connections
@@ -267,7 +267,7 @@ metrics:
     sum:
       value_type: double
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   mongodbatlas.process.cpu.usage.max:
     enabled: true
     description: CPU Usage (%)
@@ -424,7 +424,7 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   mongodbatlas.process.oplog.time:
     enabled: true
     description: Execution time by operation
@@ -457,7 +457,7 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   mongodbatlas.process.page_faults:
     enabled: true
     description: Page faults
@@ -696,7 +696,7 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   mongodbatlas.system.fts.disk.used:
     enabled: true
     description: Full text search disk usage

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -87,7 +87,7 @@ metrics:
     unit: "{operations}"
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: true
     attributes: [type]
@@ -96,7 +96,7 @@ metrics:
     unit: "{collections}"
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: false
     attributes: [database]
@@ -105,7 +105,7 @@ metrics:
     unit: By
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: false
     attributes: [database]
@@ -115,7 +115,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: [database, connection_type]
   mongodb.extent.count:
@@ -123,7 +123,7 @@ metrics:
     unit: "{extents}"
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: false
     attributes: [database]
@@ -132,7 +132,7 @@ metrics:
     unit: ms
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: true
     attributes: []
@@ -141,7 +141,7 @@ metrics:
     unit: "{indexes}"
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: false
     attributes: [database]
@@ -150,7 +150,7 @@ metrics:
     unit: By
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: false
     attributes: [database]
@@ -159,7 +159,7 @@ metrics:
     unit: By
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: false
     attributes: [database, memory_type]
@@ -168,7 +168,7 @@ metrics:
     unit: "{objects}"
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: false
     attributes: [database]
@@ -184,7 +184,7 @@ metrics:
     unit: "{operations}"
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: true
     attributes: [operation]
@@ -193,7 +193,7 @@ metrics:
     unit: "{operations}"
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: true
     attributes: [ operation ]
@@ -203,7 +203,7 @@ metrics:
     unit: By
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       monotonic: true
     attributes: [database]
@@ -213,7 +213,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: []
   mongodb.index.access.count:
@@ -222,7 +222,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: [database, collection]
   mongodb.document.operation.count:
@@ -231,7 +231,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: [database, operation]
   mongodb.network.io.receive:
@@ -240,7 +240,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: []
   mongodb.network.io.transmit:
@@ -249,7 +249,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: []
   mongodb.network.request.count:
@@ -258,7 +258,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: []
   mongodb.operation.time:
@@ -267,7 +267,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [operation]
   mongodb.session.count:
@@ -276,7 +276,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: []
   mongodb.cursor.count:
@@ -285,7 +285,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: []
   mongodb.cursor.timeout.count:
@@ -294,7 +294,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     attributes: []
   mongodb.lock.acquire.count:
@@ -303,7 +303,7 @@ metrics:
     enabled: false
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [database, lock_type, lock_mode]
   mongodb.lock.acquire.wait_count:
@@ -312,7 +312,7 @@ metrics:
     enabled: false
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [database, lock_type, lock_mode]
   mongodb.lock.acquire.time:
@@ -321,7 +321,7 @@ metrics:
     enabled: false
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [database, lock_type, lock_mode]
   mongodb.lock.deadlock.count:
@@ -330,7 +330,7 @@ metrics:
     enabled: false
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
     attributes: [database, lock_type, lock_mode]
   mongodb.health:
@@ -350,5 +350,5 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [ ]

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -176,7 +176,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [buffer_pool_pages]
   mysql.buffer_pool.data_pages:
     enabled: true
@@ -185,7 +185,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [buffer_pool_data]
   mysql.buffer_pool.page_flushes:
     enabled: true
@@ -195,7 +195,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   mysql.buffer_pool.operations:
     enabled: true
     description: The number of operations on the InnoDB buffer pool.
@@ -204,7 +204,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [buffer_pool_operations]
   mysql.buffer_pool.limit:
     enabled: true
@@ -214,7 +214,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   mysql.buffer_pool.usage:
     enabled: true
     description: The number of bytes in the InnoDB buffer pool.
@@ -222,7 +222,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [buffer_pool_data]
   mysql.prepared_statements:
     enabled: true
@@ -232,7 +232,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [prepared_statements_command]
   mysql.commands:
     enabled: false
@@ -242,7 +242,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [command]
   mysql.handlers:
     enabled: true
@@ -252,7 +252,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [handler]
   mysql.double_writes:
     enabled: true
@@ -262,7 +262,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [double_writes]
   mysql.log_operations:
     enabled: true
@@ -272,7 +272,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [log_operations]
   mysql.operations:
     enabled: true
@@ -282,7 +282,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [operations]
   mysql.page_operations:
     enabled: true
@@ -292,7 +292,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [page_operations]
   mysql.table.io.wait.count:
     enabled: true
@@ -301,7 +301,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [io_waits_operations, table_name, schema]
   mysql.table.io.wait.time:
     enabled: true
@@ -310,7 +310,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [io_waits_operations, table_name, schema]
   mysql.index.io.wait.count:
     enabled: true
@@ -319,7 +319,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [io_waits_operations, table_name, schema, index_name]
   mysql.index.io.wait.time:
     enabled: true
@@ -328,7 +328,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [io_waits_operations, table_name, schema, index_name]
   mysql.row_locks:
     enabled: true
@@ -338,7 +338,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [row_locks]
   mysql.row_operations:
     enabled: true
@@ -348,7 +348,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [row_operations]
   mysql.locks:
     enabled: true
@@ -358,7 +358,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [locks]
   mysql.sorts:
     enabled: true
@@ -368,7 +368,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [sorts]
   mysql.threads:
     enabled: true
@@ -378,7 +378,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [threads]
   mysql.client.network.io:
     enabled: false
@@ -388,7 +388,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [direction]
   mysql.opened_resources:
     enabled: true
@@ -398,7 +398,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [opened_resources]
   mysql.uptime:
     enabled: true
@@ -408,7 +408,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   mysql.table.lock_wait.read.count:
     enabled: false
     description: The total table lock wait read events.
@@ -416,7 +416,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [schema, table_name, read_lock_type]
   mysql.table.lock_wait.read.time:
     enabled: false
@@ -425,7 +425,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [schema, table_name, read_lock_type]
   mysql.table.lock_wait.write.count:
     enabled: false
@@ -434,7 +434,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [schema, table_name, write_lock_type]
   mysql.table.lock_wait.write.time:
     enabled: false
@@ -443,7 +443,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [schema, table_name, write_lock_type]
   mysql.connection.count:
     enabled: false
@@ -453,7 +453,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   mysql.connection.errors:
     enabled: false
     description: Errors that occur during the client connection process.
@@ -462,7 +462,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [connection_error]
   mysql.mysqlx_connections:
     enabled: true
@@ -473,7 +473,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [connection_status]
   mysql.joins:
     enabled: false
@@ -483,7 +483,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [join_kind]
   mysql.tmp_resources:
     enabled: true
@@ -493,7 +493,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [tmp_resource]
   mysql.replica.time_behind_source:
     enabled: false
@@ -502,7 +502,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   mysql.replica.sql_delay:
     enabled: false
@@ -511,7 +511,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   mysql.statement_event.count:
     enabled: false
@@ -520,7 +520,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [schema, digest, digest_text, event_state]
   mysql.statement_event.wait.time:
     enabled: false
@@ -529,7 +529,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [schema, digest, digest_text]
   mysql.mysqlx_worker_threads:
     enabled: false
@@ -540,7 +540,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [mysqlx_threads]
   mysql.table_open_cache:
     enabled: false
@@ -550,7 +550,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [cache_status]
   mysql.query.client.count:
     enabled: false
@@ -560,7 +560,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   mysql.query.count:
     enabled: false
     description: The number of statements executed by the server.
@@ -569,7 +569,7 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   mysql.query.slow.count:
     enabled: false
     description: The number of slow queries.
@@ -578,4 +578,4 @@ metrics:
       value_type: int
       input_type: string
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative

--- a/receiver/nginxreceiver/metadata.yaml
+++ b/receiver/nginxreceiver/metadata.yaml
@@ -26,7 +26,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   nginx.connections_accepted:
     enabled: true
@@ -35,7 +35,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   nginx.connections_handled:
     enabled: true
@@ -44,7 +44,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   nginx.connections_current:
     enabled: true
@@ -53,7 +53,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [state]
 
 # Old version of metric, to be removed when featuregate is stable

--- a/receiver/nsxtreceiver/metadata.yaml
+++ b/receiver/nsxtreceiver/metadata.yaml
@@ -61,7 +61,7 @@ metrics:
     unit: "By"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
     attributes: [direction]
@@ -70,7 +70,7 @@ metrics:
     unit: "{packets}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
     attributes: [direction, packet.type]
@@ -93,7 +93,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     enabled: true
     attributes: [disk_state]
   nsxt.node.memory.usage:
@@ -102,7 +102,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     enabled: true
   nsxt.node.memory.cache.usage:
     description: The size of the node's memory cache.
@@ -110,5 +110,5 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     enabled: true

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -30,7 +30,7 @@ metrics:
     description: Cumulative CPU time, in seconds
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: double
     unit: s
@@ -39,7 +39,7 @@ metrics:
       sessions.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -50,7 +50,7 @@ metrics:
       are the only operations that perform exchanges.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -59,7 +59,7 @@ metrics:
     description: Total number of calls (user and recursive) that executed SQL statements
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -68,7 +68,7 @@ metrics:
     description: Number of logical reads
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -77,7 +77,7 @@ metrics:
     description: Number of hard parses
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -86,7 +86,7 @@ metrics:
     description: Total number of parse calls.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -95,7 +95,7 @@ metrics:
     description: Session PGA (Program Global Area) memory
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -104,7 +104,7 @@ metrics:
     description: Number of physical reads
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -115,7 +115,7 @@ metrics:
       to disk. Commits often represent the closest thing to a user transaction rate.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -125,7 +125,7 @@ metrics:
       error occurs during a user's transactions
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -238,7 +238,7 @@ metrics:
     description: Number of times a current block was requested from the buffer cache.
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string
@@ -247,7 +247,7 @@ metrics:
     description: Number of times a consistent read was requested for a block from the buffer cache.
     enabled: false
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
       input_type: string

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -87,7 +87,7 @@ metrics:
     description: Number of buffers allocated.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{buffers}"
@@ -97,7 +97,7 @@ metrics:
     description: Number of buffers written.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{buffers}"
@@ -107,7 +107,7 @@ metrics:
     description: The number of checkpoints performed.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{checkpoints}"
@@ -117,7 +117,7 @@ metrics:
     description: Total time spent writing and syncing files to disk by checkpoints.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: double
     unit: ms
@@ -125,7 +125,7 @@ metrics:
     description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: 1
@@ -136,7 +136,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [database, table, source]
   postgresql.commits:
     enabled: true
@@ -145,14 +145,14 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [database]
   postgresql.database.count:
     attributes: []
     description: Number of user databases.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: "{databases}"
@@ -163,7 +163,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [database]
   postgresql.backends:
     enabled: true
@@ -172,7 +172,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [database]
   postgresql.connection.max:
     enabled: true
@@ -187,14 +187,14 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [database, table, state]
   postgresql.index.scans:
     attributes: []
     description: The number of index scans on a table.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
     unit: "{scans}"
@@ -212,7 +212,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [database, table, operation]
   postgresql.replication.data_delay:
     attributes: [replication_client]
@@ -228,14 +228,14 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [database]
   postgresql.table.count:
     attributes: []
     description: Number of user tables in a database.
     enabled: true
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
     unit: "{table}"
@@ -245,7 +245,7 @@ metrics:
     enabled: true
     unit: By
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
       value_type: int
   postgresql.table.vacuum.count:
@@ -254,7 +254,7 @@ metrics:
     enabled: true
     unit: "{vacuums}"
     sum:
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: true
       value_type: int
   postgresql.wal.age:

--- a/receiver/rabbitmqreceiver/metadata.yaml
+++ b/receiver/rabbitmqreceiver/metadata.yaml
@@ -36,7 +36,7 @@ metrics:
     unit: "{consumers}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   rabbitmq.message.delivered:
@@ -44,7 +44,7 @@ metrics:
     unit: "{messages}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   rabbitmq.message.published:
@@ -52,7 +52,7 @@ metrics:
     unit: "{messages}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   rabbitmq.message.acknowledged:
@@ -60,7 +60,7 @@ metrics:
     unit: "{messages}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   rabbitmq.message.dropped:
@@ -68,7 +68,7 @@ metrics:
     unit: "{messages}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   rabbitmq.message.current:
@@ -76,7 +76,7 @@ metrics:
     unit: "{messages}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [message.state]
     enabled: true

--- a/receiver/redisreceiver/metadata.yaml
+++ b/receiver/redisreceiver/metadata.yaml
@@ -61,7 +61,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [role]
 
   redis.cmd.calls:
@@ -71,7 +71,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [cmd]
 
   redis.cmd.usec:
@@ -81,7 +81,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [cmd]
 
   redis.uptime:
@@ -91,7 +91,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.cpu.time:
     enabled: true
@@ -100,7 +100,7 @@ metrics:
     sum:
       value_type: double
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [state]
 
   redis.clients.connected:
@@ -110,7 +110,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.clients.max_input_buffer:
     enabled: true
@@ -133,7 +133,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.keys.expired:
     enabled: true
@@ -142,7 +142,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
 
   redis.keys.evicted:
@@ -152,7 +152,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.connections.received:
     enabled: true
@@ -161,7 +161,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.connections.rejected:
     enabled: true
@@ -170,7 +170,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.memory.used:
     enabled: true
@@ -214,7 +214,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.commands:
     enabled: true
@@ -230,7 +230,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.net.input:
     enabled: true
@@ -239,7 +239,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.net.output:
     enabled: true
@@ -248,7 +248,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.keyspace.hits:
     enabled: true
@@ -257,7 +257,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.keyspace.misses:
     enabled: true
@@ -266,7 +266,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.latest_fork:
     enabled: true
@@ -282,7 +282,7 @@ metrics:
     sum:
       value_type: int
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
 
   redis.replication.backlog_first_byte_offset:
     enabled: true

--- a/receiver/riakreceiver/metadata.yaml
+++ b/receiver/riakreceiver/metadata.yaml
@@ -35,7 +35,7 @@ metrics:
     unit: "{operation}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
     attributes: [request]
@@ -51,7 +51,7 @@ metrics:
     unit: "{read_repair}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   riak.memory.limit:
@@ -59,7 +59,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
   riak.vnode.operation.count:
@@ -67,7 +67,7 @@ metrics:
     unit: "{operation}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     enabled: true
     attributes: [request]
@@ -76,7 +76,7 @@ metrics:
     unit: "{operation}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
     attributes: [operation]
     enabled: true

--- a/receiver/saphanareceiver/metadata.yaml
+++ b/receiver/saphanareceiver/metadata.yaml
@@ -207,7 +207,7 @@ metrics:
     unit: '{connections}'
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [connection_status]
@@ -217,7 +217,7 @@ metrics:
     unit: ms
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [cpu_type]
@@ -227,7 +227,7 @@ metrics:
     unit: '{alerts}'
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [alert_rating]
@@ -237,7 +237,7 @@ metrics:
     unit: s
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [system, database]
@@ -247,7 +247,7 @@ metrics:
     unit: us
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [primary_host, secondary_host, port, replication_mode]
@@ -257,7 +257,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [primary_host, secondary_host, port, replication_mode]
@@ -283,7 +283,7 @@ metrics:
     unit: '{transactions}'
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [transaction_type]
@@ -293,7 +293,7 @@ metrics:
     unit: '{transactions}'
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -311,7 +311,7 @@ metrics:
     unit: '{licenses}'
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [system, product]
@@ -321,7 +321,7 @@ metrics:
     unit: '{licenses}'
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [system, product]
@@ -331,7 +331,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [memory_state_used_free]
@@ -341,7 +341,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -351,7 +351,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -361,7 +361,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: []
@@ -371,7 +371,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [memory_state_used_free]
@@ -381,7 +381,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [host_swap_state]
@@ -391,7 +391,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [column_memory_type, column_memory_subtype]
@@ -401,7 +401,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [row_memory_type]
@@ -411,7 +411,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [component]
@@ -421,7 +421,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [schema, schema_memory_type]
@@ -431,7 +431,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [schema]
@@ -441,7 +441,7 @@ metrics:
     unit: '{records}'
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [schema, schema_record_type]
@@ -451,7 +451,7 @@ metrics:
     unit: '{records}'
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [schema]
@@ -461,7 +461,7 @@ metrics:
     unit: '{operations}'
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [schema, schema_operation_type]
@@ -471,7 +471,7 @@ metrics:
     unit: '{services}'
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [service_status]
@@ -481,7 +481,7 @@ metrics:
     unit: '{threads}'
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [thread_status]
@@ -491,7 +491,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [service, service_memory_used_type]
@@ -501,7 +501,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [service]
@@ -511,7 +511,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [service]
@@ -521,7 +521,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [service, memory_state_used_free]
@@ -531,7 +531,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [service, memory_state_used_free]
@@ -541,7 +541,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [service]
@@ -551,7 +551,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [service]
@@ -561,7 +561,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [service]
@@ -571,7 +571,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [service]
@@ -581,7 +581,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [path, disk_usage_type, disk_state_used_free]
@@ -591,7 +591,7 @@ metrics:
     unit: '{operations}'
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [path, disk_usage_type, volume_operation_type]
@@ -601,7 +601,7 @@ metrics:
     unit: By
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [path, disk_usage_type, volume_operation_type]
@@ -611,7 +611,7 @@ metrics:
     unit: ms
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [path, disk_usage_type, volume_operation_type]
@@ -621,7 +621,7 @@ metrics:
     unit: '{requests}'
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [active_pending_request_state]
@@ -631,7 +631,7 @@ metrics:
     unit: '{requests}'
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
       input_type: string
     attributes: [internal_external_request_type]

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -109,7 +109,7 @@ metrics:
     unit: "{growths}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
   sqlserver.transaction_log.shrink.count:
     enabled: true
@@ -117,7 +117,7 @@ metrics:
     unit: "{shrinks}"
     sum:
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
   sqlserver.transaction_log.usage:
     enabled: true

--- a/receiver/sshcheckreceiver/metadata.yaml
+++ b/receiver/sshcheckreceiver/metadata.yaml
@@ -24,7 +24,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     unit: 1
   sshcheck.duration:
@@ -38,7 +38,7 @@ metrics:
     enabled: true
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     unit: "{error}"
     attributes: [error.message]
@@ -47,7 +47,7 @@ metrics:
     enabled: false
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     unit: 1
   sshcheck.sftp_duration:
@@ -61,7 +61,7 @@ metrics:
     enabled: false
     sum:
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       monotonic: false
     unit: "{error}"
     attributes: [error.message]

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -81,7 +81,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.cluster.cpu.effective:
     enabled: true
@@ -90,7 +90,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.cluster.memory.limit:
     enabled: true
@@ -99,7 +99,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.cluster.memory.effective:
     enabled: true
@@ -108,7 +108,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.cluster.memory.used:
     enabled: true
@@ -117,7 +117,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.cluster.vm.count:
     enabled: true
@@ -126,7 +126,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [vm_count_power_state]
   vcenter.cluster.host.count:
     enabled: true
@@ -135,7 +135,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [host_effective]
   vcenter.datastore.disk.usage:
     enabled: true
@@ -144,7 +144,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [disk_state]
   vcenter.datastore.disk.utilization:
     enabled: true
@@ -167,7 +167,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.host.disk.throughput:
     enabled: true
@@ -176,7 +176,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [disk_direction]
     extended_documentation: As measured over the most recent 20s interval. Aggregated disk I/O rate. Requires Performance Level 4.
   vcenter.host.disk.latency.avg:
@@ -209,7 +209,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.host.network.throughput:
     enabled: true
@@ -218,7 +218,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [throughput_direction]
     extended_documentation: As measured over the most recent 20s interval.
   vcenter.host.network.usage:
@@ -228,7 +228,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.host.network.packet.errors:
     enabled: true
@@ -237,7 +237,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [throughput_direction]
     extended_documentation: As measured over the most recent 20s interval.
   vcenter.host.network.packet.count:
@@ -247,7 +247,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [throughput_direction]
   vcenter.resource_pool.memory.usage:
     enabled: true
@@ -256,7 +256,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.resource_pool.memory.shares:
     enabled: true
@@ -265,7 +265,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.resource_pool.cpu.usage:
     enabled: true
@@ -274,7 +274,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.resource_pool.cpu.shares:
     enabled: true
@@ -283,7 +283,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.vm.memory.ballooned:
     enabled: true
@@ -292,7 +292,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.vm.memory.usage:
     enabled: true
@@ -301,7 +301,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.vm.memory.swapped:
     enabled: true
@@ -310,7 +310,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.vm.memory.swapped_ssd:
     enabled: true
@@ -319,7 +319,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.vm.disk.usage:
     enabled: true
@@ -328,7 +328,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [disk_state]
   vcenter.vm.disk.utilization:
     enabled: true
@@ -359,7 +359,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.vm.network.throughput:
     enabled: true
@@ -368,7 +368,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [throughput_direction]
     extended_documentation: As measured over the most recent 20s interval.
   vcenter.vm.network.packet.count:
@@ -378,7 +378,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: [throughput_direction]
   vcenter.vm.network.usage:
     enabled: true
@@ -387,7 +387,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
     extended_documentation: As measured over the most recent 20s interval.
   vcenter.vm.cpu.utilization:
@@ -404,7 +404,7 @@ metrics:
     sum:
       monotonic: false
       value_type: int
-      aggregation: cumulative
+      aggregation_temporality: cumulative
     attributes: []
   vcenter.vm.memory.utilization:
     enabled: false

--- a/receiver/zookeeperreceiver/metadata.yaml
+++ b/receiver/zookeeperreceiver/metadata.yaml
@@ -40,7 +40,7 @@ metrics:
     attributes: [state]
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
   zookeeper.sync.pending:
     enabled: true
@@ -48,7 +48,7 @@ metrics:
     unit: "{syncs}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
   zookeeper.latency.avg:
     enabled: true
@@ -74,7 +74,7 @@ metrics:
     unit: "{connections}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
   zookeeper.request.active:
     enabled: true
@@ -82,7 +82,7 @@ metrics:
     unit: "{requests}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
   zookeeper.znode.count:
     enabled: true
@@ -90,7 +90,7 @@ metrics:
     unit: "{znodes}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
   zookeeper.watch.count:
     enabled: true
@@ -98,7 +98,7 @@ metrics:
     unit: "{watches}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
   zookeeper.data_tree.ephemeral_node.count:
     enabled: true
@@ -106,7 +106,7 @@ metrics:
     unit: "{nodes}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
   zookeeper.data_tree.size:
     enabled: true
@@ -114,7 +114,7 @@ metrics:
     unit: By
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
   zookeeper.file_descriptor.open:
     enabled: true
@@ -122,7 +122,7 @@ metrics:
     unit: "{file_descriptors}"
     sum:
       monotonic: false
-      aggregation: cumulative
+      aggregation_temporality: cumulative
       value_type: int
   zookeeper.file_descriptor.limit:
     enabled: true
@@ -138,7 +138,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   zookeeper.fsync.exceeded_threshold.count:
     enabled: true
     description: Number of times fsync duration has exceeded warning threshold.
@@ -146,7 +146,7 @@ metrics:
     sum:
       value_type: int
       monotonic: true
-      aggregation: cumulative
+      aggregation_temporality: cumulative
   zookeeper.ruok:
     enabled: true
     description: Response from zookeeper ruok command


### PR DESCRIPTION
**Description:**
This is a breaking change to mdatagen. With this change we change the field `aggregation` to `aggregation_temporality` for sum metrics. This change helps pave the way to setting aggregation settings on metrics.

**Link to tracking Issue:**
open-telemetry/opentelemetry-collector#10726
