### PR TITLE
[chore] add a few additional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -129,6 +129,7 @@ linters-settings:
 
 linters:
   enable:
+    - decorder
     - depguard
     - errcheck
     - errorlint
@@ -141,12 +142,16 @@ linters:
     - gosec
     - govet
     - misspell
+    - prealloc
+    - predeclared
+    - reassign
     - revive
     - staticcheck
     - tenv
     - unconvert
     - unparam
     - unused
+    - wastedassign
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -142,7 +142,6 @@ linters:
     - gosec
     - govet
     - misspell
-    - prealloc
     - predeclared
     - reassign
     - revive


### PR DESCRIPTION
Adds a few linters that seem to prove most useful:
* https://golangci-lint.run/usage/linters/#decorder
* https://golangci-lint.run/usage/linters/#prealloc
* https://golangci-lint.run/usage/linters/#predeclared
* https://golangci-lint.run/usage/linters/#reassign
* https://golangci-lint.run/usage/linters/#wastedassign