### PR TITLE
Upgrade aliyun-log-go-sdk library

### DIFF
--- a/exporter/alibabacloudlogserviceexporter/uploader.go
+++ b/exporter/alibabacloudlogserviceexporter/uploader.go
@@ -49,13 +49,10 @@ func newLogServiceClient(config *Config, logger *zap.Logger) (logServiceClient, 
 
 	producerConfig := producer.GetDefaultProducerConfig()
 	producerConfig.Endpoint = config.Endpoint
-	producerConfig.AccessKeyID = config.AccessKeyID
-	producerConfig.AccessKeySecret = string(config.AccessKeySecret)
 	if config.ECSRamRole != "" || config.TokenFilePath != "" {
 		tokenUpdateFunc, _ := slsutil.NewTokenUpdateFunc(config.ECSRamRole, config.TokenFilePath)
-		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26987
-		// nolint
-		producerConfig.UpdateStsToken = tokenUpdateFunc
+		provider := sls.NewUpdateFuncProviderAdapter(tokenUpdateFunc)
+		producerConfig.CredentialsProvider = provider
 		producerConfig.StsTokenShutDown = make(chan struct{})
 	}
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Replace deprecated UpdateStsToken, AccessKeyID, and AccessKeySecret fields in ProducerConfig with CredentialsProvider and UpdateFuncProviderAdapter as per aliyun/aliyun-log-go-sdk#216.


Fixes #26456
