### PR TITLE
[receiver/filelog] fix behavior of add operator when using env function

### DIFF
--- a/.chloggen/filelog-os_env_func_add.yaml
+++ b/.chloggen/filelog-os_env_func_add.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the behavior of the add operator to continue to support EXPR(env("MY_ENV_VAR")) expressions
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26373]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/stanza/operator/transformer/add/add.go
+++ b/pkg/stanza/operator/transformer/add/add.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/vm"
 	"go.uber.org/zap"
 
@@ -58,15 +57,14 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		addOperator.Value = c.Value
 		return addOperator, nil
 	}
-	exprStr := strings.TrimPrefix(strVal, "EXPR(")
-	exprStr = strings.TrimSuffix(exprStr, ")")
+	v := helper.ExprStringConfig(strVal)
+	compiled, err := v.Build()
 
-	compiled, err := expr.Compile(exprStr, expr.AllowUndefinedVariables())
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile expression '%s': %w", c.IfExpr, err)
 	}
 
-	addOperator.program = compiled
+	addOperator.program = compiled.SubExprs[0]
 	return addOperator, nil
 }
 


### PR DESCRIPTION
**Description:**
Fix the behavior of the add operator to continue to support EXPR(env("MY_ENV_VAR")) expressions

**Link to tracking Issue:**
#26373

**Testing:**
Unit test.