### PR TITLE
[receiver/zookeeper] remove duplicate Timeout field

### DIFF
--- a/.chloggen/codeboten_rm-dupe-timeout-zookeeper.yaml
+++ b/.chloggen/codeboten_rm-dupe-timeout-zookeeper.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: zookeeperreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Removes duplicate `Timeout` field. This change has no impact on end users of the component."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26082]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/receiver/zookeeperreceiver/config.go
+++ b/receiver/zookeeperreceiver/config.go
@@ -4,8 +4,6 @@
 package zookeeperreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver"
 
 import (
-	"time"
-
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 
@@ -16,7 +14,4 @@ type Config struct {
 	scraperhelper.ScraperControllerSettings `mapstructure:",squash"`
 	confignet.TCPAddr                       `mapstructure:",squash"`
 	metadata.MetricsBuilderConfig           `mapstructure:",squash"`
-
-	// Timeout within which requests should be completed.
-	Timeout time.Duration `mapstructure:"timeout"`
 }

--- a/receiver/zookeeperreceiver/factory.go
+++ b/receiver/zookeeperreceiver/factory.go
@@ -32,13 +32,13 @@ func NewFactory() receiver.Factory {
 func createDefaultConfig() component.Config {
 	cfg := scraperhelper.NewDefaultScraperControllerSettings(metadata.Type)
 	cfg.CollectionInterval = defaultCollectionInterval
+	cfg.Timeout = defaultTimeout
 
 	return &Config{
 		ScraperControllerSettings: cfg,
 		TCPAddr: confignet.TCPAddr{
 			Endpoint: ":2181",
 		},
-		Timeout:              defaultTimeout,
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 	}
 }

--- a/receiver/zookeeperreceiver/scraper.go
+++ b/receiver/zookeeperreceiver/scraper.go
@@ -77,15 +77,12 @@ func (z *zookeeperMetricsScraper) shutdown(_ context.Context) error {
 }
 
 func (z *zookeeperMetricsScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
-	var ctxWithTimeout context.Context
-	ctxWithTimeout, z.cancel = context.WithTimeout(ctx, z.config.Timeout)
-
-	responseMntr, err := z.runCommand(ctxWithTimeout, "mntr")
+	responseMntr, err := z.runCommand(ctx, "mntr")
 	if err != nil {
 		return pmetric.NewMetrics(), err
 	}
 
-	responseRuok, err := z.runCommand(ctxWithTimeout, "ruok")
+	responseRuok, err := z.runCommand(ctx, "ruok")
 	if err != nil {
 		return pmetric.NewMetrics(), err
 	}

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -299,7 +299,8 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			if tt.sendCmd != nil {
 				z.sendCmd = tt.sendCmd
 			}
-			ctx, _ := context.WithTimeout(context.Background(), z.config.Timeout)
+			ctx, cancel := context.WithTimeout(context.Background(), z.config.Timeout)
+			defer cancel()
 			actualMetrics, err := z.scrape(ctx)
 			require.NoError(t, z.shutdown(ctx))
 

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -288,8 +288,6 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, "zookeeper", z.Name())
 
-			ctx := context.Background()
-
 			if tt.setConnectionDeadline != nil {
 				z.setConnectionDeadline = tt.setConnectionDeadline
 			}
@@ -301,7 +299,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 			if tt.sendCmd != nil {
 				z.sendCmd = tt.sendCmd
 			}
-
+			ctx, _ := context.WithTimeout(context.Background(), z.config.Timeout)
 			actualMetrics, err := z.scrape(ctx)
 			require.NoError(t, z.shutdown(ctx))
 


### PR DESCRIPTION
Rely on the scraper helper's Timeout instead
