### PR TITLE
[chore] Move a few entries between changelogs

### DIFF
--- a/CHANGELOG-API.md
+++ b/CHANGELOG-API.md
@@ -16,8 +16,14 @@ If you are looking for user-facing changes, check out [CHANGELOG.md](./CHANGELOG
 - `solacereceiver`: Move model package to the internal package (#24890)
 - `receiver/statsdreceiver`: Move protocol and transport packages to internal (#24892)
 - `filterprocessor`: Unexport `Strict` and `Regexp` (#24845)
+- `mdatagen`: Rename the mdatagen sum field `aggregation` to `aggregation_temporality` (#16374)
 - `metricstransformprocessor`: Unexport elements of the Go API of the processor (#24846)
 - `mezmoexporter`: Unexport the `MezmoLogLine` and `MezmoLogBody` structs (#24842)
+- `pkg/stanza`: Remove deprecated 'fileconsumer.FileAttributes' (#24688)
+- `pkg/stanza`: Remove deprecated 'fileconsumer.EmitFunc' (#24688)
+- `pkg/stanza`: Remove deprecated `fileconsumer.Finder` (#24688)
+- `pkg/stanza`: Remove deprecated `fileconsumer.BaseSortRule` and `fileconsumer.SortRuleImpl` (#24688)
+- `pkg/stanza`: Remove deprecated 'fileconsumer.Reader' (#24688)
 
 ### 🚩 Deprecations 🚩
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,8 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
   - Remove predefined metrics definitions from metadata.yaml because they are controlled by `node_conditions_to_report` 
     and `allocatable_types_to_report` config options.
   
-- `pkg/stanza`: Remove deprecated 'fileconsumer.FileAttributes' (#24688)
-- `pkg/stanza`: Remove deprecated 'fileconsumer.EmitFunc' (#24688)
-- `pkg/stanza`: Remove deprecated `fileconsumer.Finder` (#24688)
-- `pkg/stanza`: Remove deprecated `fileconsumer.BaseSortRule` and `fileconsumer.SortRuleImpl` (#24688)
-- `pkg/stanza`: Remove deprecated 'fileconsumer.Reader' (#24688)
 - `prometheusexporter`: Remove invalid unit translations from the prometheus exporters (#24647)
 - `receiver/prometheusexec`: Removes the deprecated prometheus_exec receiver (#24740)
-- `mdatagen`: Rename the mdatagen sum field `aggregation` to `aggregation_temporality` (#16374)
 
 ### 🚀 New components 🚀
 


### PR DESCRIPTION
Followup to the v0.83.0 release.

The chloggen tool was recently upgraded to support multiple separate changelogs. While the tool worked correctly, several entries were added prior to the new feature being added, resulting in several entries going to the default (user) changelog rather than the api changelog.