### PR TITLE
[chore] Remove unused BUILD_INFO from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,7 @@ OTEL_VERSION=main
 OTEL_RC_VERSION=main
 OTEL_STABLE_VERSION=main
 
-BUILD_INFO_IMPORT_PATH=github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelcontribcore/internal/version
 VERSION=$(shell git describe --always --match "v[0-9]*" HEAD)
-BUILD_INFO=-ldflags "-X $(BUILD_INFO_IMPORT_PATH).Version=$(VERSION)"
 
 COMP_REL_PATH=cmd/otelcontribcol/components.go
 MOD_NAME=github.com/open-telemetry/opentelemetry-collector-contrib
@@ -286,7 +284,7 @@ genotelcontribcol: $(BUILDER)
 .PHONY: otelcontribcol
 otelcontribcol:
 	cd ./cmd/otelcontribcol && GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/otelcontribcol_$(GOOS)_$(GOARCH)$(EXTENSION) \
-		$(BUILD_INFO) -tags $(GO_BUILD_TAGS) .
+		-tags $(GO_BUILD_TAGS) .
 
 .PHONY: genoteltestbedcol
 genoteltestbedcol: $(BUILDER)
@@ -297,13 +295,13 @@ genoteltestbedcol: $(BUILDER)
 .PHONY: oteltestbedcol
 oteltestbedcol:
 	cd ./cmd/oteltestbedcol && GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/oteltestbedcol_$(GOOS)_$(GOARCH)$(EXTENSION) \
-		$(BUILD_INFO) -tags $(GO_BUILD_TAGS) .
+		-tags $(GO_BUILD_TAGS) .
 
 # Build the telemetrygen executable.
 .PHONY: telemetrygen
 telemetrygen:
 	cd ./cmd/telemetrygen && GO111MODULE=on CGO_ENABLED=0 $(GOCMD) build -trimpath -o ../../bin/telemetrygen_$(GOOS)_$(GOARCH)$(EXTENSION) \
-		$(BUILD_INFO) -tags $(GO_BUILD_TAGS) .
+		-tags $(GO_BUILD_TAGS) .
 
 .PHONY: update-dep
 update-dep:


### PR DESCRIPTION
**Description:**

This PR removes unused `BUILD_INFO` from Makefile which was originally deleted in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16828. As far as I checked briefly, the file itself was already deleted, and no one uses it now.

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/11867

**Testing:**

```shell-session
$ make otelcontribcol
cd ./cmd/otelcontribcol && GO111MODULE=on CGO_ENABLED=0 go build -trimpath -o ../../bin/otelcontribcol_darwin_arm64 \
		-tags "" .
$ ./bin/otelcontribcol_darwin_arm64 -v
otelcontribcol version 0.83.0-dev
```
