### PR TITLE
[extension/jaegerremotesampling] Support reload_interval option in remote mode of usage

### DIFF
--- a/.chloggen/zcross_jaegerremotesampling_support-remote-policy-ttl-caching.yaml
+++ b/.chloggen/zcross_jaegerremotesampling_support-remote-policy-ttl-caching.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+# If your change doesn't affect end users, such as a test fix or a tooling change,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: extension/jaegerremotesampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: gRPC remote source usage in jaegerremotesampling extension supports optional caching via existing `reload_interval` config
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24840]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/extension/jaegerremotesampling/README.md
+++ b/extension/jaegerremotesampling/README.md
@@ -24,7 +24,7 @@ Note that the port `14250` will clash with the Jaeger Receiver. When both are us
 
 Although this extension is derived from Jaeger, it can be used by any clients who can consume this standard, such as the [OpenTelemetry Java SDK](https://github.com/open-telemetry/opentelemetry-java/tree/v1.9.1/sdk-extensions/jaeger-remote-sampler).
 
-At this moment, the `reload_interval` option is only effective for the `file` source. In the future, this property will be used to control a local cache for a `remote` source.
+The `reload_interval` option is used to poll a file when using the `file` source. It is used to control a local cache for a `remote` source.
 
 The `file` source can be used to load files from the local file system or from remote HTTP/S sources. The `remote` source must be used with a gRPC server that provides a Jaeger remote sampling service.
 
@@ -34,6 +34,7 @@ The `file` source can be used to load files from the local file system or from r
 extensions:
   jaegerremotesampling:
     source:
+      reload_interval: 30s
       remote:
         endpoint: jaeger-collector:14250
   jaegerremotesampling/1:

--- a/extension/jaegerremotesampling/extension.go
+++ b/extension/jaegerremotesampling/extension.go
@@ -64,7 +64,13 @@ func (jrse *jrsExtension) Start(ctx context.Context, host component.Host) error 
 			return fmt.Errorf("failed to create the remote strategy store: %w", err)
 		}
 		jrse.closers = append(jrse.closers, conn.Close)
