### PR TITLE
[chore] remove unused constant related to gopsutil env var names HOST_PROC

### DIFF
--- a/internal/aws/containerinsight/const.go
+++ b/internal/aws/containerinsight/const.go
@@ -9,8 +9,6 @@ import (
 
 // define metric names, attribute names, metric types, and units for both EKS and ECS Container Insights
 const (
-	GoPSUtilProcDirEnv = "HOST_PROC"
-
 	// We assume 50 micro-seconds is the minimal gap between two collected data sample to be valid to calculate delta
 	MinTimeDiff = 50 * time.Microsecond
 


### PR DESCRIPTION
Marked as chore as this is an internal package and this const is not used anywhere.