### PR TITLE
[SPIKE] detect golang breaking changes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -212,6 +212,10 @@ jobs:
         run: |
           make gengithub
           git diff -s --exit-code || (echo 'Generated code is out of date, please run "make gengithub" and commit the changes in this PR.' && exit 1)
+      - name: Gen API
+        run: |
+          make genbreakcheck
+          git diff -s --exit-code || (echo 'API changes detected.' && exit 1)
       - name: Check gendependabot
         run: |
           make -j2 gendependabot

--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,10 @@ mdatagen-test:
 gengithub:
 	$(GOCMD) run cmd/githubgen/main.go .
 
+.PHONY: genbreakcheck
+genbreakcheck:
+	$(GOCMD) run cmd/breakcheck/main.go .
+
 .PHONY: update-codeowners
 update-codeowners: gengithub generate
 

--- a/cmd/breakcheck/main.go
+++ b/cmd/breakcheck/main.go
@@ -1,0 +1,198 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func main() {
+	flag.Parse()
+	folder := flag.Arg(0)
+	if err := run(folder); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type function struct {
+	Name        string   `json:"name"`
+	Receiver    string   `json:"receiver"`
+	ReturnTypes []string `json:"return_types,omitempty"`
+	ParamTypes  []string `json:"param_types,omitempty"`
+}
+
+type api struct {
+	Values    []string    `json:"values,omitempty"`
+	Structs   []string    `json:"structs,omitempty"`
+	Functions []*function `json:"functions,omitempty"`
+}
+
+func run(folder string) error {
+	return filepath.Walk(folder, func(path string, info fs.FileInfo, err error) error {
+		if info.Name() == "go.mod" {
+			if err := walkFolder(filepath.Dir(path)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func walkFolder(folder string) error {
+	result := &api{}
+	set := token.NewFileSet()
+	packs, err := parser.ParseDir(set, folder, nil, 0)
+	if err != nil {
+		return err
+	}
+
+	for _, pack := range packs {
+		for _, f := range pack.Files {
+			for _, d := range f.Decls {
+				if str, isStr := d.(*ast.GenDecl); isStr {
+					for _, s := range str.Specs {
+						if values, ok := s.(*ast.ValueSpec); ok {
+							for _, v := range values.Names {
+								if v.IsExported() {
+									result.Values = append(result.Values, v.Name)
+								}
+							}
+						}
+						if t, ok := s.(*ast.TypeSpec); ok {
+							if t.Name.IsExported() {
+								result.Structs = append(result.Structs, t.Name.String())
+							}
+						}
+
+					}
+				}
+				if fn, isFn := d.(*ast.FuncDecl); isFn {
+					if !fn.Name.IsExported() {
+						continue
+					}
+					exported := false
+					receiver := ""
+					if fn.Recv.NumFields() == 0 && !strings.HasPrefix(fn.Name.String(), "Test") && !strings.HasPrefix(fn.Name.String(), "Benchmark") {
+						exported = true
+					}
+					if fn.Recv.NumFields() > 0 {
+
+						for _, t := range fn.Recv.List {
+							for _, n := range t.Names {
+								exported = exported || n.IsExported()
+								if n.IsExported() {
+									receiver = n.Name
+								}
+							}
+						}
+					}
+					if exported {
+						var returnTypes []string
+						if fn.Type.Results.NumFields() > 0 {
+							for _, r := range fn.Type.Results.List {
+								returnTypes = append(returnTypes, exprToString(r.Type))
+							}
+						}
+						var params []string
+						if fn.Type.Params.NumFields() > 0 {
+							for _, r := range fn.Type.Params.List {
+								params = append(params, exprToString(r.Type))
+							}
+						}
+						f := &function{
+							Name:        fn.Name.Name,
+							Receiver:    receiver,
+							ParamTypes:  params,
+							ReturnTypes: returnTypes,
+						}
+						result.Functions = append(result.Functions, f)
+					}
+				}
+			}
+		}
+	}
+	sort.Strings(result.Structs)
+	sort.Strings(result.Values)
+	sort.Slice(result.Functions, func(i int, j int) bool {
+		return strings.Compare(result.Functions[i].Name, result.Functions[j].Name) < 0
+	})
+	toStore, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	if len(toStore) == 2 {
+		return nil
+	}
+
+	return os.WriteFile(filepath.Join(folder, ".api"), toStore, 0600)
+}
+
+func exprToString(expr ast.Expr) string {
+	switch expr.(type) {
+	case *ast.MapType:
+		mapExpr := expr.(*ast.MapType)
+		return fmt.Sprintf("map[%s]%s", exprToString(mapExpr.Key), exprToString(mapExpr.Value))
+	case *ast.ArrayType:
+		arrayExpr := expr.(*ast.ArrayType)
+		return fmt.Sprintf("[%s]%s", exprToString(arrayExpr.Len), exprToString(arrayExpr.Elt))
+	case *ast.StructType:
+		structExpr := expr.(*ast.StructType)
+		var fields []string
+		for _, f := range structExpr.Fields.List {
+			fields = append(fields, exprToString(f.Type))
+		}
+		return fmt.Sprintf("{%s}", strings.Join(fields, ","))
+	case *ast.InterfaceType:
+		interfaceExpr := expr.(*ast.InterfaceType)
+		var methods []string
+		for _, f := range interfaceExpr.Methods.List {
+			methods = append(methods, "func "+exprToString(f.Type))
+		}
+		return fmt.Sprintf("{%s}", strings.Join(methods, ","))
+	case *ast.ChanType:
+		chanExpr := expr.(*ast.ChanType)
+		return fmt.Sprintf("chan(%s)", exprToString(chanExpr.Value))
+	case *ast.FuncType:
+		funcExpr := expr.(*ast.FuncType)
+		var results []string
+		for _, r := range funcExpr.Results.List {
+			results = append(results, exprToString(r.Type))
+		}
+		var params []string
+		for _, r := range funcExpr.Params.List {
+			params = append(params, exprToString(r.Type))
+		}
+		return fmt.Sprintf("func(%s) %s", strings.Join(params, ","), strings.Join(results, ","))
+	case *ast.SelectorExpr:
+		selectorExpr := expr.(*ast.SelectorExpr)
+		return fmt.Sprintf("%s.%s", exprToString(selectorExpr.X), selectorExpr.Sel.Name)
+	case *ast.Ident:
+		identExpr := expr.(*ast.Ident)
+		return identExpr.Name
+	case nil:
+		return ""
+	case *ast.StarExpr:
+		starExpr := expr.(*ast.StarExpr)
+		return fmt.Sprintf("*%s", exprToString(starExpr.X))
+	case *ast.Ellipsis:
+		ellipsis := expr.(*ast.Ellipsis)
+		return fmt.Sprintf("%s...", exprToString(ellipsis.Elt))
+	case *ast.IndexExpr:
+		indexExpr := expr.(*ast.IndexExpr)
+		return fmt.Sprintf("%s[%s]", exprToString(indexExpr.X), exprToString(indexExpr.Index))
+	case *ast.BasicLit:
+		basicLit := expr.(*ast.BasicLit)
+		return basicLit.Value
+	default:
+		panic(fmt.Sprintf("Unsupported expr type: %#v", expr))
+	}
+}

--- a/cmd/configschema/.api
+++ b/cmd/configschema/.api
@@ -1,0 +1,66 @@
+{
+  "values": [
+    "DefaultModule",
+    "DefaultSrcRoot"
+  ],
+  "structs": [
+    "CfgInfo",
+    "DirResolver",
+    "DirResolverIntf",
+    "Field"
+  ],
+  "functions": [
+    {
+      "name": "GetAllCfgInfos",
+      "receiver": "",
+      "return_types": [
+        "[]CfgInfo"
+      ],
+      "param_types": [
+        "otelcol.Factories"
+      ]
+    },
+    {
+      "name": "GetCfgInfo",
+      "receiver": "",
+      "return_types": [
+        "CfgInfo",
+        "error"
+      ],
+      "param_types": [
+        "otelcol.Factories",
+        "string"
+      ]
+    },
+    {
+      "name": "NewDefaultDirResolver",
+      "receiver": "",
+      "return_types": [
+        "DirResolver"
+      ]
+    },
+    {
+      "name": "NewDirResolver",
+      "receiver": "",
+      "return_types": [
+        "DirResolver"
+      ],
+      "param_types": [
+        "string",
+        "string"
+      ]
+    },
+    {
+      "name": "ReadFields",
+      "receiver": "",
+      "return_types": [
+        "*Field",
+        "error"
+      ],
+      "param_types": [
+        "reflect.Value",
+        "DirResolver"
+      ]
+    }
+  ]
+}

--- a/cmd/mdatagen/.api
+++ b/cmd/mdatagen/.api
@@ -1,0 +1,12 @@
+{
+  "structs": [
+    "Aggregated",
+    "Codeowners",
+    "MetricData",
+    "MetricInputType",
+    "MetricValueType",
+    "Mono",
+    "Status",
+    "ValueType"
+  ]
+}

--- a/cmd/telemetrygen/.api
+++ b/cmd/telemetrygen/.api
@@ -1,0 +1,8 @@
+{
+  "functions": [
+    {
+      "name": "Execute",
+      "receiver": ""
+    }
+  ]
+}

--- a/confmap/provider/s3provider/.api
+++ b/confmap/provider/s3provider/.api
@@ -1,0 +1,21 @@
+{
+  "functions": [
+    {
+      "name": "New",
+      "receiver": "",
+      "return_types": [
+        "confmap.Provider"
+      ]
+    },
+    {
+      "name": "NewTestProvider",
+      "receiver": "",
+      "return_types": [
+        "confmap.Provider"
+      ],
+      "param_types": [
+        "string"
+      ]
+    }
+  ]
+}

--- a/connector/countconnector/.api
+++ b/connector/countconnector/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "AttributeConfig",
+    "Config",
+    "MetricInfo"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "connector.Factory"
+      ]
+    }
+  ]
+}

--- a/connector/exceptionsconnector/.api
+++ b/connector/exceptionsconnector/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "Dimension"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "connector.Factory"
+      ]
+    }
+  ]
+}

--- a/connector/routingconnector/.api
+++ b/connector/routingconnector/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "RoutingTableItem"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "connector.Factory"
+      ]
+    }
+  ]
+}

--- a/connector/servicegraphconnector/.api
+++ b/connector/servicegraphconnector/.api
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "NewFactory"
+  ]
+}

