### PR TITLE
[pkg/translator/loki] Added Attributes support to the InstrumentationScope

### DIFF
--- a/.chloggen/pkg-loki-translator-add-scope-attributes.yaml
+++ b/.chloggen/pkg-loki-translator-add-scope-attributes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: lokitranslator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added Attributes support to the InstrumentationScope
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24027]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/translator/loki/encode.go
+++ b/pkg/translator/loki/encode.go
@@ -30,8 +30,9 @@ type lokiEntry struct {
 }
 
 type instrumentationScope struct {
-	Name    string `json:"name,omitempty"`
-	Version string `json:"version,omitempty"`
+	Name       string                 `json:"name,omitempty"`
+	Version    string                 `json:"version,omitempty"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
 }
 
 // Encode converts an OTLP log record and its resource attributes into a JSON
@@ -58,14 +59,12 @@ func Encode(lr plog.LogRecord, res pcommon.Resource, scope pcommon.Instrumentati
 	}
 
 	scopeName := scope.Name()
-	scopeVersion := scope.Version()
 	if scopeName != "" {
 		logRecord.InstrumentationScope = &instrumentationScope{
 			Name: scopeName,
 		}
-		if scopeVersion != "" {
-			logRecord.InstrumentationScope.Version = scopeVersion
-		}
+		logRecord.InstrumentationScope.Version = scope.Version()
+		logRecord.InstrumentationScope.Attributes = scope.Attributes().AsRaw()
 	}
 
 	jsonRecord, err = json.Marshal(logRecord)
@@ -112,11 +111,16 @@ func EncodeLogfmt(lr plog.LogRecord, res pcommon.Resource, scope pcommon.Instrum
 
 	scopeName := scope.Name()
 	scopeVersion := scope.Version()
+
 	if scopeName != "" {
 		keyvals = append(keyvals, "instrumentation_scope_name", scopeName)
 		if scopeVersion != "" {
 			keyvals = append(keyvals, "instrumentation_scope_version", scopeVersion)
 		}
+		scope.Attributes().Range(func(k string, v pcommon.Value) bool {
+			keyvals = append(keyvals, valueToKeyvals(fmt.Sprintf("instrumentation_scope_attribute_%s", k), v)...)
+			return true
+		})
 	}
 
 	logfmtLine, err := logfmt.MarshalKeyvals(keyvals...)

--- a/pkg/translator/loki/encode_test.go
+++ b/pkg/translator/loki/encode_test.go
@@ -55,6 +55,16 @@ func TestEncodeJsonWithMapBody(t *testing.T) {
 	assert.Equal(t, in, out)
 }
 
+func TestEncodeJsonWithInstrumentationScopeAttributes(t *testing.T) {
+	in := `{"body":"Example log","traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resources":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1","attributes":{"foo":"bar"}}}`
+	log, resource, scope := exampleLog()
+	scope.Attributes().PutStr("foo", "bar")
+
+	out, err := Encode(log, resource, scope)
+	assert.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
 func TestSerializeComplexBody(t *testing.T) {
 
 	arrayval := pcommon.NewValueSlice()
@@ -211,6 +221,16 @@ func TestEncodeLogfmtWithFlags(t *testing.T) {
 	log, resource, scope := exampleLog()
 	log.Body().SetStr("msg=\"hello world\"")
 	log.SetFlags(plog.DefaultLogRecordFlags.WithIsSampled(true))
+	out, err := EncodeLogfmt(log, resource, scope)
+	assert.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
+func TestEncodeLogfmtWithInstrumentationScopeAttributes(t *testing.T) {
+	in := `msg="hello world" traceID=01020304000000000000000000000000 spanID=0506070800000000 severity=error attribute_attr1=1 attribute_attr2=2 resource_host.name=something instrumentation_scope_name=example-logger-name instrumentation_scope_version=v1 instrumentation_scope_attribute_foo=bar`
+	log, resource, scope := exampleLog()
+	scope.Attributes().PutStr("foo", "bar")
+	log.Body().SetStr("msg=\"hello world\"")
 	out, err := EncodeLogfmt(log, resource, scope)
 	assert.NoError(t, err)
 	assert.Equal(t, in, out)

--- a/pkg/translator/loki/logs_to_loki_test.go
+++ b/pkg/translator/loki/logs_to_loki_test.go
@@ -618,6 +618,26 @@ func TestLogToLokiEntry(t *testing.T) {
 			},
 		},
 		{
+			name:      "with instrumentation scope attributes",
+			timestamp: time.Unix(0, 1677592916000000000),
+			instrumentationScope: &instrumentationScope{
+				Name:    "otlp",
+				Version: "v1",
+				Attributes: map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			expected: &PushEntry{
+				Entry: &push.Entry{
+					Timestamp: time.Unix(0, 1677592916000000000),
+					Line:      `{"instrumentation_scope":{"name":"otlp","version":"v1","attributes":{"foo":"bar"}}}`,
+				},
+				Labels: model.LabelSet{
+					"exporter": "OTLP",
+				},
+			},
+		},
+		{
 			name:      "with unknown format hint",
 			timestamp: time.Unix(0, 1677592916000000000),
 			hints: map[string]interface{}{
@@ -650,6 +670,8 @@ func TestLogToLokiEntry(t *testing.T) {
 			if tt.instrumentationScope != nil {
 				scope.SetName(tt.instrumentationScope.Name)
 				scope.SetVersion(tt.instrumentationScope.Version)
+				err = scope.Attributes().FromRaw(tt.instrumentationScope.Attributes)
+				require.NoError(t, err)
 			}
 
 			resource := pcommon.NewResource()


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Added Attributes support to InstrumentationScope
Now the attributes information in the `pcommon.InstrumentationScope` structure is translated and transmitted to Loki.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24027

**Testing:** Added unit tests