### PR TITLE
Improve system.cpu.utilization description (Host metrics receiver)

### DIFF
--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Improved description of the system.cpu.utilization metrics.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [25115]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -27,7 +27,7 @@ metrics:
 
   system.cpu.utilization:
     enabled: false
-    description: Difference in system.cpu.time since the last measurement per logical CPU, divided by the elapsed time.
+    description: Difference in system.cpu.time since the last measurement per logical CPU, divided by the elapsed time (value in interval [0,1]).
     unit: 1
     gauge:
       value_type: double

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -27,7 +27,7 @@ metrics:
 
   system.cpu.utilization:
     enabled: false
-    description: Difference in system.cpu.time since the last measurement, divided by the elapsed time and number of logical CPUs.
+    description: Difference in system.cpu.time since the last measurement per logical CPU, divided by the elapsed time.
     unit: 1
     gauge:
       value_type: double


### PR DESCRIPTION
After checking with @dmitryax and @rmfitzpatrick, here's an improved description of `system.cpu.utilization`.