### PR TITLE
[exporter/googlemanagedprometheusexporter] correct zone

### DIFF
--- a/exporter/googlemanagedprometheusexporter/README.md
+++ b/exporter/googlemanagedprometheusexporter/README.md
@@ -158,7 +158,7 @@ processors:
   resource:
     attributes:
     - key: "location"
-      value: "us-east-1"
+      value: "us-east1"
       action: upsert
 ```
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The zone `us-east-1` is not a valid GCP zone, which causes writing metrics with this example processor to fail. `us-east-1` is the AWS region, which means `aws:us-east-1` would work, but this PR changes this to the GCP equivalent `us-east1`.