### PR TITLE
[chore] [dataset/exporter]: Fix flaky windows tests

### DIFF
--- a/exporter/datasetexporter/logs_exporter_test.go
+++ b/exporter/datasetexporter/logs_exporter_test.go
@@ -404,7 +404,7 @@ func TestConsumeLogsShouldSucceed(t *testing.T) {
 		DatasetURL: server.URL,
 		APIKey:     "key-lib",
 		BufferSettings: BufferSettings{
-			MaxLifetime:          time.Millisecond,
+			MaxLifetime:          500 * time.Millisecond,
 			GroupBy:              []string{"attributes.container_id"},
 			RetryInitialInterval: time.Second,
 			RetryMaxInterval:     time.Minute,


### PR DESCRIPTION
**Description:** There is flaky Windows test

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/25094

**Testing:** 
Before applying this change, it has failed in 1 test out of 60. So this should pass 200 tests without failure.

**Documentation:** <Describe the documentation added.>