--- a/connector/spanmetricsconnector/.api
+++ b/connector/spanmetricsconnector/.api
@@ -1,0 +1,22 @@
+{
+  "values": [
+    "DimensionsCacheSize"
+  ],
+  "structs": [
+    "Config",
+    "Dimension",
+    "ExemplarsConfig",
+    "ExplicitHistogramConfig",
+    "ExponentialHistogramConfig",
+    "HistogramConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "connector.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/alibabacloudlogserviceexporter/.api
+++ b/exporter/alibabacloudlogserviceexporter/.api
@@ -1,0 +1,29 @@
+{
+  "structs": [
+    "Config",
+    "KeyValue",
+    "KeyValues",
+    "LogServiceClient"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    },
+    {
+      "name": "NewLogServiceClient",
+      "receiver": "",
+      "return_types": [
+        "LogServiceClient",
+        "error"
+      ],
+      "param_types": [
+        "*Config",
+        "*zap.Logger"
+      ]
+    }
+  ]
+}

--- a/exporter/awscloudwatchlogsexporter/.api
+++ b/exporter/awscloudwatchlogsexporter/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "QueueSettings"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exp.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/awsemfexporter/.api
+++ b/exporter/awsemfexporter/.api
@@ -1,0 +1,17 @@
+{
+  "structs": [
+    "Config",
+    "LabelMatcher",
+    "MetricDeclaration",
+    "MetricDescriptor"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/awskinesisexporter/.api
+++ b/exporter/awskinesisexporter/.api
@@ -1,0 +1,67 @@
+{
+  "structs": [
+    "AWSConfig",
+    "Config",
+    "Encoding",
+    "Exporter"
+  ],
+  "functions": [
+    {
+      "name": "MustTestGeneric",
+      "receiver": "",
+      "return_types": [
+        "T"
+      ],
+      "param_types": [
+        "T",
+        "error"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    },
+    {
+      "name": "NewLogsExporter",
+      "receiver": "",
+      "return_types": [
+        "exporter.Logs",
+        "error"
+      ],
+      "param_types": [
+        "context.Context",
+        "exporter.CreateSettings",
+        "component.Config"
+      ]
+    },
+    {
+      "name": "NewMetricsExporter",
+      "receiver": "",
+      "return_types": [
+        "exporter.Metrics",
+        "error"
+      ],
+      "param_types": [
+        "context.Context",
+        "exporter.CreateSettings",
+        "component.Config"
+      ]
+    },
+    {
+      "name": "NewTracesExporter",
+      "receiver": "",
+      "return_types": [
+        "exporter.Traces",
+        "error"
+      ],
+      "param_types": [
+        "context.Context",
+        "exporter.CreateSettings",
+        "component.Config"
+      ]
+    }
+  ]
+}

--- a/exporter/awss3exporter/.api
+++ b/exporter/awss3exporter/.api
@@ -1,0 +1,33 @@
+{
+  "values": [
+    "ErrUnknownMarshaler",
+    "OtlpJSON"
+  ],
+  "structs": [
+    "Config",
+    "MarshalerType",
+    "S3UploaderConfig",
+    "TestWriter"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    },
+    {
+      "name": "NewMarshaler",
+      "receiver": "",
+      "return_types": [
+        "marshaler",
+        "error"
+      ],
+      "param_types": [
+        "MarshalerType",
+        "*zap.Logger"
+      ]
+    }
+  ]
+}

--- a/exporter/awsxrayexporter/.api
+++ b/exporter/awsxrayexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/azuredataexplorerexporter/.api
+++ b/exporter/azuredataexplorerexporter/.api
@@ -1,0 +1,19 @@
+{
+  "structs": [
+    "AdxLog",
+    "AdxMetric",
+    "AdxTrace",
+    "Config",
+    "Event",
+    "Link"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/azuremonitorexporter/.api
+++ b/exporter/azuremonitorexporter/.api
@@ -1,0 +1,29 @@
+{
+  "structs": [
+    "Config",
+    "DatabaseAttributes",
+    "ExceptionAttributes",
+    "HTTPAttributes",
+    "MessagingAttributes",
+    "NetworkAttributes",
+    "RPCAttributes",
+    "TraceVisitor"
+  ],
+  "functions": [
+    {
+      "name": "Accept",
+      "receiver": "",
+      "param_types": [
+        "ptrace.Traces",
+        "TraceVisitor"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/carbonexporter/.api
+++ b/exporter/carbonexporter/.api
@@ -1,0 +1,18 @@
+{
+  "values": [
+    "DefaultEndpoint",
+    "DefaultSendTimeout"
+  ],
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/cassandraexporter/.api
+++ b/exporter/cassandraexporter/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "Compression",
+    "Config",
+    "Replication"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/clickhouseexporter/.api
+++ b/exporter/clickhouseexporter/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "QueueSettings"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/coralogixexporter/.api
+++ b/exporter/coralogixexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exp.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/datadogexporter/.api
+++ b/exporter/datadogexporter/.api
@@ -1,0 +1,46 @@
+{
+  "values": [
+    "CumulativeMonotonicSumModeRawValue",
+    "CumulativeMonotonicSumModeToDelta",
+    "DefaultSite",
+    "HistogramModeCounters",
+    "HistogramModeDistributions",
+    "HistogramModeNoBuckets",
+    "HostnameSourceConfigOrSystem",
+    "HostnameSourceFirstResource",
+    "InitialValueModeAuto",
+    "InitialValueModeDrop",
+    "InitialValueModeKeep",
+    "SummaryModeGauges",
+    "SummaryModeNoQuantiles"
+  ],
+  "structs": [
+    "APIConfig",
+    "Config",
+    "CumulativeMonotonicSumMode",
+    "HistogramConfig",
+    "HistogramMode",
+    "HostMetadataConfig",
+    "HostnameSource",
+    "InitialValueMode",
+    "LimitedHTTPClientSettings",
+    "LimitedTLSClientSettings",
+    "LogsConfig",
+    "MetricsConfig",
+    "MetricsExporterConfig",
+    "SumConfig",
+    "SummaryConfig",
+    "SummaryMode",
+    "TagsConfig",
+    "TracesConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/datasetexporter/.api
+++ b/exporter/datasetexporter/.api
@@ -1,0 +1,34 @@
+{
+  "values": [
+    "Process",
+    "Service",
+    "ServiceNameKey"
+  ],
+  "structs": [
+    "BufferSettings",
+    "Config",
+    "CreateTest",
+    "DatasetExporter",
+    "ExporterConfig",
+    "LogsSettings",
+    "ResourceType",
+    "ServerHostSettings",
+    "TracesSettings"
+  ],
+  "functions": [
+    {
+      "name": "GenerateTracesTreesAndOrphans",
+      "receiver": "",
+      "return_types": [
+        "ptrace.Traces"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/dynatraceexporter/.api
+++ b/exporter/dynatraceexporter/.api
@@ -1,0 +1,11 @@
+{
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exp.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/elasticsearchexporter/.api
+++ b/exporter/elasticsearchexporter/.api
@@ -1,0 +1,36 @@
+{
+  "values": [
+    "MappingECS",
+    "MappingNone"
+  ],
+  "structs": [
+    "AuthenticationSettings",
+    "Config",
+    "DiscoverySettings",
+    "DynamicIndexSetting",
+    "FlushSettings",
+    "HTTPClientSettings",
+    "MappingMode",
+    "MappingsSettings",
+    "RetrySettings"
+  ],
+  "functions": [
+    {
+      "name": "DurationAsMicroseconds",
+      "receiver": "",
+      "return_types": [
+        "int64"
+      ],
+      "param_types": [
+        "time.Time"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/f5cloudexporter/.api
+++ b/exporter/f5cloudexporter/.api
@@ -1,0 +1,28 @@
+{
+  "structs": [
+    "AuthConfig",
+    "Config",
+    "ErrorRoundTripper",
+    "InvalidTokenSource",
+    "TokenSourceGetter"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    },
+    {
+      "name": "NewFactoryWithTokenSourceGetter",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ],
+      "param_types": [
+        "TokenSourceGetter"
+      ]
+    }
+  ]
+}

--- a/exporter/fileexporter/.api
+++ b/exporter/fileexporter/.api
@@ -1,0 +1,21 @@
+{
+  "values": [
+    "SizeByte",
+    "SizeKiloByte",
+    "SizeMegaByte"
+  ],
+  "structs": [
+    "Config",
+    "NopWriteCloser",
+    "Rotation"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/googlecloudexporter/.api
+++ b/exporter/googlecloudexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/googlecloudpubsubexporter/.api
+++ b/exporter/googlecloudpubsubexporter/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "Config",
+    "WatermarkBehavior",
+    "WatermarkConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/googlemanagedprometheusexporter/.api
+++ b/exporter/googlemanagedprometheusexporter/.api
@@ -1,0 +1,17 @@
+{
+  "structs": [
+    "Config",
+    "ExtraMetricsConfig",
+    "GMPConfig",
+    "MetricConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/influxdbexporter/.api
+++ b/exporter/influxdbexporter/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "V1Compatibility"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/instanaexporter/.api
+++ b/exporter/instanaexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/jaegerexporter/.api
+++ b/exporter/jaegerexporter/.api
@@ -1,0 +1,21 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "MetricViews",
+      "receiver": "",
+      "return_types": [
+        "[]*view.View"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/jaegerthrifthttpexporter/.api
+++ b/exporter/jaegerthrifthttpexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/kafkaexporter/.api
+++ b/exporter/kafkaexporter/.api
@@ -1,0 +1,71 @@
+{
+  "structs": [
+    "AWSMSKConfig",
+    "Authentication",
+    "Config",
+    "FactoryOption",
+    "KerberosConfig",
+    "LogsMarshaler",
+    "Metadata",
+    "MetadataRetry",
+    "MetricsMarshaler",
+    "PlainTextConfig",
+    "Producer",
+    "SASLConfig",
+    "TracesMarshaler",
+    "XDGSCRAMClient"
+  ],
+  "functions": [
+    {
+      "name": "ConfigureAuthentication",
+      "receiver": "",
+      "return_types": [
+        "error"
+      ],
+      "param_types": [
+        "Authentication",
+        "*sarama.Config"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ],
+      "param_types": [
+        "FactoryOption..."
+      ]
+    },
+    {
+      "name": "WithLogsMarshalers",
+      "receiver": "",
+      "return_types": [
+        "FactoryOption"
+      ],
+      "param_types": [
+        "LogsMarshaler..."
+      ]
+    },
+    {
+      "name": "WithMetricsMarshalers",
+      "receiver": "",
+      "return_types": [
+        "FactoryOption"
+      ],
+      "param_types": [
+        "MetricsMarshaler..."
+      ]
+    },
+    {
+      "name": "WithTracesMarshalers",
+      "receiver": "",
+      "return_types": [
+        "FactoryOption"
+      ],
+      "param_types": [
+        "TracesMarshaler..."
+      ]
+    }
+  ]
+}

--- a/exporter/loadbalancingexporter/.api
+++ b/exporter/loadbalancingexporter/.api
@@ -1,0 +1,26 @@
+{
+  "structs": [
+    "Config",
+    "DNSResolver",
+    "K8sSvcResolver",
+    "Protocol",
+    "ResolverSettings",
+    "StaticResolver"
+  ],
+  "functions": [
+    {
+      "name": "MetricViews",
+      "receiver": "",
+      "return_types": [
+        "[]*view.View"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/logicmonitorexporter/.api
+++ b/exporter/logicmonitorexporter/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "APIToken",
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/logzioexporter/.api
+++ b/exporter/logzioexporter/.api
@@ -1,0 +1,33 @@
+{
+  "values": [
+    "TestLogTime",
+    "TestLogTimeUnixMilli",
+    "TestLogTimestamp"
+  ],
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "GenerateLogRecordWithMultiTypeValues",
+      "receiver": "",
+      "return_types": [
+        "plog.LogRecord"
+      ]
+    },
+    {
+      "name": "GenerateLogRecordWithNestedBody",
+      "receiver": "",
+      "return_types": [
+        "plog.LogRecord"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/lokiexporter/.api
+++ b/exporter/lokiexporter/.api
@@ -1,0 +1,21 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "MetricViews",
+      "receiver": "",
+      "return_types": [
+        "[]*view.View"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/mezmoexporter/.api
+++ b/exporter/mezmoexporter/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "Config",
+    "MezmoLogBody",
+    "MezmoLogLine"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/opencensusexporter/.api
+++ b/exporter/opencensusexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/opensearchexporter/.api
+++ b/exporter/opensearchexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/parquetexporter/.api
+++ b/exporter/parquetexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/prometheusexporter/.api
+++ b/exporter/prometheusexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/prometheusremotewriteexporter/.api
+++ b/exporter/prometheusremotewriteexporter/.api
@@ -1,0 +1,18 @@
+{
+  "structs": [
+    "Config",
+    "CreatedMetric",
+    "RemoteWriteQueue",
+    "TargetInfo",
+    "WALConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/pulsarexporter/.api
+++ b/exporter/pulsarexporter/.api
@@ -1,0 +1,57 @@
+{
+  "values": [
+    "Better",
+    "Default",
+    "DefaultBatchBuilder",
+    "Faster",
+    "JavaStringHash",
+    "KeyBasedBatchBuilder",
+    "LZ4",
+    "Murmur3_32Hash",
+    "None",
+    "ZLib",
+    "ZStd"
+  ],
+  "structs": [
+    "Athenz",
+    "Authentication",
+    "BatchBuilderType",
+    "CompressionLevel",
+    "CompressionType",
+    "Config",
+    "FactoryOption",
+    "HashingScheme",
+    "LogsMarshaler",
+    "MetricsMarshaler",
+    "OAuth2",
+    "Producer",
+    "PulsarLogsProducer",
+    "PulsarMetricsProducer",
+    "PulsarTracesProducer",
+    "TLS",
+    "Token",
+    "TracesMarshaler"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ],
+      "param_types": [
+        "FactoryOption..."
+      ]
+    },
+    {
+      "name": "WithTracesMarshalers",
+      "receiver": "",
+      "return_types": [
+        "FactoryOption"
+      ],
+      "param_types": [
+        "TracesMarshaler..."
+      ]
+    }
+  ]
+}

--- a/exporter/sapmexporter/.api
+++ b/exporter/sapmexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/sentryexporter/.api
+++ b/exporter/sentryexporter/.api
@@ -1,0 +1,53 @@
+{
+  "structs": [
+    "ClassifyOrphanSpanTestCase",
+    "Config",
+    "PushTraceDataTestCase",
+    "SentryExporter",
+    "SpanDescriptorsCase",
+    "SpanEventToSentryEventCases",
+    "SpanStatusCase",
+    "TransactionFromSpanMarshalEventTestCase"
+  ],
+  "functions": [
+    {
+      "name": "CreateSentryExporter",
+      "receiver": "",
+      "return_types": [
+        "exporter.Traces",
+        "error"
+      ],
+      "param_types": [
+        "*Config",
+        "exporter.CreateSettings"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    },
+    {
+      "name": "SpanIDFromHex",
+      "receiver": "",
+      "return_types": [
+        "sentry.SpanID"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "TraceIDFromHex",
+      "receiver": "",
+      "return_types": [
+        "sentry.TraceID"
+      ],
+      "param_types": [
+        "string"
+      ]
+    }
+  ]
+}

--- a/exporter/signalfxexporter/.api
+++ b/exporter/signalfxexporter/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "DimensionClientConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/skywalkingexporter/.api
+++ b/exporter/skywalkingexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/splunkhecexporter/.api
+++ b/exporter/splunkhecexporter/.api
@@ -1,0 +1,17 @@
+{
+  "structs": [
+    "Config",
+    "HecHeartbeat",
+    "HecTelemetry",
+    "OtelToHecFields"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -184,14 +184,14 @@ type receivedRequest struct {
 	headers http.Header
 }
 
-type CapturingData struct {
+type capturingData struct {
 	testing          *testing.T
 	receivedRequest  chan receivedRequest
 	statusCode       int
 	checkCompression bool
 }
 
-func (c *CapturingData) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (c *capturingData) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 
 	if c.checkCompression && r.Header.Get("Content-Encoding") != "gzip" {
@@ -219,7 +219,7 @@ func runMetricsExport(cfg *Config, metrics pmetric.Metrics, expectedBatchesNum i
 	cfg.UseMultiMetricFormat = useMultiMetricsFormat
 
 	rr := make(chan receivedRequest)
-	capture := CapturingData{testing: t, receivedRequest: rr, statusCode: 200, checkCompression: !cfg.DisableCompression}
+	capture := capturingData{testing: t, receivedRequest: rr, statusCode: 200, checkCompression: !cfg.DisableCompression}
 	s := &http.Server{
 		Handler:           &capture,
 		ReadHeaderTimeout: 20 * time.Second,
@@ -272,7 +272,7 @@ func runTraceExport(testConfig *Config, traces ptrace.Traces, expectedBatchesNum
 	cfg.Token = "1234-1234"
 
 	rr := make(chan receivedRequest)
-	capture := CapturingData{testing: t, receivedRequest: rr, statusCode: 200, checkCompression: !cfg.DisableCompression}
+	capture := capturingData{testing: t, receivedRequest: rr, statusCode: 200, checkCompression: !cfg.DisableCompression}
 	s := &http.Server{
 		Handler:           &capture,
 		ReadHeaderTimeout: 20 * time.Second,
@@ -332,7 +332,7 @@ func runLogExport(cfg *Config, ld plog.Logs, expectedBatchesNum int, t *testing.
 	cfg.Token = "1234-1234"
 
 	rr := make(chan receivedRequest)
-	capture := CapturingData{testing: t, receivedRequest: rr, statusCode: 200, checkCompression: !cfg.DisableCompression}
+	capture := capturingData{testing: t, receivedRequest: rr, statusCode: 200, checkCompression: !cfg.DisableCompression}
 	s := &http.Server{
 		Handler:           &capture,
 		ReadHeaderTimeout: 20 * time.Second,
@@ -1274,7 +1274,7 @@ func TestReceiveMetricsWithCompression(t *testing.T) {
 
 func TestErrorReceived(t *testing.T) {
 	rr := make(chan receivedRequest)
-	capture := CapturingData{receivedRequest: rr, statusCode: 500}
+	capture := capturingData{receivedRequest: rr, statusCode: 500}
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)
@@ -1364,7 +1364,7 @@ func TestInvalidURL(t *testing.T) {
 
 func TestHeartbeatStartupFailed(t *testing.T) {
 	rr := make(chan receivedRequest)
-	capture := CapturingData{receivedRequest: rr, statusCode: 403}
+	capture := capturingData{receivedRequest: rr, statusCode: 403}
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)
@@ -1400,7 +1400,7 @@ func TestHeartbeatStartupFailed(t *testing.T) {
 
 func TestHeartbeatStartupPass_Disabled(t *testing.T) {
 	rr := make(chan receivedRequest)
-	capture := CapturingData{receivedRequest: rr, statusCode: 403}
+	capture := capturingData{receivedRequest: rr, statusCode: 403}
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)
@@ -1435,7 +1435,7 @@ func TestHeartbeatStartupPass_Disabled(t *testing.T) {
 
 func TestHeartbeatStartupPass(t *testing.T) {
 	rr := make(chan receivedRequest)
-	capture := CapturingData{receivedRequest: rr, statusCode: 200}
+	capture := capturingData{receivedRequest: rr, statusCode: 200}
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)

--- a/exporter/sumologicexporter/.api
+++ b/exporter/sumologicexporter/.api
@@ -1,0 +1,57 @@
+{
+  "values": [
+    "Carbon2Format",
+    "DefaultClient",
+    "DefaultCompress",
+    "DefaultCompressEncoding",
+    "DefaultGraphiteTemplate",
+    "DefaultLogFormat",
+    "DefaultMaxRequestBodySize",
+    "DefaultMetricFormat",
+    "DefaultSourceCategory",
+    "DefaultSourceHost",
+    "DefaultSourceName",
+    "DeflateCompression",
+    "GZIPCompression",
+    "GraphiteFormat",
+    "JSONFormat",
+    "LogsPipeline",
+    "MetricsPipeline",
+    "NoCompression",
+    "PrometheusFormat",
+    "TextFormat"
+  ],
+  "structs": [
+    "CompressEncodingType",
+    "Config",
+    "LogFormatType",
+    "MetricFormatType",
+    "PipelineType"
+  ],
+  "functions": [
+    {
+      "name": "CreateDefaultHTTPClientSettings",
+      "receiver": "",
+      "return_types": [
+        "confighttp.HTTPClientSettings"
+      ]
+    },
+    {
+      "name": "LogRecordsToLogs",
+      "receiver": "",
+      "return_types": [
+        "plog.Logs"
+      ],
+      "param_types": [
+        "[]plog.LogRecord"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/syslogexporter/.api
+++ b/exporter/syslogexporter/.api
@@ -1,0 +1,29 @@
+{
+  "values": [
+    "DefaultNetwork",
+    "DefaultPort",
+    "DefaultProtocol"
+  ],
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "LogRecordsToLogs",
+      "receiver": "",
+      "return_types": [
+        "plog.Logs"
+      ],
+      "param_types": [
+        "plog.LogRecord"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/tanzuobservabilityexporter/.api
+++ b/exporter/tanzuobservabilityexporter/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "Config",
+    "MetricsConfig",
+    "TracesConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/tencentcloudlogserviceexporter/.api
+++ b/exporter/tencentcloudlogserviceexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/exporter/zipkinexporter/.api
+++ b/exporter/zipkinexporter/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/asapauthextension/.api
+++ b/extension/asapauthextension/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/awsproxy/.api
+++ b/extension/awsproxy/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/basicauthextension/.api
+++ b/extension/basicauthextension/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "ClientAuthSettings",
+    "Config",
+    "HtpasswdSettings"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/bearertokenauthextension/.api
+++ b/extension/bearertokenauthextension/.api
@@ -1,0 +1,17 @@
+{
+  "structs": [
+    "BearerAuthRoundTripper",
+    "BearerTokenAuth",
+    "Config",
+    "PerRPCAuth"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/headerssetterextension/.api
+++ b/extension/headerssetterextension/.api
@@ -1,0 +1,23 @@
+{
+  "values": [
+    "DELETE",
+    "INSERT",
+    "UPDATE",
+    "UPSERT"
+  ],
+  "structs": [
+    "ActionValue",
+    "Config",
+    "Header",
+    "HeaderConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/healthcheckextension/.api
+++ b/extension/healthcheckextension/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "ResponseBodySettings"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/httpforwarder/.api
+++ b/extension/httpforwarder/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/jaegerremotesampling/.api
+++ b/extension/jaegerremotesampling/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "Source"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/oauth2clientauthextension/.api
+++ b/extension/oauth2clientauthextension/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/observer/.api
+++ b/extension/observer/.api
@@ -1,0 +1,48 @@
+{
+  "values": [
+    "ContainerType",
+    "HostPortType",
+    "K8sNodeType",
+    "PodType",
+    "PortType",
+    "ProtocolTCP",
+    "ProtocolTCP4",
+    "ProtocolTCP6",
+    "ProtocolUDP",
+    "ProtocolUDP4",
+    "ProtocolUDP6",
+    "ProtocolUnknown"
+  ],
+  "structs": [
+    "Container",
+    "Endpoint",
+    "EndpointDetails",
+    "EndpointEnv",
+    "EndpointID",
+    "EndpointType",
+    "EndpointsLister",
+    "EndpointsWatcher",
+    "HostPort",
+    "K8sNode",
+    "Notify",
+    "NotifyID",
+    "Observable",
+    "Pod",
+    "Port",
+    "Transport"
+  ],
+  "functions": [
+    {
+      "name": "NewEndpointsWatcher",
+      "receiver": "",
+      "return_types": [
+        "*EndpointsWatcher"
+      ],
+      "param_types": [
+        "EndpointsLister",
+        "time.Duration",
+        "*zap.Logger"
+      ]
+    }
+  ]
+}

--- a/extension/observer/dockerobserver/.api
+++ b/extension/observer/dockerobserver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/observer/ecsobserver/.api
+++ b/extension/observer/ecsobserver/.api
@@ -1,0 +1,25 @@
+{
+  "structs": [
+    "CommonExporterConfig",
+    "Config",
+    "DockerLabelConfig",
+    "ServiceConfig",
+    "TaskDefinitionConfig"
+  ],
+  "functions": [
+    {
+      "name": "DefaultConfig",
+      "receiver": "",
+      "return_types": [
+        "Config"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/observer/ecstaskobserver/.api
+++ b/extension/observer/ecstaskobserver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/observer/hostobserver/.api
+++ b/extension/observer/hostobserver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/observer/k8sobserver/.api
+++ b/extension/observer/k8sobserver/.api
@@ -1,0 +1,34 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    },
+    {
+      "name": "NewNode",
+      "receiver": "",
+      "return_types": [
+        "*v1.Node"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "NewPod",
+      "receiver": "",
+      "return_types": [
+        "*v1.Pod"
+      ],
+      "param_types": [
+        "string"
+      ]
+    }
+  ]
+}

--- a/extension/oidcauthextension/.api
+++ b/extension/oidcauthextension/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/pprofextension/.api
+++ b/extension/pprofextension/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/extension/sigv4authextension/.api
+++ b/extension/sigv4authextension/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "AssumeRole",
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "extension.Factory"
+      ]
+    }
+  ]
+}

--- a/internal/aws/awsutil/.api
+++ b/internal/aws/awsutil/.api
@@ -1,0 +1,58 @@
+{
+  "values": [
+    "STSAwsCnPartitionIDSuffix",
+    "STSEndpointPrefix",
+    "STSEndpointSuffix"
+  ],
+  "structs": [
+    "AWSSessionSettings",
+    "Conn",
+    "ConnAttr"
+  ],
+  "functions": [
+    {
+      "name": "CreateDefaultSessionConfig",
+      "receiver": "",
+      "return_types": [
+        "AWSSessionSettings"
+      ]
+    },
+    {
+      "name": "GetAWSConfigSession",
+      "receiver": "",
+      "return_types": [
+        "*aws.Config",
+        "*session.Session",
+        "error"
+      ],
+      "param_types": [
+        "*zap.Logger",
+        "ConnAttr",
+        "*AWSSessionSettings"
+      ]
+    },
+    {
+      "name": "GetDefaultSession",
+      "receiver": "",
+      "return_types": [
+        "*session.Session",
+        "error"
+      ],
+      "param_types": [
+        "*zap.Logger"
+      ]
+    },
+    {
+      "name": "ProxyServerTransport",
+      "receiver": "",
+      "return_types": [
+        "*http.Transport",
+        "error"
+      ],
+      "param_types": [
+        "*zap.Logger",
+        "*AWSSessionSettings"
+      ]
+    }
+  ]
+}

--- a/internal/aws/containerinsight/.api
+++ b/internal/aws/containerinsight/.api
@@ -1,0 +1,219 @@
+{
+  "values": [
+    "AutoScalingGroupNameKey",
+    "CPULimit",
+    "CPURequest",
+    "CPUReservedCapacity",
+    "CPUSystem",
+    "CPUTotal",
+    "CPUUser",
+    "CPUUtilization",
+    "CPUUtilizationOverPodLimit",
+    "ClusterNameKey",
+    "ContainerCount",
+    "ContainerIDkey",
+    "ContainerInstanceIDKey",
+    "ContainerLastTerminationReason",
+    "ContainerNamekey",
+    "ContainerRestartCount",
+    "ContainerStatus",
+    "ContainerStatusReason",
+    "CronJob",
+    "DaemonSet",
+    "Deployment",
+    "DiskDev",
+    "DiskIOAsync",
+    "DiskIORead",
+    "DiskIOServiceBytesPrefix",
+    "DiskIOServicedPrefix",
+    "DiskIOSync",
+    "DiskIOTotal",
+    "DiskIOWrite",
+    "ECS",
+    "EKS",
+    "EbsVolumeID",
+    "FSAvailable",
+    "FSCapacity",
+    "FSInodes",
+    "FSInodesfree",
+    "FSType",
+    "FSUsage",
+    "FSUtilization",
+    "FailedNodeCount",
+    "FullPodNameKey",
+    "GoPSUtilProcDirEnv",
+    "HostEbsVolumeID",
+    "InstanceID",
+    "InstanceType",
+    "Job",
+    "K8sNamespace",
+    "K8sPodNameKey",
+    "KubeSecurePort",
+    "Kubernetes",
+    "MemCache",
+    "MemFailcnt",
+    "MemHierarchicalPgfault",
+    "MemHierarchicalPgmajfault",
+    "MemLimit",
+    "MemMappedfile",
+    "MemMaxusage",
+    "MemPgfault",
+    "MemPgmajfault",
+    "MemRequest",
+    "MemReservedCapacity",
+    "MemRss",
+    "MemSwap",
+    "MemUsage",
+    "MemUtilization",
+    "MemUtilizationOverPodLimit",
+    "MemWorkingset",
+    "MetricType",
+    "MinTimeDiff",
+    "NetIfce",
+    "NetRxBytes",
+    "NetRxDropped",
+    "NetRxErrors",
+    "NetRxPackets",
+    "NetTotalBytes",
+    "NetTxBytes",
+    "NetTxDropped",
+    "NetTxErrors",
+    "NetTxPackets",
+    "NodeCount",
+    "NodeNameKey",
+    "PodIDKey",
+    "PodNameKey",
+    "PodStatus",
+    "ReplicaSet",
+    "ReplicationController",
+    "RunningContainerCount",
+    "RunningPodCount",
+    "RunningTaskCount",
+    "SourcesKey",
+    "StatefulSet",
+    "Timestamp",
+    "TypeCluster",
+    "TypeClusterNamespace",
+    "TypeClusterService",
+    "TypeContainer",
+    "TypeContainerDiskIO",
+    "TypeContainerFS",
+    "TypeInfraContainer",
+    "TypeInstance",
+    "TypeInstanceDiskIO",
+    "TypeInstanceFS",
+    "TypeInstanceNet",
+    "TypeNode",
+    "TypeNodeDiskIO",
+    "TypeNodeFS",
+    "TypeNodeNet",
+    "TypePod",
+    "TypePodNet",
+    "TypeService",
+    "UnitBytes",
+    "UnitBytesPerSec",
+    "UnitCount",
+    "UnitCountPerSec",
+    "UnitMegaBytes",
+    "UnitNanoSecond",
+    "UnitPercent",
+    "UnitVCPU",
+    "Version"
+  ],
+  "functions": [
+    {
+      "name": "ConvertToOTLPMetrics",
+      "receiver": "",
+      "return_types": [
+        "pmetric.Metrics"
+      ],
+      "param_types": [
+        "map[string]{}",
+        "map[string]string",
+        "*zap.Logger"
+      ]
+    },
+    {
+      "name": "GetUnitForMetric",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "IsContainer",
+      "receiver": "",
+      "return_types": [
+        "bool"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "IsInstance",
+      "receiver": "",
+      "return_types": [
+        "bool"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "IsNode",
+      "receiver": "",
+      "return_types": [
+        "bool"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "IsPod",
+      "receiver": "",
+      "return_types": [
+        "bool"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "MetricName",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "string",
+        "string"
+      ]
+    },
+    {
+      "name": "RemovePrefix",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "string",
+        "string"
+      ]
+    },
+    {
+      "name": "SumFields",
+      "receiver": "",
+      "return_types": [
+        "map[string]float64"
+      ],
+      "param_types": [
+        "[]map[string]{}"
+      ]
+    }
+  ]
+}

--- a/internal/aws/cwlogs/.api
+++ b/internal/aws/cwlogs/.api
@@ -1,0 +1,72 @@
+{
+  "structs": [
+    "ByTimestamp",
+    "Client",
+    "Event",
+    "Pusher",
+    "PusherKey",
+    "UnknownError"
+  ],
+  "functions": [
+    {
+      "name": "NewClient",
+      "receiver": "",
+      "return_types": [
+        "*Client"
+      ],
+      "param_types": [
+        "*zap.Logger",
+        "*aws.Config",
+        "component.BuildInfo",
+        "string",
+        "int64",
+        "map[string]*string",
+        "*session.Session"
+      ]
+    },
+    {
+      "name": "NewEvent",
+      "receiver": "",
+      "return_types": [
+        "*Event"
+      ],
+      "param_types": [
+        "int64",
+        "string"
+      ]
+    },
+    {
+      "name": "NewPusher",
+      "receiver": "",
+      "return_types": [
+        "Pusher"
+      ],
+      "param_types": [
+        "PusherKey",
+        "int",
+        "Client",
+        "*zap.Logger"
+      ]
+    },
+    {
+      "name": "ValidateRetentionValue",
+      "receiver": "",
+      "return_types": [
+        "error"
+      ],
+      "param_types": [
+        "int64"
+      ]
+    },
+    {
+      "name": "ValidateTagsInput",
+      "receiver": "",
+      "return_types": [
+        "error"
+      ],
+      "param_types": [
+        "map[string]*string"
+      ]
+    }
+  ]
+}

--- a/internal/aws/ecsutil/.api
+++ b/internal/aws/ecsutil/.api
@@ -1,0 +1,74 @@
+{
+  "structs": [
+    "Client",
+    "ClientProvider",
+    "ContainerMetadata",
+    "Limits",
+    "LogOptions",
+    "MetadataProvider",
+    "Network",
+    "RestClient",
+    "TaskMetadata",
+    "TaskMetadataRestClient"
+  ],
+  "functions": [
+    {
+      "name": "NewClientProvider",
+      "receiver": "",
+      "return_types": [
+        "ClientProvider"
+      ],
+      "param_types": [
+        "url.URL",
+        "confighttp.HTTPClientSettings",
+        "component.Host",
+        "component.TelemetrySettings"
+      ]
+    },
+    {
+      "name": "NewDetectedTaskMetadataProvider",
+      "receiver": "",
+      "return_types": [
+        "MetadataProvider",
+        "error"
+      ],
+      "param_types": [
+        "component.TelemetrySettings"
+      ]
+    },
+    {
+      "name": "NewRestClient",
+      "receiver": "",
+      "return_types": [
+        "RestClient",
+        "error"
+      ],
+      "param_types": [
+        "url.URL",
+        "confighttp.HTTPClientSettings",
+        "component.TelemetrySettings"
+      ]
+    },
+    {
+      "name": "NewRestClientFromClient",
+      "receiver": "",
+      "return_types": [
+        "*TaskMetadataRestClient"
+      ],
+      "param_types": [
+        "Client"
+      ]
+    },
+    {
+      "name": "NewTaskMetadataProvider",
+      "receiver": "",
+      "return_types": [
+        "MetadataProvider"
+      ],
+      "param_types": [
+        "RestClient",
+        "*zap.Logger"
+      ]
+    }
+  ]
+}

--- a/internal/aws/metrics/.api
+++ b/internal/aws/metrics/.api
@@ -1,0 +1,49 @@
+{
+  "structs": [
+    "CalculateFunc",
+    "Key",
+    "MapWithExpiry",
+    "MetricCalculator",
+    "MetricValue"
+  ],
+  "functions": [
+    {
+      "name": "NewFloat64DeltaCalculator",
+      "receiver": "",
+      "return_types": [
+        "MetricCalculator"
+      ]
+    },
+    {
+      "name": "NewKey",
+      "receiver": "",
+      "return_types": [
+        "Key"
+      ],
+      "param_types": [
+        "{}",
+        "map[string]string"
+      ]
+    },
+    {
+      "name": "NewMapWithExpiry",
+      "receiver": "",
+      "return_types": [
+        "*MapWithExpiry"
+      ],
+      "param_types": [
+        "time.Duration"
+      ]
+    },
+    {
+      "name": "NewMetricCalculator",
+      "receiver": "",
+      "return_types": [
+        "MetricCalculator"
+      ],
+      "param_types": [
+        "CalculateFunc"
+      ]
+    }
+  ]
+}

--- a/internal/aws/proxy/.api
+++ b/internal/aws/proxy/.api
@@ -1,0 +1,27 @@
+{
+  "structs": [
+    "Config",
+    "Server"
+  ],
+  "functions": [
+    {
+      "name": "DefaultConfig",
+      "receiver": "",
+      "return_types": [
+        "*Config"
+      ]
+    },
+    {
+      "name": "NewServer",
+      "receiver": "",
+      "return_types": [
+        "Server",
+        "error"
+      ],
+      "param_types": [
+        "*Config",
+        "*zap.Logger"
+      ]
+    }
+  ]
+}

--- a/internal/aws/xray/.api
+++ b/internal/aws/xray/.api
@@ -1,0 +1,88 @@
+{
+  "values": [
+    "AWSAccountAttribute",
+    "AWSOperationAttribute",
+    "AWSQueueURLAttribute",
+    "AWSQueueURLAttribute2",
+    "AWSRegionAttribute",
+    "AWSRequestIDAttribute",
+    "AWSRequestIDAttribute2",
+    "AWSServiceAttribute",
+    "AWSTableNameAttribute",
+    "AWSTableNameAttribute2",
+    "AWSXRayInProgressAttribute",
+    "AWSXRayResourceARNAttribute",
+    "AWSXRayTracedAttribute",
+    "AWSXRayXForwardedForAttribute",
+    "AWSXrayExceptionCauseAttribute",
+    "AWSXrayExceptionIDAttribute",
+    "AWSXrayExceptionRemoteAttribute",
+    "AWSXrayExceptionSkippedAttribute",
+    "AWSXrayExceptionTruncatedAttribute",
+    "AWSXrayRetriesAttribute",
+    "AWSXraySegmentAnnotationsAttribute",
+    "AWSXraySegmentMetadataAttributePrefix",
+    "CauseTypeExceptionID",
+    "CauseTypeObject"
+  ],
+  "structs": [
+    "AWSData",
+    "BeanstalkMetadata",
+    "CauseData",
+    "CauseObject",
+    "CauseType",
+    "EC2Data",
+    "EC2Metadata",
+    "ECSData",
+    "ECSMetadata",
+    "EKSMetadata",
+    "ElasticBeanstalkData",
+    "Exception",
+    "HTTPData",
+    "LogGroupMetadata",
+    "RequestData",
+    "ResponseData",
+    "SQLData",
+    "Segment",
+    "ServiceData",
+    "SpanLinkData",
+    "StackFrame",
+    "XRayClient",
+    "XRayMetaData"
+  ],
+  "functions": [
+    {
+      "name": "NewXRayClient",
+      "receiver": "",
+      "return_types": [
+        "XRayClient"
+      ],
+      "param_types": [
+        "*zap.Logger",
+        "*aws.Config",
+        "component.BuildInfo",
+        "*session.Session"
+      ]
+    },
+    {
+      "name": "String",
+      "receiver": "",
+      "return_types": [
+        "*string"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "StringOrEmpty",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "*string"
+      ]
+    }
+  ]
+}

--- a/internal/aws/xray/testdata/sampleapp/.api
+++ b/internal/aws/xray/testdata/sampleapp/.api
@@ -1,0 +1,5 @@
+{
+  "structs": [
+    "Record"
+  ]
+}

--- a/internal/docker/.api
+++ b/internal/docker/.api
@@ -1,0 +1,53 @@
+{
+  "structs": [
+    "Client",
+    "Config",
+    "Container"
+  ],
+  "functions": [
+    {
+      "name": "ContainerEnvToMap",
+      "receiver": "",
+      "return_types": [
+        "map[string]string"
+      ],
+      "param_types": [
+        "[]string"
+      ]
+    },
+    {
+      "name": "NewConfig",
+      "receiver": "",
+      "return_types": [
+        "*Config",
+        "error"
+      ],
+      "param_types": [
+        "string",
+        "time.Duration",
+        "[]string",
+        "float64"
+      ]
+    },
+    {
+      "name": "NewDefaultConfig",
+      "receiver": "",
+      "return_types": [
+        "*Config"
+      ]
+    },
+    {
+      "name": "NewDockerClient",
+      "receiver": "",
+      "return_types": [
+        "*Client",
+        "error"
+      ],
+      "param_types": [
+        "*Config",
+        "*zap.Logger",
+        "docker.Opt..."
+      ]
+    }
+  ]
+}

--- a/internal/k8sconfig/.api
+++ b/internal/k8sconfig/.api
@@ -1,0 +1,58 @@
+{
+  "values": [
+    "AuthTypeKubeConfig",
+    "AuthTypeNone",
+    "AuthTypeServiceAccount",
+    "AuthTypeTLS"
+  ],
+  "structs": [
+    "APIConfig",
+    "AuthType"
+  ],
+  "functions": [
+    {
+      "name": "CreateRestConfig",
+      "receiver": "",
+      "return_types": [
+        "*rest.Config",
+        "error"
+      ],
+      "param_types": [
+        "APIConfig"
+      ]
+    },
+    {
+      "name": "MakeClient",
+      "receiver": "",
+      "return_types": [
+        "k8s.Interface",
+        "error"
+      ],
+      "param_types": [
+        "APIConfig"
+      ]
+    },
+    {
+      "name": "MakeDynamicClient",
+      "receiver": "",
+      "return_types": [
+        "dynamic.Interface",
+        "error"
+      ],
+      "param_types": [
+        "APIConfig"
+      ]
+    },
+    {
+      "name": "MakeOpenShiftQuotaClient",
+      "receiver": "",
+      "return_types": [
+        "quotaclientset.Interface",
+        "error"
+      ],
+      "param_types": [
+        "APIConfig"
+      ]
+    }
+  ]
+}

--- a/internal/k8stest/.api
+++ b/internal/k8stest/.api
@@ -1,0 +1,96 @@
+{
+  "structs": [
+    "TelemetrygenObjInfo"
+  ],
+  "functions": [
+    {
+      "name": "CreateCollectorObjects",
+      "receiver": "",
+      "return_types": [
+        "[]*unstructured.Unstructured"
+      ],
+      "param_types": [
+        "*testing.T",
+        "*dynamic.DynamicClient",
+        "string"
+      ]
+    },
+    {
+      "name": "CreateObject",
+      "receiver": "",
+      "return_types": [
+        "*unstructured.Unstructured",
+        "error"
+      ],
+      "param_types": [
+        "*dynamic.DynamicClient",
+        "[]byte"
+      ]
+    },
+    {
+      "name": "CreateTelemetryGenObjects",
+      "receiver": "",
+      "return_types": [
+        "[]*unstructured.Unstructured",
+        "[]*TelemetrygenObjInfo"
+      ],
+      "param_types": [
+        "*testing.T",
+        "*dynamic.DynamicClient",
+        "string"
+      ]
+    },
+    {
+      "name": "DeleteObject",
+      "receiver": "",
+      "return_types": [
+        "error"
+      ],
+      "param_types": [
+        "*dynamic.DynamicClient",
+        "*unstructured.Unstructured"
+      ]
+    },
+    {
+      "name": "HostEndpoint",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "*testing.T"
+      ]
+    },
+    {
+      "name": "SelectorFromMap",
+      "receiver": "",
+      "return_types": [
+        "labels.Selector"
+      ],
+      "param_types": [
+        "map[string]any"
+      ]
+    },
+    {
+      "name": "WaitForCollectorToStart",
+      "receiver": "",
+      "param_types": [
+        "*testing.T",
+        "*dynamic.DynamicClient",
+        "string",
+        "map[string]any"
+      ]
+    },
+    {
+      "name": "WaitForTelemetryGenToStart",
+      "receiver": "",
+      "param_types": [
+        "*testing.T",
+        "*dynamic.DynamicClient",
+        "string",
+        "map[string]any",
+        "string"
+      ]
+    }
+  ]
+}

--- a/internal/kubelet/.api
+++ b/internal/kubelet/.api
@@ -1,0 +1,22 @@
+{
+  "structs": [
+    "Client",
+    "ClientConfig",
+    "ClientProvider"
+  ],
+  "functions": [
+    {
+      "name": "NewClientProvider",
+      "receiver": "",
+      "return_types": [
+        "ClientProvider",
+        "error"
+      ],
+      "param_types": [
+        "string",
+        "*ClientConfig",
+        "*zap.Logger"
+      ]
+    }
+  ]
+}

--- a/internal/sharedcomponent/.api
+++ b/internal/sharedcomponent/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "SharedComponent",
+    "SharedComponents"
+  ],
+  "functions": [
+    {
+      "name": "NewSharedComponents",
+      "receiver": "",
+      "return_types": [
+        "*SharedComponents"
+      ]
+    }
+  ]
+}

--- a/internal/splunk/.api
+++ b/internal/splunk/.api
@@ -1,0 +1,55 @@
+{
+  "values": [
+    "DefaultHealthPath",
+    "DefaultIndexLabel",
+    "DefaultNameLabel",
+    "DefaultRawPath",
+    "DefaultSeverityNumberLabel",
+    "DefaultSeverityTextLabel",
+    "DefaultSourceLabel",
+    "DefaultSourceTypeLabel",
+    "HECTokenHeader",
+    "HeaderRetryAfter",
+    "HecEventMetricType",
+    "HecTokenLabel",
+    "HostIDKeyAWS",
+    "HostIDKeyAzure",
+    "HostIDKeyGCP",
+    "HostIDKeyHost",
+    "SFxAccessTokenHeader",
+    "SFxAccessTokenLabel",
+    "SFxEventCategoryKey",
+    "SFxEventPropertiesKey",
+    "SFxEventType"
+  ],
+  "structs": [
+    "AccessTokenPassthroughConfig",
+    "Event",
+    "HecToOtelAttrs",
+    "HostID",
+    "HostIDKey"
+  ],
+  "functions": [
+    {
+      "name": "HandleHTTPCode",
+      "receiver": "",
+      "return_types": [
+        "error"
+      ],
+      "param_types": [
+        "*http.Response"
+      ]
+    },
+    {
+      "name": "ResourceToHostID",
+      "receiver": "",
+      "return_types": [
+        "HostID",
+        "bool"
+      ],
+      "param_types": [
+        "pcommon.Resource"
+      ]
+    }
+  ]
+}

--- a/pkg/batchperresourceattr/.api
+++ b/pkg/batchperresourceattr/.api
@@ -1,0 +1,37 @@
+{
+  "functions": [
+    {
+      "name": "NewBatchPerResourceLogs",
+      "receiver": "",
+      "return_types": [
+        "consumer.Logs"
+      ],
+      "param_types": [
+        "string",
+        "consumer.Logs"
+      ]
+    },
+    {
+      "name": "NewBatchPerResourceMetrics",
+      "receiver": "",
+      "return_types": [
+        "consumer.Metrics"
+      ],
+      "param_types": [
+        "string",
+        "consumer.Metrics"
+      ]
+    },
+    {
+      "name": "NewBatchPerResourceTraces",
+      "receiver": "",
+      "return_types": [
+        "consumer.Traces"
+      ],
+      "param_types": [
+        "string",
+        "consumer.Traces"
+      ]
+    }
+  ]
+}

--- a/pkg/batchpersignal/.api
+++ b/pkg/batchpersignal/.api
@@ -1,0 +1,24 @@
+{
+  "functions": [
+    {
+      "name": "SplitLogs",
+      "receiver": "",
+      "return_types": [
+        "[]plog.Logs"
+      ],
+      "param_types": [
+        "plog.Logs"
+      ]
+    },
+    {
+      "name": "SplitTraces",
+      "receiver": "",
+      "return_types": [
+        "[]ptrace.Traces"
+      ],
+      "param_types": [
+        "ptrace.Traces"
+      ]
+    }
+  ]
+}

--- a/pkg/experimentalmetricmetadata/.api
+++ b/pkg/experimentalmetricmetadata/.api
@@ -1,0 +1,27 @@
+{
+  "values": [
+    "EventTypeDelete",
+    "EventTypeNone",
+    "EventTypeState"
+  ],
+  "structs": [
+    "EntityDeleteDetails",
+    "EntityEvent",
+    "EntityEventsSlice",
+    "EntityStateDetails",
+    "EventType",
+    "MetadataDelta",
+    "MetadataExporter",
+    "MetadataUpdate",
+    "ResourceID"
+  ],
+  "functions": [
+    {
+      "name": "NewEntityEventsSlice",
+      "receiver": "",
+      "return_types": [
+        "EntityEventsSlice"
+      ]
+    }
+  ]
+}

--- a/pkg/ottl/.api
+++ b/pkg/ottl/.api
@@ -1,0 +1,145 @@
+{
+  "values": [
+    "ADD",
+    "DIV",
+    "EQ",
+    "GT",
+    "GTE",
+    "IgnoreError",
+    "LT",
+    "LTE",
+    "MULT",
+    "NE",
+    "PropagateError",
+    "SUB"
+  ],
+  "structs": [
+    "Arguments",
+    "BoolExpr",
+    "CreateFunctionFunc",
+    "Enum",
+    "EnumParser",
+    "EnumSymbol",
+    "ErrorMode",
+    "Expr",
+    "ExprFunc",
+    "Factory",
+    "FactoryOption",
+    "Field",
+    "FloatGetter",
+    "FloatLikeGetter",
+    "FunctionContext",
+    "GetSetter",
+    "Getter",
+    "IntGetter",
+    "IntLikeGetter",
+    "Key",
+    "Option",
+    "PMapGetter",
+    "Parser",
+    "Path",
+    "PathExpressionParser",
+    "Setter",
+    "StandardFloatGetter",
+    "StandardFloatLikeGetter",
+    "StandardGetSetter",
+    "StandardIntGetter",
+    "StandardIntLikeGetter",
+    "StandardPMapGetter",
+    "StandardStringGetter",
+    "StandardStringLikeGetter",
+    "Statement",
+    "Statements",
+    "StatementsOption",
+    "StringGetter",
+    "StringLikeGetter",
+    "TypeError"
+  ],
+  "functions": [
+    {
+      "name": "CreateFactoryMap",
+      "receiver": "",
+      "return_types": [
+        "map[string]Factory[K]"
+      ],
+      "param_types": [
+        "Factory[K]..."
+      ]
+    },
+    {
+      "name": "False",
+      "receiver": "",
+      "return_types": [
+        "ExprFunc[any]",
+        "error"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "Factory[K]"
+      ],
+      "param_types": [
+        "string",
+        "Arguments",
+        "CreateFunctionFunc[K]",
+        "FactoryOption[K]..."
+      ]
+    },
+    {
+      "name": "NewParser",
+      "receiver": "",
+      "return_types": [
+        "Parser[K]",
+        "error"
+      ],
+      "param_types": [
+        "map[string]Factory[K]",
+        "PathExpressionParser[K]",
+        "component.TelemetrySettings",
+        "Option[K]..."
+      ]
+    },
+    {
+      "name": "NewStatements",
+      "receiver": "",
+      "return_types": [
+        "Statements[K]"
+      ],
+      "param_types": [
+        "[]*Statement[K]",
+        "component.TelemetrySettings",
+        "StatementsOption[K]..."
+      ]
+    },
+    {
+      "name": "True",
+      "receiver": "",
+      "return_types": [
+        "ExprFunc[any]",
+        "error"
+      ]
+    },
+    {
+      "name": "WithEnumParser",
+      "receiver": "",
+      "return_types": [
+        "Option[K]"
+      ],
+      "param_types": [
+        "EnumParser"
+      ]
+    },
+    {
+      "name": "WithErrorMode",
+      "receiver": "",
+      "return_types": [
+        "StatementsOption[K]"
+      ],
+      "param_types": [
+        "ErrorMode"
+      ]
+    }
+  ]
+}

--- a/pkg/pdatautil/.api
+++ b/pkg/pdatautil/.api
@@ -1,0 +1,24 @@
+{
+  "functions": [
+    {
+      "name": "MapHash",
+      "receiver": "",
+      "return_types": [
+        "[16]byte"
+      ],
+      "param_types": [
+        "pcommon.Map"
+      ]
+    },
+    {
+      "name": "ValueHash",
+      "receiver": "",
+      "return_types": [
+        "[16]byte"
+      ],
+      "param_types": [
+        "pcommon.Value"
+      ]
+    }
+  ]
+}

--- a/pkg/resourcetotelemetry/.api
+++ b/pkg/resourcetotelemetry/.api
@@ -1,0 +1,18 @@
+{
+  "structs": [
+    "Settings"
+  ],
+  "functions": [
+    {
+      "name": "WrapMetricsExporter",
+      "receiver": "",
+      "return_types": [
+        "exporter.Metrics"
+      ],
+      "param_types": [
+        "Settings",
+        "exporter.Metrics"
+      ]
+    }
+  ]
+}

--- a/pkg/translator/jaeger/.api
+++ b/pkg/translator/jaeger/.api
@@ -1,0 +1,37 @@
+{
+  "functions": [
+    {
+      "name": "ProtoFromTraces",
+      "receiver": "",
+      "return_types": [
+        "[]*model.Batch",
+        "error"
+      ],
+      "param_types": [
+        "ptrace.Traces"
+      ]
+    },
+    {
+      "name": "ProtoToTraces",
+      "receiver": "",
+      "return_types": [
+        "ptrace.Traces",
+        "error"
+      ],
+      "param_types": [
+        "[]*model.Batch"
+      ]
+    },
+    {
+      "name": "ThriftToTraces",
+      "receiver": "",
+      "return_types": [
+        "ptrace.Traces",
+        "error"
+      ],
+      "param_types": [
+        "*jaeger.Batch"
+      ]
+    }
+  ]
+}

--- a/pkg/translator/loki/.api
+++ b/pkg/translator/loki/.api
@@ -1,0 +1,94 @@
+{
+  "structs": [
+    "Log",
+    "PushEntry",
+    "PushReport",
+    "PushRequest"
+  ],
+  "functions": [
+    {
+      "name": "ConvertEntryToLogRecord",
+      "receiver": "",
+      "param_types": [
+        "*push.Entry",
+        "*plog.LogRecord",
+        "model.LabelSet",
+        "bool"
+      ]
+    },
+    {
+      "name": "Encode",
+      "receiver": "",
+      "return_types": [
+        "string",
+        "error"
+      ],
+      "param_types": [
+        "plog.LogRecord",
+        "pcommon.Resource",
+        "pcommon.InstrumentationScope"
+      ]
+    },
+    {
+      "name": "EncodeLogfmt",
+      "receiver": "",
+      "return_types": [
+        "string",
+        "error"
+      ],
+      "param_types": [
+        "plog.LogRecord",
+        "pcommon.Resource",
+        "pcommon.InstrumentationScope"
+      ]
+    },
+    {
+      "name": "GetTenantFromTenantHint",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "pcommon.Map",
+        "pcommon.Map"
+      ]
+    },
+    {
+      "name": "LogToLokiEntry",
+      "receiver": "",
+      "return_types": [
+        "*PushEntry",
+        "error"
+      ],
+      "param_types": [
+        "plog.LogRecord",
+        "pcommon.Resource",
+        "pcommon.InstrumentationScope",
+        "map[string]bool"
+      ]
+    },
+    {
+      "name": "LogsToLokiRequests",
+      "receiver": "",
+      "return_types": [
+        "map[string]PushRequest"
+      ],
+      "param_types": [
+        "plog.Logs",
+        "map[string]bool"
+      ]
+    },
+    {
+      "name": "PushRequestToLogs",
+      "receiver": "",
+      "return_types": [
+        "plog.Logs",
+        "error"
+      ],
+      "param_types": [
+        "*push.PushRequest",
+        "bool"
+      ]
+    }
+  ]
+}

--- a/pkg/translator/opencensus/.api
+++ b/pkg/translator/opencensus/.api
@@ -1,0 +1,52 @@
+{
+  "functions": [
+    {
+      "name": "OCToMetrics",
+      "receiver": "",
+      "return_types": [
+        "pmetric.Metrics"
+      ],
+      "param_types": [
+        "*occommon.Node",
+        "*ocresource.Resource",
+        "[]*ocmetrics.Metric"
+      ]
+    },
+    {
+      "name": "OCToTraces",
+      "receiver": "",
+      "return_types": [
+        "ptrace.Traces"
+      ],
+      "param_types": [
+        "*occommon.Node",
+        "*ocresource.Resource",
+        "[]*octrace.Span"
+      ]
+    },
+    {
+      "name": "ResourceMetricsToOC",
+      "receiver": "",
+      "return_types": [
+        "*occommon.Node",
+        "*ocresource.Resource",
+        "[]*ocmetrics.Metric"
+      ],
+      "param_types": [
+        "pmetric.ResourceMetrics"
+      ]
+    },
+    {
+      "name": "ResourceSpansToOC",
+      "receiver": "",
+      "return_types": [
+        "*occommon.Node",
+        "*ocresource.Resource",
+        "[]*octrace.Span"
+      ],
+      "param_types": [
+        "ptrace.ResourceSpans"
+      ]
+    }
+  ]
+}

--- a/pkg/translator/prometheus/.api
+++ b/pkg/translator/prometheus/.api
@@ -1,0 +1,69 @@
+{
+  "functions": [
+    {
+      "name": "BuildCompliantName",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "pmetric.Metric",
+        "string",
+        "bool"
+      ]
+    },
+    {
+      "name": "BuildPromCompliantName",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "pmetric.Metric",
+        "string"
+      ]
+    },
+    {
+      "name": "CleanUpString",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "NormalizeLabel",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "RemovePromForbiddenRunes",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "TrimPromSuffixes",
+      "receiver": "",
+      "return_types": [
+        "string"
+      ],
+      "param_types": [
+        "string",
+        "pmetric.MetricType",
+        "string"
+      ]
+    }
+  ]
+}

--- a/pkg/translator/prometheusremotewrite/.api
+++ b/pkg/translator/prometheusremotewrite/.api
@@ -1,0 +1,20 @@
+{
+  "structs": [
+    "ByLabelName",
+    "Settings"
+  ],
+  "functions": [
+    {
+      "name": "FromMetrics",
+      "receiver": "",
+      "return_types": [
+        "map[string]*prompb.TimeSeries",
+        "error"
+      ],
+      "param_types": [
+        "pmetric.Metrics",
+        "Settings"
+      ]
+    }
+  ]
+}

--- a/pkg/translator/signalfx/.api
+++ b/pkg/translator/signalfx/.api
@@ -1,0 +1,6 @@
+{
+  "structs": [
+    "FromTranslator",
+    "ToTranslator"
+  ]
+}

--- a/pkg/winperfcounters/.api
+++ b/pkg/winperfcounters/.api
@@ -1,0 +1,41 @@
+{
+  "structs": [
+    "CounterValue",
+    "PerfCounterWatcher"
+  ],
+  "functions": [
+    {
+      "name": "ExpandWildCardPath",
+      "receiver": "",
+      "return_types": [
+        "[]string",
+        "error"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "NewWatcher",
+      "receiver": "",
+      "return_types": [
+        "PerfCounterWatcher",
+        "error"
+      ],
+      "param_types": [
+        "string"
+      ]
+    },
+    {
+      "name": "NewWatcherFromPath",
+      "receiver": "",
+      "return_types": [
+        "PerfCounterWatcher",
+        "error"
+      ],
+      "param_types": [
+        "string"
+      ]
+    }
+  ]
+}

--- a/processor/attributesprocessor/.api
+++ b/processor/attributesprocessor/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/cumulativetodeltaprocessor/.api
+++ b/processor/cumulativetodeltaprocessor/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "MatchMetrics"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/datadogprocessor/.api
+++ b/processor/datadogprocessor/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/deltatorateprocessor/.api
+++ b/processor/deltatorateprocessor/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/filterprocessor/.api
+++ b/processor/filterprocessor/.api
@@ -1,0 +1,32 @@
+{
+  "values": [
+    "Regexp",
+    "Strict",
+    "TestLogTime",
+    "TestLogTimestamp",
+    "TestObservedTime",
+    "TestObservedTimestamp",
+    "TestSpanEndTime",
+    "TestSpanEndTimestamp",
+    "TestSpanStartTime",
+    "TestSpanStartTimestamp"
+  ],
+  "structs": [
+    "Config",
+    "LogFilters",
+    "LogMatchProperties",
+    "LogMatchType",
+    "LogSeverityNumberMatchProperties",
+    "MetricFilters",
+    "TraceFilters"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/groupbyattrsprocessor/.api
+++ b/processor/groupbyattrsprocessor/.api
@@ -1,0 +1,21 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "MetricViews",
+      "receiver": "",
+      "return_types": [
+        "[]*view.View"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/groupbytraceprocessor/.api
+++ b/processor/groupbytraceprocessor/.api
@@ -1,0 +1,21 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "MetricViews",
+      "receiver": "",
+      "return_types": [
+        "[]*view.View"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/k8sattributesprocessor/.api
+++ b/processor/k8sattributesprocessor/.api
@@ -1,0 +1,22 @@
+{
+  "structs": [
+    "Config",
+    "ExcludeConfig",
+    "ExcludePodConfig",
+    "ExtractConfig",
+    "FieldExtractConfig",
+    "FieldFilterConfig",
+    "FilterConfig",
+    "PodAssociationConfig",
+    "PodAssociationSourceConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/logstransformprocessor/.api
+++ b/processor/logstransformprocessor/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/metricsgenerationprocessor/.api
+++ b/processor/metricsgenerationprocessor/.api
@@ -1,0 +1,17 @@
+{
+  "structs": [
+    "Config",
+    "GenerationType",
+    "OperationType",
+    "Rule"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/metricstransformprocessor/.api
+++ b/processor/metricstransformprocessor/.api
@@ -1,0 +1,56 @@
+{
+  "values": [
+    "ActionFieldName",
+    "AddLabel",
+    "AggregateLabelValues",
+    "AggregateLabels",
+    "AggregationTypeFieldName",
+    "Combine",
+    "DeleteLabelValue",
+    "Group",
+    "GroupResourceLabelsFieldName",
+    "IncludeFieldName",
+    "Insert",
+    "LabelFieldName",
+    "Lower",
+    "MatchTypeFieldName",
+    "Max",
+    "Mean",
+    "Min",
+    "NewLabelFieldName",
+    "NewNameFieldName",
+    "NewValueFieldName",
+    "RegexpMatchType",
+    "ScaleFieldName",
+    "ScaleValue",
+    "StrictMatchType",
+    "SubmatchCaseFieldName",
+    "Sum",
+    "ToggleScalarDataType",
+    "Update",
+    "UpdateLabel",
+    "Upper"
+  ],
+  "structs": [
+    "AggregationType",
+    "Config",
+    "ConfigAction",
+    "FilterConfig",
+    "MatchType",
+    "Operation",
+    "OperationAction",
+    "StringMatcher",
+    "SubmatchCase",
+    "Transform",
+    "ValueAction"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/probabilisticsamplerprocessor/.api
+++ b/processor/probabilisticsamplerprocessor/.api
@@ -1,0 +1,25 @@
+{
+  "structs": [
+    "AttributeSource",
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    },
+    {
+      "name": "SamplingProcessorMetricViews",
+      "receiver": "",
+      "return_types": [
+        "[]*view.View"
+      ],
+      "param_types": [
+        "configtelemetry.Level"
+      ]
+    }
+  ]
+}

--- a/processor/redactionprocessor/.api
+++ b/processor/redactionprocessor/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/remoteobserverprocessor/.api
+++ b/processor/remoteobserverprocessor/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/resourcedetectionprocessor/.api
+++ b/processor/resourcedetectionprocessor/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "Config",
+    "DetectorConfig",
+    "MockDetector"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/resourceprocessor/.api
+++ b/processor/resourceprocessor/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/routingprocessor/.api
+++ b/processor/routingprocessor/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "AttributeSource",
+    "Config",
+    "RoutingTableItem"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/schemaprocessor/.api
+++ b/processor/schemaprocessor/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/servicegraphprocessor/.api
+++ b/processor/servicegraphprocessor/.api
@@ -1,0 +1,26 @@
+{
+  "structs": [
+    "Config",
+    "StoreConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewConnectorFactoryFunc",
+      "receiver": "",
+      "return_types": [
+        "func() connector.Factory"
+      ],
+      "param_types": [
+        "component.Type",
+        "component.StabilityLevel"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/spanmetricsprocessor/.api
+++ b/processor/spanmetricsprocessor/.api
@@ -1,0 +1,18 @@
+{
+  "values": [
+    "DimensionsCacheSize"
+  ],
+  "structs": [
+    "Config",
+    "Dimension"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/spanprocessor/.api
+++ b/processor/spanprocessor/.api
@@ -1,0 +1,17 @@
+{
+  "structs": [
+    "Config",
+    "Name",
+    "Status",
+    "ToAttributes"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/processor/tailsamplingprocessor/.api
+++ b/processor/tailsamplingprocessor/.api
@@ -1,0 +1,57 @@
+{
+  "values": [
+    "AlwaysSample",
+    "And",
+    "BooleanAttribute",
+    "Composite",
+    "Latency",
+    "NumericAttribute",
+    "OTTLCondition",
+    "Probabilistic",
+    "RateLimiting",
+    "SpanCount",
+    "StatusCode",
+    "StringAttribute",
+    "TraceState"
+  ],
+  "structs": [
+    "AndCfg",
+    "AndSubPolicyCfg",
+    "BooleanAttributeCfg",
+    "CompositeCfg",
+    "CompositeSubPolicyCfg",
+    "Config",
+    "LatencyCfg",
+    "NumericAttributeCfg",
+    "OTTLConditionCfg",
+    "PolicyCfg",
+    "PolicyType",
+    "ProbabilisticCfg",
+    "RateAllocationCfg",
+    "RateLimitingCfg",
+    "SpanCountCfg",
+    "StatusCodeCfg",
+    "StringAttributeCfg",
+    "TestPolicyEvaluator",
+    "TraceStateCfg"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    },
+    {
+      "name": "SamplingProcessorMetricViews",
+      "receiver": "",
+      "return_types": [
+        "[]*view.View"
+      ],
+      "param_types": [
+        "configtelemetry.Level"
+      ]
+    }
+  ]
+}

--- a/processor/transformprocessor/.api
+++ b/processor/transformprocessor/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "processor.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/activedirectorydsreceiver/.api
+++ b/receiver/activedirectorydsreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/aerospikereceiver/.api
+++ b/receiver/aerospikereceiver/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Aerospike",
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/apachereceiver/.api
+++ b/receiver/apachereceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/apachesparkreceiver/.api
+++ b/receiver/apachesparkreceiver/.api
@@ -1,0 +1,17 @@
+{
+  "values": [
+    "URL"
+  ],
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/awscloudwatchmetricsreceiver/.api
+++ b/receiver/awscloudwatchmetricsreceiver/.api
@@ -1,0 +1,17 @@
+{
+  "structs": [
+    "Config",
+    "MetricDimensionsConfig",
+    "MetricsConfig",
+    "NamedConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/awscloudwatchreceiver/.api
+++ b/receiver/awscloudwatchreceiver/.api
@@ -1,0 +1,18 @@
+{
+  "structs": [
+    "AutodiscoverConfig",
+    "Config",
+    "GroupConfig",
+    "LogsConfig",
+    "StreamConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/awscontainerinsightreceiver/.api
+++ b/receiver/awscontainerinsightreceiver/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "Config",
+    "MockCadvisor",
+    "MockK8sAPIServer"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/awsecscontainermetricsreceiver/.api
+++ b/receiver/awsecscontainermetricsreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/awsfirehosereceiver/.api
+++ b/receiver/awsfirehosereceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/awsxrayreceiver/.api
+++ b/receiver/awsxrayreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/azureblobreceiver/.api
+++ b/receiver/azureblobreceiver/.api
@@ -1,0 +1,20 @@
+{
+  "structs": [
+    "Config",
+    "EventHubConfig",
+    "LogsConfig",
+    "MockBlobClient",
+    "MockLogsDataConsumer",
+    "MockTracesDataConsumer",
+    "TracesConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/azureeventhubreceiver/.api
+++ b/receiver/azureeventhubreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/azuremonitorreceiver/.api
+++ b/receiver/azuremonitorreceiver/.api
@@ -1,0 +1,17 @@
+{
+  "structs": [
+    "ArmClient",
+    "Config",
+    "MetricsDefinitionsClientInterface",
+    "MetricsValuesClient"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/bigipreceiver/.api
+++ b/receiver/bigipreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/carbonreceiver/.api
+++ b/receiver/carbonreceiver/.api
@@ -1,0 +1,27 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "New",
+      "receiver": "",
+      "return_types": [
+        "receiver.Metrics",
+        "error"
+      ],
+      "param_types": [
+        "receiver.CreateSettings",
+        "Config",
+        "consumer.Metrics"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/chronyreceiver/.api
+++ b/receiver/chronyreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/cloudflarereceiver/.api
+++ b/receiver/cloudflarereceiver/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "LogsConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/cloudfoundryreceiver/.api
+++ b/receiver/cloudfoundryreceiver/.api
@@ -1,0 +1,20 @@
+{
+  "structs": [
+    "Config",
+    "EnvelopeStreamFactory",
+    "LimitedHTTPClientSettings",
+    "LimitedTLSClientSetting",
+    "RLPGatewayConfig",
+    "UAAConfig",
+    "UAATokenProvider"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/collectdreceiver/.api
+++ b/receiver/collectdreceiver/.api
@@ -1,0 +1,25 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "LabelsFromName",
+      "receiver": "",
+      "return_types": [
+        "string",
+        "map[string]string"
+      ],
+      "param_types": [
+        "*string"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/couchdbreceiver/.api
+++ b/receiver/couchdbreceiver/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "MockClient"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/datadogreceiver/.api
+++ b/receiver/datadogreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/dockerstatsreceiver/.api
+++ b/receiver/dockerstatsreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "rcvr.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/elasticsearchreceiver/.api
+++ b/receiver/elasticsearchreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/expvarreceiver/.api
+++ b/receiver/expvarreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/filelogreceiver/.api
+++ b/receiver/filelogreceiver/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "FileLogConfig",
+    "ReceiverType"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/filereceiver/.api
+++ b/receiver/filereceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/filestatsreceiver/.api
+++ b/receiver/filestatsreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/flinkmetricsreceiver/.api
+++ b/receiver/flinkmetricsreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/fluentforwardreceiver/.api
+++ b/receiver/fluentforwardreceiver/.api
@@ -1,0 +1,51 @@
+{
+  "values": [
+    "ForwardMode",
+    "MessageMode",
+    "PackedForwardMode",
+    "UnknownMode"
+  ],
+  "structs": [
+    "AckResponse",
+    "Collector",
+    "Config",
+    "Event",
+    "EventMode",
+    "ForwardEventLogRecords",
+    "Log",
+    "MessageEventLogRecord",
+    "OptionsMap",
+    "PackedForwardEventLogRecords",
+    "Peeker"
+  ],
+  "functions": [
+    {
+      "name": "DetermineNextEventMode",
+      "receiver": "",
+      "return_types": [
+        "EventMode",
+        "error"
+      ],
+      "param_types": [
+        "Peeker"
+      ]
+    },
+    {
+      "name": "Logs",
+      "receiver": "",
+      "return_types": [
+        "plog.Logs"
+      ],
+      "param_types": [
+        "Log..."
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/googlecloudpubsubreceiver/.api
+++ b/receiver/googlecloudpubsubreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/googlecloudspannerreceiver/.api
+++ b/receiver/googlecloudspannerreceiver/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "Config",
+    "Instance",
+    "Project"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/haproxyreceiver/.api
+++ b/receiver/haproxyreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/hostmetricsreceiver/.api
+++ b/receiver/hostmetricsreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/httpcheckreceiver/.api
+++ b/receiver/httpcheckreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/iisreceiver/.api
+++ b/receiver/iisreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/influxdbreceiver/.api
+++ b/receiver/influxdbreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/jaegerreceiver/.api
+++ b/receiver/jaegerreceiver/.api
@@ -1,0 +1,25 @@
+{
+  "structs": [
+    "Config",
+    "ProtocolUDP",
+    "Protocols",
+    "RemoteSamplingConfig",
+    "ServerConfigUDP"
+  ],
+  "functions": [
+    {
+      "name": "DefaultServerConfigUDP",
+      "receiver": "",
+      "return_types": [
+        "ServerConfigUDP"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/jmxreceiver/.api
+++ b/receiver/jmxreceiver/.api
@@ -1,0 +1,19 @@
+{
+  "values": [
+    "AdditionalTargetSystems",
+    "MetricsGathererHash"
+  ],
+  "structs": [
+    "Config",
+    "JMXIntegrationSuite"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/journaldreceiver/.api
+++ b/receiver/journaldreceiver/.api
@@ -1,0 +1,23 @@
+{
+  "structs": [
+    "JournaldConfig",
+    "JournaldConfig",
+    "ReceiverType"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/k8sclusterreceiver/.api
+++ b/receiver/k8sclusterreceiver/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "MockExporter"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/k8seventsreceiver/.api
+++ b/receiver/k8seventsreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/k8sobjectsreceiver/.api
+++ b/receiver/k8sobjectsreceiver/.api
@@ -1,0 +1,30 @@
+{
+  "values": [
+    "PullMode",
+    "WatchMode"
+  ],
+  "structs": [
+    "Config",
+    "K8sObjectsConfig",
+    "MockDiscovery"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    },
+    {
+      "name": "NewTicker",
+      "receiver": "",
+      "return_types": [
+        "*time.Ticker"
+      ],
+      "param_types": [
+        "time.Duration"
+      ]
+    }
+  ]
+}

--- a/receiver/kafkametricsreceiver/.api
+++ b/receiver/kafkametricsreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/kafkareceiver/.api
+++ b/receiver/kafkareceiver/.api
@@ -1,0 +1,61 @@
+{
+  "structs": [
+    "AutoCommit",
+    "Config",
+    "FactoryOption",
+    "LogsUnmarshaler",
+    "LogsUnmarshalerWithEnc",
+    "MessageMarking",
+    "MetricsUnmarshaler",
+    "TracesUnmarshaler"
+  ],
+  "functions": [
+    {
+      "name": "MetricViews",
+      "receiver": "",
+      "return_types": [
+        "[]*view.View"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ],
+      "param_types": [
+        "FactoryOption..."
+      ]
+    },
+    {
+      "name": "WithLogsUnmarshalers",
+      "receiver": "",
+      "return_types": [
+        "FactoryOption"
+      ],
+      "param_types": [
+        "LogsUnmarshaler..."
+      ]
+    },
+    {
+      "name": "WithMetricsUnmarshalers",
+      "receiver": "",
+      "return_types": [
+        "FactoryOption"
+      ],
+      "param_types": [
+        "MetricsUnmarshaler..."
+      ]
+    },
+    {
+      "name": "WithTracesUnmarshalers",
+      "receiver": "",
+      "return_types": [
+        "FactoryOption"
+      ],
+      "param_types": [
+        "TracesUnmarshaler..."
+      ]
+    }
+  ]
+}

--- a/receiver/kubeletstatsreceiver/.api
+++ b/receiver/kubeletstatsreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/lokireceiver/.api
+++ b/receiver/lokireceiver/.api
@@ -1,0 +1,19 @@
+{
+  "values": [
+    "ErrAtLeastOneEntryFailedToProcess"
+  ],
+  "structs": [
+    "Config",
+    "Log",
+    "Protocols"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/memcachedreceiver/.api
+++ b/receiver/memcachedreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/mongodbatlasreceiver/.api
+++ b/receiver/mongodbatlasreceiver/.api
@@ -1,0 +1,50 @@
+{
+  "structs": [
+    "AccessLogsConfig",
+    "AlertConfig",
+    "Config",
+    "EventsConfig",
+    "LogConfig",
+    "LogsProjectConfig",
+    "OrgConfig",
+    "ProjectConfig",
+    "ProjectContext"
+  ],
+  "functions": [
+    {
+      "name": "GetTestAuditEvent4_2",
+      "receiver": "",
+      "return_types": [
+        "model.AuditLog"
+      ]
+    },
+    {
+      "name": "GetTestAuditEvent5_0",
+      "receiver": "",
+      "return_types": [
+        "model.AuditLog"
+      ]
+    },
+    {
+      "name": "GetTestEvent4_2",
+      "receiver": "",
+      "return_types": [
+        "model.LogEntry"
+      ]
+    },
+    {
+      "name": "GetTestEvent4_4",
+      "receiver": "",
+      "return_types": [
+        "model.LogEntry"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "rcvr.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/mongodbreceiver/.api
+++ b/receiver/mongodbreceiver/.api
@@ -1,0 +1,27 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewClient",
+      "receiver": "",
+      "return_types": [
+        "client",
+        "error"
+      ],
+      "param_types": [
+        "context.Context",
+        "*Config",
+        "*zap.Logger"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/mysqlreceiver/.api
+++ b/receiver/mysqlreceiver/.api
@@ -1,0 +1,32 @@
+{
+  "structs": [
+    "Config",
+    "IndexIoWaitsStats",
+    "IoWaitsStats",
+    "ReplicaStatusStats",
+    "StatementEventStats",
+    "StatementEventsConfig",
+    "TableIoWaitsStats"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    },
+    {
+      "name": "Query",
+      "receiver": "",
+      "return_types": [
+        "map[string]string",
+        "error"
+      ],
+      "param_types": [
+        "mySQLClient",
+        "string"
+      ]
+    }
+  ]
+}

--- a/receiver/nginxreceiver/.api
+++ b/receiver/nginxreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/nsxtreceiver/.api
+++ b/receiver/nsxtreceiver/.api
@@ -1,0 +1,26 @@
+{
+  "structs": [
+    "Client",
+    "Config",
+    "MockClient"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    },
+    {
+      "name": "NewMockClient",
+      "receiver": "",
+      "return_types": [
+        "*MockClient"
+      ],
+      "param_types": [
+        "testing.TB"
+      ]
+    }
+  ]
+}

--- a/receiver/opencensusreceiver/.api
+++ b/receiver/opencensusreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/oracledbreceiver/.api
+++ b/receiver/oracledbreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/otlpjsonfilereceiver/.api
+++ b/receiver/otlpjsonfilereceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "rcvr.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/podmanreceiver/.api
+++ b/receiver/podmanreceiver/.api
@@ -1,0 +1,17 @@
+{
+  "structs": [
+    "Config",
+    "ContainerScraper",
+    "MockClient",
+    "PodmanClient"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "rcvr.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/postgresqlreceiver/.api
+++ b/receiver/postgresqlreceiver/.api
@@ -1,0 +1,21 @@
+{
+  "values": [
+    "ErrHostPort",
+    "ErrNoPassword",
+    "ErrNoUsername",
+    "ErrNotSupported",
+    "ErrTransportsSupported"
+  ],
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/prometheusreceiver/.api
+++ b/receiver/prometheusreceiver/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "Config",
+    "MockTargetAllocator",
+    "Responses"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/pulsarreceiver/.api
+++ b/receiver/pulsarreceiver/.api
@@ -1,0 +1,56 @@
+{
+  "structs": [
+    "Athenz",
+    "Authentication",
+    "Config",
+    "FactoryOption",
+    "LogsUnmarshaler",
+    "MetricsUnmarshaler",
+    "OAuth2",
+    "TLS",
+    "Token",
+    "TracesUnmarshaler"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ],
+      "param_types": [
+        "FactoryOption..."
+      ]
+    },
+    {
+      "name": "WithLogsUnmarshalers",
+      "receiver": "",
+      "return_types": [
+        "FactoryOption"
+      ],
+      "param_types": [
+        "LogsUnmarshaler..."
+      ]
+    },
+    {
+      "name": "WithMetricsUnmarshalers",
+      "receiver": "",
+      "return_types": [
+        "FactoryOption"
+      ],
+      "param_types": [
+        "MetricsUnmarshaler..."
+      ]
+    },
+    {
+      "name": "WithTracesUnmarshalers",
+      "receiver": "",
+      "return_types": [
+        "FactoryOption"
+      ],
+      "param_types": [
+        "TracesUnmarshaler..."
+      ]
+    }
+  ]
+}

--- a/receiver/purefareceiver/.api
+++ b/receiver/purefareceiver/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "Config",
+    "ReloadIntervals",
+    "Settings"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/purefbreceiver/.api
+++ b/receiver/purefbreceiver/.api
@@ -1,0 +1,16 @@
+{
+  "structs": [
+    "Config",
+    "ReloadIntervals",
+    "Settings"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/rabbitmqreceiver/.api
+++ b/receiver/rabbitmqreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/receivercreator/.api
+++ b/receiver/receivercreator/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/redisreceiver/.api
+++ b/receiver/redisreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/riakreceiver/.api
+++ b/receiver/riakreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/saphanareceiver/.api
+++ b/receiver/saphanareceiver/.api
@@ -1,0 +1,18 @@
+{
+  "values": [
+    "ErrNoPassword",
+    "ErrNoUsername"
+  ],
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/sapmreceiver/.api
+++ b/receiver/sapmreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/signalfxreceiver/.api
+++ b/receiver/signalfxreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/simpleprometheusreceiver/.api
+++ b/receiver/simpleprometheusreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/skywalkingreceiver/.api
+++ b/receiver/skywalkingreceiver/.api
@@ -1,0 +1,25 @@
+{
+  "structs": [
+    "Config",
+    "Protocols"
+  ],
+  "functions": [
+    {
+      "name": "MockGrpcTraceSegment",
+      "receiver": "",
+      "return_types": [
+        "*agent.SegmentObject"
+      ],
+      "param_types": [
+        "int"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/snmpreceiver/.api
+++ b/receiver/snmpreceiver/.api
@@ -1,0 +1,24 @@
+{
+  "structs": [
+    "Attribute",
+    "AttributeConfig",
+    "ColumnOID",
+    "Config",
+    "GaugeMetric",
+    "MetricConfig",
+    "MockClient",
+    "ResourceAttributeConfig",
+    "SNMPData",
+    "ScalarOID",
+    "SumMetric"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/snowflakereceiver/.api
+++ b/receiver/snowflakereceiver/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "MockDB"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/solacereceiver/.api
+++ b/receiver/solacereceiver/.api
@@ -1,0 +1,20 @@
+{
+  "structs": [
+    "Authentication",
+    "Config",
+    "FlowControl",
+    "FlowControlDelayedRetry",
+    "SaslExternalConfig",
+    "SaslPlainTextConfig",
+    "SaslXAuth2Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/splunkhecreceiver/.api
+++ b/receiver/splunkhecreceiver/.api
@@ -1,0 +1,19 @@
+{
+  "values": [
+    "SplittingStrategyLine",
+    "SplittingStrategyNone"
+  ],
+  "structs": [
+    "Config",
+    "SplittingStrategy"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/sqlqueryreceiver/.api
+++ b/receiver/sqlqueryreceiver/.api
@@ -1,0 +1,31 @@
+{
+  "values": [
+    "MetricAggregationCumulative",
+    "MetricAggregationDelta",
+    "MetricAggregationUnspecified",
+    "MetricTypeGauge",
+    "MetricTypeSum",
+    "MetricTypeUnspecified",
+    "MetricValueTypeDouble",
+    "MetricValueTypeInt",
+    "MetricValueTypeUnspecified"
+  ],
+  "structs": [
+    "Config",
+    "LogsCfg",
+    "MetricAggregation",
+    "MetricCfg",
+    "MetricType",
+    "MetricValueType",
+    "Query"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/sqlserverreceiver/.api
+++ b/receiver/sqlserverreceiver/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "MockPerfCounterWatcher"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/sshcheckreceiver/.api
+++ b/receiver/sshcheckreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/statsdreceiver/.api
+++ b/receiver/statsdreceiver/.api
@@ -1,0 +1,27 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "New",
+      "receiver": "",
+      "return_types": [
+        "receiver.Metrics",
+        "error"
+      ],
+      "param_types": [
+        "receiver.CreateSettings",
+        "Config",
+        "consumer.Metrics"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/syslogreceiver/.api
+++ b/receiver/syslogreceiver/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "ReceiverType",
+    "SysLogConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/tcplogreceiver/.api
+++ b/receiver/tcplogreceiver/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "ReceiverType",
+    "TCPLogConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/udplogreceiver/.api
+++ b/receiver/udplogreceiver/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "ReceiverType",
+    "UDPLogConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/vcenterreceiver/.api
+++ b/receiver/vcenterreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/wavefrontreceiver/.api
+++ b/receiver/wavefrontreceiver/.api
@@ -1,0 +1,15 @@
+{
+  "structs": [
+    "Config",
+    "WavefrontParser"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/webhookeventreceiver/.api
+++ b/receiver/webhookeventreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/windowseventlogreceiver/.api
+++ b/receiver/windowseventlogreceiver/.api
@@ -1,0 +1,23 @@
+{
+  "structs": [
+    "ReceiverType",
+    "WindowsLogConfig",
+    "WindowsLogConfig"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/windowsperfcountersreceiver/.api
+++ b/receiver/windowsperfcountersreceiver/.api
@@ -1,0 +1,20 @@
+{
+  "structs": [
+    "Config",
+    "CounterConfig",
+    "GaugeMetric",
+    "MetricConfig",
+    "MetricRep",
+    "ObjectConfig",
+    "SumMetric"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/zipkinreceiver/.api
+++ b/receiver/zipkinreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/receiver/zookeeperreceiver/.api
+++ b/receiver/zookeeperreceiver/.api
@@ -1,0 +1,14 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    }
+  ]
+}

--- a/testbed/mockdatareceivers/mockawsxrayreceiver/.api
+++ b/testbed/mockdatareceivers/mockawsxrayreceiver/.api
@@ -1,0 +1,39 @@
+{
+  "structs": [
+    "Config",
+    "MockAwsXrayReceiver"
+  ],
+  "functions": [
+    {
+      "name": "New",
+      "receiver": "",
+      "return_types": [
+        "*MockAwsXrayReceiver",
+        "error"
+      ],
+      "param_types": [
+        "consumer.Traces",
+        "receiver.CreateSettings",
+        "*Config"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "receiver.Factory"
+      ]
+    },
+    {
+      "name": "ToTraces",
+      "receiver": "",
+      "return_types": [
+        "ptrace.Traces",
+        "error"
+      ],
+      "param_types": [
+        "[]byte"
+      ]
+    }
+  ]
+}

--- a/testbed/mockdatasenders/mockdatadogagentexporter/.api
+++ b/testbed/mockdatasenders/mockdatadogagentexporter/.api
@@ -1,0 +1,27 @@
+{
+  "structs": [
+    "Config"
+  ],
+  "functions": [
+    {
+      "name": "CreateTracesExporter",
+      "receiver": "",
+      "return_types": [
+        "exporter.Traces",
+        "error"
+      ],
+      "param_types": [
+        "context.Context",
+        "exporter.CreateSettings",
+        "component.Config"
+      ]
+    },
+    {
+      "name": "NewFactory",
+      "receiver": "",
+      "return_types": [
+        "exporter.Factory"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a tool that scrapes through all top level packages associated with a go.mod file, and documents the API they expose. It stores the API into a .api file as JSON. And it adds a step to CI to fail if any API is changed.

This is a work in progress to initiate a discussion about how we want to manage our go API moving forward.