### PR TITLE
[receiver/awscontainerinsights]  HOST_PROC usage

### DIFF
--- a/.chloggen/use-envmap-awscontainerinsightsreceiver.yaml
+++ b/.chloggen/use-envmap-awscontainerinsightsreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/awscontainerinsightsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the need to set an env var in the receiver to get CPU and memory info
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24777]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity.go
@@ -4,16 +4,13 @@
 package host // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/host"
 
 import (
-	"fmt"
+	"context"
 	"os"
 
+	"github.com/shirou/gopsutil/v3/common"
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/mem"
 	"go.uber.org/zap"
-)
-
-const (
-	goPSUtilProcDirEnv = "HOST_PROC"
 )
 
 type nodeCapacityProvider interface {
@@ -30,8 +27,8 @@ type nodeCapacity struct {
 	osLstat func(name string) (os.FileInfo, error)
 	// osSetenv sets the value of the environment variable named by the key
 	osSetenv      func(key string, value string) error
-	virtualMemory func() (*mem.VirtualMemoryStat, error)
-	cpuInfo       func() ([]cpu.InfoStat, error)
+	virtualMemory func(ctx context.Context) (*mem.VirtualMemoryStat, error)
+	cpuInfo       func(ctx context.Context) ([]cpu.InfoStat, error)
 }
 
 type nodeCapacityOption func(*nodeCapacity)
@@ -41,8 +38,8 @@ func newNodeCapacity(logger *zap.Logger, options ...nodeCapacityOption) (nodeCap
 		logger:        logger,
 		osLstat:       os.Lstat,
 		osSetenv:      os.Setenv,
-		virtualMemory: mem.VirtualMemory,
-		cpuInfo:       cpu.Info,
+		virtualMemory: mem.VirtualMemoryWithContext,
+		cpuInfo:       cpu.InfoWithContext,
 	}
 
 	for _, opt := range options {
@@ -52,17 +49,16 @@ func newNodeCapacity(logger *zap.Logger, options ...nodeCapacityOption) (nodeCap
 	if _, err := nc.osLstat(hostProc); os.IsNotExist(err) {
 		return nil, err
 	}
-	if err := nc.osSetenv(goPSUtilProcDirEnv, hostProc); err != nil {
-		return nil, fmt.Errorf("NodeCapacity cannot set goPSUtilProcDirEnv to %s: %w", hostProc, err)
-	}
+	envMap := common.EnvMap{common.HostProcEnvKey: hostProc}
+	ctx := context.WithValue(context.Background(), common.EnvKey, envMap)
 
-	nc.parseCPU()
-	nc.parseMemory()
+	nc.parseCPU(ctx)
+	nc.parseMemory(ctx)
 	return nc, nil
 }
 
-func (nc *nodeCapacity) parseMemory() {
-	if memStats, err := nc.virtualMemory(); err == nil {
+func (nc *nodeCapacity) parseMemory(ctx context.Context) {
+	if memStats, err := nc.virtualMemory(ctx); err == nil {
 		nc.memCapacity = int64(memStats.Total)
 	} else {
 		// If any error happen, then there will be no mem utilization metrics
@@ -70,8 +66,8 @@ func (nc *nodeCapacity) parseMemory() {
 	}
 }
 
-func (nc *nodeCapacity) parseCPU() {
-	if cpuInfos, err := nc.cpuInfo(); err == nil {
+func (nc *nodeCapacity) parseCPU(ctx context.Context) {
+	if cpuInfos, err := nc.cpuInfo(ctx); err == nil {
 		numCores := len(cpuInfos)
 		nc.cpuCapacity = int64(numCores)
 	} else {

--- a/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
@@ -4,6 +4,7 @@
 package host
 
 import (
+	"context"
 	"errors"
 	"os"
 	"testing"
@@ -31,28 +32,20 @@ func TestNodeCapacity(t *testing.T) {
 			return nil, nil
 		}
 	}
-	setEnvOption := func(nc *nodeCapacity) {
-		nc.osSetenv = func(key, value string) error {
-			return errors.New("error")
-		}
-	}
-	nc, err = newNodeCapacity(zap.NewNop(), lstatOption, setEnvOption)
-	assert.Nil(t, nc)
-	assert.NotNil(t, err)
 
 	// can't parse cpu and mem info
-	setEnvOption = func(nc *nodeCapacity) {
+	setEnvOption := func(nc *nodeCapacity) {
 		nc.osSetenv = func(key, value string) error {
 			return nil
 		}
 	}
 	virtualMemOption := func(nc *nodeCapacity) {
-		nc.virtualMemory = func() (*mem.VirtualMemoryStat, error) {
+		nc.virtualMemory = func(ctx context.Context) (*mem.VirtualMemoryStat, error) {
 			return nil, errors.New("error")
 		}
 	}
 	cpuInfoOption := func(nc *nodeCapacity) {
-		nc.cpuInfo = func() ([]cpu.InfoStat, error) {
+		nc.cpuInfo = func(ctx context.Context) ([]cpu.InfoStat, error) {
 			return nil, errors.New("error")
 		}
 	}
@@ -64,14 +57,14 @@ func TestNodeCapacity(t *testing.T) {
 
 	// normal case where everything is working
 	virtualMemOption = func(nc *nodeCapacity) {
-		nc.virtualMemory = func() (*mem.VirtualMemoryStat, error) {
+		nc.virtualMemory = func(ctx context.Context) (*mem.VirtualMemoryStat, error) {
 			return &mem.VirtualMemoryStat{
 				Total: 1024,
 			}, nil
 		}
 	}
 	cpuInfoOption = func(nc *nodeCapacity) {
-		nc.cpuInfo = func() ([]cpu.InfoStat, error) {
+		nc.cpuInfo = func(ctx context.Context) ([]cpu.InfoStat, error) {
 			return []cpu.InfoStat{
 				{},
 				{},


### PR DESCRIPTION

**Description:**
Remove the need to set the environment variable HOST_PROC as part of the awscontainerinsightsreceiver

**Link to tracking Issue:**
#24777 

**Testing:**
Unit tests pass

**Documentation:**
N/A