### PR TITLE
[chore] Update go versions in workflows to latest

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -44,7 +44,7 @@ jobs:
         run: Install-WindowsFeature -name Web-Server -IncludeManagementTools
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-mod-cache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -265,13 +265,13 @@ jobs:
           path: ~/.cache/go-build
           key: go-test-build-${{ runner.os }}-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
-        if: ${{ matrix.go-version == '1.19' }}
+        if: startsWith( matrix.go-version, '1.19' )
         run: make gotest GROUP=${{ matrix.group }}
       - name: Run Unit Tests With Coverage
-        if: ${{ matrix.go-version == '1.20' }} # only run coverage on one version
+        if: startsWith( matrix.go-version, '~1.20' ) # only run coverage on one version
         run: make gotest-with-cover GROUP=${{ matrix.group }}
       - uses: actions/upload-artifact@v3
-        if: ${{ matrix.go-version == '1.20' }} # only run coverage on one version
+        if: startsWith( matrix.go-version, '~1.21' ) # only run coverage on one version
         with:
           name: coverage-artifacts
           path: ${{ matrix.group }}-coverage.txt

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache
@@ -141,7 +141,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache
@@ -224,7 +224,7 @@ jobs:
   unittest-matrix:
     strategy:
       matrix:
-        go-version: ["1.21", "1.20"] # 1.20 is interpreted as 1.2 without quotes
+        go-version: ["~1.21.1", "~1.20.8"] # 1.20 is interpreted as 1.2 without quotes
         group:
           - receiver-0
           - receiver-1
@@ -316,7 +316,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache
@@ -337,7 +337,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache
@@ -363,7 +363,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache
@@ -427,7 +427,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache
@@ -559,7 +559,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Mkdir bin and dist
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -271,7 +271,7 @@ jobs:
         if: startsWith( matrix.go-version, '~1.20' ) # only run coverage on one version
         run: make gotest-with-cover GROUP=${{ matrix.group }}
       - uses: actions/upload-artifact@v3
-        if: startsWith( matrix.go-version, '~1.21' ) # only run coverage on one version
+        if: startsWith( matrix.go-version, '~1.20' ) # only run coverage on one version
         with:
           name: coverage-artifacts
           path: ${{ matrix.group }}-coverage.txt

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -12,7 +12,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install zsh
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Run dependabot-pr.sh
         run: ./.github/workflows/scripts/dependabot-pr.sh

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,7 +26,7 @@ jobs:
           path: opentelemetry-collector-contrib
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Prepare release for contrib
         working-directory: opentelemetry-collector-contrib

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -26,7 +26,7 @@ jobs:
           path: opentelemetry-collector-contrib
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.7
+          go-version: ~1.20.8
           cache: false
       - name: Cache Go
         id: go-cache


### PR DESCRIPTION
**Description:** This is a defensive PR to update the go versions used in workflows to use the latest patch versions of `v1.21` and `v1.20`. The latest patch releases contains security related fixes. 