### PR TITLE
[chore] use context when making a http request

### DIFF
--- a/exporter/signalfxexporter/internal/dimensions/dimclient.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient.go
@@ -317,7 +317,8 @@ func (dc *DimensionClient) makePatchRequest(dim *DimensionUpdate) (*http.Request
 		return nil, err
 	}
 
-	req, err := http.NewRequest(
+	req, err := http.NewRequestWithContext(
+		context.Background(),
 		"PATCH",
 		strings.TrimRight(url.String(), "/")+"/_/sfxagent",
 		bytes.NewReader(json))


### PR DESCRIPTION
No context object is available in dimclient, so passing context.Background() for now.