### PR TITLE
[exporter/signalfxexporter] convert translated vmpage_io* metrics from bytes to pages

### DIFF
--- a/.chloggen/signalfx_exporter_vmpage_io.yaml
+++ b/.chloggen/signalfx_exporter_vmpage_io.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: convert vmpage_io* translated metrics to pages
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [25064]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/signalfxexporter/internal/translation/constants.go
+++ b/exporter/signalfxexporter/internal/translation/constants.go
@@ -395,6 +395,14 @@ translation_rules:
     major: vmpage_io.swap.out
     minor: vmpage_io.memory.out
 
+# convert from bytes to pages
+- action: divide_int
+  scale_factors_int:
+    vmpage_io.swap.in: 4096
+    vmpage_io.swap.out: 4096
+    vmpage_io.memory.in: 4096
+    vmpage_io.memory.out: 4096
+
 # process metric
 - action: copy_metrics
   mapping:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The current value is in bytes and vmpage_io* metrics should be in number o pages

**Testing:** <Describe what testing was performed and which tests were added.>
manual validation 
**Documentation:** <Describe the documentation added.>