### PR TITLE
[internal/coreinternal] Transition featuregate `coreinternal.attraction.hash.sha256`  to stable

### DIFF
--- a/.chloggen/sha256-featuregate-stable.yaml
+++ b/.chloggen/sha256-featuregate-stable.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: attributesprocessor, resourceprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Transition featuregate `coreinternal.attraction.hash.sha256` to stable
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [4759]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/coreinternal/attraction/attraction.go
+++ b/internal/coreinternal/attraction/attraction.go
@@ -17,8 +17,9 @@ import (
 
 var enableSha256Gate = featuregate.GlobalRegistry().MustRegister(
 	"coreinternal.attraction.hash.sha256",
-	featuregate.StageBeta,
+	featuregate.StageStable,
 	featuregate.WithRegisterDescription("When enabled, switches hashing algorithm from SHA-1 to SHA-2 256"),
+	featuregate.WithRegisterToVersion("0.85.0"),
 )
 
 // Settings specifies the processor settings.


### PR DESCRIPTION
**Description:** 
Transition featuregate `coreinternal.attraction.hash.sha256` to stable

**Link to tracking Issue:**
#4759
