### PR TITLE
[pkg/stanza] Fully decompose the tokenize package

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -119,7 +119,7 @@ func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit emit.Callback
 	}
 
 	// Ensure that splitter is buildable
-	factory := splitter.NewCustomFactory(splitFunc, c.FlushPeriod)
+	factory := splitter.NewCustomSplitFuncFactory(splitFunc, c.TrimConfig.Func(), c.FlushPeriod)
 	if _, err := factory.SplitFunc(); err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/fileconsumer/internal/splitter/custom.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/custom.go
@@ -13,14 +13,16 @@ import (
 
 type customFactory struct {
 	splitFunc   bufio.SplitFunc
+	trimFunc    trim.Func
 	flushPeriod time.Duration
 }
 
 var _ Factory = (*customFactory)(nil)
 
-func NewCustomFactory(splitFunc bufio.SplitFunc, flushPeriod time.Duration) Factory {
+func NewCustomSplitFuncFactory(splitFunc bufio.SplitFunc, trimFunc trim.Func, flushPeriod time.Duration) Factory {
 	return &customFactory{
 		splitFunc:   splitFunc,
+		trimFunc:    trimFunc,
 		flushPeriod: flushPeriod,
 	}
 }

--- a/pkg/stanza/fileconsumer/internal/splitter/custom_test.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/custom_test.go
@@ -9,27 +9,29 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
 func TestCustomFactory(t *testing.T) {
 	tests := []struct {
 		name        string
-		splitter    bufio.SplitFunc
+		splitFunc   bufio.SplitFunc
 		flushPeriod time.Duration
 		wantErr     bool
 	}{
 		{
 			name: "default configuration",
-			splitter: func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+			splitFunc: func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 				return len(data), data, nil
 			},
-			flushPeriod: 100 * time.Millisecond,
+			flushPeriod: 500 * time.Millisecond,
 			wantErr:     false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			factory := NewCustomFactory(tt.splitter, tt.flushPeriod)
+			factory := NewCustomSplitFuncFactory(tt.splitFunc, trim.Whitespace, tt.flushPeriod)
 			got, err := factory.SplitFunc()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Build() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/stanza/fileconsumer/internal/splitter/multiline_test.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/multiline_test.go
@@ -32,7 +32,7 @@ func TestSplitFuncFactory(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name: "split config  error",
+			name: "split config error",
 			splitConfig: split.Config{
 				LineStartPattern: "START",
 				LineEndPattern:   "END",

--- a/pkg/stanza/fileconsumer/internal/splitter/multiline_test.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/multiline_test.go
@@ -45,7 +45,7 @@ func TestSplitFuncFactory(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			factory := NewSplitFuncFactory(tt.splitConfig, tt.encoding, tt.maxLogSize, trim.Nop, tt.flushPeriod)
+			factory := NewSplitFuncFactory(tt.splitConfig, tt.encoding, tt.maxLogSize, trim.Whitespace, tt.flushPeriod)
 			got, err := factory.SplitFunc()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SplitFunc() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -81,9 +81,8 @@ type BaseConfig struct {
 
 type SplitFuncBuilder func(enc encoding.Encoding) (bufio.SplitFunc, error)
 
-func (c Config) defaultMultilineBuilder(enc encoding.Encoding) (bufio.SplitFunc, error) {
-	trimFunc := c.TrimConfig.Func()
-	splitFunc, err := c.SplitConfig.Func(enc, true, int(c.MaxLogSize), trimFunc)
+func (c Config) defaultSplitFuncBuilder(enc encoding.Encoding) (bufio.SplitFunc, error) {
+	splitFunc, err := c.SplitConfig.Func(enc, true, int(c.MaxLogSize), c.TrimConfig.Func())
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +120,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 	}
 
 	if c.SplitFuncBuilder == nil {
-		c.SplitFuncBuilder = c.defaultMultilineBuilder
+		c.SplitFuncBuilder = c.defaultSplitFuncBuilder
 	}
 
 	// Build split func

--- a/pkg/stanza/split/splittest/splittest.go
+++ b/pkg/stanza/split/splittest/splittest.go
@@ -71,15 +71,13 @@ func (r *testReader) splitFunc(split bufio.SplitFunc) bufio.SplitFunc {
 }
 
 type TestCase struct {
-	Name                        string
-	Pattern                     string
-	Input                       []byte
-	ExpectedTokens              []string
-	ExpectedError               error
-	Sleep                       time.Duration
-	AdditionalIterations        int
-	PreserveLeadingWhitespaces  bool
-	PreserveTrailingWhitespaces bool
+	Name                 string
+	Pattern              string
+	Input                []byte
+	ExpectedTokens       []string
+	ExpectedError        error
+	Sleep                time.Duration
+	AdditionalIterations int
 }
 
 func (tc TestCase) Run(split bufio.SplitFunc) func(t *testing.T) {


### PR DESCRIPTION
Major additional refactoring, following https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26040.

I will peel off several smaller PRs while working towards this overall set of changes.
- Breaks apart the `tokenize` package:
  - Deletes `SplitterConfig` and instead makes its fields more composable.
  - Pulls all flushing concerns into a new `flush` package which can apply a stateful time-based flush behavior to any `bufio.SplitFunc`.
    - Adds dedicated test coverage for this package.
  - This leaves only the `Multline` struct in the `tokenize` package, so renames the package to `split` and the config to `split.Config`.
    - Enhances test coverage for this package.