### PR TITLE
Revert "[chore][fileconsumer] Cleanup file handle when closed by reader"

### DIFF
--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -157,7 +157,10 @@ func (m *Manager) consume(ctx context.Context, paths []string) {
 			r.ReadToEnd(ctx)
 			// Delete a file if deleteAfterRead is enabled and we reached the end of the file
 			if m.deleteAfterRead && r.eof {
-				r.Delete()
+				r.Close()
+				if err := os.Remove(r.file.Name()); err != nil {
+					m.Errorf("could not delete %s", r.file.Name())
+				}
 			}
 		}(r)
 	}

--- a/pkg/stanza/fileconsumer/reader.go
+++ b/pkg/stanza/fileconsumer/reader.go
@@ -124,25 +124,12 @@ func (r *reader) finalizeHeader() {
 	r.HeaderFinalized = true
 }
 
-// Delete will close and delete the file
-func (r *reader) Delete() {
-	if r.file == nil {
-		return
-	}
-	f := r.file
-	r.Close()
-	if err := os.Remove(f.Name()); err != nil {
-		r.Errorf("could not delete %s", f.Name())
-	}
-}
-
 // Close will close the file
 func (r *reader) Close() {
 	if r.file != nil {
 		if err := r.file.Close(); err != nil {
 			r.Debugw("Problem closing reader", zap.Error(err))
 		}
-		r.file = nil
 	}
 
 	if r.headerReader != nil {


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#25912

This change appears to have caused special behaviors on windows.