### PR TITLE
[exporter/loki]. Rename resources to resource field in JSON format

### DIFF
--- a/.chloggen/loki-exporter-rename-resources-field.yaml
+++ b/.chloggen/loki-exporter-rename-resources-field.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: lokiexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added feature gate flag `exporter.loki.sendWithResourceInJSONFormat`. If enabled, loki exporter sends `resource` instead of `resources` field in JSON format to align the name with the opentelemetry log data model specification
+
+# One or more tracking issues related to the change
+issues: [21161]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/exporter/lokiexporter/README.md
+++ b/exporter/lokiexporter/README.md
@@ -152,6 +152,9 @@ The following formats are supported:
 
 OpenTelemetry uses `record.severity` to track log levels where loki uses `record.attributes.level` for the same. The exporter automatically maps the two, except if a "level" attribute already exists.
 
+## Flags
+In v0.85.0 added feature gate flag `exporter.loki.sendWithResourceInJSONFormat`. If enabled, loki exporter sends `resource` instead of `resources` field in JSON format to align the name with the opentelemetry log data model specification
+
 ## Advanced Configuration
 
 Several helper files are leveraged to provide additional capabilities automatically:

--- a/exporter/lokiexporter/config.go
+++ b/exporter/lokiexporter/config.go
@@ -17,7 +17,8 @@ type Config struct {
 	exporterhelper.QueueSettings  `mapstructure:"sending_queue"`
 	exporterhelper.RetrySettings  `mapstructure:"retry_on_failure"`
 
-	DefaultLabelsEnabled map[string]bool `mapstructure:"default_labels_enabled"`
+	DefaultLabelsEnabled                 map[string]bool `mapstructure:"default_labels_enabled"`
+	sendResourceFieldInJSONFormatEnabled bool
 }
 
 func (c *Config) Validate() error {

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -47,7 +47,13 @@ func newExporter(config *Config, settings component.TelemetrySettings) *lokiExpo
 }
 
 func (l *lokiExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
-	requests := loki.LogsToLokiRequests(ld, l.config.DefaultLabelsEnabled)
+	var requests map[string]loki.PushRequest
+
+	if l.config.sendResourceFieldInJSONFormatEnabled {
+		requests = loki.LogsToLokiRequestsWithResourceFieldInJSONFormat(ld, l.config.DefaultLabelsEnabled)
+	} else {
+		requests = loki.LogsToLokiRequests(ld, l.config.DefaultLabelsEnabled)
+	}
 
 	var errs error
 	for tenant, request := range requests {

--- a/exporter/lokiexporter/exporter.go
+++ b/exporter/lokiexporter/exporter.go
@@ -50,10 +50,12 @@ func (l *lokiExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
 	var requests map[string]loki.PushRequest
 
 	if l.config.sendResourceFieldInJSONFormatEnabled {
-		requests = loki.LogsToLokiRequestsWithResourceFieldInJSONFormat(ld, l.config.DefaultLabelsEnabled)
-	} else {
-		requests = loki.LogsToLokiRequests(ld, l.config.DefaultLabelsEnabled)
+		count := ld.LogRecordCount()
+		for i := 0; i < count; i++ {
+			ld.ResourceLogs().At(i).Resource().Attributes().PutBool(loki.UseResourceFieldInJSONFormat, true)
+		}
 	}
+	requests = loki.LogsToLokiRequests(ld, l.config.DefaultLabelsEnabled)
 
 	var errs error
 	for tenant, request := range requests {

--- a/exporter/lokiexporter/factory.go
+++ b/exporter/lokiexporter/factory.go
@@ -23,7 +23,7 @@ import (
 var sendResourceInJSONFormat = featuregate.GlobalRegistry().MustRegister(
 	"exporter.loki.sendWithResourceInJSONFormat",
 	featuregate.StageAlpha,
-	featuregate.WithRegisterFromVersion("0.84.0"),
+	featuregate.WithRegisterFromVersion("0.85.0"),
 	featuregate.WithRegisterDescription("When enabled, sends 'resource' instead of 'resources' in JSON format"),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21161"),
 )

--- a/exporter/lokiexporter/factory.go
+++ b/exporter/lokiexporter/factory.go
@@ -15,8 +15,17 @@ import (
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/featuregate"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter/internal/metadata"
+)
+
+var sendResourceInJSONFormat = featuregate.GlobalRegistry().MustRegister(
+	"exporter.loki.sendWithResourceInJSONFormat",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterFromVersion("0.84.0"),
+	featuregate.WithRegisterDescription("When enabled, sends 'resource' instead of 'resources' in JSON format"),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21161"),
 )
 
 // NewFactory creates a factory for the legacy Loki exporter.
@@ -47,6 +56,7 @@ func createDefaultConfig() component.Config {
 			"instance": true,
 			"level":    true,
 		},
+		sendResourceFieldInJSONFormatEnabled: sendResourceInJSONFormat.IsEnabled(),
 	}
 }
 

--- a/exporter/lokiexporter/go.mod
+++ b/exporter/lokiexporter/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.84.0
 	go.opentelemetry.io/collector/consumer v0.84.0
 	go.opentelemetry.io/collector/exporter v0.84.0
+	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0014
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0014
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.25.0
@@ -62,7 +63,6 @@ require (
 	go.opentelemetry.io/collector/config/internal v0.84.0 // indirect
 	go.opentelemetry.io/collector/extension v0.84.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.84.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0014 // indirect
 	go.opentelemetry.io/collector/processor v0.84.0 // indirect
 	go.opentelemetry.io/collector/receiver v0.84.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.84.0 // indirect

--- a/pkg/translator/loki/convert_test.go
+++ b/pkg/translator/loki/convert_test.go
@@ -40,7 +40,7 @@ func TestConvertAttributesAndMerge(t *testing.T) {
 		{
 			desc: "selected resource attribute should be included",
 			logAttrs: map[string]interface{}{
-				hintResources: "host.name",
+				hintResource: "host.name",
 			},
 			resAttrs: map[string]interface{}{
 				"host.name": "guarana",
@@ -55,9 +55,9 @@ func TestConvertAttributesAndMerge(t *testing.T) {
 			desc:     "selected attributes from resource attributes should be included",
 			logAttrs: map[string]interface{}{},
 			resAttrs: map[string]interface{}{
-				hintResources: "host.name",
-				"host.name":   "hostname-from-resources",
-				"pod.name":    "should-be-ignored",
+				hintResource: "host.name",
+				"host.name":  "hostname-from-resources",
+				"pod.name":   "should-be-ignored",
 			},
 			expected: model.LabelSet{
 				"exporter":  "OTLP",
@@ -69,7 +69,7 @@ func TestConvertAttributesAndMerge(t *testing.T) {
 			logAttrs: map[string]interface{}{
 				"host.name":    "hostname-from-attributes",
 				hintAttributes: "host.name",
-				hintResources:  "host.name",
+				hintResource:   "host.name",
 			},
 			resAttrs: map[string]interface{}{
 				"host.name": "hostname-from-resources",
@@ -256,7 +256,7 @@ func TestRemoveAttributes(t *testing.T) {
 			desc: "remove hints",
 			attrs: map[string]interface{}{
 				hintAttributes: "some.field",
-				hintResources:  "some.other.field",
+				hintResource:   "some.other.field",
 				hintFormat:     "logfmt",
 				hintTenant:     "some_tenant",
 				"host.name":    "guarana",

--- a/pkg/translator/loki/encode_test.go
+++ b/pkg/translator/loki/encode_test.go
@@ -41,6 +41,15 @@ func TestEncodeJsonWithStringBody(t *testing.T) {
 	assert.Equal(t, in, out)
 }
 
+func TestEncodeJsonWithStringBodyWithResourceField(t *testing.T) {
+	in := `{"body":"Example log","traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resource":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
+	log, resource, scope := exampleLog()
+
+	out, err := EncodeWithResourceField(log, resource, scope)
+	assert.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
 func TestEncodeJsonWithMapBody(t *testing.T) {
 	in := `{"body":{"key1":"value","key2":"value"},"traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resources":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
 
@@ -51,6 +60,20 @@ func TestEncodeJsonWithMapBody(t *testing.T) {
 	mapVal.CopyTo(log.Body())
 
 	out, err := Encode(log, resource, scope)
+	assert.NoError(t, err)
+	assert.Equal(t, in, out)
+}
+
+func TestEncodeJsonWithMapBodyWithResourceField(t *testing.T) {
+	in := `{"body":{"key1":"value","key2":"value"},"traceid":"01020304000000000000000000000000","spanid":"0506070800000000","severity":"error","attributes":{"attr1":"1","attr2":"2"},"resource":{"host.name":"something"},"instrumentation_scope":{"name":"example-logger-name","version":"v1"}}`
+
+	log, resource, scope := exampleLog()
+	mapVal := pcommon.NewValueMap()
+	mapVal.Map().PutStr("key1", "value")
+	mapVal.Map().PutStr("key2", "value")
+	mapVal.CopyTo(log.Body())
+
+	out, err := EncodeWithResourceField(log, resource, scope)
 	assert.NoError(t, err)
 	assert.Equal(t, in, out)
 }

--- a/pkg/translator/loki/logs_to_loki.go
+++ b/pkg/translator/loki/logs_to_loki.go
@@ -114,6 +114,73 @@ func LogsToLokiRequests(ld plog.Logs, defaultLabelsEnabled map[string]bool) map[
 	return requests
 }
 
+func LogsToLokiRequestsWithResourceFieldInJSONFormat(ld plog.Logs, defaultLabelsEnabled map[string]bool) map[string]PushRequest {
+	groups := map[string]pushRequestGroup{}
+
+	rls := ld.ResourceLogs()
+	for i := 0; i < rls.Len(); i++ {
+		ills := rls.At(i).ScopeLogs()
+		resource := rls.At(i).Resource()
+
+		for j := 0; j < ills.Len(); j++ {
+			logs := ills.At(j).LogRecords()
+			scope := ills.At(j).Scope()
+			for k := 0; k < logs.Len(); k++ {
+				log := logs.At(k)
+				tenant := GetTenantFromTenantHint(log.Attributes(), resource.Attributes())
+				group, ok := groups[tenant]
+				if !ok {
+					group = pushRequestGroup{
+						report:  &PushReport{},
+						streams: make(map[string]*push.Stream),
+					}
+					groups[tenant] = group
+				}
+
+				entry, err := LogToLokiEntryWithResourceFieldInJSONFormat(log, resource, scope, defaultLabelsEnabled)
+				if err != nil {
+					// Couldn't convert so dropping log.
+					group.report.Errors = append(group.report.Errors, fmt.Errorf("failed to convert, dropping log: %w", err))
+					group.report.NumDropped++
+					continue
+				}
+
+				group.report.NumSubmitted++
+
+				// create the stream name based on the labels
+				labels := entry.Labels.String()
+				if stream, ok := group.streams[labels]; ok {
+					stream.Entries = append(stream.Entries, *entry.Entry)
+					continue
+				}
+
+				group.streams[labels] = &push.Stream{
+					Labels:  labels,
+					Entries: []push.Entry{*entry.Entry},
+				}
+			}
+		}
+	}
+
+	requests := make(map[string]PushRequest)
+	for tenant, g := range groups {
+		pr := &push.PushRequest{
+			Streams: make([]push.Stream, len(g.streams)),
+		}
+
+		i := 0
+		for _, stream := range g.streams {
+			pr.Streams[i] = *stream
+			i++
+		}
+		requests[tenant] = PushRequest{
+			PushRequest: pr,
+			Report:      g.report,
+		}
+	}
+	return requests
+}
+
 // PushEntry is Loki log entry enriched with labels
 type PushEntry struct {
 	Entry  *push.Entry
@@ -143,6 +210,46 @@ func LogToLokiEntry(lr plog.LogRecord, rl pcommon.Resource, scope pcommon.Instru
 	removeAttributes(resource.Attributes(), mergedLabels)
 
 	entry, err := convertLogToLokiEntry(log, resource, format, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := model.LabelSet{}
+	for label := range mergedLabels {
+		// Loki doesn't support dots in label names
+		// labelName is normalized label name to follow Prometheus label names standard
+		labelName := prometheustranslator.NormalizeLabel(string(label))
+		labels[model.LabelName(labelName)] = mergedLabels[label]
+	}
+
+	return &PushEntry{
+		Entry:  entry,
+		Labels: labels,
+	}, nil
+}
+
+func LogToLokiEntryWithResourceFieldInJSONFormat(lr plog.LogRecord, rl pcommon.Resource, scope pcommon.InstrumentationScope, defaultLabelsEnabled map[string]bool) (*PushEntry, error) {
+	// we may remove attributes, so change only our version
+	log := plog.NewLogRecord()
+	lr.CopyTo(log)
+
+	// similarly, we may remove attributes, so we make a copy and change our version
+	resource := pcommon.NewResource()
+	rl.CopyTo(resource)
+
+	if enabled, ok := defaultLabelsEnabled[levelLabel]; !ok || enabled {
+		// adds level attribute from log.severityNumber
+		addLogLevelAttributeAndHint(log)
+	}
+
+	format := getFormatFromFormatHint(log.Attributes(), resource.Attributes())
+
+	mergedLabels := convertAttributesAndMerge(log.Attributes(), resource.Attributes(), defaultLabelsEnabled)
+	// remove the attributes that were promoted to labels
+	removeAttributes(log.Attributes(), mergedLabels)
+	removeAttributes(resource.Attributes(), mergedLabels)
+
+	entry, err := convertLogToLokiEntryWithResourceFieldInJSONFormat(log, resource, format, scope)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/translator/loki/logs_to_loki_test.go
+++ b/pkg/translator/loki/logs_to_loki_test.go
@@ -458,6 +458,9 @@ func TestLogsToLokiRequestWithoutTenant(t *testing.T) {
 					res[hintResource] = val
 				}
 				assert.NoError(t, ld.ResourceLogs().At(0).Resource().Attributes().FromRaw(res))
+				if tt.sendResourceFieldInJSONFormatEnabled {
+					ld.ResourceLogs().At(0).Resource().Attributes().PutBool(UseResourceFieldInJSONFormat, true)
+				}
 			}
 
 			rlogs := ld.ResourceLogs()
@@ -489,12 +492,7 @@ func TestLogsToLokiRequestWithoutTenant(t *testing.T) {
 			}
 
 			// test
-			var requests map[string]PushRequest
-			if tt.sendResourceFieldInJSONFormatEnabled {
-				requests = LogsToLokiRequestsWithResourceFieldInJSONFormat(ld, tt.defaultLebelsEnabled)
-			} else {
-				requests = LogsToLokiRequests(ld, tt.defaultLebelsEnabled)
-			}
+			requests := LogsToLokiRequests(ld, tt.defaultLebelsEnabled)
 
 			assert.Len(t, requests, 1)
 			request := requests[""]
@@ -734,10 +732,9 @@ func TestLogToLokiEntry(t *testing.T) {
 
 			var log *PushEntry
 			if tt.sendResourceFieldInJSONFormatEnabled {
-				log, err = LogToLokiEntryWithResourceFieldInJSONFormat(lr, resource, scope, tt.defaultLabelsEnabled)
-			} else {
-				log, err = LogToLokiEntry(lr, resource, scope, tt.defaultLabelsEnabled)
+				resource.Attributes().PutBool(UseResourceFieldInJSONFormat, true)
 			}
+			log, err = LogToLokiEntry(lr, resource, scope, tt.defaultLabelsEnabled)
 
 			assert.Equal(t, tt.err, err)
 			assert.Equal(t, tt.expected, log)


### PR DESCRIPTION
This is a resurrection of the PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/21162 (I can't reopen it, that's why created a new one)

**Description:**
Lokiexporter sends resources field to Loki in JSON format. This name is not following the opentelemetry log data model specification: https://opentelemetry.io/docs/reference/specification/logs/data-model/#field-resource
The field name should be resource

**Link to tracking Issue:**
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21161
