### PR TITLE
[chore] [extension/storage/filestorage] do not assign a variable to be reassigned next

### DIFF
--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -269,7 +269,7 @@ func TestCompaction(t *testing.T) {
 	require.NoError(t, err)
 
 	var key string
-	i := 0
+	var i int
 
 	// magic numbers giving enough data to force bbolt to allocate a new page
 	// see https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/9004 for some discussion


### PR DESCRIPTION
Very simple lint fix found by wastedassign linter.