### PR TITLE
[extension/healthcheck] remove dependency on jaeger package

### DIFF
--- a/extension/healthcheckextension/go.mod
+++ b/extension/healthcheckextension/go.mod
@@ -3,7 +3,6 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/healt
 go 1.20
 
 require (
-	github.com/jaegertracing/jaeger v1.41.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.83.0
 	github.com/stretchr/testify v1.8.4
 	go.opencensus.io v0.24.0

--- a/extension/healthcheckextension/go.sum
+++ b/extension/healthcheckextension/go.sum
@@ -142,8 +142,6 @@ github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvh
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hjson/hjson-go/v4 v4.0.0/go.mod h1:KaYt3bTw3zhBjYqnXkYywcYctk0A2nxeEFTse3rH13E=
-github.com/jaegertracing/jaeger v1.41.0 h1:vVNky8dP46M2RjGaZ7qRENqylW+tBFay3h57N16Ip7M=
-github.com/jaegertracing/jaeger v1.41.0/go.mod h1:SIkAT75iVmA9U+mESGYuMH6UQv6V9Qy4qxo0lwfCQAc=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=

--- a/extension/healthcheckextension/healthcheckextension.go
+++ b/extension/healthcheckextension/healthcheckextension.go
@@ -10,11 +10,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/jaegertracing/jaeger/pkg/healthcheck"
 	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension/internal/healthcheck"
 )
 
 type healthCheckExtension struct {

--- a/extension/healthcheckextension/internal/healthcheck/handler.go
+++ b/extension/healthcheckextension/internal/healthcheck/handler.go
@@ -1,0 +1,147 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+//
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Status represents the state of the service.
+type Status int
+
+const (
+	// Unavailable indicates the service is not able to handle requests
+	Unavailable Status = iota
+	// Ready indicates the service is ready to handle requests
+	Ready
+	// Broken indicates that the healthcheck itself is broken, not serving HTTP
+	Broken
+)
+
+func (s Status) String() string {
+	switch s {
+	case Unavailable:
+		return "unavailable"
+	case Ready:
+		return "ready"
+	case Broken:
+		return "broken"
+	default:
+		return "unknown"
+	}
+}
+
+type healthCheckResponse struct {
+	statusCode int
+	StatusMsg  string    `json:"status"`
+	UpSince    time.Time `json:"upSince"`
+	Uptime     string    `json:"uptime"`
+}
+
+type state struct {
+	status  Status
+	upSince time.Time
+}
+
+// HealthCheck provides an HTTP endpoint that returns the health status of the service
+type HealthCheck struct {
+	state     atomic.Value // stores state struct
+	logger    *zap.Logger
+	responses map[Status]healthCheckResponse
+}
+
+// New creates a HealthCheck with the specified initial state.
+func New() *HealthCheck {
+	hc := &HealthCheck{
+		logger: zap.NewNop(),
+		responses: map[Status]healthCheckResponse{
+			Unavailable: {
+				statusCode: http.StatusServiceUnavailable,
+				StatusMsg:  "Server not available",
+			},
+			Ready: {
+				statusCode: http.StatusOK,
+				StatusMsg:  "Server available",
+			},
+		},
+	}
+	hc.state.Store(state{status: Unavailable})
+	return hc
+}
+
+// SetLogger initializes a logger.
+func (hc *HealthCheck) SetLogger(logger *zap.Logger) {
+	hc.logger = logger
+}
+
+// Handler creates a new HTTP handler.
+func (hc *HealthCheck) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hcState := hc.getState()
+		template := hc.responses[hcState.status]
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(template.statusCode)
+
+		_, _ = w.Write(hc.createRespBody(hcState, template))
+	})
+}
+
+func (hc *HealthCheck) createRespBody(state state, template healthCheckResponse) []byte {
+	resp := template // clone
+	if state.status == Ready {
+		resp.UpSince = state.upSince
+		resp.Uptime = fmt.Sprintf("%v", time.Since(state.upSince))
+	}
+	healthCheckStatus, _ := json.Marshal(resp)
+	return healthCheckStatus
+}
+
+// Set a new health check status
+func (hc *HealthCheck) Set(status Status) {
+	oldState := hc.getState()
+	newState := state{status: status}
+	if status == Ready {
+		if oldState.status != Ready {
+			newState.upSince = time.Now()
+		}
+	}
+	hc.state.Store(newState)
+	hc.logger.Info("Health Check state change", zap.Stringer("status", status))
+}
+
+// Get the current status of this health check
+func (hc *HealthCheck) Get() Status {
+	return hc.getState().status
+}
+
+func (hc *HealthCheck) getState() state {
+	return hc.state.Load().(state)
+}
+
+// Ready is a shortcut for Set(Ready) (kept for backwards compatibility)
+func (hc *HealthCheck) Ready() {
+	hc.Set(Ready)
+}

--- a/extension/healthcheckextension/internal/healthcheck/handler.go
+++ b/extension/healthcheckextension/internal/healthcheck/handler.go
@@ -16,7 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package healthcheck
+package healthcheck // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension/internal/healthcheck"
 
 import (
 	"encoding/json"


### PR DESCRIPTION
This extension was pulling in a dependency on jaeger for a fairly small amount of code. I've copied the code into an internal package instead to remove the dep.
