### PR TITLE
Promoting X-Ray consumer spans to segments

### DIFF
--- a/.chloggen/awsxray-promote-consumer-span.yaml
+++ b/.chloggen/awsxray-promote-consumer-span.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: awsxrayexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Promoting consumer spans to segments and naming them after their resoruce service name
+note: Promoting consumer spans to segments and follow server span naming
 
 # One or more tracking issues related to the change
 issues: [25177]

--- a/.chloggen/awsxray-promote-consumer-span.yaml
+++ b/.chloggen/awsxray-promote-consumer-span.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promoting consumer spans to segments and naming them after their resoruce service name
+
+# One or more tracking issues related to the change
+issues: [25177]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -175,7 +175,7 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 	}
 
 	if name == "" && (span.Kind() == ptrace.SpanKindServer || span.Kind() == ptrace.SpanKindConsumer) {
-		// Only for a server span, we can use the resource.
+		// Only for a server and consumer spans, we can use the resource.
 		if service, ok := resource.Attributes().Get(conventions.AttributeServiceName); ok {
 			name = service.Str()
 		}

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -82,6 +82,7 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 
 	storeResource := true
 	if span.Kind() != ptrace.SpanKindServer &&
+		span.Kind() != ptrace.SpanKindConsumer &&
 		!span.ParentSpanID().IsEmpty() {
 		segmentType = "subsegment"
 		// We only store the resource information for segments, the local root.
@@ -124,6 +125,7 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 			name = localServiceName.Str()
 		}
 	}
+
 	if span.Kind() == ptrace.SpanKindClient || span.Kind() == ptrace.SpanKindProducer {
 		if remoteServiceName, ok := attributes.Get(awsRemoteService); ok {
 			name = remoteServiceName.Str()
@@ -172,7 +174,7 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 		}
 	}
 
-	if name == "" && span.Kind() == ptrace.SpanKindServer {
+	if name == "" && (span.Kind() == ptrace.SpanKindServer || span.Kind() == ptrace.SpanKindConsumer) {
 		// Only for a server span, we can use the resource.
 		if service, ok := resource.Attributes().Get(conventions.AttributeServiceName); ok {
 			name = service.Str()

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -947,7 +947,7 @@ func TestProducerSpanWithAwsRemoteServiceName(t *testing.T) {
 	assert.False(t, strings.Contains(jsonStr, "user"))
 }
 
-func TestConsumerSpanWithoutNameOverrides(t *testing.T) {
+func TestConsumerSpanWithoutSegmentNameOverrides(t *testing.T) {
 	spanName := "destination receive"
 	parentSpanID := newSegmentID()
 	user := "testingT"


### PR DESCRIPTION
**Description:**
Promote consumer spans to segments and follow server span naming.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/25177

**Testing:**
Unit Testing