### PR TITLE
[chore] Update datadog-agent replacements

### DIFF
--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -1116,9 +1116,9 @@ replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api
 replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristretto v0.2.1
 
 // v0.47.x and v0.48.x are incompatible, prefer to use v0.48.x
-replace github.com/DataDog/datadog-agent/pkg/proto v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/proto => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
 
-replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver => ../../receiver/snowflakereceiver
 

--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -418,5 +418,5 @@ replaces:
   - github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector => ../../connector/spanmetricsconnector
   - github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20180801171038-322a19404e37
   - github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristretto v0.2.1
-  - github.com/DataDog/datadog-agent/pkg/proto v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
-  - github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
+  - github.com/DataDog/datadog-agent/pkg/proto => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
+  - github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -1136,9 +1136,9 @@ replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api
 
 replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristretto v0.2.1
 
-replace github.com/DataDog/datadog-agent/pkg/proto v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/proto => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
 
-replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
 
 // ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules
 replace cloud.google.com/go => cloud.google.com/go v0.110.2

--- a/cmd/oteltestbedcol/builder-config.yaml
+++ b/cmd/oteltestbedcol/builder-config.yaml
@@ -96,5 +96,5 @@ replaces:
   - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil => ../../pkg/pdatautil
   - github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20180801171038-322a19404e37
   - github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristretto v0.2.1
-  - github.com/DataDog/datadog-agent/pkg/proto v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
-  - github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
+  - github.com/DataDog/datadog-agent/pkg/proto => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
+  - github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1

--- a/cmd/oteltestbedcol/go.mod
+++ b/cmd/oteltestbedcol/go.mod
@@ -380,9 +380,9 @@ replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api
 
 replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristretto v0.2.1
 
-replace github.com/DataDog/datadog-agent/pkg/proto v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/proto => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
 
-replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
 
 // ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules
 replace cloud.google.com/go => cloud.google.com/go v0.110.2

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -270,9 +270,9 @@ replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api
 replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristretto v0.2.1
 
 // v0.47.x and v0.48.x are incompatible, prefer to use v0.48.x
-replace github.com/DataDog/datadog-agent/pkg/proto v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/proto => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
 
-replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
 

--- a/go.mod
+++ b/go.mod
@@ -1128,8 +1128,8 @@ replace github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api
 replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristretto v0.2.1
 
 // v0.47.x and v0.48.x are incompatible, prefer to use v0.48.x
-replace github.com/DataDog/datadog-agent/pkg/proto v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/proto => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
 
-replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver => ./receiver/snowflakereceiver

--- a/internal/datadog/go.mod
+++ b/internal/datadog/go.mod
@@ -73,6 +73,6 @@ require (
 )
 
 // v0.47.x and v0.48.x are incompatible, prefer to use v0.48.x
-replace github.com/DataDog/datadog-agent/pkg/proto v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/proto => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
 
-replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1

--- a/processor/datadogprocessor/go.mod
+++ b/processor/datadogprocessor/go.mod
@@ -94,9 +94,9 @@ require (
 replace github.com/outcaste-io/ristretto v0.2.0 => github.com/outcaste-io/ristretto v0.2.1
 
 // v0.47.x and v0.48.x are incompatible, prefer to use v0.48.x
-replace github.com/DataDog/datadog-agent/pkg/proto v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/proto => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
 
-replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog => ../../internal/datadog
 

--- a/receiver/datadogreceiver/go.mod
+++ b/receiver/datadogreceiver/go.mod
@@ -69,9 +69,9 @@ require (
 )
 
 // v0.47.x and v0.48.x are incompatible, prefer to use v0.48.x
-replace github.com/DataDog/datadog-agent/pkg/proto v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/proto => github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1
 
-replace github.com/DataDog/datadog-agent/pkg/trace v0.47.0-rc.7 => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
+replace github.com/DataDog/datadog-agent/pkg/trace => github.com/DataDog/datadog-agent/pkg/trace v0.48.0-beta.1
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent => ../../internal/sharedcomponent
 


### PR DESCRIPTION
To unblock Dependabot PRs. After https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/25070, it tries to downgrade to v0.47.0-rc.6 https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/5801209655/job/15724957045

cc @songy23 