### PR TITLE
Add support for linux/s390x architecture

### DIFF
--- a/.chloggen/s390x-platform-enablement.yaml
+++ b/.chloggen/s390x-platform-enablement.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: supported platforms
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `linux/s390x` architecture to cross build tests in CI
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [25138]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -406,6 +406,7 @@ jobs:
           - arm
           - arm64
           - ppc64le
+          - s390x
         include:
           - os: linux
           - arch: arm
@@ -417,12 +418,16 @@ jobs:
             arch: arm
           - os: darwin
             arch: ppc64le
+          - os: darwin
+            arch: s390x
           - os: windows
             arch: arm
           - os: windows
             arch: arm64
           - os: windows
             arch: ppc64le
+          - os: windows
+            arch: s390x
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
@@ -485,6 +490,8 @@ jobs:
         run: ./internal/buildscripts/packaging/fpm/${{ matrix.package_type }}/build.sh "${{ steps.github_tag.outputs.tag }}" "arm64" "./dist/"
       - name: Build ${{ matrix.package_type }} ppc64le package
         run: ./internal/buildscripts/packaging/fpm/${{ matrix.package_type }}/build.sh "${{ steps.github_tag.outputs.tag }}" "ppc64le" "./dist/"
+      - name: Build ${{ matrix.package_type }} s390x package
+        run: ./internal/buildscripts/packaging/fpm/${{ matrix.package_type }}/build.sh "${{ steps.github_tag.outputs.tag }}" "s390x" "./dist/"
       - name: Test ${{ matrix.package_type }} package
         run: |
           if [[ "${{ matrix.package_type }}" = "deb" ]]; then

--- a/.github/workflows/scripts/verify-dist-files-exist.sh
+++ b/.github/workflows/scripts/verify-dist-files-exist.sh
@@ -9,6 +9,7 @@ files=(
     bin/otelcontribcol_linux_arm64
     bin/otelcontribcol_linux_ppc64le
     bin/otelcontribcol_linux_amd64
+    bin/otelcontribcol_linux_s390x
     bin/otelcontribcol_windows_amd64.exe
     dist/otel-contrib-collector-*.aarch64.rpm
     dist/otel-contrib-collector_*_amd64.deb
@@ -16,6 +17,8 @@ files=(
     dist/otel-contrib-collector_*_arm64.deb
     dist/otel-contrib-collector-*.ppc64le.rpm
     dist/otel-contrib-collector_*_ppc64le.deb
+    dist/otel-contrib-collector_*_s390x.deb
+    dist/otel-contrib-collector-*.s390x.rpm
     # skip. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10113
     # dist/otel-contrib-collector-*amd64.msi
 


### PR DESCRIPTION
The `s390x` CPU architecture is the base for IBM zSeries (aka mainframe) systems. It is beneficial for users of this platform to have a supported way to install pre-compiled binaries for the OpenTelemetry collector in a Linux environment. This issue and associated pull requests will enable the building of all relevant binary artifacts for `linux/s390x` as part of the regular CI pipeline.

IBM has performed tests internally to ensure successful build (via cross-compilation) and runtime (on native platform) integrity of the OpenTelemetry collector (core and contrib) via the unit test suites and specific use-cases.

For more information and discussion please refer to the initial feature request issue (open-telemetry/opentelemetry-collector-releases#378).

Resolves: #25138