### PR TITLE
Adding a mechanism on singalfxexporter in order not to  translate histogram buckets into sfx datapoints

### DIFF
--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -133,6 +133,10 @@ type Config struct {
 	// MaxConnections is used to set a limit to the maximum idle HTTP connection the exporter can keep open.
 	// Deprecated: use HTTPClientSettings.MaxIdleConns or HTTPClientSettings.MaxIdleConnsPerHost instead.
 	MaxConnections int `mapstructure:"max_connections"`
+
+	// Whether to drop  histogram bucket metrics dispatched to Splunk Observability.
+	// Default value is set to true.
+	EnableHistogramBuckets bool `mapstructure:"enable_histogram_buckets"`
 }
 
 type DimensionClientConfig struct {

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -83,6 +83,7 @@ func newSignalFxExporter(
 		config.ExcludeMetrics,
 		config.IncludeMetrics,
 		config.NonAlphanumericDimensionChars,
+		config.EnableHistogramBuckets,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create metric converter: %w", err)

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -189,7 +189,7 @@ func TestConsumeMetrics(t *testing.T) {
 			client, err := cfg.ToClient(componenttest.NewNopHost(), exportertest.NewNopCreateSettings().TelemetrySettings)
 			require.NoError(t, err)
 
-			c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil, "")
+			c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil, "", false)
 			require.NoError(t, err)
 			require.NotNil(t, c)
 			dpClient := &sfxDPClient{
@@ -729,6 +729,7 @@ func TestConsumeMetadata(t *testing.T) {
 		cfg.ExcludeMetrics,
 		cfg.IncludeMetrics,
 		cfg.NonAlphanumericDimensionChars,
+		false,
 	)
 	require.NoError(t, err)
 	type args struct {
@@ -1088,7 +1089,7 @@ func BenchmarkExporterConsumeData(b *testing.B) {
 	serverURL, err := url.Parse(server.URL)
 	assert.NoError(b, err)
 
-	c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil, "")
+	c, err := translation.NewMetricsConverter(zap.NewNop(), nil, nil, nil, "", false)
 	require.NoError(b, err)
 	require.NotNil(b, c)
 	dpClient := &sfxDPClient{
@@ -1281,7 +1282,7 @@ func TestTLSIngestConnection(t *testing.T) {
 func TestDefaultSystemCPUTimeExcludedAndTranslated(t *testing.T) {
 	translator, err := translation.NewMetricTranslator(defaultTranslationRules, 3600)
 	require.NoError(t, err)
-	converter, err := translation.NewMetricsConverter(zap.NewNop(), translator, defaultExcludeMetrics, nil, "_-.")
+	converter, err := translation.NewMetricsConverter(zap.NewNop(), translator, defaultExcludeMetrics, nil, "_-.", false)
 	require.NoError(t, err)
 
 	md := pmetric.NewMetrics()
@@ -1324,7 +1325,7 @@ func TestTLSAPIConnection(t *testing.T) {
 		cfg.ExcludeMetrics,
 		cfg.IncludeMetrics,
 		cfg.NonAlphanumericDimensionChars,
-	)
+		false)
 	require.NoError(t, err)
 
 	metadata := []*metadata.MetadataUpdate{

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -123,7 +123,7 @@ func TestDefaultTranslationRules(t *testing.T) {
 	require.NoError(t, err)
 	data := testMetricsData()
 
-	c, err := translation.NewMetricsConverter(zap.NewNop(), tr, nil, nil, "")
+	c, err := translation.NewMetricsConverter(zap.NewNop(), tr, nil, nil, "", false)
 	require.NoError(t, err)
 	translated := c.MetricsToSignalFxV2(data)
 	require.NotNil(t, translated)
@@ -493,7 +493,7 @@ func TestHostmetricsCPUTranslations(t *testing.T) {
 	f := NewFactory()
 	cfg := f.CreateDefaultConfig().(*Config)
 	require.NoError(t, setDefaultExcludes(cfg))
-	converter, err := translation.NewMetricsConverter(zap.NewNop(), testGetTranslator(t), cfg.ExcludeMetrics, cfg.IncludeMetrics, "")
+	converter, err := translation.NewMetricsConverter(zap.NewNop(), testGetTranslator(t), cfg.ExcludeMetrics, cfg.IncludeMetrics, "", false)
 	require.NoError(t, err)
 
 	md1, err := golden.ReadMetrics(filepath.Join("testdata", "hostmetrics_system_cpu_time_1.yaml"))
@@ -534,7 +534,7 @@ func TestDefaultExcludesTranslated(t *testing.T) {
 	cfg := f.CreateDefaultConfig().(*Config)
 	require.NoError(t, setDefaultExcludes(cfg))
 
-	converter, err := translation.NewMetricsConverter(zap.NewNop(), testGetTranslator(t), cfg.ExcludeMetrics, cfg.IncludeMetrics, "")
+	converter, err := translation.NewMetricsConverter(zap.NewNop(), testGetTranslator(t), cfg.ExcludeMetrics, cfg.IncludeMetrics, "", false)
 	require.NoError(t, err)
 
 	var metrics []map[string]string
@@ -557,7 +557,7 @@ func TestDefaultExcludes_not_translated(t *testing.T) {
 	cfg := f.CreateDefaultConfig().(*Config)
 	require.NoError(t, setDefaultExcludes(cfg))
 
-	converter, err := translation.NewMetricsConverter(zap.NewNop(), nil, cfg.ExcludeMetrics, cfg.IncludeMetrics, "")
+	converter, err := translation.NewMetricsConverter(zap.NewNop(), nil, cfg.ExcludeMetrics, cfg.IncludeMetrics, "", false)
 	require.NoError(t, err)
 
 	var metrics []map[string]string
@@ -577,7 +577,7 @@ func BenchmarkMetricConversion(b *testing.B) {
 	tr, err := translation.NewMetricTranslator(rules, 1)
 	require.NoError(b, err)
 
-	c, err := translation.NewMetricsConverter(zap.NewNop(), tr, nil, nil, "")
+	c, err := translation.NewMetricsConverter(zap.NewNop(), tr, nil, nil, "", false)
 	require.NoError(b, err)
 
 	bytes, err := os.ReadFile("testdata/json/hostmetrics.json")

--- a/exporter/signalfxexporter/internal/dimensions/metadata_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/metadata_test.go
@@ -204,6 +204,7 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 				nil,
 				nil,
 				"-_.",
+				false,
 			)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, getDimensionUpdateFromMetadata(tt.args.metadata, *converter))

--- a/exporter/signalfxexporter/internal/translation/converter.go
+++ b/exporter/signalfxexporter/internal/translation/converter.go
@@ -32,11 +32,12 @@ var (
 // MetricsConverter converts MetricsData to sfxpb DataPoints. It holds an optional
 // MetricTranslator to translate SFx metrics using translation rules.
 type MetricsConverter struct {
-	logger             *zap.Logger
-	metricTranslator   *MetricTranslator
-	filterSet          *dpfilters.FilterSet
-	datapointValidator *datapointValidator
-	translator         *signalfx.FromTranslator
+	logger                 *zap.Logger
+	metricTranslator       *MetricTranslator
+	filterSet              *dpfilters.FilterSet
+	datapointValidator     *datapointValidator
+	translator             *signalfx.FromTranslator
+	enableHistogramBuckets bool
 }
 
 // NewMetricsConverter creates a MetricsConverter from the passed in logger and
@@ -47,17 +48,19 @@ func NewMetricsConverter(
 	t *MetricTranslator,
 	excludes []dpfilters.MetricFilter,
 	includes []dpfilters.MetricFilter,
-	nonAlphanumericDimChars string) (*MetricsConverter, error) {
+	nonAlphanumericDimChars string,
+	enableHistogramBuckets bool) (*MetricsConverter, error) {
 	fs, err := dpfilters.NewFilterSet(excludes, includes)
 	if err != nil {
 		return nil, err
 	}
 	return &MetricsConverter{
-		logger:             logger,
-		metricTranslator:   t,
-		filterSet:          fs,
-		datapointValidator: newDatapointValidator(logger, nonAlphanumericDimChars),
-		translator:         &signalfx.FromTranslator{},
+		logger:                 logger,
+		metricTranslator:       t,
+		filterSet:              fs,
+		datapointValidator:     newDatapointValidator(logger, nonAlphanumericDimChars),
+		translator:             &signalfx.FromTranslator{},
+		enableHistogramBuckets: enableHistogramBuckets,
 	}, nil
 }
 
@@ -66,7 +69,6 @@ func NewMetricsConverter(
 // dropped because of errors or warnings.
 func (c *MetricsConverter) MetricsToSignalFxV2(md pmetric.Metrics) []*sfxpb.DataPoint {
 	var sfxDataPoints []*sfxpb.DataPoint
-
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
@@ -75,8 +77,11 @@ func (c *MetricsConverter) MetricsToSignalFxV2(md pmetric.Metrics) []*sfxpb.Data
 		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
 			ilm := rm.ScopeMetrics().At(j)
 			var initialDps []*sfxpb.DataPoint
-
 			for k := 0; k < ilm.Metrics().Len(); k++ {
+				if !c.enableHistogramBuckets && (ilm.Metrics().At(k).Type() == pmetric.MetricTypeHistogram || ilm.Metrics().At(k).Type() == pmetric.MetricTypeExponentialHistogram) {
+					fmt.Println("Disabled histogram metrics")
+					continue
+				}
 				dps := c.translator.FromMetric(ilm.Metrics().At(k), extraDimensions)
 				initialDps = append(initialDps, dps...)
 			}

--- a/exporter/signalfxexporter/internal/translation/converter_test.go
+++ b/exporter/signalfxexporter/internal/translation/converter_test.go
@@ -36,33 +36,12 @@ var (
 	int64Val  = int64(123)
 )
 
-func Test_MetricDataToSignalFxV2(t *testing.T) {
+func Test_MetricDataToSignalFxV2WithoutHistogramBuckets(t *testing.T) {
 	logger := zap.NewNop()
 
 	labelMap := map[string]interface{}{
 		"k0": "v0",
 		"k1": "v1",
-	}
-
-	labelMapBucket1 := map[string]interface{}{
-		"k0": "v0",
-		"k1": "v1",
-		"le": "1",
-	}
-	labelMapBucket2 := map[string]interface{}{
-		"k0": "v0",
-		"k1": "v1",
-		"le": "2",
-	}
-	labelMapBucket3 := map[string]interface{}{
-		"k0": "v0",
-		"k1": "v1",
-		"le": "4",
-	}
-	labelMapBucket4 := map[string]interface{}{
-		"k0": "v0",
-		"k1": "v1",
-		"le": "+Inf",
 	}
 
 	longLabelMap := map[string]interface{}{
@@ -106,31 +85,6 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 	initInt64PtWithLabels := func(int64PtWithLabels pmetric.NumberDataPoint) {
 		initInt64Pt(int64PtWithLabels)
 		assert.NoError(t, int64PtWithLabels.Attributes().FromRaw(labelMap))
-	}
-
-	initHistDP := func(histDP pmetric.HistogramDataPoint) {
-		histDP.SetTimestamp(ts)
-		histDP.SetCount(uint64(int64Val))
-		histDP.SetSum(doubleVal)
-		histDP.ExplicitBounds().FromRaw([]float64{1, 2, 4})
-		histDP.BucketCounts().FromRaw([]uint64{4, 2, 3, 7})
-		assert.NoError(t, histDP.Attributes().FromRaw(labelMap))
-	}
-	histDP := pmetric.NewHistogramDataPoint()
-	initHistDP(histDP)
-
-	initHistDPNoBuckets := func(histDP pmetric.HistogramDataPoint) {
-		histDP.SetCount(uint64(int64Val))
-		histDP.SetSum(doubleVal)
-		histDP.SetTimestamp(ts)
-		assert.NoError(t, histDP.Attributes().FromRaw(labelMap))
-	}
-	histDPNoBuckets := pmetric.NewHistogramDataPoint()
-	initHistDPNoBuckets(histDPNoBuckets)
-
-	initHistPt := func(histDP pmetric.HistogramDataPoint) {
-		histDP.SetCount(uint64(int64Val))
-		histDP.SetTimestamp(ts)
 	}
 
 	tests := []struct {
@@ -196,11 +150,6 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 					m.SetEmptySum().SetIsMonotonic(false)
 					initInt64Pt(m.Sum().DataPoints().AppendEmpty())
 				}
-				{
-					m := ilm.Metrics().AppendEmpty()
-					m.SetName("histo_empty_metric")
-					initHistPt(m.SetEmptyHistogram().DataPoints().AppendEmpty())
-				}
 				return out
 			},
 			wantSfxDataPoints: []*sfxpb.DataPoint{
@@ -212,7 +161,6 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 				int64SFxDataPoint("delta_int_with_dims", &sfxMetricTypeCounter, nil),
 				doubleSFxDataPoint("gauge_sum_double_with_dims", &sfxMetricTypeGauge, nil),
 				int64SFxDataPoint("gauge_sum_int_with_dims", &sfxMetricTypeGauge, nil),
-				int64SFxDataPoint("histo_empty_metric_count", &sfxMetricTypeCumulativeCounter, nil),
 			},
 		},
 		{
@@ -243,16 +191,6 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 					m.SetEmptySum().SetIsMonotonic(true)
 					initInt64PtWithLabels(m.Sum().DataPoints().AppendEmpty())
 				}
-				{
-					m := ilm.Metrics().AppendEmpty()
-					m.SetName("histo_with_no_buckets_dims")
-					initHistDPNoBuckets(m.SetEmptyHistogram().DataPoints().AppendEmpty())
-				}
-				{
-					m := ilm.Metrics().AppendEmpty()
-					m.SetName("histo_with_buckets_dims")
-					initHistDP(m.SetEmptyHistogram().DataPoints().AppendEmpty())
-				}
 
 				return out
 			},
@@ -261,14 +199,6 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 				int64SFxDataPoint("gauge_int_with_dims", &sfxMetricTypeGauge, labelMap),
 				doubleSFxDataPoint("cumulative_double_with_dims", &sfxMetricTypeCumulativeCounter, labelMap),
 				int64SFxDataPoint("cumulative_int_with_dims", &sfxMetricTypeCumulativeCounter, labelMap),
-				int64SFxDataPoint("histo_with_no_buckets_dims_count", &sfxMetricTypeCumulativeCounter, labelMap),
-				doubleSFxDataPoint("histo_with_no_buckets_dims_sum", &sfxMetricTypeCumulativeCounter, labelMap),
-				int64SFxDataPoint("histo_with_buckets_dims_count", &sfxMetricTypeCumulativeCounter, labelMap),
-				doubleSFxDataPoint("histo_with_buckets_dims_sum", &sfxMetricTypeCumulativeCounter, labelMap),
-				histoValue(int64SFxDataPoint("histo_with_buckets_dims_bucket", &sfxMetricTypeCumulativeCounter, labelMapBucket1), 4),
-				histoValue(int64SFxDataPoint("histo_with_buckets_dims_bucket", &sfxMetricTypeCumulativeCounter, labelMapBucket2), 6),
-				histoValue(int64SFxDataPoint("histo_with_buckets_dims_bucket", &sfxMetricTypeCumulativeCounter, labelMapBucket3), 9),
-				histoValue(int64SFxDataPoint("histo_with_buckets_dims_bucket", &sfxMetricTypeCumulativeCounter, labelMapBucket4), 16),
 			},
 		},
 		{
@@ -673,7 +603,236 @@ func Test_MetricDataToSignalFxV2(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewMetricsConverter(logger, nil, tt.excludeMetrics, tt.includeMetrics, "")
+			c, err := NewMetricsConverter(logger, nil, tt.excludeMetrics, tt.includeMetrics, "", false)
+			require.NoError(t, err)
+			md := tt.metricsFn()
+			gotSfxDataPoints := c.MetricsToSignalFxV2(md)
+			// Sort SFx dimensions since they are built from maps and the order
+			// of those is not deterministic.
+			sortDimensions(tt.wantSfxDataPoints)
+			sortDimensions(gotSfxDataPoints)
+			assert.Equal(t, tt.wantSfxDataPoints, gotSfxDataPoints)
+		})
+	}
+}
+
+func Test_MetricDataToSignalFxV2WithHistogramBuckets(t *testing.T) {
+	logger := zap.NewNop()
+
+	labelMap := map[string]interface{}{
+		"k0": "v0",
+		"k1": "v1",
+	}
+
+	labelMapBucket1 := map[string]interface{}{
+		"k0": "v0",
+		"k1": "v1",
+		"le": "1",
+	}
+	labelMapBucket2 := map[string]interface{}{
+		"k0": "v0",
+		"k1": "v1",
+		"le": "2",
+	}
+	labelMapBucket3 := map[string]interface{}{
+		"k0": "v0",
+		"k1": "v1",
+		"le": "4",
+	}
+	labelMapBucket4 := map[string]interface{}{
+		"k0": "v0",
+		"k1": "v1",
+		"le": "+Inf",
+	}
+
+	ts := pcommon.NewTimestampFromTime(time.Unix(unixSecs, unixNSecs))
+
+	initDoublePt := func(doublePt pmetric.NumberDataPoint) {
+		doublePt.SetTimestamp(ts)
+		doublePt.SetDoubleValue(doubleVal)
+	}
+
+	initDoublePtWithLabels := func(doublePtWithLabels pmetric.NumberDataPoint) {
+		initDoublePt(doublePtWithLabels)
+		assert.NoError(t, doublePtWithLabels.Attributes().FromRaw(labelMap))
+	}
+	initInt64Pt := func(int64Pt pmetric.NumberDataPoint) {
+		int64Pt.SetTimestamp(ts)
+		int64Pt.SetIntValue(int64Val)
+	}
+
+	initInt64PtWithLabels := func(int64PtWithLabels pmetric.NumberDataPoint) {
+		initInt64Pt(int64PtWithLabels)
+		assert.NoError(t, int64PtWithLabels.Attributes().FromRaw(labelMap))
+	}
+
+	initHistDP := func(histDP pmetric.HistogramDataPoint) {
+		histDP.SetTimestamp(ts)
+		histDP.SetCount(uint64(int64Val))
+		histDP.SetSum(doubleVal)
+		histDP.ExplicitBounds().FromRaw([]float64{1, 2, 4})
+		histDP.BucketCounts().FromRaw([]uint64{4, 2, 3, 7})
+		assert.NoError(t, histDP.Attributes().FromRaw(labelMap))
+	}
+	histDP := pmetric.NewHistogramDataPoint()
+	initHistDP(histDP)
+
+	initHistDPNoBuckets := func(histDP pmetric.HistogramDataPoint) {
+		histDP.SetCount(uint64(int64Val))
+		histDP.SetSum(doubleVal)
+		histDP.SetTimestamp(ts)
+		assert.NoError(t, histDP.Attributes().FromRaw(labelMap))
+	}
+	histDPNoBuckets := pmetric.NewHistogramDataPoint()
+	initHistDPNoBuckets(histDPNoBuckets)
+
+	initHistPt := func(histDP pmetric.HistogramDataPoint) {
+		histDP.SetCount(uint64(int64Val))
+		histDP.SetTimestamp(ts)
+	}
+
+	tests := []struct {
+		name              string
+		metricsFn         func() pmetric.Metrics
+		excludeMetrics    []dpfilters.MetricFilter
+		includeMetrics    []dpfilters.MetricFilter
+		wantSfxDataPoints []*sfxpb.DataPoint
+	}{
+		{
+			name: "nil_node_nil_resources_no_dims",
+			metricsFn: func() pmetric.Metrics {
+				out := pmetric.NewMetrics()
+				ilm := out.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("gauge_double_with_dims")
+					initDoublePt(m.SetEmptyGauge().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("gauge_int_with_dims")
+					initInt64Pt(m.SetEmptyGauge().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("cumulative_double_with_dims")
+					m.SetEmptySum().SetIsMonotonic(true)
+					m.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+					initDoublePt(m.Sum().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("cumulative_int_with_dims")
+					m.SetEmptySum().SetIsMonotonic(true)
+					m.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+					initInt64Pt(m.Sum().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("delta_double_with_dims")
+					m.SetEmptySum().SetIsMonotonic(true)
+					m.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+					initDoublePt(m.Sum().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("delta_int_with_dims")
+					m.SetEmptySum().SetIsMonotonic(true)
+					m.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+					initInt64Pt(m.Sum().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("gauge_sum_double_with_dims")
+					m.SetEmptySum().SetIsMonotonic(false)
+					initDoublePt(m.Sum().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("gauge_sum_int_with_dims")
+					m.SetEmptySum().SetIsMonotonic(false)
+					initInt64Pt(m.Sum().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("histo_empty_metric")
+					initHistPt(m.SetEmptyHistogram().DataPoints().AppendEmpty())
+				}
+				return out
+			},
+			wantSfxDataPoints: []*sfxpb.DataPoint{
+				doubleSFxDataPoint("gauge_double_with_dims", &sfxMetricTypeGauge, nil),
+				int64SFxDataPoint("gauge_int_with_dims", &sfxMetricTypeGauge, nil),
+				doubleSFxDataPoint("cumulative_double_with_dims", &sfxMetricTypeCumulativeCounter, nil),
+				int64SFxDataPoint("cumulative_int_with_dims", &sfxMetricTypeCumulativeCounter, nil),
+				doubleSFxDataPoint("delta_double_with_dims", &sfxMetricTypeCounter, nil),
+				int64SFxDataPoint("delta_int_with_dims", &sfxMetricTypeCounter, nil),
+				doubleSFxDataPoint("gauge_sum_double_with_dims", &sfxMetricTypeGauge, nil),
+				int64SFxDataPoint("gauge_sum_int_with_dims", &sfxMetricTypeGauge, nil),
+				int64SFxDataPoint("histo_empty_metric_count", &sfxMetricTypeCumulativeCounter, nil),
+			},
+		},
+		{
+			name: "nil_node_and_resources_with_dims",
+			metricsFn: func() pmetric.Metrics {
+				out := pmetric.NewMetrics()
+				ilm := out.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("gauge_double_with_dims")
+					initDoublePtWithLabels(m.SetEmptyGauge().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("gauge_int_with_dims")
+					initInt64PtWithLabels(m.SetEmptyGauge().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("cumulative_double_with_dims")
+					m.SetEmptySum().SetIsMonotonic(true)
+					initDoublePtWithLabels(m.Sum().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("cumulative_int_with_dims")
+					m.SetEmptySum().SetIsMonotonic(true)
+					initInt64PtWithLabels(m.Sum().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("histo_with_no_buckets_dims")
+					initHistDPNoBuckets(m.SetEmptyHistogram().DataPoints().AppendEmpty())
+				}
+				{
+					m := ilm.Metrics().AppendEmpty()
+					m.SetName("histo_with_buckets_dims")
+					initHistDP(m.SetEmptyHistogram().DataPoints().AppendEmpty())
+				}
+
+				return out
+			},
+			wantSfxDataPoints: []*sfxpb.DataPoint{
+				doubleSFxDataPoint("gauge_double_with_dims", &sfxMetricTypeGauge, labelMap),
+				int64SFxDataPoint("gauge_int_with_dims", &sfxMetricTypeGauge, labelMap),
+				doubleSFxDataPoint("cumulative_double_with_dims", &sfxMetricTypeCumulativeCounter, labelMap),
+				int64SFxDataPoint("cumulative_int_with_dims", &sfxMetricTypeCumulativeCounter, labelMap),
+				int64SFxDataPoint("histo_with_no_buckets_dims_count", &sfxMetricTypeCumulativeCounter, labelMap),
+				doubleSFxDataPoint("histo_with_no_buckets_dims_sum", &sfxMetricTypeCumulativeCounter, labelMap),
+				int64SFxDataPoint("histo_with_buckets_dims_count", &sfxMetricTypeCumulativeCounter, labelMap),
+				doubleSFxDataPoint("histo_with_buckets_dims_sum", &sfxMetricTypeCumulativeCounter, labelMap),
+				histoValue(int64SFxDataPoint("histo_with_buckets_dims_bucket", &sfxMetricTypeCumulativeCounter, labelMapBucket1), 4),
+				histoValue(int64SFxDataPoint("histo_with_buckets_dims_bucket", &sfxMetricTypeCumulativeCounter, labelMapBucket2), 6),
+				histoValue(int64SFxDataPoint("histo_with_buckets_dims_bucket", &sfxMetricTypeCumulativeCounter, labelMapBucket3), 9),
+				histoValue(int64SFxDataPoint("histo_with_buckets_dims_bucket", &sfxMetricTypeCumulativeCounter, labelMapBucket4), 16),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewMetricsConverter(logger, nil, tt.excludeMetrics, tt.includeMetrics, "", true)
 			require.NoError(t, err)
 			md := tt.metricsFn()
 			gotSfxDataPoints := c.MetricsToSignalFxV2(md)
@@ -720,7 +879,7 @@ func TestMetricDataToSignalFxV2WithTranslation(t *testing.T) {
 			},
 		},
 	}
-	c, err := NewMetricsConverter(zap.NewNop(), translator, nil, nil, "")
+	c, err := NewMetricsConverter(zap.NewNop(), translator, nil, nil, "", false)
 	require.NoError(t, err)
 	assert.EqualValues(t, expected, c.MetricsToSignalFxV2(md))
 }
@@ -759,7 +918,7 @@ func TestDimensionKeyCharsWithPeriod(t *testing.T) {
 			},
 		},
 	}
-	c, err := NewMetricsConverter(zap.NewNop(), translator, nil, nil, "_-.")
+	c, err := NewMetricsConverter(zap.NewNop(), translator, nil, nil, "_-.", false)
 	require.NoError(t, err)
 	assert.EqualValues(t, expected, c.MetricsToSignalFxV2(md))
 
@@ -777,7 +936,7 @@ func TestInvalidNumberOfDimensions(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		dp.Attributes().PutStr(fmt.Sprint("dim_key_", i), fmt.Sprint("dim_val_", i))
 	}
-	c, err := NewMetricsConverter(logger, nil, nil, nil, "_-.")
+	c, err := NewMetricsConverter(logger, nil, nil, nil, "_-.", false)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, len(c.MetricsToSignalFxV2(md)))
 	// No log message should be printed
@@ -883,7 +1042,7 @@ func TestNewMetricsConverter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewMetricsConverter(zap.NewNop(), nil, tt.excludes, nil, "")
+			got, err := NewMetricsConverter(zap.NewNop(), nil, tt.excludes, nil, "", false)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -943,7 +1102,7 @@ func TestMetricsConverter_ConvertDimension(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewMetricsConverter(zap.NewNop(), tt.fields.metricTranslator, nil, nil, tt.fields.nonAlphanumericDimChars)
+			c, err := NewMetricsConverter(zap.NewNop(), tt.fields.metricTranslator, nil, nil, tt.fields.nonAlphanumericDimChars, false)
 			require.NoError(t, err)
 			if got := c.ConvertDimension(tt.args.dim); got != tt.want {
 				t.Errorf("ConvertDimension() = %v, want %v", got, tt.want)

--- a/exporter/signalfxexporter/internal/translation/translator_test.go
+++ b/exporter/signalfxexporter/internal/translation/translator_test.go
@@ -2960,7 +2960,7 @@ func testConverter(t *testing.T, mapping map[string]string) *MetricsConverter {
 	tr, err := NewMetricTranslator(rules, 1)
 	require.NoError(t, err)
 
-	c, err := NewMetricsConverter(zap.NewNop(), tr, nil, nil, "")
+	c, err := NewMetricsConverter(zap.NewNop(), tr, nil, nil, "", false)
 	require.NoError(t, err)
 	return c
 }


### PR DESCRIPTION
… to drop histogram type metrics

**Description:** To support histogram metrics currently,  here we add a way for the signalfx exporter to drop bucket metrics instead of sending them as separate MTS as currently. The option is made available by default. Users needs to set enableHistogramBuckets  to enable histogram buckets from configuration file.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>