### PR TITLE
[chore] [CI] Fix check-collector-module-version.sh

### DIFF
--- a/.github/workflows/scripts/check-collector-module-version.sh
+++ b/.github/workflows/scripts/check-collector-module-version.sh
@@ -36,8 +36,8 @@ check_collector_versions_correct() {
 
    # Loop through all the module files, checking the collector version
    for mod_file in $mod_files; do
-      if grep -q "$collector_module" "$mod_file"; then
-         mod_line=$(grep -m1 "$collector_module" "$mod_file")
+      if grep -q "$collector_module " "$mod_file"; then
+         mod_line=$(grep -m1 "$collector_module " "$mod_file")
          version=$(echo "$mod_line" | cut -d" " -f2)
 
          # To account for a module on its own 'require' line,


### PR DESCRIPTION
Fix the module matching pattern in go.mod to always expect the space before the version and avoid matching the existing comment:
```
// Code generated by "go.opentelemetry.io/collector/cmd/builder". DO NOT EDIT.
```

Fixes test failing in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26296