### PR TITLE
Remove defunct elastic_output reference from operator README

### DIFF
--- a/pkg/stanza/docs/operators/README.md
+++ b/pkg/stanza/docs/operators/README.md
@@ -1,7 +1,7 @@
 ## What is an operator?
 An operator is the most basic unit of log processing. Each operator fulfills a single responsibility, such as reading lines from a file, or parsing JSON from a field. Operators are then chained together in a pipeline to achieve a desired result.
 
-For instance, a user may read lines from a file using the `file_input` operator. From there, the results of this operation may be sent to a `regex_parser` operator that creates fields based on a regex pattern. And then finally, these results may be sent to a `elastic_output` operator that writes each line to Elasticsearch.
+For instance, a user may read lines from a file using the `file_input` operator. From there, the results of this operation may be sent to a `regex_parser` operator that creates fields based on a regex pattern. And then finally, these results may be sent to a `file_output` operator that writes each line to a file on disk.
 
 
 ## What operators are available?


### PR DESCRIPTION
**Description:** The operators README file still included a reference to the `elastic_output` which was removed a while back in favor of the `elasticsearchexporter`. This PR replaces the example with a file_output example, which still exists.