### PR TITLE
[processor/resourcedetectionprocessor] handle partial presence of heroku metadata

### DIFF
--- a/.chloggen/log-partial-metadata-heroku.yaml
+++ b/.chloggen/log-partial-metadata-heroku.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Collect heroku metadata available instead of exiting early. Log at debug level if metadata is missing to help troubleshooting.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [25059]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []


### PR DESCRIPTION
**Description:**
Currently, heroku metadata is only collected if the `HEROKU_DYNO_ID` environment variable is present.

It turns that under some circumstances this environment variable may be missing, but the rest of the variables may still be present. We collect what we can and offer to log at debug level if some or all metadata is missing to avoid cluttering logs.

**Testing:**
Unit tests.

**Documentation:**
No changes.