-		jrse.samplingStore = internal.NewRemoteStrategyStore(conn, jrse.cfg.Source.Remote)
+		remoteStore, closer := internal.NewRemoteStrategyStore(
+			conn,
+			jrse.cfg.Source.Remote,
+			jrse.cfg.Source.ReloadInterval,
+		)
+		jrse.closers = append(jrse.closers, closer.Close)
+		jrse.samplingStore = remoteStore
 	}
 
 	if jrse.cfg.HTTPServerSettings != nil {

--- a/extension/jaegerremotesampling/go.mod
+++ b/extension/jaegerremotesampling/go.mod
@@ -3,8 +3,10 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaege
 go 1.19
 
 require (
+	github.com/fortytw2/leaktest v1.3.0
 	github.com/jaegertracing/jaeger v1.41.0
 	github.com/stretchr/testify v1.8.4
+	github.com/tilinna/clock v1.1.0
 	go.opentelemetry.io/collector/component v0.82.0
 	go.opentelemetry.io/collector/config/configgrpc v0.82.0
 	go.opentelemetry.io/collector/config/confighttp v0.82.0

--- a/extension/jaegerremotesampling/go.sum
+++ b/extension/jaegerremotesampling/go.sum
@@ -102,6 +102,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
+github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -391,6 +393,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
+github.com/tilinna/clock v1.1.0 h1:6IQQQCo6KoBxVudv6gwtY8o4eDfhHo8ojA5dP0MfhSs=
+github.com/tilinna/clock v1.1.0/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=
 github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=

--- a/extension/jaegerremotesampling/internal/remote_strategy_cache.go
+++ b/extension/jaegerremotesampling/internal/remote_strategy_cache.go
@@ -1,0 +1,137 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling/internal"
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/tilinna/clock"
+)
+
+type serviceStrategyCache interface {
+	get(ctx context.Context, serviceName string) (*sampling.SamplingStrategyResponse, bool)
+	put(ctx context.Context, serviceName string, response *sampling.SamplingStrategyResponse)
+	Close() error
+}
+
+// serviceStrategyCacheEntry is a timestamped sampling strategy response
+type serviceStrategyCacheEntry struct {
+	retrievedAt      time.Time
+	strategyResponse *sampling.SamplingStrategyResponse
+}
+
+// serviceStrategyTTLCache is a naive in-memory TTL serviceStrategyTTLCache of service-specific sampling strategies
+// returned from the remote source. Each cached item has its own TTL used to determine whether it is valid for read
+// usage (based on the time of write).
+type serviceStrategyTTLCache struct {
+	itemTTL time.Duration
+
+	stopCh chan struct{}
+	rw     sync.RWMutex
+	items  map[string]serviceStrategyCacheEntry
+}
+
+// Initial size of cache's underlying map
+const initialRemoteResponseCacheSize = 32
+
+func newServiceStrategyCache(itemTTL time.Duration) serviceStrategyCache {
+	result := &serviceStrategyTTLCache{
+		itemTTL: itemTTL,
+		items:   make(map[string]serviceStrategyCacheEntry, initialRemoteResponseCacheSize),
+		stopCh:  make(chan struct{}),
+	}
+
+	// Launches a "cleaner" goroutine that naively blows away stale items with a frequency equal to the item TTL.
+	// Note that this is for memory usage and not for correctness (the get() function checks item validity).
+	go result.periodicallyClearCache(context.Background(), itemTTL)
+	return result
+}
+
+// get returns a cached sampling strategy if one is present and is no older than the serviceStrategyTTLCache's per-item TTL.
+func (c *serviceStrategyTTLCache) get(
+	ctx context.Context,
+	serviceName string,
+) (*sampling.SamplingStrategyResponse, bool) {
+	c.rw.RLock()
+	defer c.rw.RUnlock()
+	found, ok := c.items[serviceName]
+	if !ok {
+		return nil, false
+	}
+	if c.staleItem(ctx, found) {
+		return nil, false
+	}
+	return found.strategyResponse, true
+}
+
+// put unconditionally overwrites the given service's serviceStrategyTTLCache item entry and resets its timestamp used for TTL checks.
+func (c *serviceStrategyTTLCache) put(
+	ctx context.Context,
+	serviceName string,
+	response *sampling.SamplingStrategyResponse,
+) {
+	c.rw.Lock()
+	defer c.rw.Unlock()
+	c.items[serviceName] = serviceStrategyCacheEntry{
+		strategyResponse: response,
+		retrievedAt:      clock.Now(ctx),
+	}
+}
+
+// periodicallyClearCache provides a secondary "cleanup" mechanism motivated by wanting to guarantee
+// that the memory usage of this serviceStrategyTTLCache does not grow unbounded over long periods of collector uptime.
+// Ideally, this is really unnecessary because the get/put access pattern suffices to maintain a small
+// set of services. If that assumption is violated, this async process will periodically flush stale items.
+func (c *serviceStrategyTTLCache) periodicallyClearCache(
+	ctx context.Context,
+	schedulingPeriod time.Duration,
+) {
+	ticker := clock.NewTicker(ctx, schedulingPeriod)
+	for {
+		select {
+		case <-ticker.C:
+			c.rw.Lock()
+			newItems := make(map[string]serviceStrategyCacheEntry, initialRemoteResponseCacheSize)
+			for serviceName, item := range c.items {
+				if !c.staleItem(ctx, item) {
+					newItems[serviceName] = item
+				}
+			}
+			// Notice that we swap the map rather than using map's delete (which doesn't reduce its allocated size).
+			c.items = newItems
+			c.rw.Unlock()
+		case <-c.stopCh:
+			return
+		}
+	}
+}
+
+func (c *serviceStrategyTTLCache) Close() error {
+	close(c.stopCh)
+	return nil
+}
+
+func (c *serviceStrategyTTLCache) staleItem(ctx context.Context, item serviceStrategyCacheEntry) bool {
+	return clock.Now(ctx).After(item.retrievedAt.Add(c.itemTTL))
+}
+
+type noopStrategyCache struct{}
+
+func (n *noopStrategyCache) get(_ context.Context, _ string) (*sampling.SamplingStrategyResponse, bool) {
+	return nil, false
+}
+
+func (n *noopStrategyCache) put(_ context.Context, _ string, _ *sampling.SamplingStrategyResponse) {
+}
+
+func (n *noopStrategyCache) Close() error {
+	return nil
+}
+
+func newNoopStrategyCache() serviceStrategyCache {
+	return &noopStrategyCache{}
+}

--- a/extension/jaegerremotesampling/internal/remote_strategy_cache.go
+++ b/extension/jaegerremotesampling/internal/remote_strategy_cache.go
@@ -82,10 +82,9 @@ func (c *serviceStrategyTTLCache) put(
 	}
 }
 
