### PR TITLE
Add an interface in fileconsumer instead

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -80,7 +80,7 @@ type HeaderConfig struct {
 }
 
 // Build will build a file input operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback) (*Manager, error) {
+func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback) (ManagerInterface, error) {
 	if err := c.validate(); err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback) (*Manager, 
 }
 
 // BuildWithSplitFunc will build a file input operator with customized splitFunc function
-func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit emit.Callback, splitFunc bufio.SplitFunc) (*Manager, error) {
+func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit emit.Callback, splitFunc bufio.SplitFunc) (ManagerInterface, error) {
 	if err := c.validate(); err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit emit.Callback
 	return c.buildManager(logger, emit, factory)
 }
 
-func (c Config) buildManager(logger *zap.SugaredLogger, emit emit.Callback, factory splitterFactory) (*Manager, error) {
+func (c Config) buildManager(logger *zap.SugaredLogger, emit emit.Callback, factory splitterFactory) (ManagerInterface, error) {
 	if emit == nil {
 		return nil, fmt.Errorf("must provide emit function")
 	}

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -631,7 +631,7 @@ func TestBuild(t *testing.T) {
 				return
 			}
 
-			tc.validate(t, input)
+			tc.validate(t, input.(*Manager))
 		})
 	}
 }
@@ -710,7 +710,7 @@ func TestBuildWithSplitFunc(t *testing.T) {
 				return
 			}
 
-			tc.validate(t, input)
+			tc.validate(t, input.(*Manager))
 		})
 	}
 }
@@ -796,7 +796,7 @@ func TestBuildWithHeader(t *testing.T) {
 			if err != nil {
 				return
 			}
-			tc.validate(t, input)
+			tc.validate(t, input.(*Manager))
 		})
 	}
 }

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -26,6 +26,11 @@ const (
 	logFilePathResolved = "log.file.path_resolved"
 )
 
+type ManagerInterface interface {
+	Start(operator.Persister) error
+	Stop() error
+}
+
 type Manager struct {
 	*zap.SugaredLogger
 	wg     sync.WaitGroup

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -91,7 +91,7 @@ func buildTestManager(t *testing.T, cfg *Config, opts ...testManagerOption) (*Ma
 	}
 	input, err := cfg.Build(testutil.Logger(t), testEmitFunc(tmc.emitChan))
 	require.NoError(t, err)
-	return input, tmc.emitChan
+	return input.(*Manager), tmc.emitChan
 }
 
 func openFile(tb testing.TB, path string) *os.File {

--- a/pkg/stanza/operator/input/file/file.go
+++ b/pkg/stanza/operator/input/file/file.go
@@ -19,7 +19,7 @@ type toBodyFunc func([]byte) interface{}
 type Input struct {
 	helper.InputOperator
 
-	fileConsumer *fileconsumer.Manager
+	fileConsumer fileconsumer.ManagerInterface
 
 	toBody toBodyFunc
 }

--- a/receiver/otlpjsonfilereceiver/file.go
+++ b/receiver/otlpjsonfilereceiver/file.go
@@ -45,7 +45,7 @@ func createDefaultConfig() component.Config {
 }
 
 type receiver struct {
-	input     *fileconsumer.Manager
+	input     fileconsumer.ManagerInterface
 	id        component.ID
 	storageID *component.ID
 }


### PR DESCRIPTION
**Description:** Create a Manager Interface for `fileconsumer`. 
This would result in a cleaner and more readable code for threadpool PR. 
Going with the interface is much better and it will keep the threadpool wholly isolated. 

@djaglowski, I have the threadpool changes ready to be pushed. I need to know your POV for my approach to moving towards interfaces. 