### PR TITLE
Fix replace_all_patterns attributes for transform readme

### DIFF
--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -116,7 +116,7 @@ transform:
       statements:
         - set(severity_text, "FAIL") where body == "request failed"
         - replace_all_matches(attributes, "/user/*/list/*", "/user/{userId}/list/{listId}")
-        - replace_all_patterns(attributes, "/account/\\d{4}", "/account/{accountId}")
+        - replace_all_patterns(attributes, "value", "/account/\\d{4}", "/account/{accountId}")
         - set(body, attributes["http.route"])
 ```
 


### PR DESCRIPTION
In the transform processor readme, there's still one instance of the replace_all_patterns without the mode parameter. This PR fixed that.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