-// periodicallyClearCache provides a secondary "cleanup" mechanism motivated by wanting to guarantee
-// that the memory usage of this serviceStrategyTTLCache does not grow unbounded over long periods of collector uptime.
-// Ideally, this is really unnecessary because the get/put access pattern suffices to maintain a small
-// set of services. If that assumption is violated, this async process will periodically flush stale items.
+// periodicallyClearCache periodically clears expired items from the cache and replaces the backing map with only
+// valid (fresh) items. Note that this is not necessary for correctness, just preferred for memory usage hygiene.
+// Client request activity drives the replacement of stale items with fresh items upon cache misses for any service.
 func (c *serviceStrategyTTLCache) periodicallyClearCache(
 	ctx context.Context,
 	schedulingPeriod time.Duration,

--- a/extension/jaegerremotesampling/internal/remote_strategy_cache_test.go
+++ b/extension/jaegerremotesampling/internal/remote_strategy_cache_test.go
@@ -1,0 +1,259 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/jaegertracing/jaeger/thrift-gen/sampling"
+	"github.com/stretchr/testify/assert"
+	"github.com/tilinna/clock"
+)
+
+const cacheTestItemTTL = 50 * time.Millisecond
+
+var testStrategyResponseA = &sampling.SamplingStrategyResponse{
+	ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+		SamplingRate: 0.1337,
+	},
+}
+
+var testStrategyResponseB = &sampling.SamplingStrategyResponse{
+	OperationSampling: &sampling.PerOperationSamplingStrategies{
+		DefaultSamplingProbability: 0.001,
+		PerOperationStrategies: []*sampling.OperationSamplingStrategy{
+			{
+				Operation: "always-sampled-op",
+				ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+					SamplingRate: 1.0,
+				},
+			},
+			{
+				Operation: "never-sampled-op",
+				ProbabilisticSampling: &sampling.ProbabilisticSamplingStrategy{
+					SamplingRate: 0,
+				},
+			},
+		},
+	},
+}
+
+func Test_serviceStrategyCache_ReadWriteSequence(t *testing.T) {
+	testTime := time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC)
+	mock := clock.NewMock(testTime)
+	ctx, cfn := mock.DeadlineContext(context.Background(), testTime.Add(3*time.Minute))
+	defer cfn()
+
+	cache := newServiceStrategyCache(cacheTestItemTTL).(*serviceStrategyTTLCache)
+	defer func() {
+		assert.NoError(t, cache.Close())
+	}()
+
+	// initial read returns nothing
+	result, ok := cache.get(ctx, "fooSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+	result, ok = cache.get(ctx, "barSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+
+	// perform a write for fooSvc at testTime
+	firstWriteTime := mock.Now()
+	cache.put(ctx, "fooSvc", testStrategyResponseA)
+
+	// whitebox assert for internal timestamp tracking (we don't want a caching bug manifesting as stale data serving)
+	// (post-write)
+	assert.Equal(t, serviceStrategyCacheEntry{
+		retrievedAt:      firstWriteTime,
+		strategyResponse: testStrategyResponseA,
+	}, cache.items["fooSvc"])
+
+	// read without time advancing
+	result, ok = cache.get(ctx, "fooSvc")
+	assert.True(t, ok)
+	assert.Equal(t, testStrategyResponseA, result)
+	result, ok = cache.get(ctx, "barSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+
+	// reading does not mutate internal cache state
+	assert.Equal(t, serviceStrategyCacheEntry{
+		retrievedAt:      firstWriteTime,
+		strategyResponse: testStrategyResponseA,
+	}, cache.items["fooSvc"])
+
+	// advance time (still within TTL time range)
+	mock.Add(20 * time.Millisecond)
+
+	// the written item is still available
+	result, ok = cache.get(ctx, "fooSvc")
+	assert.True(t, ok)
+	assert.Equal(t, testStrategyResponseA, result)
+	result, ok = cache.get(ctx, "barSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+
+	// advance time (just before end of TTL time range)
+	mock.Add(30 * time.Millisecond)
+
+	// the written item is still available
+	result, ok = cache.get(ctx, "fooSvc")
+	assert.True(t, ok)
+	assert.Equal(t, testStrategyResponseA, result)
+	result, ok = cache.get(ctx, "barSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+
+	// advance time (across TTL range)
+	mock.Add(1 * time.Millisecond)
+
+	// the (now stale) cached item is no longer available
+	result, ok = cache.get(ctx, "fooSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+	result, ok = cache.get(ctx, "barSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+
+	assert.Equal(t, serviceStrategyCacheEntry{
+		retrievedAt:      firstWriteTime,
+		strategyResponse: testStrategyResponseA,
+	}, cache.items["fooSvc"])
+}
+
+func Test_serviceStrategyCache_WritesUpdateTimestamp(t *testing.T) {
+	startTime := time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC)
+	mock := clock.NewMock(startTime)
+	ctx, cfn := mock.DeadlineContext(context.Background(), startTime.Add(3*time.Minute))
+	defer cfn()
+
+	cache := newServiceStrategyCache(cacheTestItemTTL).(*serviceStrategyTTLCache)
+	defer func() {
+		assert.NoError(t, cache.Close())
+	}()
+
+	// initial read returns nothing
+	result, ok := cache.get(ctx, "fooSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+	result, ok = cache.get(ctx, "barSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+
+	// perform a write for barSvc at startTime + 10ms
+	firstWriteTime := mock.Add(10 * time.Millisecond)
+	cache.put(ctx, "barSvc", testStrategyResponseA)
+
+	// whitebox assert for internal timestamp tracking
+	assert.Equal(t, serviceStrategyCacheEntry{
+		retrievedAt:      firstWriteTime,
+		strategyResponse: testStrategyResponseA,
+	}, cache.items["barSvc"])
+
+	// read without time advancing
+	result, ok = cache.get(ctx, "fooSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+	result, ok = cache.get(ctx, "barSvc")
+	assert.True(t, ok)
+	assert.Equal(t, testStrategyResponseA, result)
+
+	// advance time (still within TTL time range)
+	mock.Add(10 * time.Millisecond)
+
+	// the written item is still available
+	result, ok = cache.get(ctx, "fooSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+	result, ok = cache.get(ctx, "barSvc")
+	assert.True(t, ok)
+	assert.Equal(t, testStrategyResponseA, result)
+
+	// perform a write for barSvc at startTime + 30ms (still within TTL, but we retain this more recent data)
+	secondWriteTime := mock.Add(10 * time.Millisecond)
+	cache.put(ctx, "barSvc", testStrategyResponseB)
+
+	// whitebox assert for internal timestamp tracking (post-write, still-fresh cache entry replaced with newer data)
+	assert.Equal(t, serviceStrategyCacheEntry{
+		retrievedAt:      secondWriteTime,
+		strategyResponse: testStrategyResponseB,
+	}, cache.items["barSvc"])
+
+	// the written item is still available
+	result, ok = cache.get(ctx, "fooSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+	result, ok = cache.get(ctx, "barSvc")
+	assert.True(t, ok)
+	assert.Equal(t, testStrategyResponseB, result)
+
+	// advance time (to end of what is now a new/full TTL for the new fresh item)
+	mock.Add(cacheTestItemTTL)
+
+	result, ok = cache.get(ctx, "fooSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+	result, ok = cache.get(ctx, "barSvc")
+	assert.True(t, ok)
+	assert.Equal(t, testStrategyResponseB, result)
+
+	// advance time beyond the newer item's TTL
+	mock.Add(1)
+
+	// the (now stale) cached item is no longer available
+	result, ok = cache.get(ctx, "fooSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+	result, ok = cache.get(ctx, "barSvc")
+	assert.False(t, ok)
+	assert.Nil(t, result)
+
+	// internal state for now-stale second written item is still maintained
+	assert.Equal(t, serviceStrategyCacheEntry{
+		retrievedAt:      secondWriteTime,
+		strategyResponse: testStrategyResponseB,
+	}, cache.items["barSvc"])
+}
+
+func Test_serviceStrategyCache_Concurrency(t *testing.T) {
+	defer leaktest.CheckTimeout(t, time.Minute*3)
+
+	cache := newServiceStrategyCache(cacheTestItemTTL).(*serviceStrategyTTLCache)
+	defer func() {
+		assert.NoError(t, cache.Close())
+	}()
+
+	// newServiceStrategyCache invokes this as well but with a practically-motivated period that is too long for tests.
+	// We should at least exercise it for consideration by the race detector.
+	// NB: We don't use a mock clock in this concurrency test case.
+	go cache.periodicallyClearCache(context.Background(), time.Millisecond*1)
+
+	numThreads := 4
+	numIterationsPerThread := 32
+
+	wg := sync.WaitGroup{}
+	wg.Add(numThreads)
+	for i := 0; i < numThreads; i++ {
+		ii := i
+		go func() {
+			for j := 0; j < numIterationsPerThread; j++ {
+				for _, svcName := range []string{
+					fmt.Sprintf("thread-specific-service-%d", ii),
+					"contended-for-service",
+				} {
+					if _, ok := cache.get(context.Background(), svcName); !ok {
+						cache.put(context.Background(), svcName, &sampling.SamplingStrategyResponse{})
+					}
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Updates the jaegerremotesampling extension's `remote` mode of usage to support the `reload_interval` caching option already supported in `file` mode of usage.

**Link to tracking Issue:** #24840

**Testing:** 
* Integration test updates show collector<>remote interaction with and without caching
* Unit tests cover specific caching behavior inclusive of concurrency (leak detector / race detector etc)

**Documentation:** Existing readme snippet referring to the `reload_interval` config option explains that it works for both modes of `remote`.

(Reopened after closing #24854 – after addressing its incremental feedback – to double check my EasyCLA settings)