### PR TITLE
[chore] add wastedassign linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -149,6 +149,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - wastedassign
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/exporter/dynatraceexporter/internal/serialization/histogram.go
+++ b/exporter/dynatraceexporter/internal/serialization/histogram.go
@@ -160,7 +160,7 @@ func histDataPointToSummary(dp pmetric.HistogramDataPoint) (float64, float64, fl
 }
 
 func estimateSingleBucketHistogram(dp pmetric.HistogramDataPoint) (float64, float64, float64) {
-	min, max, sum := 0.0, 0.0, 0.0
+	var min, max, sum float64
 
 	if dp.HasSum() {
 		sum = dp.Sum()

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -227,7 +227,7 @@ func (prwe *prweWAL) continuallyPopWALThenExport(ctx context.Context, signalStar
 		}
 		reqL = append(reqL, req)
 
-		shouldExport := false
+		var shouldExport bool
 		select {
 		case <-timer.C:
 			shouldExport = true

--- a/exporter/sumologicexporter/exporter.go
+++ b/exporter/sumologicexporter/exporter.go
@@ -140,7 +140,7 @@ func (se *sumologicexporter) start(_ context.Context, host component.Host) (err 
 // so they can be handled by OTC retry mechanism
 func (se *sumologicexporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
 	var (
-		currentMetadata  = newFields(pcommon.NewMap())
+		currentMetadata  fields
 		previousMetadata = newFields(pcommon.NewMap())
 		errs             error
 		droppedRecords   []plog.LogRecord
@@ -233,7 +233,7 @@ func (se *sumologicexporter) pushLogsData(ctx context.Context, ld plog.Logs) err
 // so they can be handle by the OTC retry mechanism
 func (se *sumologicexporter) pushMetricsData(ctx context.Context, md pmetric.Metrics) error {
 	var (
-		currentMetadata  = newFields(pcommon.NewMap())
+		currentMetadata  fields
 		previousMetadata = newFields(pcommon.NewMap())
 		errs             error
 		droppedRecords   []metricPair

--- a/pkg/ottl/contexts/internal/value.go
+++ b/pkg/ottl/contexts/internal/value.go
@@ -71,7 +71,8 @@ func SetValue(value pcommon.Value, val interface{}) error {
 }
 
 func getIndexableValue(value pcommon.Value, keys []ottl.Key) (any, error) {
-	val, ok := value, false
+	val := value
+	var ok bool
 	for i := 0; i < len(keys); i++ {
 		switch val.Type() {
 		case pcommon.ValueTypeMap:

--- a/receiver/mongodbatlasreceiver/logs.go
+++ b/receiver/mongodbatlasreceiver/logs.go
@@ -169,7 +169,7 @@ func (s *logsReceiver) collectClusterLogs(clusters []mongodbatlas.Cluster, proje
 
 func filterClusters(clusters []mongodbatlas.Cluster, projectCfg ProjectConfig) ([]mongodbatlas.Cluster, error) {
 	include, exclude := projectCfg.IncludeClusters, projectCfg.ExcludeClusters
-	whitelist := false
+	var allowed bool
 	var clusterNameSet map[string]struct{}
 	// check to include or exclude clusters
 	switch {
@@ -178,11 +178,11 @@ func filterClusters(clusters []mongodbatlas.Cluster, projectCfg ProjectConfig) (
 		return clusters, nil
 	// include is initialized
 	case len(include) > 0 && len(exclude) == 0:
-		whitelist = true
+		allowed = true
 		clusterNameSet = projectCfg.includesByClusterName
 	// exclude is initialized
 	case len(exclude) > 0 && len(include) == 0:
-		whitelist = false
+		allowed = false
 		clusterNameSet = projectCfg.excludesByClusterName
 	// both are initialized
 	default:
@@ -191,7 +191,7 @@ func filterClusters(clusters []mongodbatlas.Cluster, projectCfg ProjectConfig) (
 
 	var filtered []mongodbatlas.Cluster
 	for _, cluster := range clusters {
-		if _, ok := clusterNameSet[cluster.Name]; (!ok && !whitelist) || (ok && whitelist) {
+		if _, ok := clusterNameSet[cluster.Name]; (!ok && !allowed) || (ok && allowed) {
 			filtered = append(filtered, cluster)
 		}
 	}

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -322,7 +322,7 @@ func (mf *metricFamily) appendMetric(metrics pmetric.MetricSlice, trimSuffixes b
 	metric.SetDescription(mf.metadata.Help)
 	metric.SetUnit(prometheus.UnitWordToUCUM(mf.metadata.Unit))
 
-	pointCount := 0
+	var pointCount int
 
 	switch mf.mtype {
 	case pmetric.MetricTypeHistogram:

--- a/receiver/prometheusreceiver/internal/util.go
+++ b/receiver/prometheusreceiver/internal/util.go
@@ -74,7 +74,7 @@ func timestampFromMs(timeAtMs int64) pcommon.Timestamp {
 }
 
 func getBoundary(metricType pmetric.MetricType, labels labels.Labels) (float64, error) {
-	val := ""
+	var val string
 	switch metricType {
 	case pmetric.MetricTypeHistogram:
 		val = labels.Get(model.BucketLabel)


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/25060 for original request.

This adds the wastedassign linter with default configuration. It ensures no assignmnent is made to a variable and then not used.