### PR TITLE
[receiver/influxdb] Fix time precision parser (#24974)

### DIFF
--- a/.chloggen/jgm-issue-24974.yaml
+++ b/.chloggen/jgm-issue-24974.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/influxdb
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add allowable inputs to line protocol precision parameter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24974]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/influxdbreceiver/receiver.go
+++ b/receiver/influxdbreceiver/receiver.go
@@ -106,10 +106,14 @@ const (
 )
 
 var precisions = map[string]lineprotocol.Precision{
-	lineprotocol.Nanosecond.String():  lineprotocol.Nanosecond,
-	lineprotocol.Microsecond.String(): lineprotocol.Microsecond,
-	lineprotocol.Millisecond.String(): lineprotocol.Millisecond,
-	lineprotocol.Second.String():      lineprotocol.Second,
+	"ns": lineprotocol.Nanosecond,
+	"n":  lineprotocol.Nanosecond,
+	"µs": lineprotocol.Microsecond,
+	"µ":  lineprotocol.Microsecond,
+	"us": lineprotocol.Microsecond,
+	"u":  lineprotocol.Microsecond,
+	"ms": lineprotocol.Millisecond,
+	"s":  lineprotocol.Second,
 }
 
 func (r *metricsReceiver) handleWrite(w http.ResponseWriter, req *http.Request) {

--- a/receiver/influxdbreceiver/receiver_test.go
+++ b/receiver/influxdbreceiver/receiver_test.go
@@ -46,7 +46,7 @@ func TestWriteLineProtocol_v2API(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		batchPoints, err := influxdb1.NewBatchPoints(influxdb1.BatchPointsConfig{})
+		batchPoints, err := influxdb1.NewBatchPoints(influxdb1.BatchPointsConfig{Precision: "µs"})
 		require.NoError(t, err)
 		point, err := influxdb1.NewPoint("cpu_temp", map[string]string{"foo": "bar"}, map[string]interface{}{"gauge": 87.332})
 		require.NoError(t, err)
@@ -68,7 +68,9 @@ func TestWriteLineProtocol_v2API(t *testing.T) {
 	t.Run("influxdb-client-v2", func(t *testing.T) {
 		nextConsumer.lastMetricsConsumed = pmetric.NewMetrics()
 
-		client := influxdb2.NewClient("http://"+addr, "")
+		o := influxdb2.DefaultOptions()
+		o.SetPrecision(time.Microsecond)
+		client := influxdb2.NewClientWithOptions("http://"+addr, "", o)
 		t.Cleanup(client.Close)
 
 		err := client.WriteAPIBlocking("my-org", "my-bucket").WriteRecord(context.Background(), "cpu_temp,foo=bar gauge=87.332")


### PR DESCRIPTION
Add precision=n and precision=u to line protocol endpoint handler. This explicitly matches the behavior of InfluxDB 1.11, and allows a certain [Java client](https://github.com/influxdata/influxdb-java/blob/master/src/main/java/org/influxdb/impl/TimeUtil.java#L63) to write to OpenTelemetry.

Also adds precision=µ and precision=µs for more complete compatibility with github.com/influxdata/line-protocol .

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>