### PR TITLE
[receiver/kubeletstatsreciever] add volume attrs for CSI-backed PVCs

### DIFF
--- a/receiver/kubeletstatsreceiver/documentation.md
+++ b/receiver/kubeletstatsreceiver/documentation.md
@@ -382,6 +382,8 @@ The inodes used by the filesystem. This may not equal inodes - free because file
 | ---- | ----------- | ------ | ------- |
 | aws.volume.id | The id of the AWS Volume | Any Str | true |
 | container.id | Container id used to identify container | Any Str | true |
+| csi.driver | CSI driver | Any Str | true |
+| csi.volume.handle | CSI volume handle | Any Str | true |
 | fs.type | The filesystem type of the Volume | Any Str | true |
 | gce.pd.name | The name of the persistent disk in GCE | Any Str | true |
 | glusterfs.endpoints.name | The endpoint name that details Glusterfs topology | Any Str | true |

--- a/receiver/kubeletstatsreceiver/internal/kubelet/conventions.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/conventions.go
@@ -16,5 +16,6 @@ const (
 	labelValueLocalVolume           = "local"
 	labelValueAWSEBSVolume          = "awsElasticBlockStore"
 	labelValueGCEPDVolume           = "gcePersistentDisk"
+	labelValueCSIPersistentVolume   = "csiPersistentVolume"
 	labelValueGlusterFSVolume       = "glusterfs"
 )

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_config.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_config.go
@@ -209,6 +209,8 @@ type ResourceAttributeConfig struct {
 type ResourceAttributesConfig struct {
 	AwsVolumeID                  ResourceAttributeConfig `mapstructure:"aws.volume.id"`
 	ContainerID                  ResourceAttributeConfig `mapstructure:"container.id"`
+	CsiDriver                    ResourceAttributeConfig `mapstructure:"csi.driver"`
+	CsiVolumeHandle              ResourceAttributeConfig `mapstructure:"csi.volume.handle"`
 	FsType                       ResourceAttributeConfig `mapstructure:"fs.type"`
 	GcePdName                    ResourceAttributeConfig `mapstructure:"gce.pd.name"`
 	GlusterfsEndpointsName       ResourceAttributeConfig `mapstructure:"glusterfs.endpoints.name"`
@@ -230,6 +232,12 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 			Enabled: true,
 		},
 		ContainerID: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		CsiDriver: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		CsiVolumeHandle: ResourceAttributeConfig{
 			Enabled: true,
 		},
 		FsType: ResourceAttributeConfig{

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_config_test.go
@@ -72,6 +72,8 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				ResourceAttributes: ResourceAttributesConfig{
 					AwsVolumeID:                  ResourceAttributeConfig{Enabled: true},
 					ContainerID:                  ResourceAttributeConfig{Enabled: true},
+					CsiDriver:                    ResourceAttributeConfig{Enabled: true},
+					CsiVolumeHandle:              ResourceAttributeConfig{Enabled: true},
 					FsType:                       ResourceAttributeConfig{Enabled: true},
 					GcePdName:                    ResourceAttributeConfig{Enabled: true},
 					GlusterfsEndpointsName:       ResourceAttributeConfig{Enabled: true},
@@ -138,6 +140,8 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				ResourceAttributes: ResourceAttributesConfig{
 					AwsVolumeID:                  ResourceAttributeConfig{Enabled: false},
 					ContainerID:                  ResourceAttributeConfig{Enabled: false},
+					CsiDriver:                    ResourceAttributeConfig{Enabled: false},
+					CsiVolumeHandle:              ResourceAttributeConfig{Enabled: false},
 					FsType:                       ResourceAttributeConfig{Enabled: false},
 					GcePdName:                    ResourceAttributeConfig{Enabled: false},
 					GlusterfsEndpointsName:       ResourceAttributeConfig{Enabled: false},
@@ -189,6 +193,8 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				AwsVolumeID:                  ResourceAttributeConfig{Enabled: true},
 				ContainerID:                  ResourceAttributeConfig{Enabled: true},
+				CsiDriver:                    ResourceAttributeConfig{Enabled: true},
+				CsiVolumeHandle:              ResourceAttributeConfig{Enabled: true},
 				FsType:                       ResourceAttributeConfig{Enabled: true},
 				GcePdName:                    ResourceAttributeConfig{Enabled: true},
 				GlusterfsEndpointsName:       ResourceAttributeConfig{Enabled: true},
@@ -209,6 +215,8 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				AwsVolumeID:                  ResourceAttributeConfig{Enabled: false},
 				ContainerID:                  ResourceAttributeConfig{Enabled: false},
+				CsiDriver:                    ResourceAttributeConfig{Enabled: false},
+				CsiVolumeHandle:              ResourceAttributeConfig{Enabled: false},
 				FsType:                       ResourceAttributeConfig{Enabled: false},
 				GcePdName:                    ResourceAttributeConfig{Enabled: false},
 				GlusterfsEndpointsName:       ResourceAttributeConfig{Enabled: false},

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics_test.go
@@ -225,6 +225,8 @@ func TestMetricsBuilder(t *testing.T) {
 			rb := mb.NewResourceBuilder()
 			rb.SetAwsVolumeID("aws.volume.id-val")
 			rb.SetContainerID("container.id-val")
+			rb.SetCsiDriver("csi.driver-val")
+			rb.SetCsiVolumeHandle("csi.volume.handle-val")
 			rb.SetFsType("fs.type-val")
 			rb.SetGcePdName("gce.pd.name-val")
 			rb.SetGlusterfsEndpointsName("glusterfs.endpoints.name-val")

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_resource.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_resource.go
@@ -35,6 +35,20 @@ func (rb *ResourceBuilder) SetContainerID(val string) {
 	}
 }
 
+// SetCsiDriver sets provided value as "csi.driver" attribute.
+func (rb *ResourceBuilder) SetCsiDriver(val string) {
+	if rb.config.CsiDriver.Enabled {
+		rb.res.Attributes().PutStr("csi.driver", val)
+	}
+}
+
+// SetCsiVolumeHandle sets provided value as "csi.volume.handle" attribute.
+func (rb *ResourceBuilder) SetCsiVolumeHandle(val string) {
+	if rb.config.CsiVolumeHandle.Enabled {
+		rb.res.Attributes().PutStr("csi.volume.handle", val)
+	}
+}
+
 // SetFsType sets provided value as "fs.type" attribute.
 func (rb *ResourceBuilder) SetFsType(val string) {
 	if rb.config.FsType.Enabled {

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_resource_test.go
@@ -15,6 +15,8 @@ func TestResourceBuilder(t *testing.T) {
 			rb := NewResourceBuilder(cfg)
 			rb.SetAwsVolumeID("aws.volume.id-val")
 			rb.SetContainerID("container.id-val")
+			rb.SetCsiDriver("csi.driver-val")
+			rb.SetCsiVolumeHandle("csi.volume.handle-val")
 			rb.SetFsType("fs.type-val")
 			rb.SetGcePdName("gce.pd.name-val")
 			rb.SetGlusterfsEndpointsName("glusterfs.endpoints.name-val")
@@ -34,9 +36,9 @@ func TestResourceBuilder(t *testing.T) {
 
 			switch test {
 			case "default":
-				assert.Equal(t, 15, res.Attributes().Len())
+				assert.Equal(t, 17, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 15, res.Attributes().Len())
+				assert.Equal(t, 17, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -53,6 +55,16 @@ func TestResourceBuilder(t *testing.T) {
 			assert.True(t, ok)
 			if ok {
 				assert.EqualValues(t, "container.id-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("csi.driver")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "csi.driver-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("csi.volume.handle")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "csi.volume.handle-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("fs.type")
 			assert.True(t, ok)

--- a/receiver/kubeletstatsreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/kubeletstatsreceiver/internal/metadata/testdata/config.yaml
@@ -90,6 +90,10 @@ all_set:
       enabled: true
     container.id:
       enabled: true
+    csi.driver:
+      enabled: true
+    csi.volume.handle:
+      enabled: true
     fs.type:
       enabled: true
     gce.pd.name:
@@ -206,6 +210,10 @@ none_set:
     aws.volume.id:
       enabled: false
     container.id:
+      enabled: false
+    csi.driver:
+      enabled: false
+    csi.volume.handle:
       enabled: false
     fs.type:
       enabled: false

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -69,6 +69,14 @@ resource_attributes:
     description: "Glusterfs volume path"
     enabled: true
     type: string
+  csi.volume.handle:
+    description: "CSI volume handle"
+    enabled: true
+    type: string
+  csi.driver:
+    description: "CSI driver"
+    enabled: true
+    type: string
 
 attributes:
   interface:


### PR DESCRIPTION
**Description:**
Add a couple new attrs to record information about CSI volume types:
* `csi.driver`: The raw CSI.Driver field.
* `csi.volume.handle`: The raw CSI.VolumeHandle field. This is intended to be a unique ID referencing a disk for the underlying driver.

A new label value for `k8s.volume.type`: `csiPersistentVolume`. I kept "PersistentVolume" in there to disambiguate from CSI-backed disks that are ephemeral. I skipped supporting ephemeral disks because I'm less sure about how those come together.

Also, if we can identify the CSI driver as a GCP-backed one, use the `VolumeHandle` to populate `gce.pd.name`. This gives parity with the legacy `GCEPersistentDisk` in-tree PV kind.


**Link to tracking Issue:** n/a

**Testing:** 
A test is added to validate all labels described above are populated.

**Documentation:**
None. Should a changelog entry be added?