### PR TITLE
[chore] [CI] Temporarily disable check codeowners step in the check job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -211,11 +211,6 @@ jobs:
         run: |
           make -j2 generate
           git diff --exit-code ':!*go.sum' || (echo 'Generated code is out of date, please run "make generate" and commit the changes in this PR.' && exit 1)
-      - name: Check codeowners
-        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
-        run: |
-          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} make gengithub
-          git diff -s --exit-code || (echo 'Generated code is out of date, please run "make gengithub" and commit the changes in this PR.' && exit 1)
       - name: Check gendependabot
         run: |
           make -j2 gendependabot


### PR DESCRIPTION
To restore the main build and unblock the release

Updates https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26124