### PR TITLE
[chore] Fix GitHub add-label workflow to ping codeowners

### DIFF
--- a/.github/workflows/scripts/add-labels.sh
+++ b/.github/workflows/scripts/add-labels.sh
@@ -59,7 +59,7 @@ for LABEL_REQ in ${LABELS}; do
 
         # Labels added by a GitHub Actions workflow don't trigger other workflows
         # by design, so we have to manually ping code owners here.
-        COMPONENT="${LABEL}" ISSUE=${ISSUE} SENDER="${SENDER}" bash "${CUR_DIRECTORY}/ping-codeowners.sh"
+        COMPONENT="${LABEL}" ISSUE=${ISSUE} SENDER="${SENDER}" bash "${CUR_DIRECTORY}/ping-codeowners-issues.sh"
     else
         gh issue edit "${ISSUE}" --remove-label "${LABEL}"
     fi


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The add-label workflow is used by GitHub when manually adding labels to issues. When adding a new component to an issue, the workflow attempts to ping codeowners of the given component. However, the link to the ping codeowners script was outdated, and was failing. This change references the moved script.

**Link to tracking Issue:** <Issue number if applicable>
Resolves #26361

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>