### PR TITLE
[extension/oauth2clientauth] Enable dynamically reading ClientID and ClientSecret from files

### DIFF
--- a/.chloggen/feature-oauth2clientauth-read-from-file.yaml
+++ b/.chloggen/feature-oauth2clientauth-read-from-file.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: oauth2clientauthextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable dynamically reading ClientID and ClientSecret from files
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26117]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Read the client ID and/or secret from a file by specifying the file path to the ClientIDFile (`client_id_file`) and ClientSecretFile (`client_secret_file`) fields respectively.
+  - The file is read every time the client issues a new token. This means that the corresponding value can change dynamically during the execution by modifying the file contents.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/extension/oauth2clientauthextension/README.md
+++ b/extension/oauth2clientauthextension/README.md
@@ -74,7 +74,11 @@ Following are the configuration fields
 
 - [**token_url**](https://datatracker.ietf.org/doc/html/rfc6749#section-3.2) - The resource server's token endpoint URLs.
 - [**client_id**](https://datatracker.ietf.org/doc/html/rfc6749#section-2.2) - The client identifier issued to the client.
+- **client_id_file** - The file path to retrieve the client identifier issued to the client.
+  This setting takes precedence over `client_id`.
 - [**client_secret**](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) - The secret string associated with above identifier.
+- **client_secret_file** - The file path to retrieve the secret string associated with above identifier.
+  This setting takes precedence over `client_secret`.
 - [**endpoint_params**](https://github.com/golang/oauth2/blob/master/clientcredentials/clientcredentials.go#L44) - Additional parameters that are sent to the token endpoint.
 - [**scopes**](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3) - **Optional** optional requested permissions associated for the client.
 - [**timeout**](https://golang.org/src/net/http/client.go#L90) -  **Optional** specifies the timeout on the underlying client to authorization server for fetching the tokens (initial and while refreshing).

--- a/extension/oauth2clientauthextension/README.md
+++ b/extension/oauth2clientauthextension/README.md
@@ -75,9 +75,11 @@ Following are the configuration fields
 - [**token_url**](https://datatracker.ietf.org/doc/html/rfc6749#section-3.2) - The resource server's token endpoint URLs.
 - [**client_id**](https://datatracker.ietf.org/doc/html/rfc6749#section-2.2) - The client identifier issued to the client.
 - **client_id_file** - The file path to retrieve the client identifier issued to the client.
+  The extension reads this file and updates the client ID used whenever it needs to issue a new token. This enables dynamically changing the client credentials by modifying the file contents when, for example, they need to rotate. <!-- Intended whitespace for compact new line -->  
   This setting takes precedence over `client_id`.
 - [**client_secret**](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) - The secret string associated with above identifier.
 - **client_secret_file** - The file path to retrieve the secret string associated with above identifier.
+  The extension reads this file and updates the client secret used whenever it needs to issue a new token. This enables dynamically changing the client credentials by modifying the file contents when, for example, they need to rotate. <!-- Intended whitespace for compact new line -->  
   This setting takes precedence over `client_secret`.
 - [**endpoint_params**](https://github.com/golang/oauth2/blob/master/clientcredentials/clientcredentials.go#L44) - Additional parameters that are sent to the token endpoint.
 - [**scopes**](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3) - **Optional** optional requested permissions associated for the client.

--- a/extension/oauth2clientauthextension/clientcredentialsconfig.go
+++ b/extension/oauth2clientauthextension/clientcredentialsconfig.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2clientauthextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension"
+
+import (
+	"context"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// clientCredentialsConfig is a clientcredentials.Config wrapper.
+type clientCredentialsConfig struct {
+	clientcredentials.Config
+}
+
+type clientCredentialsTokenSource struct {
+	ctx    context.Context
+	config *clientCredentialsConfig
+}
+
+// clientCredentialsTokenSource implements TokenSource
+var _ oauth2.TokenSource = (*clientCredentialsTokenSource)(nil)
+
+// createConfig creates a proper clientcredentials.Config with values retrieved
+// from files, if the user has specified a "file:" prefix
+func (c *clientCredentialsConfig) createConfig() (*clientcredentials.Config, error) {
+	return &clientcredentials.Config{
+		ClientID:       c.ClientID,
+		ClientSecret:   c.ClientSecret,
+		TokenURL:       c.TokenURL,
+		Scopes:         c.Scopes,
+		EndpointParams: c.EndpointParams,
+	}, nil
+}
+
+func (c *clientCredentialsConfig) TokenSource(ctx context.Context) oauth2.TokenSource {
+	return oauth2.ReuseTokenSource(nil, clientCredentialsTokenSource{ctx: ctx, config: c})
+}
+
+func (ts clientCredentialsTokenSource) Token() (*oauth2.Token, error) {
+	cfg, err := ts.config.createConfig()
+	if err != nil {
+		return nil, err
+	}
+	return cfg.TokenSource(ts.ctx).Token()
+}

--- a/extension/oauth2clientauthextension/clientcredentialsconfig.go
+++ b/extension/oauth2clientauthextension/clientcredentialsconfig.go
@@ -60,18 +60,15 @@ func readCredentialsFile(path string) (string, error) {
 }
 
 func getActualValue(value, filepath string) (string, error) {
-	actualValue := value
-	var err error
-
 	if len(filepath) > 0 {
-		actualValue, err = readCredentialsFile(filepath)
+		return readCredentialsFile(filepath)
 	}
 
-	return actualValue, err
+	return value, nil
 }
 
 // createConfig creates a proper clientcredentials.Config with values retrieved
-// from files, if the user has specified a "file:" prefix
+// from files, if the user has specified '*_file' values
 func (c *clientCredentialsConfig) createConfig() (*clientcredentials.Config, error) {
 	clientID, err := getActualValue(c.ClientID, c.ClientIDFile)
 	if err != nil {

--- a/extension/oauth2clientauthextension/config.go
+++ b/extension/oauth2clientauthextension/config.go
@@ -26,9 +26,15 @@ type Config struct {
 	// See https://datatracker.ietf.org/doc/html/rfc6749#section-2.2
 	ClientID string `mapstructure:"client_id"`
 
+	// ClientIDFile is the file path to read the application's ID from.
+	ClientIDFile string `mapstructure:"client_id_file"`
+
 	// ClientSecret is the application's secret.
 	// See https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
 	ClientSecret configopaque.String `mapstructure:"client_secret"`
+
+	// ClientSecretFile is the file pathg to read the application's secret from.
+	ClientSecretFile string `mapstructure:"client_secret_file"`
 
 	// EndpointParams specifies additional parameters for requests to the token endpoint.
 	EndpointParams url.Values `mapstructure:"endpoint_params"`
@@ -54,10 +60,10 @@ var _ component.Config = (*Config)(nil)
 
 // Validate checks if the extension configuration is valid
 func (cfg *Config) Validate() error {
-	if cfg.ClientID == "" {
+	if cfg.ClientID == "" && cfg.ClientIDFile == "" {
 		return errNoClientIDProvided
 	}
-	if cfg.ClientSecret == "" {
+	if cfg.ClientSecret == "" && cfg.ClientSecretFile == "" {
 		return errNoClientSecretProvided
 	}
 	if cfg.TokenURL == "" {

--- a/extension/oauth2clientauthextension/extension.go
+++ b/extension/oauth2clientauthextension/extension.go
@@ -36,10 +36,10 @@ var _ oauth2.TokenSource = (*errorWrappingTokenSource)(nil)
 var errFailedToGetSecurityToken = fmt.Errorf("failed to get security token from token endpoint")
 
 func newClientAuthenticator(cfg *Config, logger *zap.Logger) (*clientAuthenticator, error) {
-	if cfg.ClientID == "" {
+	if cfg.ClientID == "" && cfg.ClientIDFile == "" {
 		return nil, errNoClientIDProvided
 	}
-	if cfg.ClientSecret == "" {
+	if cfg.ClientSecret == "" && cfg.ClientSecretFile == "" {
 		return nil, errNoClientSecretProvided
 	}
 	if cfg.TokenURL == "" {
@@ -63,6 +63,8 @@ func newClientAuthenticator(cfg *Config, logger *zap.Logger) (*clientAuthenticat
 				Scopes:         cfg.Scopes,
 				EndpointParams: cfg.EndpointParams,
 			},
+			ClientIDFile:     cfg.ClientIDFile,
+			ClientSecretFile: cfg.ClientSecretFile,
 		},
 		logger: logger,
 		client: &http.Client{

--- a/extension/oauth2clientauthextension/extension.go
+++ b/extension/oauth2clientauthextension/extension.go
@@ -19,7 +19,7 @@ import (
 // clientAuthenticator provides implementation for providing client authentication using OAuth2 client credentials
 // workflow for both gRPC and HTTP clients.
 type clientAuthenticator struct {
-	clientCredentials *clientcredentials.Config
+	clientCredentials *clientCredentialsConfig
 	logger            *zap.Logger
 	client            *http.Client
 }
@@ -55,12 +55,14 @@ func newClientAuthenticator(cfg *Config, logger *zap.Logger) (*clientAuthenticat
 	transport.TLSClientConfig = tlsCfg
 
 	return &clientAuthenticator{
-		clientCredentials: &clientcredentials.Config{
-			ClientID:       cfg.ClientID,
-			ClientSecret:   string(cfg.ClientSecret),
-			TokenURL:       cfg.TokenURL,
-			Scopes:         cfg.Scopes,
-			EndpointParams: cfg.EndpointParams,
+		clientCredentials: &clientCredentialsConfig{
+			Config: clientcredentials.Config{
+				ClientID:       cfg.ClientID,
+				ClientSecret:   string(cfg.ClientSecret),
+				TokenURL:       cfg.TokenURL,
+				Scopes:         cfg.Scopes,
+				EndpointParams: cfg.EndpointParams,
+			},
 		},
 		logger: logger,
 		client: &http.Client{

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -148,7 +148,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 		settings             *Config
 		expectedClientConfig *clientcredentials.Config
 		shouldError          bool
-		expectedError        string
+		expectedError        error
 	}{
 		{
 			name: "client_id_file",
@@ -163,7 +163,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 				ClientSecret: "testsecret",
 			},
 			shouldError:   false,
-			expectedError: "",
+			expectedError: nil,
 		},
 		{
 			name: "client_secret_file",
@@ -178,7 +178,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 				ClientSecret: "testcreds",
 			},
 			shouldError:   false,
-			expectedError: "",
+			expectedError: nil,
 		},
 		{
 			name: "empty_client_creds_file",
@@ -189,7 +189,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 				Scopes:       []string{"resource.read"},
 			},
 			shouldError:   true,
-			expectedError: errNoClientIDProvided.Error(),
+			expectedError: errNoClientIDProvided,
 		},
 		{
 			name: "missing_client_creds_file",
@@ -200,7 +200,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 				Scopes:           []string{"resource.read"},
 			},
 			shouldError:   true,
-			expectedError: errNoClientSecretProvided.Error(),
+			expectedError: errNoClientSecretProvided,
 		},
 	}
 
@@ -210,7 +210,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			cfg, err := rc.clientCredentials.createConfig()
 			if test.shouldError {
 				assert.NotNil(t, err)
-				assert.Contains(t, err.Error(), test.expectedError)
+				assert.ErrorAs(t, err, &test.expectedError)
 				return
 			}
 			assert.NoError(t, err)

--- a/extension/oauth2clientauthextension/testdata/test-cred.txt
+++ b/extension/oauth2clientauthextension/testdata/test-cred.txt
@@ -1,0 +1,1 @@
+testcreds


### PR DESCRIPTION
**Description:**
This PR implements the feature described in detail in the issue linked below.

In a nutshell, it extends the `oauth2clientauth` extension to read ClientID and/or ClientSecret from files whenever a new token is needed for the OAuth flow.
As a result, the extension can use updated credentials (when the old ones expire for example) without the need to restart the OTEL collector, as long as the file contents are in sync.

**Link to tracking Issue:** #26117 

**Testing:**
Apart from the unit testing you can see in the PR, I've tested this feature in two real-life environments:

1. As a systemd service exporting `otlphttp` data
2. A Kubernetes microservice (deployed by an OpenTelemetryCollector CR) exporting `otlphttp` data

In both cases, the collectors export the data to a service which sits behind an OIDC authentication proxy.
Using the `oauth2clientauth` extension, the `otlphttp` exporter hits the authentication provider to issue tokens for the OIDC client and successfully authenticates to the service.

In my cases, the ClientSecret gets rotated quite frequently and there is a stack making sure the ClientID and ClientSecret in the corresponding files are up-to-date.

**Documentation:**
I have extended the extension's README file. I'm open to more suggestions!

cc @jpkrohling @pavankrish123 