### PR TITLE
[examples/kubernetes] Fix the incorrect ordering

### DIFF
--- a/examples/kubernetes/otel-collector-config.yml
+++ b/examples/kubernetes/otel-collector-config.yml
@@ -43,9 +43,6 @@ receivers:
         timestamp:
           parse_from: attributes.time
           layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-      - type: move
-        from: attributes.log
-        to: body
       # Extract metadata from file path
       - type: regex_parser
         id: extract_metadata_from_filepath
@@ -53,6 +50,10 @@ receivers:
         parse_from: attributes["log.file.path"]
         cache:
           size: 128  # default maximum amount of Pods per Node is 110
+      # Update body field after finishing all parsing
+      - type: move
+        from: attributes.log
+        to: body
       # Rename attributes
       - type: move
         from: attributes.stream

--- a/examples/kubernetes/otel-collector.yaml
+++ b/examples/kubernetes/otel-collector.yaml
@@ -50,9 +50,6 @@ data:
             timestamp:
               parse_from: attributes.time
               layout: '%Y-%m-%dT%H:%M:%S.%LZ'
-          - type: move
-            from: attributes.log
-            to: body
           # Extract metadata from file path
           - type: regex_parser
             id: extract_metadata_from_filepath
@@ -60,6 +57,10 @@ data:
             parse_from: attributes["log.file.path"]
             cache:
               size: 128  # default maximum amount of Pods per Node is 110
+          # Update body field after finishing all parsing
+          - type: move
+            from: attributes.log
+            to: body
           # Rename attributes
           - type: move
             from: attributes.stream


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
After `parser-crio/parser-containerd/json_parser operator`, the next step is `extract_metadata_from_filepath`. Putting `move` operator between them doesn't work as expected.
Move `move` operator after `extract_metadata_from_filepath` so `body` changes.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Before this fix, the body doesn't change
```
LogRecord #0
ObservedTimestamp: 2023-08-03 17:49:51.007074834 +0000 UTC
Timestamp: 2021-02-16 08:59:31.252009327 +0000 UTC
SeverityText:
SeverityNumber: Unspecified(0)
Body: Str(2021-02-16T08:59:31.252009327+00:00 stdout F example: 11 Tue Feb 16 08:59:31 UTC 2021)
Attributes:
     -> log.file.path: Str(/var/log/pods/crio_logs-0_111122223333444455556666777788889999/logs/0.log)
     -> logtag: Str(F)
     -> log: Str(example: 11 Tue Feb 16 08:59:31 UTC 2021)
     -> time: Str(2021-02-16T08:59:31.252009327+00:00)
     -> log.iostream: Str(stdout)
Trace ID:
Span ID:
Flags: 0
```

After this fix, body has changed
```
LogRecord #0
ObservedTimestamp: 2023-08-03 18:04:08.915536468 +0000 UTC
Timestamp: 2021-02-16 08:59:31.252009327 +0000 UTC
SeverityText:
SeverityNumber: Unspecified(0)
Body: Str(example: 11 Tue Feb 16 08:59:31 UTC 2021)
Attributes:
     -> log.file.path: Str(/var/log/pods/crio_logs-0_111122223333444455556666777788889999/logs/0.log)
     -> time: Str(2021-02-16T08:59:31.252009327+00:00)
     -> logtag: Str(F)
     -> log.iostream: Str(stdout)
Trace ID:
Span ID:
Flags: 0
```

**Documentation:** <Describe the documentation added.>