### PR TITLE
[chore] add decorder linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -129,6 +129,7 @@ linters-settings:
 
 linters:
   enable:
+    - decorder
     - depguard
     - errcheck
     - errorlint


### PR DESCRIPTION
See #25060 for original request.

This adds the decorder linter with default configuration, just ensuring init blocks are at the top of the file for now.