### PR TITLE
[chore] [internal/aws] Change TestMapWithExpiry to explicitly test cleanup

### DIFF
--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -119,9 +119,9 @@ func TestMapWithExpiryAdd(t *testing.T) {
 
 func TestMapWithExpiryCleanup(t *testing.T) {
 	// This test is meant to explicitly test the CleanUp method. We do not need to use NewMapWithExpiry().
-	// Instead, manually create a Map Object, sleep, and then call cleanup to ensure that entires are erased.
+	// Instead, manually create a Map Object, sleep, and then call cleanup to ensure that entries are erased.
 	// The sweep method is tested in a later unit test.
-	// Explicitly testing CleanUp allows us to avoid tes race conditions when the sweep ticker may not fire within
+	// Explicitly testing CleanUp allows us to avoid test race conditions when the sweep ticker may not fire within
 	//the allotted sleep time.
 	store := &MapWithExpiry{
 		ttl:     time.Second,

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -124,7 +124,7 @@ func TestMapWithExpiryCleanup(t *testing.T) {
 	// Explicitly testing CleanUp allows us to avoid test race conditions when the sweep ticker may not fire within
 	// the allotted sleep time.
 	store := &MapWithExpiry{
-		ttl:     time.Second,
+		ttl:     time.Millisecond,
 		entries: make(map[interface{}]*MetricValue),
 		lock:    &sync.Mutex{},
 	}
@@ -139,7 +139,7 @@ func TestMapWithExpiryCleanup(t *testing.T) {
 	assert.Equal(t, 1, store.Size())
 	store.Unlock()
 
-	time.Sleep(time.Second * 2)
+	time.Sleep(time.Millisecond * 5)
 	store.CleanUp(time.Now())
 	store.Lock()
 	val, ok = store.Get(Key{MetricMetadata: "key1"})

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -139,7 +139,7 @@ func TestMapWithExpiryCleanup(t *testing.T) {
 	assert.Equal(t, 1, store.Size())
 	store.Unlock()
 
-	time.Sleep(time.Millisecond * 5)
+	time.Sleep(time.Millisecond * 2)
 	store.CleanUp(time.Now())
 	store.Lock()
 	val, ok = store.Get(Key{MetricMetadata: "key1"})

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -118,7 +118,16 @@ func TestMapWithExpiryAdd(t *testing.T) {
 }
 
 func TestMapWithExpiryCleanup(t *testing.T) {
-	store := NewMapWithExpiry(time.Second)
+	// This test is meant to explicitly test the CleanUp method. We do not need to use NewMapWithExpiry().
+	// Instead, manually create a Map Object, sleep, and then call cleanup to ensure that entires are erased.
+	// The sweep method is tested in a later unit test.
+	// Explicitly testing CleanUp allows us to avoid tes race conditions when the sweep ticker may not fire within
+	//the allotted sleep time.
+	store := &MapWithExpiry{
+		ttl:     time.Second,
+		entries: make(map[interface{}]*MetricValue),
+		lock:    &sync.Mutex{},
+	}
 	value1 := rand.Float64()
 	store.Lock()
 	store.Set(Key{MetricMetadata: "key1"}, MetricValue{RawValue: value1, Timestamp: time.Now()})
@@ -130,14 +139,14 @@ func TestMapWithExpiryCleanup(t *testing.T) {
 	assert.Equal(t, 1, store.Size())
 	store.Unlock()
 
-	time.Sleep(time.Second + time.Millisecond)
+	time.Sleep(time.Second * 2)
+	store.CleanUp(time.Now())
 	store.Lock()
 	val, ok = store.Get(Key{MetricMetadata: "key1"})
 	assert.Equal(t, false, ok)
 	assert.True(t, val == nil)
 	assert.Equal(t, 0, store.Size())
 	store.Unlock()
-	require.NoError(t, store.Shutdown())
 }
 
 func TestMapWithExpiryConcurrency(t *testing.T) {

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -122,7 +122,7 @@ func TestMapWithExpiryCleanup(t *testing.T) {
 	// Instead, manually create a Map Object, sleep, and then call cleanup to ensure that entries are erased.
 	// The sweep method is tested in a later unit test.
 	// Explicitly testing CleanUp allows us to avoid test race conditions when the sweep ticker may not fire within
-	//the allotted sleep time.
+	// the allotted sleep time.
 	store := &MapWithExpiry{
 		ttl:     time.Second,
 		entries: make(map[interface{}]*MetricValue),


### PR DESCRIPTION
**Description:** Changes the behavior of the specific test case to be more aligned with its behavior pre #25066

**Link to tracking Issue:** #25095 

