### PR TITLE
[cmd/telemetrygen] fix status-code args default value

### DIFF
--- a/.chloggen/telemetrygen-status-code-default-value-bug.yaml
+++ b/.chloggen/telemetrygen-status-code-default-value-bug.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/telemetrygen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix the default value of the arg status-code
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [25849]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/telemetrygen/internal/traces/config.go
+++ b/cmd/telemetrygen/internal/traces/config.go
@@ -26,7 +26,7 @@ func (c *Config) Flags(fs *pflag.FlagSet) {
 	fs.IntVar(&c.NumTraces, "traces", 1, "Number of traces to generate in each worker (ignored if duration is provided)")
 	fs.BoolVar(&c.PropagateContext, "marshal", false, "Whether to marshal trace context via HTTP headers")
 	fs.StringVar(&c.ServiceName, "service", "telemetrygen", "Service name to use")
-	fs.StringVar(&c.StatusCode, "status-code", "", "Status code to use for the spans, one of (Unset, Error, Ok) or the equivalent integer (0,1,2)")
+	fs.StringVar(&c.StatusCode, "status-code", "0", "Status code to use for the spans, one of (Unset, Error, Ok) or the equivalent integer (0,1,2)")
 	fs.BoolVar(&c.Batch, "batch", true, "Whether to batch traces")
 	fs.IntVar(&c.LoadSize, "size", 0, "Desired minimum size in MB of string data for each trace generated. This can be used to test traces with large payloads, i.e. when testing the OTLP receiver endpoint max receive size.")
 }

--- a/cmd/telemetrygen/internal/traces/config.go
+++ b/cmd/telemetrygen/internal/traces/config.go
@@ -26,7 +26,7 @@ func (c *Config) Flags(fs *pflag.FlagSet) {
 	fs.IntVar(&c.NumTraces, "traces", 1, "Number of traces to generate in each worker (ignored if duration is provided)")
 	fs.BoolVar(&c.PropagateContext, "marshal", false, "Whether to marshal trace context via HTTP headers")
 	fs.StringVar(&c.ServiceName, "service", "telemetrygen", "Service name to use")
-	fs.StringVar(&c.StatusCode, "status-code", "Unset", "Status code to use for the spans, one of (Unset, Error, Ok) or the equivalent integer (0,1,2)")
+	fs.StringVar(&c.StatusCode, "status-code", "", "Status code to use for the spans, one of (Unset, Error, Ok) or the equivalent integer (0,1,2)")
 	fs.BoolVar(&c.Batch, "batch", true, "Whether to batch traces")
 	fs.IntVar(&c.LoadSize, "size", 0, "Desired minimum size in MB of string data for each trace generated. This can be used to test traces with large payloads, i.e. when testing the OTLP receiver endpoint max receive size.")
 }


### PR DESCRIPTION
**Description:** 
Fix #25849

after adding more logs for failed telemetrygen pod, I found traces-job keeps failing with the error log 

```
Error: expected `status-code` to be one of (Unset, Error, Ok) or (0, 1, 2), got "Unset" instead
```

here is a failed run https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/5899236967/job/16005926116

I thinks this bug is brought in by the pr #24673 , the default value `Unset` for arg `status-code` is not a legal one, the legal one is `"Unset"`

