### PR TITLE
Add and support receiver creator endpoint properties

### DIFF
--- a/.chloggen/receivercreatorconfigfromenv.yaml
+++ b/.chloggen/receivercreatorconfigfromenv.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver_creator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support `accept_endpoint_environments` for dynamic template evaluation from observer endpoint environments
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [17418]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/receivercreator/config.go
+++ b/receiver/receivercreator/config.go
@@ -65,6 +65,7 @@ func newReceiverTemplate(name string, cfg userConfigMap) (receiverTemplate, erro
 			config:     cfg,
 			endpointID: observer.EndpointID("endpoint.id"),
 		},
+		ResourceAttributes: map[string]any{},
 	}, nil
 }
 
@@ -78,6 +79,9 @@ type Config struct {
 	// ResourceAttributes is a map of default resource attributes to add to each resource
 	// object received by this receiver from dynamically created receivers.
 	ResourceAttributes resourceAttributes `mapstructure:"resource_attributes"`
+	// AcceptEndpointProperties determines whether properties specified in observer.EndpointEnv
+	// should be used in determining receiver runtime configuration for a given endpoint.
+	AcceptEndpointProperties bool `mapstructure:"accept_endpoint_properties"`
 }
 
 func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
@@ -134,4 +138,24 @@ func (cfg *Config) Unmarshal(componentParser *confmap.Conf) error {
 	}
 
 	return nil
+}
+
+func (rt receiverTemplate) copy() receiverTemplate {
+	cp := receiverTemplate{
+		receiverConfig: receiverConfig{
+			id: rt.id, endpointID: rt.endpointID,
+			config: map[string]any{},
+		},
+		Rule:               rt.Rule,
+		ResourceAttributes: map[string]any{},
+		rule:               rt.rule,
+	}
+
+	for k, v := range rt.config {
+		cp.config[k] = v
+	}
+	for k, v := range rt.ResourceAttributes {
+		cp.ResourceAttributes[k] = v
+	}
+	return cp
 }

