### PR TITLE
[chore] [CI] Exclude go version matrix from the unittest job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -277,9 +277,6 @@ jobs:
           path: ${{ matrix.group }}-coverage.txt
   unittest:
     if: ${{ github.actor != 'dependabot[bot]' && always() }}
-    strategy:
-      matrix:
-        go-version: ["1.20", 1.19] # 1.20 is interpreted as 1.2 without quotes
     runs-on: ubuntu-latest
     needs: [setup-environment, unittest-matrix]
     steps:


### PR DESCRIPTION
To not update required jobs every time a new go version is released.

Needed for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/25116