### PR TITLE
[exporter/opensearch] Schema fix in sso_model

### DIFF
--- a/.chloggen/opensearchexporter-tostring_attribute.yaml
+++ b/.chloggen/opensearchexporter-tostring_attribute.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+
+component: opensearchexporter
+
+note: clean up rejected attribute in json by joining an array to string
+
+issues: [23611]
+
+subtext: related to: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/24540 

--- a/.chloggen/opensearchexporter-tostring_attribute.yaml
+++ b/.chloggen/opensearchexporter-tostring_attribute.yaml
@@ -6,4 +6,4 @@ note: clean up rejected attribute in json by joining an array to string
 
 issues: [23611]
 
-subtext: related to: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/24540 
+subtext: related to: [24540] 

--- a/.chloggen/opensearchexporter-tostring_attribute.yaml
+++ b/.chloggen/opensearchexporter-tostring_attribute.yaml
@@ -6,4 +6,5 @@ note: clean up rejected attribute in json by joining an array to string
 
 issues: [23611]
 
-subtext: related to: [24540] 
+subtext: 
+

--- a/exporter/opensearchexporter/sso_model.go
+++ b/exporter/opensearchexporter/sso_model.go
@@ -43,13 +43,13 @@ type ssoSpan struct {
 		SchemaURL              string         `json:"schemaUrl"`
 		Version                string         `json:"version"`
 	} `json:"instrumentationScope,omitempty"`
-	Kind         string         `json:"kind"`
-	Links        []ssoSpanLinks `json:"links,omitempty"`
-	Name         string         `json:"name"`
-	ParentSpanID string         `json:"parentSpanId"`
-	Resource     map[string]any `json:"resource,omitempty"`
-	SpanID       string         `json:"spanId"`
-	StartTime    time.Time      `json:"startTime"`
+	Kind         string            `json:"kind"`
+	Links        []ssoSpanLinks    `json:"links,omitempty"`
+	Name         string            `json:"name"`
+	ParentSpanID string            `json:"parentSpanId"`
+	Resource     map[string]string `json:"resource,omitempty"`
+	SpanID       string            `json:"spanId"`
+	StartTime    time.Time         `json:"startTime"`
 	Status       struct {
 		Code    string `json:"code"`
 		Message string `json:"message"`

--- a/exporter/opensearchexporter/trace_bulk_indexer.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer.go
@@ -194,6 +194,15 @@ func responseAsError(item opensearchutil.BulkIndexerResponseItem) error {
 	return errors.New(string(errorJSON))
 }
 
+func attributesToMapString(attributes pcommon.Map) map[string]string {
+	m := make(map[string]string, attributes.Len())
+	attributes.Range(func(k string, v pcommon.Value) bool {
+		m[k] = v.AsString()
+		return true
+	})
+	return m
+}
+
 func shouldRetryEvent(status int) bool {
 	var retryOnStatus = []int{500, 502, 503, 504, 429}
 	for _, retryable := range retryOnStatus {


### PR DESCRIPTION
**Description:** 
Fixes issue found in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/24540
The exported JSON was rejected by the inbound service because the JSON did not match the ss4o schema.  To fix, converted an attribute from array of strings to a joined string. 

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23611

**Testing:** 
1. demo docker instance now pushes data into OpenSearch container without error
2. inspected data in OpenSearch container looks good

**Documentation:** 
None.  Exporter now works as expected. 