### PR TITLE
[exporter/prometheusremotewrite] don't wrap error as permanent error for handleExport func

### DIFF
--- a/.chloggen/recoverable-error-on-network-issue.yaml
+++ b/.chloggen/recoverable-error-on-network-issue.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'prometheusremotewriteexporter'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "don't wrap error as permanent error for handleExport func"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [12998]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -203,7 +203,7 @@ func (prwe *prwExporter) export(ctx context.Context, requests []*prompb.WriteReq
 					}
 					if errExecute := prwe.execute(ctx, request); errExecute != nil {
 						mu.Lock()
-						errs = multierr.Append(errs, consumererror.NewPermanent(errExecute))
+						errs = multierr.Append(errs, errExecute)
 						mu.Unlock()
 					}
 				}
@@ -239,7 +239,7 @@ func (prwe *prwExporter) execute(ctx context.Context, writeReq *prompb.WriteRequ
 
 	resp, err := prwe.client.Do(req)
 	if err != nil {
-		return consumererror.NewPermanent(err)
+		return fmt.Errorf("remote write network issue; err = %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -455,12 +456,14 @@ func Test_PushMetrics(t *testing.T) {
 		returnErr          bool
 		isStaleMarker      bool
 		skipForWAL         bool
+		isPermanentErr     bool
 	}{
 		{
 			name:             "invalid_type_case",
 			metrics:          invalidTypeBatch,
 			httpResponseCode: http.StatusAccepted,
 			returnErr:        true,
+			isPermanentErr:   true,
 		},
 		{
 			name:               "intSum_case",
@@ -562,6 +565,7 @@ func Test_PushMetrics(t *testing.T) {
 			reqTestFunc:      checkFunc,
 			httpResponseCode: http.StatusAccepted,
 			returnErr:        true,
+			isPermanentErr:   true,
 		},
 		{
 			name:             "emptyCumulativeSum_case",
@@ -569,6 +573,7 @@ func Test_PushMetrics(t *testing.T) {
 			reqTestFunc:      checkFunc,
 			httpResponseCode: http.StatusAccepted,
 			returnErr:        true,
+			isPermanentErr:   true,
 		},
 		{
 			name:             "emptyCumulativeHistogram_case",
@@ -576,6 +581,7 @@ func Test_PushMetrics(t *testing.T) {
 			reqTestFunc:      checkFunc,
 			httpResponseCode: http.StatusAccepted,
 			returnErr:        true,
+			isPermanentErr:   true,
 		},
 		{
 			name:             "emptySummary_case",
@@ -583,6 +589,7 @@ func Test_PushMetrics(t *testing.T) {
 			reqTestFunc:      checkFunc,
 			httpResponseCode: http.StatusAccepted,
 			returnErr:        true,
+			isPermanentErr:   true,
 		},
 		{
 			name:               "staleNaNIntGauge_case",
@@ -708,6 +715,7 @@ func Test_PushMetrics(t *testing.T) {
 					err := prwe.PushMetrics(ctx, tt.metrics)
 					if tt.returnErr {
 						assert.Error(t, err)
+						assert.Equal(t, tt.isPermanentErr, consumererror.IsPermanent(err))
 						return
 					}
 					assert.NoError(t, err)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Fix issue error not retryable in prometheusRemoteWrite.

There is some cases when we encounter network issue, the error is marked as permanentError instead of retryable. 

This PR unwraps the error return from execute func.

**Link to tracking Issue:** <Issue number if applicable>

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/19211

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12998

**Testing:** <Describe what testing was performed and which tests were added.>

- Add flag on testTable in export_test.go to check if it should be a permanentError or not
- Local testing (building otel in local) and run without prometheus server running

```
2023-08-04T02:57:06.002+0700    info    exporterhelper/queued_retry.go:423      Exporting failed. Will retry the request after interval.        {"kind": "exporter", "data_type": "metrics", "name": "prometheusremotewrite", "error": "remote write network issue; err = Post \"http://prometheus:9090/api/v1/write\": dial tcp: lookup prometheus on 172.21.32.1:53: no such host", "interval": "35.843126ms"}

2023-08-04T02:57:16.064+0700    info    exporterhelper/queued_retry.go:423      Exporting failed. Will retry the request after interval.        {"kind": "exporter", "data_type": "metrics", "name": "prometheusremotewrite", "error": "remote write network issue; err = Post \"http://prometheus:9090/api/v1/write\": dial tcp: lookup prometheus on 172.21.32.1:53: no such host", "interval": "155.250272ms"}

2023-08-04T02:58:05.904+0700    error   exporterhelper/queued_retry.go:165      Exporting failed. No more retries left. Dropping data.  {"kind": "exporter", "data_type": "metrics", "name": "prometheusremotewrite", "error": "max elapsed time expired remote write network issue; err = Post \"http://prometheus:9090/api/v1/write\": dial tcp: lookup prometheus on 172.21.32.1:53: no such host", "dropped_items": 5}
```

**Documentation:** <Describe the documentation added.>