### PR TITLE
[chore] add reassign linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -142,6 +142,7 @@ linters:
     - gosec
     - govet
     - misspell
+    - reassign
     - revive
     - staticcheck
     - tenv


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/25060 for original request.

This adds the reassign linter, checking no package variables are reassigned.