### PR TITLE
[receiver/loki] Link readme to config helpers

### DIFF
--- a/receiver/lokireceiver/README.md
+++ b/receiver/lokireceiver/README.md
@@ -31,6 +31,17 @@ receivers:
   loki:
     protocols:
       http:
+        endpoint: 0.0.0.0:3500
       grpc:
+        endpoint: 0.0.0.0:3600
     use_incoming_timestamp: true
 ```
+
+## Advanced Configuration
+
+Several helper files are leveraged to provide additional capabilities automatically:
+
+- [gRPC settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md) including CORS
+- [HTTP settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md)
+- [TLS and mTLS settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)
+- [Auth settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configauth/README.md)


### PR DESCRIPTION
Add a link from the Loki receiver's readme to some of the helpers that can be used with it.

closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26352

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
