### PR TITLE
[chore] only check for codeowners on main branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -208,17 +208,11 @@ jobs:
         run: |
           make -j2 generate
           git diff --exit-code ':!*go.sum' || (echo 'Generated code is out of date, please run "make generate" and commit the changes in this PR.' && exit 1)
-      - uses: dorny/paths-filter@v2
-        id: codeowner-changes
-        with:
-          filters: |
-            src:
-              - '**/metadata.yaml'
       - name: Check codeowners
-        if: steps.codeowner-changes.outputs.src == 'true'
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
         run: |
           GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} make gengithub
-          git diff -s --exit-code || (echo 'Generated code or members.txt are out of date, please run "make gengithubcheck" and commit the changes in this PR.' && exit 1)
+          git diff -s --exit-code || (echo 'Generated code is out of date, please run "make gengithub" and commit the changes in this PR.' && exit 1)
       - name: Check gendependabot
         run: |
           make -j2 gendependabot


### PR DESCRIPTION
Restrict when this step is run to make sure the secret GITHUB_TOKEN is set.