### PR TITLE
[chore][fileconsumer] Remove generation field from reader

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -177,7 +177,6 @@ func (c Config) buildManager(logger *zap.SugaredLogger, emit emit.Callback, fact
 		maxBatchFiles:   c.MaxConcurrentFiles / 2,
 		maxBatches:      c.MaxBatches,
 		deleteAfterRead: c.DeleteAfterRead,
-		knownFiles:      make([]*reader, 0, 10),
 		seenPaths:       make(map[string]struct{}, 100),
 	}, nil
 }

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -1535,8 +1535,14 @@ func TestDeleteAfterRead_SkipPartials(t *testing.T) {
 	require.FileExists(t, longFile.Name())
 
 	// Verify that only long file is remembered and that (0 < offset < fileSize)
-	require.Equal(t, 1, len(operator.knownFiles))
-	reader := operator.knownFiles[0]
+
+	// Due to the way we manage known files, we expect an empty slice, followed by one with one element.
+	// The intention is to extract this data structure into a separate package and expose a more reasonable api.
+	require.Equal(t, 2, len(operator.knownFiles))
+	require.Equal(t, 0, len(operator.knownFiles[0]))
+	require.Equal(t, 1, len(operator.knownFiles[1]))
+	reader := operator.knownFiles[1][0]
+
 	require.Equal(t, longFile.Name(), reader.file.Name())
 	require.Greater(t, reader.Offset, int64(0))
 	require.Less(t, reader.Offset, int64(longFileSize))

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -47,7 +47,6 @@ type reader struct {
 	decoder       *decoder.Decoder
 	headerReader  *header.Reader
 	processFunc   emit.Callback
-	generation    int
 	eof           bool
 }
 

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -92,7 +92,7 @@ func (f *readerFactory) build(file *os.File, m *readerMetadata, lineSplitFunc bu
 	// Resolve file name and path attributes
 	resolved := file.Name()
 
-	// Dirty solution, waiting for this permanent fix https://github.com/golang/go/issues/39786
+	// Dirty solution, waiting for this permanent fix https://githuf.com/golang/go/issues/39786
 	// EvalSymlinks on windows is partially working depending on the way you use Symlinks and Junctions
 	if runtime.GOOS != "windows" {
 		resolved, err = filepath.EvalSymlinks(file.Name())


### PR DESCRIPTION
The `fileconsumer` package remembers all files it has seen for a short period of time. This ensures that we do not double-ingest files in the rare case where a file "temporarily disappears", such as may happen when with a file rotation strategy that involves use of a temp file name that is outside the include glob. In such cases, we may know of a file during one poll interval, then subsequently fail to find it in the next, then find it again in the next. 

We manage this short-term memory by remember files for a given number of poll intervals, currently hardcoded to 3. This PR restructures the way that we manage these generations. Previously, the `reader` struct had a field called `generation`, which was incremented when rotating generations. All previously known readers were stored in a single slice, which was appended to and cut as appropriate to rotate the generations. 

Now, each generation is stored in a separate slice, so we can manage generations without the need to increment or check a `generation` field. This has a couple benefits:
1. The management of generations is a concern that is outside the reader itself, so the reader should not have to carry this information or expose it externally as would be necessary if it were in a dedicated package.
2. Management of generations may change in the future, but it's likely that some notion of generations will persist. Future designs can more easily slot into a `[]generation` pattern, vs a `[]reader` pattern.