### PR TITLE
[receiver/datadog] Test case level retries for flaky DD receiver integration test

### DIFF
--- a/receiver/datadogreceiver/go.mod
+++ b/receiver/datadogreceiver/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/DataDog/datadog-agent/pkg/trace v0.48.0-devel
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.82.0
 	github.com/stretchr/testify v1.8.4
 	github.com/vmihailenco/msgpack/v4 v4.3.12

--- a/receiver/datadogreceiver/go.sum
+++ b/receiver/datadogreceiver/go.sum
@@ -30,6 +30,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Hopefully reduces the probability (without guaranteeing anything, because test executions have a timeout of a few minutes and shouldn't spend a lot of time retrying) of this class of test flake:

E.g., https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/5752929108/job/15595049479
```
make[2]: Entering directory '/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/receiver/datadogreceiver'
go test -race -timeout 300s -parallel 4 --tags="" ./...
...
--- FAIL: TestDatadogServer (0.00s)
    receiver_test.go:47: 
        	Error Trace:	/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/receiver/datadogreceiver/receiver_test.go:47
        	Error:      	Received unexpected error:
        	            	failed to create datadog listener: listen tcp 127.0.0.1:8126: bind: address already in use
        	Test:       	TestDatadogServer
FAIL
FAIL	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver	0.028s
?   	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/metadata	[no test files]
FAIL
```

**Link to tracking Issue:** N/A

**Testing:** Tests pass locally with same `-parallel N` invocation used by CI

**Documentation:** N/A