### PR TITLE
[exporter/signalfxexporter] do not exclude system.disk.io by default

### DIFF
--- a/.chloggen/do_not_exclude_system_disk_io.yaml
+++ b/.chloggen/do_not_exclude_system_disk_io.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not exclude the metric "system.disk.io" in signalfxexporter by default.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [25840]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  To continue to exclude this metric, add `system.disk.io` to the `exclude_metrics` configuration of signalfxexporter.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -565,7 +565,7 @@ func TestDefaultExcludes_not_translated(t *testing.T) {
 	require.NoError(t, err)
 
 	md := getMetrics(metrics)
-	require.Equal(t, 69, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	require.Equal(t, 68, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
 	dps := converter.MetricsToSignalFxV2(md)
 	require.Equal(t, 0, len(dps))
 }

--- a/exporter/signalfxexporter/internal/translation/default_metrics.go
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.go
@@ -58,7 +58,6 @@ exclude_metrics:
 # Disk-IO metrics.
 - metric_names:
   - system.disk.merged
-  - system.disk.io
   - system.disk.time
   - system.disk.io_time
   - system.disk.operation_time

--- a/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
+++ b/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
@@ -42,9 +42,6 @@
     "system.disk.merged": null
   },
   {
-    "system.disk.io": null
-  },
-  {
     "system.disk.time": null
   },
   {


### PR DESCRIPTION
This removes the `system.disk.io` metric from the default exclusion list of the signalfxexporter.