### PR TITLE
[chore] [clickhouseexporter] use errors.Join instead of go.uber.org/multierr

### DIFF
--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.uber.org/multierr"
 )
 
 // Config defines configuration for Elastic exporter.
@@ -59,17 +58,17 @@ var (
 // Validate the clickhouse server configuration.
 func (cfg *Config) Validate() (err error) {
 	if cfg.Endpoint == "" {
-		err = multierr.Append(err, errConfigNoEndpoint)
+		err = errors.Join(err, errConfigNoEndpoint)
 	}
 	dsn, e := cfg.buildDSN(cfg.Database)
 	if e != nil {
-		err = multierr.Append(err, e)
+		err = errors.Join(err, e)
 	}
 
 	// Validate DSN with clickhouse driver.
 	// Last chance to catch invalid config.
 	if _, e := clickhouse.ParseDSN(dsn); e != nil {
-		err = multierr.Append(err, e)
+		err = errors.Join(err, e)
 	}
 
 	return err

--- a/exporter/clickhouseexporter/exporter_logs_test.go
+++ b/exporter/clickhouseexporter/exporter_logs_test.go
@@ -16,7 +16,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
@@ -61,10 +60,10 @@ func TestLogsExporter_New(t *testing.T) {
 
 			var err error
 			exporter, err := newLogsExporter(zap.NewNop(), test.config)
-			err = multierr.Append(err, err)
+			err = errors.Join(err, err)
 
 			if exporter != nil {
-				err = multierr.Append(err, exporter.start(context.TODO(), nil))
+				err = errors.Join(err, exporter.start(context.TODO(), nil))
 				defer func() {
 					require.NoError(t, exporter.shutdown(context.TODO()))
 				}()

--- a/exporter/clickhouseexporter/exporter_metrics.go
+++ b/exporter/clickhouseexporter/exporter_metrics.go
@@ -6,11 +6,11 @@ package clickhouseexporter // import "github.com/open-telemetry/opentelemetry-co
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter/internal"
@@ -68,15 +68,15 @@ func (e *metricsExporter) pushMetricsData(ctx context.Context, md pmetric.Metric
 				//exhaustive:enforce
 				switch r.Type() {
 				case pmetric.MetricTypeGauge:
-					errs = multierr.Append(errs, metricsMap[pmetric.MetricTypeGauge].Add(resAttr, metrics.SchemaUrl(), scopeInstr, scopeURL, r.Gauge(), r.Name(), r.Description(), r.Unit()))
+					errs = errors.Join(errs, metricsMap[pmetric.MetricTypeGauge].Add(resAttr, metrics.SchemaUrl(), scopeInstr, scopeURL, r.Gauge(), r.Name(), r.Description(), r.Unit()))
 				case pmetric.MetricTypeSum:
-					errs = multierr.Append(errs, metricsMap[pmetric.MetricTypeSum].Add(resAttr, metrics.SchemaUrl(), scopeInstr, scopeURL, r.Sum(), r.Name(), r.Description(), r.Unit()))
+					errs = errors.Join(errs, metricsMap[pmetric.MetricTypeSum].Add(resAttr, metrics.SchemaUrl(), scopeInstr, scopeURL, r.Sum(), r.Name(), r.Description(), r.Unit()))
 				case pmetric.MetricTypeHistogram:
-					errs = multierr.Append(errs, metricsMap[pmetric.MetricTypeHistogram].Add(resAttr, metrics.SchemaUrl(), scopeInstr, scopeURL, r.Histogram(), r.Name(), r.Description(), r.Unit()))
+					errs = errors.Join(errs, metricsMap[pmetric.MetricTypeHistogram].Add(resAttr, metrics.SchemaUrl(), scopeInstr, scopeURL, r.Histogram(), r.Name(), r.Description(), r.Unit()))
 				case pmetric.MetricTypeExponentialHistogram:
-					errs = multierr.Append(errs, metricsMap[pmetric.MetricTypeExponentialHistogram].Add(resAttr, metrics.SchemaUrl(), scopeInstr, scopeURL, r.ExponentialHistogram(), r.Name(), r.Description(), r.Unit()))
+					errs = errors.Join(errs, metricsMap[pmetric.MetricTypeExponentialHistogram].Add(resAttr, metrics.SchemaUrl(), scopeInstr, scopeURL, r.ExponentialHistogram(), r.Name(), r.Description(), r.Unit()))
 				case pmetric.MetricTypeSummary:
-					errs = multierr.Append(errs, metricsMap[pmetric.MetricTypeSummary].Add(resAttr, metrics.SchemaUrl(), scopeInstr, scopeURL, r.Summary(), r.Name(), r.Description(), r.Unit()))
+					errs = errors.Join(errs, metricsMap[pmetric.MetricTypeSummary].Add(resAttr, metrics.SchemaUrl(), scopeInstr, scopeURL, r.Summary(), r.Name(), r.Description(), r.Unit()))
 				case pmetric.MetricTypeEmpty:
 					return fmt.Errorf("metrics type is unset")
 				default:

--- a/exporter/clickhouseexporter/go.mod
+++ b/exporter/clickhouseexporter/go.mod
@@ -13,7 +13,6 @@ require (
 	go.opentelemetry.io/collector/exporter v0.82.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0014
 	go.opentelemetry.io/collector/semconv v0.82.0
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.25.0
 )
 
@@ -53,6 +52,7 @@ require (
 	go.opentelemetry.io/otel v1.16.0 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	go.opentelemetry.io/otel/trace v1.16.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect
 	golang.org/x/text v0.12.0 // indirect

--- a/exporter/clickhouseexporter/internal/metrics_model.go
+++ b/exporter/clickhouseexporter/internal/metrics_model.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -14,7 +15,6 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 
@@ -101,7 +101,7 @@ func InsertMetrics(ctx context.Context, db *sql.DB, metricsMap map[pmetric.Metri
 	close(errsChan)
 	var errs error
 	for err := range errsChan {
-		errs = multierr.Append(errs, err)
+		errs = errors.Join(errs, err)
 	}
 	return errs
 }


### PR DESCRIPTION
Part of: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/25121