### PR TITLE
[connector/datadog] Fix `go` directive

### DIFF
--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector
 
-go 1.19
+go 1.20
 
 require (
 	github.com/DataDog/datadog-agent/pkg/proto v0.48.0-beta.1


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

The `go` directive was pointing to Go 1.19 instead of Go 1.20.