--- a/receiver/receivercreator/config_test.go
+++ b/receiver/receivercreator/config_test.go
@@ -78,6 +78,7 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, "1"),
 			expected: &Config{
+				AcceptEndpointProperties: true,
 				receiverTemplates: map[string]receiverTemplate{
 					"examplereceiver/1": {
 						receiverConfig: receiverConfig{
@@ -161,8 +162,19 @@ func TestInvalidReceiverResourceAttributeValueType(t *testing.T) {
 }
 
 type nopWithEndpointConfig struct {
-	Endpoint string `mapstructure:"endpoint"`
-	IntField int    `mapstructure:"int_field"`
+	Endpoint   string  `mapstructure:"endpoint"`
+	IntField   int     `mapstructure:"int_field"`
+	FloatField float64 `mapstructure:"float_field"`
+	Nested     nested  `mapstructure:"nested"`
+}
+
+type nested struct {
+	BoolField    bool         `mapstructure:"bool_field"`
+	DoublyNested doublyNested `mapstructure:"doubly_nested"`
+}
+
+type doublyNested struct {
+	MapField map[string]any `mapstructure:"map_field"`
 }
 
 type nopWithEndpointFactory struct {

--- a/receiver/receivercreator/factory.go
+++ b/receiver/receivercreator/factory.go
@@ -53,7 +53,8 @@ func createDefaultConfig() component.Config {
 				conventions.AttributeK8SNodeUID:  "`uid`",
 			},
 		},
-		receiverTemplates: map[string]receiverTemplate{},
+		receiverTemplates:        map[string]receiverTemplate{},
+		AcceptEndpointProperties: false,
 	}
 }
 

--- a/receiver/receivercreator/go.mod
+++ b/receiver/receivercreator/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receiv
 go 1.20
 
 require (
+	github.com/alecthomas/participle/v2 v2.0.0
 	github.com/antonmedv/expr v1.15.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.86.1-0.20231006161201-d364ad61c4d7
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.86.1-0.20231006161201-d364ad61c4d7
@@ -19,6 +20,8 @@ require (
 	go.opentelemetry.io/collector/semconv v0.86.1-0.20231006161201-d364ad61c4d7
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.26.0
+	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/apimachinery v0.27.4
 )
 
 require (
@@ -97,7 +100,7 @@ require (
 	google.golang.org/grpc v1.58.2 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/utils v0.0.0-20230209194617-a36077c30491 // indirect
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer => ../../extension/observer

--- a/receiver/receivercreator/go.sum
+++ b/receiver/receivercreator/go.sum
@@ -35,6 +35,10 @@ contrib.go.opencensus.io/exporter/prometheus v0.4.2/go.mod h1:dvEHbiKmgvbr5pjaF9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/alecthomas/assert/v2 v2.2.2 h1:Z/iVC0xZfWTaFNE6bA3z07T86hd45Xe2eLt6WVy2bbk=
+github.com/alecthomas/participle/v2 v2.0.0 h1:Fgrq+MbuSsJwIkw3fEj9h75vDP0Er5JzepJ0/HNHv0g=
+github.com/alecthomas/participle/v2 v2.0.0/go.mod h1:rAKZdJldHu8084ojcWevWAL8KmEU+AT+Olodb+WoN2Y=
+github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -225,6 +229,7 @@ github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoI
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -833,6 +838,10 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+k8s.io/apimachinery v0.27.4 h1:CdxflD4AF61yewuid0fLl6bM4a3q04jWel0IlP+aYjs=
+k8s.io/apimachinery v0.27.4/go.mod h1:XNfZ6xklnMCOGGFNqXG7bUrQCoR04dh/E7FprV6pb+E=
+k8s.io/utils v0.0.0-20230209194617-a36077c30491 h1:r0BAOLElQnnFhE/ApUsg3iHdVYYPBjNSSOMowRZxxsY=
+k8s.io/utils v0.0.0-20230209194617-a36077c30491/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/receiver/receivercreator/internal/properties.go
+++ b/receiver/receivercreator/internal/properties.go
@@ -29,11 +29,11 @@ const (
 var doubleUnderscoreRE = regexp.MustCompile("__")
 
 // Receiver creator endpoint properties are the method of configuring individual receivers from a given observer endpoint environment.
-// (io.opentelemetry.collector.receiver-creator|receiver-creator.collector.opentelemetry.io).<receiver-type(/name)>: <full mapping value>
-// (io.opentelemetry.collector.receiver-creator|receiver-creator.collector.opentelemetry.io).<receiver-type(/name)>.config.<field>(<::subfield>)*: value
-// (io.opentelemetry.collector.receiver-creator|receiver-creator.collector.opentelemetry.io).<receiver-type(/name)>.rule: value
-// (io.opentelemetry.collector.receiver-creator|receiver-creator.collector.opentelemetry.io).<receiver-type(/name)>.resoureceiver-creatore_attributes.<resoureceiver-creatore_attribute>: value
-// (io.opentelemetry.collector.receiver-creator|receiver-creator.collector.opentelemetry.io).<receiver-type(/name)>.resoureceiver-creatore_attributes: "attribute: value"
+// (io.opentelemetry.collector.receiver-creator.|receiver-creator.collector.opentelemetry.io/)<receiver-type(/name)>: <full mapping value>
+// (io.opentelemetry.collector.receiver-creator.|receiver-creator.collector.opentelemetry.io/)<receiver-type(/name)>.config.<field>(<::subfield>)*: value
+// (io.opentelemetry.collector.receiver-creator.|receiver-creator.collector.opentelemetry.io/)<receiver-type(/name)>.rule: value
+// (io.opentelemetry.collector.receiver-creator.|receiver-creator.collector.opentelemetry.io/)<receiver-type(/name)>.resource_attributes.<resource_attribute>: value
+// (io.opentelemetry.collector.receiver-creator.|receiver-creator.collector.opentelemetry.io/)<receiver-type(/name)>.resource_attributes: "attribute: value"
 // Parsing properties requires lookaheads (backtracking) so we use participle instead of re2.
 
 var lex = lexer.MustSimple([]lexer.SimpleRule{

--- a/receiver/receivercreator/internal/properties.go
+++ b/receiver/receivercreator/internal/properties.go
@@ -1,0 +1,326 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator/internal"
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+const (
+	ConfigType             string = "config"
+	RuleType               string = "rule"
+	ResourceAttributesType string = "resource_attributes"
+	FullMappingType        string = ""
+)
+
+var doubleUnderscoreRE = regexp.MustCompile("__")
+
+// Receiver creator endpoint properties are the method of configuring individual receivers from a given observer endpoint environment.
+// (io.opentelemetry.collector.receiver-creator|receiver-creator.collector.opentelemetry.io).<receiver-type(/name)>: <full mapping value>
+// (io.opentelemetry.collector.receiver-creator|receiver-creator.collector.opentelemetry.io).<receiver-type(/name)>.config.<field>(<::subfield>)*: value
+// (io.opentelemetry.collector.receiver-creator|receiver-creator.collector.opentelemetry.io).<receiver-type(/name)>.rule: value
+// (io.opentelemetry.collector.receiver-creator|receiver-creator.collector.opentelemetry.io).<receiver-type(/name)>.resoureceiver-creatore_attributes.<resoureceiver-creatore_attribute>: value
+// (io.opentelemetry.collector.receiver-creator|receiver-creator.collector.opentelemetry.io).<receiver-type(/name)>.resoureceiver-creatore_attributes: "attribute: value"
+// Parsing properties requires lookaheads (backtracking) so we use participle instead of re2.
+
+var lex = lexer.MustSimple([]lexer.SimpleRule{
+	{Name: "Dot", Pattern: `\.`},
+	{Name: "ForwardSlash", Pattern: `/|__`},
+	{Name: "Whitespace", Pattern: `\s+`},
+	// Anything that isn't a Dot or ForwardSlash (doesn't support terminating '_').
+	{Name: "String", Pattern: `([^./_]*(_[^./_])*)*`},
+})
+
+var parser = participle.MustBuild[property](
+	participle.Lexer(lex),
+	participle.Elide("Whitespace"),
+	participle.UseLookahead(participle.MaxLookahead),
+)
+
+// property is the ast for a parsed property.
+type property struct {
+	// map storing the parsed contents for confmap.Conf form
+	stringMap map[string]map[string]any
+	// Namespace support `io.opentelemetry.collector.receiver-creator.` reverse-DNS (docker) and `receiver-creator.collector.opentelemetry.io/` prefixes
+	Namespace string `parser:"@(('io' Dot 'opentelemetry' Dot 'collector' Dot 'receiver-creator' Dot)|('receiver-creator' Dot 'collector' Dot 'opentelemetry' Dot 'io' ForwardSlash))"`
+	Receiver  CID    `parser:"@@"`
+	Type      string `parser:"( ( Dot ( @('config'|'resource_attributes') Dot? ) | Dot @'rule' ) | @'' )"`
+	Field     string `parser:"@(String|Dot|ForwardSlash)*"`
+	Val       string
+	Raw       string
+}
+
+type CID struct {
+	// CID.Type is anything that isn't the ForwardSlash or Type identifier
+	Type string `parser:"@~(ForwardSlash | (Dot (?= ('config'|'rule'|'resource_attributes'))))+"`
+	// CID.Name is anything after a ForwardSlash that isn't the Type identifier
+	Name string `parser:"(ForwardSlash @(~(Dot (?= ('config'|'rule'|'resource_attributes')))+)*)?"`
+}
+
+func newProperty(key, value string) (*property, bool, error) {
+	p, err := parser.ParseString("receiver_creator", key)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid property %q (parsing error): %w", key, err)
+	}
+	p.Raw = key
+	p.Val = value
+	p.Receiver.Name = doubleUnderscoreRE.ReplaceAllString(p.Receiver.Name, "/")
+	switch p.Type {
+	case FullMappingType:
+		var dst map[string]any
+		if err = yaml.Unmarshal([]byte(value), &dst); err != nil {
+			return nil, true, fmt.Errorf("failed unmarshaling full mapping property (%q) -> %w", key, err)
+		}
+		sm := confmap.NewFromStringMap(dst).ToStringMap()
+		var invalidKeys []string
+		var invalidVals []string
+		propStringMap := map[string]map[string]any{}
+		for k, v := range sm {
+			switch k {
+			case RuleType, ConfigType, ResourceAttributesType:
+				var vMap map[string]any
+				var ok bool
+				if k == RuleType {
+					vMap = map[string]any{RuleType: v}
+				} else {
+					if vMap, ok = v.(map[string]any); !ok {
+						invalidVals = append(invalidVals, fmt.Sprintf("%s: %v", k, v))
+						continue
+					}
+				}
+				propStringMap[k] = vMap
+			default:
+				invalidKeys = append(invalidKeys, k)
+			}
+		}
+		if len(invalidKeys) != 0 {
+			return nil, true, fmt.Errorf(`invalid endpoint property keys: %v. Must be in ["config", "resource_attributes", "rule"]`, invalidKeys)
+		}
+		if len(invalidVals) != 0 {
+			return nil, true, fmt.Errorf(`invalid endpoint property vals: %v. Must be valid yaml mapping`, invalidVals)
+		}
+		p.stringMap = propStringMap
+	case RuleType:
+		p.stringMap = map[string]map[string]any{p.Type: {p.Type: p.Val}}
+	case ConfigType, ResourceAttributesType:
+		var dst map[string]any
+		var cfgItem []byte
+
+		if strings.Contains(value, confmap.KeyDelimiter) {
+			var innerDst map[string]any
+			innerItem := []byte(value)
+			if e := yaml.Unmarshal(innerItem, &innerDst); e != nil {
+				return nil, true, fmt.Errorf("failed unmarshaling inner property item %q: %w", innerItem, err)
+			}
+			innerYaml := confmap.NewFromStringMap(innerDst).ToStringMap()
+			if p.Field != "" {
+				innerYaml = map[string]any{
+					p.Field: innerYaml,
+				}
+				p.Field = ""
+			}
+			if v, e := yaml.Marshal(innerYaml); e == nil {
+				value = string(v)
+			}
+		}
+
+		if p.Field == "" {
+			cfgItem = []byte(value)
+		} else {
+			cfgItem = []byte(fmt.Sprintf("%s: %s", p.Field, value))
+		}
+		if err = yaml.Unmarshal(cfgItem, &dst); err != nil {
+			return nil, true, fmt.Errorf("failed unmarshaling property (%q) %q -> %w", key, cfgItem, err)
+		}
+		p.stringMap = map[string]map[string]any{
+			p.Type: confmap.NewFromStringMap(dst).ToStringMap(),
+		}
+	default:
+		return nil, true, fmt.Errorf("invalid type %q from %q (%q)", p.Type, key, p.componentID().String())
+	}
+	return p, true, nil
+}
+
+// toStringMap returns a map[string]any equivalent to the sub-level confmap.ToStringMap()
+func (p *property) toStringMap() map[string]any {
+	if p != nil {
+		if p.Type == FullMappingType {
+			sm := map[string]any{}
+			for k, v := range p.stringMap {
+				var val any = v
+				if k == RuleType {
+					val = p.stringMap[RuleType][RuleType]
+				}
+				sm[k] = val
+			}
+			return sm
+		}
+		return p.stringMap[p.Type]
+	}
+	return nil
+}
+
+// componentID returns the property's receiver's component.ID
+func (p *property) componentID() component.ID {
+	if p != nil {
+		return component.NewIDWithName(component.Type(p.Receiver.Type), p.Receiver.Name)
+	}
+	return component.ID{}
+}
+
+func PropertyConfFromEndpointEnv(details observer.EndpointDetails, logger *zap.Logger) *confmap.Conf {
+	var properties []property
+
+	endpointType := details.Type()
+	env := details.Env()
+
+	var candidates map[string]string
+	switch endpointType {
+	case observer.ContainerType:
+		if l, hasLabels := env["labels"]; hasLabels {
+			if labels, isMap := l.(map[string]string); isMap {
+				candidates = labels
+			}
+		}
+	case observer.PodType, observer.PortType, observer.K8sNodeType:
+		if endpointType == observer.PortType {
+			// port endpoints nest pod env
+			if pod, hasPod := env["pod"]; hasPod {
+				if e, isEnv := pod.(observer.EndpointEnv); isEnv {
+					env = e
+				}
+			}
+		}
+		if a, hasAnnotations := env["annotations"]; hasAnnotations {
+			if annotations, isMap := a.(map[string]string); isMap {
+				candidates = annotations
+			}
+		}
+	default:
+		panic(endpointType)
+	}
+
+	for key, val := range candidates {
+		prop, isProp, err := newProperty(key, val)
+		if !isProp {
+			continue
+		}
+		if err != nil {
+			logger.Info("error creating property", zap.String("parsed", key), zap.Error(err))
+			continue
+		}
+		if prop == nil {
+			// programming error - shouldn't be reachable
+			logger.Warn("unexpectedly nil parsed property", zap.String("parsed", key))
+			continue
+		}
+		properties = append(properties, *prop)
+	}
+
+	// for best effort determinism in confmap.Merge()
+	sortProperties(properties)
+
+	confFromProperties := confmap.New()
+	for _, prop := range properties {
+		receiverID := prop.componentID().String()
+		rMap, err := confFromProperties.Sub(receiverID)
+		if err != nil {
+			logger.Info(fmt.Sprintf("error accessing %q config", receiverID), zap.Error(err))
+			continue
+		}
+		switch prop.Type {
+		case FullMappingType:
+			if mergeErr := rMap.Merge(confmap.NewFromStringMap(prop.toStringMap())); mergeErr != nil {
+				logger.Info(fmt.Sprintf("%q rMap merge error", receiverID), zap.Error(mergeErr))
+				continue
+			}
+		case RuleType:
+			if mergeErr := rMap.Merge(confmap.NewFromStringMap(prop.toStringMap())); mergeErr != nil {
+				logger.Info(fmt.Sprintf("%q rMap merge error", receiverID), zap.Error(mergeErr))
+				continue
+			}
+		case ConfigType, ResourceAttributesType:
+			subMap, err := rMap.Sub(prop.Type)
+			if err != nil {
+				logger.Info(fmt.Sprintf("error accessing %q sub-config", receiverID), zap.Error(err))
+				continue
+			}
+			propConfigMap := confmap.NewFromStringMap(prop.toStringMap())
+			if mergeErr := subMap.Merge(propConfigMap); mergeErr != nil {
+				logger.Info(fmt.Sprintf("%q %v subMap merge error", receiverID, prop.Type), zap.Error(mergeErr))
+				continue
+			}
+			if mergeErr := rMap.Merge(confmap.NewFromStringMap(map[string]any{prop.Type: subMap.ToStringMap()})); mergeErr != nil {
+				logger.Info(fmt.Sprintf("%q %v subMap merge error", prop.Type, receiverID), zap.Error(mergeErr))
+				continue
+			}
+		}
+		if mergeErr := confFromProperties.Merge(confmap.NewFromStringMap(map[string]any{receiverID: rMap.ToStringMap()})); mergeErr != nil {
+			logger.Info(fmt.Sprintf("%q confFromProperties merge error", receiverID), zap.Error(mergeErr))
+			continue
+		}
+	}
+	return confFromProperties
+}
+
+func sortProperties(properties []property) {
+	sort.SliceStable(properties, func(i, j int) bool {
+		propI := properties[i]
+		propJ := properties[j]
+		if propI.Type != propJ.Type {
+			// Full mapping will always be first (and in practice can only one to exist)
+			return propI.Type < propJ.Type
+		}
+
+		var mapI, mapJ map[string]any
+
+		switch propI.Type {
+		case ConfigType, ResourceAttributesType:
+			mapI = propI.toStringMap()
+			mapJ = propJ.toStringMap()
+		default:
+			// RuleType (shouldn't be reached otherwise)
+			return propI.Val < propJ.Val
+		}
+		if len(mapI) == 0 || len(mapJ) == 0 {
+			return len(mapI) < len(mapJ)
+		}
+		var mapIKeys, mapJKeys []string
+		for k := range mapI {
+			mapIKeys = append(mapIKeys, k)
+		}
+		for k := range mapJ {
+			mapJKeys = append(mapJKeys, k)
+		}
+		sort.Strings(mapIKeys)
+		sort.Strings(mapJKeys)
+		for ik, iKey := range mapIKeys {
+			if len(mapJKeys) <= ik {
+				return false
+			}
+			jKey := mapJKeys[ik]
+			if jKey != iKey {
+				return iKey < jKey
+			}
+			iVal := fmt.Sprintf("%v", mapI[iKey])
+			jVal := fmt.Sprintf("%v", mapJ[jKey])
+			if iVal != jVal {
+				return iVal < jVal
+			}
+		}
+		return len(mapIKeys) < len(mapJKeys)
+	})
+}

--- a/receiver/receivercreator/internal/properties_test.go
+++ b/receiver/receivercreator/internal/properties_test.go
@@ -1,0 +1,331 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator/internal"
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	zapobserver "go.uber.org/zap/zaptest/observer"
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
+)
+
+func TestParserEBNF(t *testing.T) {
+	// ensures that all grammar changes are intentional
+	require.Equal(t, `Property = (("io" <dot> "opentelemetry" <dot> "collector" <dot> "receiver-creator" <dot>) | ("receiver-creator" <dot> "collector" <dot> "opentelemetry" <dot> "io" <forwardslash>)) CID (((<dot> (("config" | "resource_attributes") <dot>?)) | (<dot> "rule")) | "") (<string> | <dot> | <forwardslash>)* .
+CID = ~(<forwardslash> | (<dot> (?= ("config" | "rule" | "resource_attributes"))))+ (<forwardslash> ~(<dot> (?= ("config" | "rule" | "resource_attributes")))+*)? .`, parser.String())
+}
+
+func TestProperties(t *testing.T) {
+	for _, tt := range []struct {
+		name                    string
+		key                     string
+		value                   string
+		expectedType            string
+		expectedMap             map[string]any
+		expectedComponentIDType string
+		expectedComponentIDName string
+		expectedError           string
+		expectedIsProp          bool
+	}{
+		{
+			name:           "invalid config property",
+			key:            "not a property",
+			value:          "some value",
+			expectedMap:    nil,
+			expectedError:  `invalid property "not a property" (parsing error): receiver_creator:1:1: unexpected token "not a property"`,
+			expectedIsProp: false,
+		},
+		{
+			name:                    "standard config separator form map",
+			key:                     "receiver-creator.collector.opentelemetry.io/receiver-type.config",
+			value:                   "one::two: null",
+			expectedType:            ConfigType,
+			expectedMap:             map[string]any{"one": map[string]any{"two": nil}},
+			expectedComponentIDType: "receiver-type",
+			expectedIsProp:          true,
+		},
+		{
+			name:                    "config map with field in key",
+			key:                     "receiver-creator.collector.opentelemetry.io/receiver-type.config.one",
+			value:                   "two::three.a: some.three.value",
+			expectedType:            ConfigType,
+			expectedMap:             map[string]any{"one": map[string]any{"two": map[string]any{"three.a": "some.three.value"}}},
+			expectedComponentIDType: "receiver-type",
+			expectedIsProp:          true,
+		},
+		{
+			name:                    "standard resource attr",
+			key:                     "receiver-creator.collector.opentelemetry.io/receiver-type.resource_attributes",
+			value:                   "attr.one: attr.one.value",
+			expectedType:            ResourceAttributesType,
+			expectedMap:             map[string]any{"attr.one": "attr.one.value"},
+			expectedComponentIDType: "receiver-type",
+			expectedIsProp:          true,
+		},
+		{
+			name:                    "resource attr in key",
+			key:                     "receiver-creator.collector.opentelemetry.io/receiver-type/receiver-name.resource_attributes.attr.two",
+			value:                   "attr.two.value",
+			expectedType:            ResourceAttributesType,
+			expectedMap:             map[string]any{"attr.two": "attr.two.value"},
+			expectedComponentIDType: "receiver-type",
+			expectedComponentIDName: "receiver-name",
+			expectedIsProp:          true,
+		},
+		{
+			name:                    "resource attr mapping",
+			key:                     "receiver-creator.collector.opentelemetry.io/receiver-type/receiver-name.resource_attributes",
+			value:                   `{"attr.one": "attr.one.value", "attr.two": "attr.two.value"}`,
+			expectedType:            ResourceAttributesType,
+			expectedMap:             map[string]any{"attr.one": "attr.one.value", "attr.two": "attr.two.value"},
+			expectedComponentIDType: "receiver-type",
+			expectedComponentIDName: "receiver-name",
+			expectedIsProp:          true,
+		},
+		{
+			name:                    "standard rule",
+			key:                     "receiver-creator.collector.opentelemetry.io/receiver-type.rule",
+			value:                   `type == "some.endpoint.type"`,
+			expectedType:            RuleType,
+			expectedMap:             map[string]any{"rule": `type == "some.endpoint.type"`},
+			expectedComponentIDType: "receiver-type",
+			expectedIsProp:          true,
+		},
+		{
+			name:                    "__ rule",
+			key:                     "receiver-creator.collector.opentelemetry.io/receiver-type__receiver-name.rule",
+			value:                   `type == "another.endpoint.type"`,
+			expectedType:            RuleType,
+			expectedMap:             map[string]any{"rule": `type == "another.endpoint.type"`},
+			expectedComponentIDType: "receiver-type",
+			expectedComponentIDName: "receiver-name",
+			expectedIsProp:          true,
+		},
+		{
+			name:                    "__ resource attr in key",
+			key:                     "receiver-creator.collector.opentelemetry.io/receiver-type__receiver-name.resource_attributes.attr.one",
+			value:                   "2.34567",
+			expectedType:            ResourceAttributesType,
+			expectedMap:             map[string]any{"attr.one": 2.34567},
+			expectedComponentIDType: "receiver-type",
+			expectedComponentIDName: "receiver-name",
+			expectedIsProp:          true,
+		},
+		{
+			name:                    "config yaml value with name",
+			key:                     "receiver-creator.collector.opentelemetry.io/receiver-type__receiver-name.config",
+			value:                   `{"one": {"two": {"three": "some value"}}}`,
+			expectedMap:             map[string]any{"one": map[string]any{"two": map[string]any{"three": "some value"}}},
+			expectedType:            ConfigType,
+			expectedComponentIDType: "receiver-type",
+			expectedComponentIDName: "receiver-name",
+			expectedIsProp:          true,
+		},
+		{
+			name:                    "config separator value with name ends in __x_y",
+			key:                     "receiver-creator.collector.opentelemetry.io/receiver-type__receiver-name__x_y.config",
+			value:                   "one::two::three: some value",
+			expectedType:            ConfigType,
+			expectedMap:             map[string]any{"one": map[string]any{"two": map[string]any{"three": "some value"}}},
+			expectedComponentIDType: "receiver-type",
+			expectedComponentIDName: "receiver-name/x_y",
+			expectedIsProp:          true,
+		},
+		{
+			name: "config literal",
+			key:  "receiver-creator.collector.opentelemetry.io/receiver-type__receiver-name.config",
+			value: `one:
+  two:
+   nested: true
+  three: some value
+`,
+			expectedType:            ConfigType,
+			expectedMap:             map[string]any{"one": map[string]any{"two": map[string]any{"nested": true}, "three": "some value"}},
+			expectedComponentIDType: "receiver-type",
+			expectedComponentIDName: "receiver-name",
+			expectedIsProp:          true,
+		},
+		{
+			name: "full mapping property",
+			key:  "receiver-creator.collector.opentelemetry.io/receiver-type",
+			value: `config:
+  one: one.value
+  two: two.value
+rule: type == "k8s.node"
+resource_attributes:
+  attr.one: attr_one_value
+  attr.two: attr_two_value`,
+			expectedType: "",
+			expectedMap: map[string]any{
+				"config": map[string]any{
+					"one": "one.value",
+					"two": "two.value",
+				},
+				"rule": `type == "k8s.node"`,
+				"resource_attributes": map[string]any{
+					"attr.one": "attr_one_value",
+					"attr.two": "attr_two_value",
+				},
+			},
+			expectedComponentIDType: "receiver-type",
+			expectedIsProp:          true,
+		},
+		{
+			name: "partial full mapping property with name",
+			key:  "receiver-creator.collector.opentelemetry.io/receiver-type__some-receiver-name",
+			value: `config:
+  one: one.value
+  two: two.value
+resource_attributes:
+  attr.one: attr_one_value
+  attr.two: attr_two_value`,
+			expectedType: "",
+			expectedMap: map[string]any{
+				"config": map[string]any{
+					"one": "one.value",
+					"two": "two.value",
+				},
+				"resource_attributes": map[string]any{
+					"attr.one": "attr_one_value",
+					"attr.two": "attr_two_value",
+				},
+			},
+			expectedComponentIDType: "receiver-type",
+			expectedComponentIDName: "some-receiver-name",
+			expectedIsProp:          true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			prop, isProp, err := newProperty(tt.key, tt.value)
+			require.Equal(t, tt.expectedIsProp, isProp)
+			if tt.expectedIsProp {
+				require.NotNil(t, prop, fmt.Errorf("unexpectedly nil prop: %w", err))
+				assert.Equal(t, tt.expectedType, prop.Type)
+			} else {
+				assert.Nil(t, prop)
+			}
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.key, prop.Raw)
+			}
+			assert.Equal(t, tt.expectedMap, prop.toStringMap())
+			assert.Equal(t, tt.expectedComponentIDType, string(prop.componentID().Type()))
+			assert.Equal(t, tt.expectedComponentIDName, prop.componentID().Name())
+		})
+	}
+}
+
+func TestParsePropertiesFromEnv(t *testing.T) {
+	k8sAnnotations := map[string]string{
+		"receiver-creator.collector.opentelemetry.io/another-receiver-type.rule":        "type == \"another.endpoint.type\"",
+		"receiver-creator.collector.opentelemetry.io/receiver-type":                     "config::one: should be overridden",
+		"receiver-creator.collector.opentelemetry.io/receiver-type.config":              "one::two: null",
+		"receiver-creator.collector.opentelemetry.io/receiver-type.config.one":          "two::three.b: 1.2345",
+		"receiver-creator.collector.opentelemetry.io/receiver-type.resource_attributes": "attr.two: attr.two.value",
+		"receiver-creator.collector.opentelemetry.io/receiver-type__name.rule":          "type == \"another.endpoint.type\"",
+	}
+
+	for k := range k8sAnnotations {
+		invalidKey := validation.IsQualifiedName(k)
+		assert.Zero(t, len(invalidKey), "invalid label key %q: %v", k, invalidKey)
+	}
+
+	dockerLabels := map[string]string{
+		"not.a.property": "some.label.value",
+		"io.opentelemetry.collector.receiver-creator.invalid":                                    "invalid::::  invalid",
+		"io.opentelemetry.collector.receiver-creator.invalid/yaml":                               `config: { """: invalid - true }`,
+		"io.opentelemetry.collector.receiver-creator.receiver-type":                              "config::one::two: should by overridden",
+		"io.opentelemetry.collector.receiver-creator.receiver-type.config.one":                   "two::three.a: some.three.value",
+		"io.opentelemetry.collector.receiver-creator.receiver-type.resource_attributes.attr.one": "attr.one.value",
+		"io.opentelemetry.collector.receiver-creator.receiver-type.rule":                         "type == \"some.endpoint.type\"",
+		"io.opentelemetry.collector.receiver-creator.receiver-type__name.config.one":             "two::three: another.three.value",
+		"io.opentelemetry.collector.receiver-creator.receiver-type__name.resource_attributes":    "attr.one: 2.34567",
+	}
+
+	properties := map[string]string{}
+
+	for _, l := range []map[string]string{k8sAnnotations, dockerLabels} {
+		for k, v := range l {
+			properties[k] = v
+		}
+	}
+
+	for _, details := range []observer.EndpointDetails{
+		&observer.Container{Labels: properties},
+		&observer.Pod{Annotations: properties},
+		&observer.Port{Pod: observer.Pod{Annotations: properties}},
+		&observer.K8sNode{Annotations: properties},
+	} {
+		t.Run(string(details.Type()), func(t *testing.T) {
+			zc, observedLogs := zapobserver.New(zap.DebugLevel)
+			// determinism check
+			for i := 0; i < 100; i++ {
+				parsed := PropertyConfFromEndpointEnv(details, zap.New(zc))
+				require.Equal(t, map[string]any{
+					"another-receiver-type": map[string]any{
+						"rule": "type == \"another.endpoint.type\"",
+					},
+					"receiver-type": map[string]any{
+						"config": map[string]any{
+							"one": map[string]any{
+								"two": map[string]any{
+									"three.a": "some.three.value",
+									"three.b": 1.2345,
+								},
+							},
+						},
+						"resource_attributes": map[string]any{
+							"attr.one": "attr.one.value",
+							"attr.two": "attr.two.value",
+						},
+						"rule": "type == \"some.endpoint.type\"",
+					},
+					"receiver-type/name": map[string]any{
+						"config": map[string]any{
+							"one": map[string]any{
+								"two": map[string]any{
+									"three": "another.three.value",
+								},
+							},
+						},
+						"resource_attributes": map[string]any{
+							"attr.one": 2.34567,
+						},
+						"rule": "type == \"another.endpoint.type\"",
+					},
+				}, parsed.ToStringMap())
+			}
+			// confirm only expected error messages logged
+			var invalid, invalidYaml int
+			for _, m := range observedLogs.All() {
+				require.Equal(t, "error creating property", m.Message)
+				cm := m.ContextMap()
+				require.Contains(t, cm, "parsed")
+				switch parsed := cm["parsed"].(string); parsed {
+				case "io.opentelemetry.collector.receiver-creator.invalid":
+					invalid++
+					require.Contains(t, cm, "error")
+					require.Equal(t, `invalid endpoint property keys: [invalid]. Must be in ["config", "resource_attributes", "rule"]`, cm["error"])
+				case "io.opentelemetry.collector.receiver-creator.invalid/yaml":
+					invalidYaml++
+					require.Contains(t, cm, "error")
+					require.Equal(t, `failed unmarshaling full mapping property ("io.opentelemetry.collector.receiver-creator.invalid/yaml") -> yaml: found unexpected end of stream`, cm["error"])
+				default:
+					t.Fatalf("unexpected parse value %q", parsed)
+				}
+			}
+			require.Equal(t, 100, invalid)
+			require.Equal(t, 100, invalidYaml)
+			require.Equal(t, 200, observedLogs.Len())
+		})
+	}
+}

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -508,6 +508,7 @@ func newObserverHandler(
 		nextLogsConsumer:      nextLogs,
 		nextMetricsConsumer:   nextMetrics,
 		nextTracesConsumer:    nextTraces,
+		logger:                set.TelemetrySettings.Logger,
 	}, mr
 }
 
@@ -789,7 +790,7 @@ func TestReceiverInvalidEndpointEnvContents(t *testing.T) {
 			core, obs := zapObserver.New(zap.DebugLevel)
 			logger := zap.New(core)
 
-			handler.params.TelemetrySettings.Logger = logger
+			handler.logger = logger
 			handler.OnAdd([]observer.Endpoint{tt.endpoint})
 
 			rcvr := mr.startedComponent

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -4,6 +4,7 @@
 package receivercreator
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +14,12 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/otelcol"
 	"go.opentelemetry.io/collector/otelcol/otelcoltest"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	zapObserver "go.uber.org/zap/zaptest/observer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 )
@@ -452,6 +458,7 @@ func newMockHost(t *testing.T) *mockHost {
 	require.Nil(t, err)
 	factories.Receivers["with.endpoint"] = &nopWithEndpointFactory{Factory: receivertest.NewNopFactory()}
 	factories.Receivers["without.endpoint"] = &nopWithoutEndpointFactory{Factory: receivertest.NewNopFactory()}
+	factories.Receivers["some.type"] = &nopWithEndpointFactory{Factory: receivertest.NewNopFactory()}
 	return &mockHost{t: t, factories: factories}
 }
 
@@ -502,4 +509,310 @@ func newObserverHandler(
 		nextMetricsConsumer:   nextMetrics,
 		nextTracesConsumer:    nextTraces,
 	}, mr
+}
+
+func TestEndpointPropertiesDisregardedByDefault(t *testing.T) {
+	endpoint := observer.Endpoint{
+		ID:     "container.with.labels",
+		Target: "some.target:2345",
+		Details: &observer.Container{
+			Labels: map[string]string{
+				"io.opentelemetry.collector.receiver-creator.some.type/some.name.config.int_field":                         "234",
+				"io.opentelemetry.collector.receiver-creator.some.type__some.name.config.float_field":                      "345.678",
+				"io.opentelemetry.collector.receiver-creator.some.type/some.name.config.nested::bool_field":                "true",
+				"io.opentelemetry.collector.receiver-creator.some.type__some.name.config.nested::doubly_nested::map_field": "{'one': true, 'two': null}",
+				"io.opentelemetry.collector.receiver-creator.some.type/some.name.rule":                                     "type == \"container\" && labels['not.a.property'] == \"some.value\"",
+				"io.opentelemetry.collector.receiver-creator.some.type__some.name.resource_attributes.attr.one":            "undesired.value.one",
+				"io.opentelemetry.collector.receiver-creator.some.type/some.name.resource_attributes.attr.two":             "undesired.value.two",
+				"not.a.property": "not.expected.value.for.rule",
+			},
+		},
+	}
+
+	containerRule := "type == \"container\""
+	containerRuleExpr, err := newRule(containerRule)
+	require.NoError(t, err)
+
+	id := component.NewIDWithName("some.type", "some.name")
+	cfg := createDefaultConfig().(*Config)
+	cfg.receiverTemplates = map[string]receiverTemplate{
+		id.String(): {
+			receiverConfig: receiverConfig{id: id, config: userConfigMap{"int_field": 123}, endpointID: endpoint.ID},
+			rule:           containerRuleExpr,
+			Rule:           containerRule,
+			ResourceAttributes: map[string]any{
+				"attr.one": "user.config.value",
+				"attr.two": "another.user.config.value",
+			},
+		},
+	}
+	sink := &consumertest.LogsSink{}
+	handler, mr := newObserverHandler(t, cfg, sink, nil, nil)
+
+	handler.OnAdd([]observer.Endpoint{endpoint})
+
+	rcvr := mr.startedComponent
+	assert.NotNil(t, rcvr)
+	assert.NoError(t, mr.lastError)
+	wr, ok := rcvr.(*wrappedReceiver)
+	require.True(t, ok)
+	r, ok := wr.logs.(*nopWithEndpointReceiver)
+	require.True(t, ok)
+	assert.Equal(t, &nopWithEndpointConfig{
+		Endpoint: "some.target:2345",
+		IntField: 123,
+		Nested: nested{
+			BoolField: false,
+		},
+	}, r.cfg)
+
+	assert.Equal(t, 1, handler.receiversByEndpointID.Size())
+
+	ld := plog.NewLogs()
+	ld.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	require.NoError(t, r.ConsumeLogs(context.Background(), ld))
+	received := sink.AllLogs()
+	require.Equal(t, 1, len(received))
+	require.Equal(t, map[string]any{
+		"attr.one": "user.config.value",
+		"attr.two": "another.user.config.value",
+	}, received[0].ResourceLogs().At(0).Resource().Attributes().AsRaw())
+}
+
+func TestReceiverAddedFromEndpointEnv(t *testing.T) {
+	for _, endpoint := range []observer.Endpoint{
+		{
+			ID:     "container.with.labels",
+			Target: "some.target:2345",
+			Details: &observer.Container{
+				Labels: map[string]string{
+					"io.opentelemetry.collector.receiver-creator.some.type/some.name.config.int_field":                         "234",
+					"io.opentelemetry.collector.receiver-creator.some.type__some.name.config.float_field":                      "345.678",
+					"io.opentelemetry.collector.receiver-creator.some.type/some.name.config.nested::bool_field":                "true",
+					"io.opentelemetry.collector.receiver-creator.some.type__some.name.config.nested::doubly_nested::map_field": "{'one': true, 'two': null}",
+					"io.opentelemetry.collector.receiver-creator.some.type/some.name.rule":                                     "type == \"container\" && labels['not.a.property'] == \"some.value\"",
+					"io.opentelemetry.collector.receiver-creator.some.type__some.name.resource_attributes.attr.one":            "value.one",
+					"io.opentelemetry.collector.receiver-creator.some.type/some.name.resource_attributes.attr.two":             "value.two",
+					"not.a.property": "some.value",
+				},
+			},
+		},
+		{
+			ID:     "pod.with.annotations",
+			Target: "another.target:3456",
+			Details: &observer.Pod{
+				Annotations: map[string]string{
+					"receiver-creator.collector.opentelemetry.io/some.type__some.name.config.int_field":                        "234",
+					"receiver-creator.collector.opentelemetry.io/some.type__some.name.config.float_field":                      "345.678",
+					"receiver-creator.collector.opentelemetry.io/some.type__some.name.config.endpoint":                         "some.target:2345",
+					"receiver-creator.collector.opentelemetry.io/some.type__some.name.config.nested::bool_field":               "true",
+					"receiver-creator.collector.opentelemetry.io/some.type__some.name.config.nested::doubly_nested::map_field": "{'one': true, 'two': null}",
+					"receiver-creator.collector.opentelemetry.io/some.type__some.name.rule":                                    "type == \"pod\" && annotations['not.a.property'] == \"some.value\"",
+					"receiver-creator.collector.opentelemetry.io/some.type__some.name.resource_attributes.attr.one":            "value.one",
+					"receiver-creator.collector.opentelemetry.io/some.type__some.name.resource_attributes.attr.two":            "value.two",
+					"not.a.property": "some.value",
+				},
+			},
+		},
+		{
+			ID:     "port.with.annotations",
+			Target: "another.target:3456",
+			Details: &observer.Port{
+				Pod: observer.Pod{
+					Annotations: map[string]string{
+						"receiver-creator.collector.opentelemetry.io/some.type__some.name.config.int_field":                        "234",
+						"receiver-creator.collector.opentelemetry.io/some.type__some.name.config.float_field":                      "345.678",
+						"receiver-creator.collector.opentelemetry.io/some.type__some.name.config.endpoint":                         "some.target:2345",
+						"receiver-creator.collector.opentelemetry.io/some.type__some.name.config.nested::bool_field":               "true",
+						"receiver-creator.collector.opentelemetry.io/some.type__some.name.config.nested::doubly_nested::map_field": "{'one': true, 'two': null}",
+						"receiver-creator.collector.opentelemetry.io/some.type__some.name.rule":                                    "type == \"port\" && pod.annotations['not.a.property'] == \"some.value\"",
+						"receiver-creator.collector.opentelemetry.io/some.type__some.name.resource_attributes.attr.one":            "value.one",
+						"receiver-creator.collector.opentelemetry.io/some.type__some.name.resource_attributes.attr.two":            "value.two",
+						"not.a.property": "some.value",
+					},
+				},
+			},
+		},
+		{
+			ID:     "port.with.full.mapping.annotations",
+			Target: "another.target:3456",
+			Details: &observer.Port{
+				Pod: observer.Pod{
+					Annotations: map[string]string{
+						"receiver-creator.collector.opentelemetry.io/some.type__some.name": `config:
+  int_field: 234
+  float_field: 345.678
+  endpoint: some.target:2345
+  nested:
+    bool_field:               true
+    doubly_nested:
+      map_field:
+        one: true
+        two: null
+rule: type == "port" && pod.annotations['not.a.property'] == "some.value"
+resource_attributes:
+  attr.one: value.one
+  attr.two: value.two
+`,
+						"not.a.property": "some.value",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(string(endpoint.ID), func(t *testing.T) {
+			set := receivertest.NewNopCreateSettings()
+			set.ID = component.NewIDWithName("some.type", "some.name")
+
+			cfg := createDefaultConfig().(*Config)
+			cfg.AcceptEndpointProperties = true
+			cfg.receiverTemplates = map[string]receiverTemplate{
+				set.ID.String(): {
+					receiverConfig: receiverConfig{id: set.ID, config: userConfigMap{"int_field": 123}, endpointID: endpoint.ID},
+					ResourceAttributes: map[string]any{
+						"attr.one":   "undesired.value",
+						"attr.two":   "another.undesired.value",
+						"attr.three": "value.three",
+					},
+				},
+			}
+			sink := &consumertest.MetricsSink{}
+			handler, mr := newObserverHandler(t, cfg, nil, sink, nil)
+			handler.OnAdd([]observer.Endpoint{endpoint})
+
+			rcvr := mr.startedComponent
+			assert.NotNil(t, rcvr)
+			assert.NoError(t, mr.lastError)
+			wr, ok := rcvr.(*wrappedReceiver)
+			require.True(t, ok)
+			r, ok := wr.metrics.(*nopWithEndpointReceiver)
+			require.True(t, ok)
+			assert.Equal(t, &nopWithEndpointConfig{
+				Endpoint:   "some.target:2345",
+				IntField:   234,
+				FloatField: 345.678,
+				Nested: nested{
+					BoolField: true,
+					DoublyNested: doublyNested{
+						MapField: map[string]any{
+							"one": true, "two": nil,
+						},
+					},
+				},
+			}, r.cfg)
+
+			assert.Equal(t, 1, handler.receiversByEndpointID.Size())
+
+			md := pmetric.NewMetrics()
+			md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+			require.NoError(t, r.ConsumeMetrics(context.Background(), md))
+			received := sink.AllMetrics()
+			require.Equal(t, 1, len(received))
+			require.Equal(t, map[string]any{
+				"attr.one":   "value.one",
+				"attr.two":   "value.two",
+				"attr.three": "value.three",
+			}, received[0].ResourceMetrics().At(0).Resource().Attributes().AsRaw())
+		})
+	}
+}
+
+func TestReceiverInvalidEndpointEnvContents(t *testing.T) {
+	for _, tt := range []struct {
+		endpoint                 observer.Endpoint
+		name                     string
+		expectedMessage          string
+		expectedContext          map[string]any
+		preventsReceiverCreation bool
+	}{
+		{
+			name:                     "missing rule",
+			expectedMessage:          "missing rule for property-created template",
+			expectedContext:          map[string]any{"receiver": "some.type/some.name"},
+			preventsReceiverCreation: true,
+			endpoint: observer.Endpoint{
+				ID:     "container.with.labels",
+				Target: "some.target:2345",
+				Details: &observer.Container{
+					Labels: map[string]string{
+						"io.opentelemetry.collector.receiver-creator.some.type/some.name.config.int_field": "123",
+					},
+				},
+			},
+		},
+		{
+			name:                     "invalid rule",
+			expectedMessage:          "failed determining valid rule for property-created template",
+			expectedContext:          map[string]any{"error": "rule must specify type", "receiver": "some.type/some.name"},
+			preventsReceiverCreation: true,
+			endpoint: observer.Endpoint{
+				ID:     "container.with.labels",
+				Target: "some.target:2345",
+				Details: &observer.Container{
+					Labels: map[string]string{
+						"io.opentelemetry.collector.receiver-creator.some.type/some.name.config.int_field": "123",
+						"io.opentelemetry.collector.receiver-creator.some.type/some.name.rule":             "invalid",
+					},
+				},
+			},
+		},
+		{
+			name:            "invalid yaml value",
+			expectedMessage: "error creating property",
+			expectedContext: map[string]any{
+				"error":  "failed unmarshaling property (\"receiver-creator.collector.opentelemetry.io/some.type/some.name.config.nested::doubly_nested::map_field\") \"nested::doubly_nested::map_field: invalid: \" -> yaml: mapping values are not allowed in this context",
+				"parsed": "receiver-creator.collector.opentelemetry.io/some.type/some.name.config.nested::doubly_nested::map_field",
+			},
+			preventsReceiverCreation: false,
+			endpoint: observer.Endpoint{
+				ID:     "pod.with.annotations",
+				Target: "another.target:3456",
+				Details: &observer.Pod{
+					Annotations: map[string]string{
+						"receiver-creator.collector.opentelemetry.io/some.type/some.name.config.nested::bool_field":               "false",
+						"receiver-creator.collector.opentelemetry.io/some.type/some.name.config.nested::doubly_nested::map_field": "invalid: ",
+						"receiver-creator.collector.opentelemetry.io/some.type/some.name.rule":                                    "type == \"pod\"",
+						"receiver-creator.collector.opentelemetry.io/some.type/some.name.resource_attributes.attr.one":            "value.one",
+						"receiver-creator.collector.opentelemetry.io/some.type/some.name.resource_attributes.attr.two":            "value.two",
+						"not.a.property": "some.value",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			cfg.AcceptEndpointProperties = true
+			sink := &consumertest.MetricsSink{}
+			handler, mr := newObserverHandler(t, cfg, nil, sink, nil)
+
+			core, obs := zapObserver.New(zap.DebugLevel)
+			logger := zap.New(core)
+
+			handler.params.TelemetrySettings.Logger = logger
+			handler.OnAdd([]observer.Endpoint{tt.endpoint})
+
+			rcvr := mr.startedComponent
+			if tt.preventsReceiverCreation {
+				assert.Nil(t, rcvr)
+				assert.NoError(t, mr.lastError)
+			} else {
+				assert.NotNil(t, rcvr)
+				assert.NoError(t, mr.lastError)
+			}
+
+			require.True(t, func() bool {
+				found := false
+				for _, log := range obs.All() {
+					if log.Message == tt.expectedMessage {
+						found = true
+						assert.Equal(t, tt.expectedContext, log.ContextMap())
+						assert.Equal(t, zapcore.InfoLevel, log.Level)
+						break
+					}
+				}
+				return found
+			}())
+		})
+	}
 }

--- a/receiver/receivercreator/receiver.go
+++ b/receiver/receivercreator/receiver.go
@@ -93,6 +93,7 @@ func (rc *receiverCreator) Start(_ context.Context, host component.Host) error {
 		nextMetricsConsumer:   rc.nextMetricsConsumer,
 		nextTracesConsumer:    rc.nextTracesConsumer,
 		runner:                newReceiverRunner(rc.params, &loggingHost{host, rc.params.Logger}),
+		logger:                rc.params.TelemetrySettings.Logger,
 	}
 
 	observers := map[component.ID]observer.Observable{}

--- a/receiver/receivercreator/testdata/config.yaml
+++ b/receiver/receivercreator/testdata/config.yaml
@@ -1,5 +1,6 @@
 receiver_creator:
 receiver_creator/1:
+  accept_endpoint_properties: true
   watch_observers:
     - mock_observer
     - mock_observer/with_name


### PR DESCRIPTION
**Description:**
Adding a feature - These changes add a new boolean `accept_endpoint_properties` config field and mechanism to evaluate remotely specified receiver template configuration by observer endpoint environment content (disabled by default). This feature will allow the receiver creator to add or modify evaluated receiver template config, rules, and resource attributes specified by the applicable observer metadata for the containing endpoint alone.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/17418

**Testing:**
Added and updated tests suites.

**Documentation:**
Updated readme to describe feature.