### PR TITLE
Allow log's body to be set in telemetrygen

### DIFF
--- a/.chloggen/telemetrygen-set-log-body.yaml
+++ b/.chloggen/telemetrygen-set-log-body.yaml
@@ -1,0 +1,20 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: telemetrygen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The telemetrygen now supports setting the log's body
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/telemetrygen/internal/logs/config.go
+++ b/cmd/telemetrygen/internal/logs/config.go
@@ -13,10 +13,12 @@ import (
 type Config struct {
 	common.Config
 	NumLogs int
+	Body    string
 }
 
 // Flags registers config flags.
 func (c *Config) Flags(fs *pflag.FlagSet) {
 	c.CommonFlags(fs)
 	fs.IntVar(&c.NumLogs, "logs", 1, "Number of logs to generate in each worker (ignored if duration is provided)")
+	fs.StringVar(&c.Body, "body", "the message", "Body of the log")
 }

--- a/cmd/telemetrygen/internal/logs/logs.go
+++ b/cmd/telemetrygen/internal/logs/logs.go
@@ -97,6 +97,7 @@ func Run(c *Config, exp exporter, logger *zap.Logger) error {
 		w := worker{
 			numLogs:        c.NumLogs,
 			limitPerSecond: limit,
+			body:           c.Body,
 			totalDuration:  c.TotalDuration,
 			running:        running,
 			wg:             &wg,

--- a/cmd/telemetrygen/internal/logs/worker.go
+++ b/cmd/telemetrygen/internal/logs/worker.go
@@ -19,6 +19,7 @@ import (
 type worker struct {
 	running        *atomic.Bool    // pointer to shared flag that indicates it's time to stop the test
 	numLogs        int             // how many logs the worker has to generate (only when duration==0)
+	body           string          // the body of the log
 	totalDuration  time.Duration   // how long to run the test for (overrides `numLogs`)
 	limitPerSecond rate.Limit      // how many logs per second to generate
 	wg             *sync.WaitGroup // notify when done
@@ -38,6 +39,7 @@ func (w worker) simulateLogs(res *resource.Resource, exporter exporter) {
 			nRes.Attributes().PutStr(string(attr.Key), attr.Value.AsString())
 		}
 		log := logs.ResourceLogs().At(0).ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+		log.Body().SetStr(w.body)
 		log.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 		log.SetDroppedAttributesCount(1)
 		log.SetSeverityNumber(plog.SeverityNumberInfo)


### PR DESCRIPTION
This change adds a flag allowing users to set the log's body. It also sets a log body to a default message.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

