### PR TITLE
[chore] [pkg/translator/opencensus] Remove deprecation mark

### DIFF
--- a/pkg/translator/opencensus/metrics_to_oc.go
+++ b/pkg/translator/opencensus/metrics_to_oc.go
@@ -24,9 +24,8 @@ type labelKeysAndType struct {
 	allNumberDataPointValueInt bool
 }
 
-// ResourceMetricsToOC may be used only by OpenCensus receiver and exporter implementations.
-// Deprecated: Use pmetric.Metrics.
-// TODO: move this function to OpenCensus package.
+// ResourceMetricsToOC converts pmetric.ResourceMetrics to OC data format,
+// may be used only by OpenCensus receiver and exporter implementations.
 func ResourceMetricsToOC(rm pmetric.ResourceMetrics) (*occommon.Node, *ocresource.Resource, []*ocmetrics.Metric) {
 	node, resource := internalResourceToOC(rm.Resource())
 	ilms := rm.ScopeMetrics()

--- a/pkg/translator/opencensus/oc_to_metrics.go
+++ b/pkg/translator/opencensus/oc_to_metrics.go
@@ -11,9 +11,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-// OCToMetrics converts OC data format to data.MetricData.
-// Deprecated: use pmetric.Metrics instead. OCToMetrics may be used only by OpenCensus
-// receiver and exporter implementations.
+// OCToMetrics converts OC data format to pmetric.Metrics,
+// may be used only by OpenCensus receiver and exporter implementations.
 func OCToMetrics(node *occommon.Node, resource *ocresource.Resource, metrics []*ocmetrics.Metric) pmetric.Metrics {
 	dest := pmetric.NewMetrics()
 	if node == nil && resource == nil && len(metrics) == 0 {


### PR DESCRIPTION
The exported functions now only used by opencensus receiver and exporter. It's still makes sense to keep it in the pkg/translator for consistency with other formats, but deprecation mark isn't needed anymore.
