### PR TITLE
[pkg/translator/loki] Moved labels names normalization to LogToLokiEntry function

### DIFF
--- a/.chloggen/pkg-loki-translator-move-label-normalization-to-LogToLokiEntry.yaml
+++ b/.chloggen/pkg-loki-translator-move-label-normalization-to-LogToLokiEntry.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: lokitranslator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Public method `LogToLokiEntry` from `pkg/loki/translator` now returns normalized (`.` replaced by `_`) label names
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26093]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/translator/loki/logs_to_loki_test.go
+++ b/pkg/translator/loki/logs_to_loki_test.go
@@ -521,7 +521,7 @@ func TestLogToLokiEntry(t *testing.T) {
 				},
 				Labels: model.LabelSet{
 					"exporter":  "OTLP",
-					"host.name": "guarana",
+					"host_name": "guarana",
 				},
 			},
 			err: nil,
@@ -543,7 +543,7 @@ func TestLogToLokiEntry(t *testing.T) {
 				},
 				Labels: model.LabelSet{
 					"exporter":  "OTLP",
-					"host.name": "guarana",
+					"host_name": "guarana",
 				},
 			},
 		},
@@ -565,7 +565,7 @@ func TestLogToLokiEntry(t *testing.T) {
 				},
 				Labels: model.LabelSet{
 					"exporter":  "OTLP",
-					"host.name": "guarana",
+					"host_name": "guarana",
 				},
 			},
 		},


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The public method `LogToLokiEntry` should return normalized label names to release developers who use it from the necessity to normalize them in their code

**Testing:** adjusted unit tests of lokitranslator