### PR TITLE
[pkg/stanza] Rename tokenize package to split

### DIFF
--- a/.chloggen/pkg-stanza-rm-tokenize.yaml
+++ b/.chloggen/pkg-stanza-rm-tokenize.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename "tokenize" package to "split"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26540]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -20,7 +20,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/matcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
@@ -53,7 +53,7 @@ func NewConfig() *Config {
 		IncludeFileNameResolved: false,
 		IncludeFilePathResolved: false,
 		PollInterval:            200 * time.Millisecond,
-		Multiline:               tokenize.NewMultilineConfig(),
+		Multiline:               split.NewMultilineConfig(),
 		Encoding:                defaultEncoding,
 		StartAt:                 "end",
 		FingerprintSize:         fingerprint.DefaultSize,
@@ -66,22 +66,22 @@ func NewConfig() *Config {
 // Config is the configuration of a file input operator
 type Config struct {
 	matcher.Criteria        `mapstructure:",squash"`
-	IncludeFileName         bool                     `mapstructure:"include_file_name,omitempty"`
-	IncludeFilePath         bool                     `mapstructure:"include_file_path,omitempty"`
-	IncludeFileNameResolved bool                     `mapstructure:"include_file_name_resolved,omitempty"`
-	IncludeFilePathResolved bool                     `mapstructure:"include_file_path_resolved,omitempty"`
-	PollInterval            time.Duration            `mapstructure:"poll_interval,omitempty"`
-	StartAt                 string                   `mapstructure:"start_at,omitempty"`
-	FingerprintSize         helper.ByteSize          `mapstructure:"fingerprint_size,omitempty"`
-	MaxLogSize              helper.ByteSize          `mapstructure:"max_log_size,omitempty"`
-	MaxConcurrentFiles      int                      `mapstructure:"max_concurrent_files,omitempty"`
-	MaxBatches              int                      `mapstructure:"max_batches,omitempty"`
-	DeleteAfterRead         bool                     `mapstructure:"delete_after_read,omitempty"`
-	Multiline               tokenize.MultilineConfig `mapstructure:"multiline,omitempty"`
-	TrimConfig              trim.Config              `mapstructure:",squash,omitempty"`
-	Encoding                string                   `mapstructure:"encoding,omitempty"`
-	FlushPeriod             time.Duration            `mapstructure:"force_flush_period,omitempty"`
-	Header                  *HeaderConfig            `mapstructure:"header,omitempty"`
+	IncludeFileName         bool                  `mapstructure:"include_file_name,omitempty"`
+	IncludeFilePath         bool                  `mapstructure:"include_file_path,omitempty"`
+	IncludeFileNameResolved bool                  `mapstructure:"include_file_name_resolved,omitempty"`
+	IncludeFilePathResolved bool                  `mapstructure:"include_file_path_resolved,omitempty"`
+	PollInterval            time.Duration         `mapstructure:"poll_interval,omitempty"`
+	StartAt                 string                `mapstructure:"start_at,omitempty"`
+	FingerprintSize         helper.ByteSize       `mapstructure:"fingerprint_size,omitempty"`
+	MaxLogSize              helper.ByteSize       `mapstructure:"max_log_size,omitempty"`
+	MaxConcurrentFiles      int                   `mapstructure:"max_concurrent_files,omitempty"`
+	MaxBatches              int                   `mapstructure:"max_batches,omitempty"`
+	DeleteAfterRead         bool                  `mapstructure:"delete_after_read,omitempty"`
+	Multiline               split.MultilineConfig `mapstructure:"multiline,omitempty"`
+	TrimConfig              trim.Config           `mapstructure:",squash,omitempty"`
+	Encoding                string                `mapstructure:"encoding,omitempty"`
+	FlushPeriod             time.Duration         `mapstructure:"force_flush_period,omitempty"`
+	Header                  *HeaderConfig         `mapstructure:"header,omitempty"`
 }
 
 type HeaderConfig struct {

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -280,7 +280,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "multiline_line_start_string",
 				Expect: func() *mockOperatorConfig {
 					cfg := NewConfig()
-					cfg.Multiline = tokenize.MultilineConfig{
+					cfg.Multiline = split.MultilineConfig{
 						LineStartPattern: "Start",
 					}
 					return newMockOperatorConfig(cfg)
@@ -290,7 +290,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "multiline_line_start_special",
 				Expect: func() *mockOperatorConfig {
 					cfg := NewConfig()
-					cfg.Multiline = tokenize.MultilineConfig{
+					cfg.Multiline = split.MultilineConfig{
 						LineStartPattern: "%",
 					}
 					return newMockOperatorConfig(cfg)
@@ -300,7 +300,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "multiline_line_end_string",
 				Expect: func() *mockOperatorConfig {
 					cfg := NewConfig()
-					cfg.Multiline = tokenize.MultilineConfig{
+					cfg.Multiline = split.MultilineConfig{
 						LineEndPattern: "Start",
 					}
 					return newMockOperatorConfig(cfg)
@@ -310,7 +310,7 @@ func TestUnmarshal(t *testing.T) {
 				Name: "multiline_line_end_special",
 				Expect: func() *mockOperatorConfig {
 					cfg := NewConfig()
-					cfg.Multiline = tokenize.MultilineConfig{
+					cfg.Multiline = split.MultilineConfig{
 						LineEndPattern: "%",
 					}
 					return newMockOperatorConfig(cfg)
@@ -452,7 +452,7 @@ func TestBuild(t *testing.T) {
 		{
 			"MultilineConfiguredStartAndEndPatterns",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineEndPattern:   "Exists",
 					LineStartPattern: "Exists",
 				}
@@ -463,7 +463,7 @@ func TestBuild(t *testing.T) {
 		{
 			"MultilineConfiguredStartPattern",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineStartPattern: "START.*",
 				}
 			},
@@ -473,7 +473,7 @@ func TestBuild(t *testing.T) {
 		{
 			"MultilineConfiguredEndPattern",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineEndPattern: "END.*",
 				}
 			},
@@ -491,7 +491,7 @@ func TestBuild(t *testing.T) {
 		{
 			"LineStartAndEnd",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineStartPattern: ".*",
 					LineEndPattern:   ".*",
 				}
@@ -502,7 +502,7 @@ func TestBuild(t *testing.T) {
 		{
 			"NoLineStartOrEnd",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{}
+				f.Multiline = split.MultilineConfig{}
 			},
 			require.NoError,
 			func(t *testing.T, f *Manager) {},
@@ -510,7 +510,7 @@ func TestBuild(t *testing.T) {
 		{
 			"InvalidLineStartRegex",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineStartPattern: "(",
 				}
 			},
@@ -520,7 +520,7 @@ func TestBuild(t *testing.T) {
 		{
 			"InvalidLineEndRegex",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineEndPattern: "(",
 				}
 			},

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/matcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
 )
 
 func TestCleanStop(t *testing.T) {
@@ -547,7 +547,7 @@ func TestNoNewline(t *testing.T) {
 	tempDir := t.TempDir()
 	cfg := NewConfig().includeDir(tempDir)
 	cfg.StartAt = "beginning"
-	cfg.Multiline = tokenize.NewMultilineConfig()
+	cfg.Multiline = split.NewMultilineConfig()
 	cfg.FlushPeriod = time.Nanosecond
 	operator, emitCalls := buildTestManager(t, cfg)
 

--- a/pkg/stanza/fileconsumer/internal/header/config.go
+++ b/pkg/stanza/fileconsumer/internal/header/config.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/pipeline"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 )
 
 type Config struct {
@@ -69,7 +69,7 @@ func NewConfig(matchRegex string, metadataOperators []operator.Config, enc encod
 		return nil, fmt.Errorf("failed to compile `pattern`: %w", err)
 	}
 
-	splitFunc, err := tokenize.NewlineSplitFunc(enc, false, func(b []byte) []byte {
+	splitFunc, err := split.NewlineSplitFunc(enc, false, func(b []byte) []byte {
 		return bytes.Trim(b, "\r\n")
 	})
 	if err != nil {

--- a/pkg/stanza/fileconsumer/internal/splitter/multiline.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/multiline.go
@@ -10,12 +10,12 @@ import (
 	"golang.org/x/text/encoding"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/flush"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
 type multilineFactory struct {
-	multilineCfg tokenize.MultilineConfig
+	multilineCfg split.MultilineConfig
 	encoding     encoding.Encoding
 	maxLogSize   int
 	trimFunc     trim.Func
@@ -25,7 +25,7 @@ type multilineFactory struct {
 var _ Factory = (*multilineFactory)(nil)
 
 func NewMultilineFactory(
-	multilineCfg tokenize.MultilineConfig,
+	multilineCfg split.MultilineConfig,
 	encoding encoding.Encoding,
 	maxLogSize int,
 	trimFunc trim.Func,

--- a/pkg/stanza/fileconsumer/internal/splitter/multiline_test.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/multiline_test.go
@@ -11,14 +11,14 @@ import (
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/unicode"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
 func TestMultilineBuild(t *testing.T) {
 	tests := []struct {
 		name         string
-		multilineCfg tokenize.MultilineConfig
+		multilineCfg split.MultilineConfig
 		encoding     encoding.Encoding
 		maxLogSize   int
 		flushPeriod  time.Duration
@@ -26,7 +26,7 @@ func TestMultilineBuild(t *testing.T) {
 	}{
 		{
 			name:         "default configuration",
-			multilineCfg: tokenize.NewMultilineConfig(),
+			multilineCfg: split.NewMultilineConfig(),
 			encoding:     unicode.UTF8,
 			maxLogSize:   1024,
 			flushPeriod:  100 * time.Millisecond,
@@ -34,7 +34,7 @@ func TestMultilineBuild(t *testing.T) {
 		},
 		{
 			name: "Multiline  error",
-			multilineCfg: tokenize.MultilineConfig{
+			multilineCfg: split.MultilineConfig{
 				LineStartPattern: "START",
 				LineEndPattern:   "END",
 			},

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -17,14 +17,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/splitter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
 func TestPersistFlusher(t *testing.T) {
 	flushPeriod := 100 * time.Millisecond
-	f, emitChan := testReaderFactory(t, tokenize.NewMultilineConfig(), defaultMaxLogSize, flushPeriod)
+	f, emitChan := testReaderFactory(t, split.NewMultilineConfig(), defaultMaxLogSize, flushPeriod)
 
 	temp := openTemp(t, t.TempDir())
 	fp, err := f.newFingerprint(temp)
@@ -110,7 +110,7 @@ func TestTokenization(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			f, emitChan := testReaderFactory(t, tokenize.NewMultilineConfig(), defaultMaxLogSize, defaultFlushPeriod)
+			f, emitChan := testReaderFactory(t, split.NewMultilineConfig(), defaultMaxLogSize, defaultFlushPeriod)
 
 			temp := openTemp(t, t.TempDir())
 			_, err := temp.Write(tc.fileContent)
@@ -140,7 +140,7 @@ func TestTokenizationTooLong(t *testing.T) {
 		[]byte("aaa"),
 	}
 
-	f, emitChan := testReaderFactory(t, tokenize.NewMultilineConfig(), 10, defaultFlushPeriod)
+	f, emitChan := testReaderFactory(t, split.NewMultilineConfig(), 10, defaultFlushPeriod)
 
 	temp := openTemp(t, t.TempDir())
 	_, err := temp.Write(fileContent)
@@ -170,7 +170,7 @@ func TestTokenizationTooLongWithLineStartPattern(t *testing.T) {
 		[]byte("2023-01-01 2"),
 	}
 
-	mCfg := tokenize.NewMultilineConfig()
+	mCfg := split.NewMultilineConfig()
 	mCfg.LineStartPattern = `\d+-\d+-\d+`
 	f, emitChan := testReaderFactory(t, mCfg, 15, defaultFlushPeriod)
 
@@ -195,7 +195,7 @@ func TestTokenizationTooLongWithLineStartPattern(t *testing.T) {
 func TestHeaderFingerprintIncluded(t *testing.T) {
 	fileContent := []byte("#header-line\naaa\n")
 
-	f, _ := testReaderFactory(t, tokenize.NewMultilineConfig(), 10, defaultFlushPeriod)
+	f, _ := testReaderFactory(t, split.NewMultilineConfig(), 10, defaultFlushPeriod)
 
 	regexConf := regex.NewConfig()
 	regexConf.Regex = "^#(?P<header>.*)"
@@ -223,7 +223,7 @@ func TestHeaderFingerprintIncluded(t *testing.T) {
 	require.Equal(t, []byte("#header-line\naaa\n"), r.Fingerprint.FirstBytes)
 }
 
-func testReaderFactory(t *testing.T, mCfg tokenize.MultilineConfig, maxLogSize int, flushPeriod time.Duration) (*readerFactory, chan *emitParams) {
+func testReaderFactory(t *testing.T, mCfg split.MultilineConfig, maxLogSize int, flushPeriod time.Duration) (*readerFactory, chan *emitParams) {
 	emitChan := make(chan *emitParams, 100)
 	enc, err := decode.LookupEncoding(defaultEncoding)
 	trimFunc := trim.Whitespace

--- a/pkg/stanza/operator/input/file/config_test.go
+++ b/pkg/stanza/operator/input/file/config_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -315,7 +315,7 @@ func TestUnmarshal(t *testing.T) {
 				ExpectErr: false,
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.Multiline = tokenize.MultilineConfig{
+					cfg.Multiline = split.MultilineConfig{
 						LineStartPattern: "Start",
 					}
 					return cfg
@@ -326,7 +326,7 @@ func TestUnmarshal(t *testing.T) {
 				ExpectErr: false,
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.Multiline = tokenize.MultilineConfig{
+					cfg.Multiline = split.MultilineConfig{
 						LineStartPattern: "%",
 					}
 					return cfg
@@ -337,7 +337,7 @@ func TestUnmarshal(t *testing.T) {
 				ExpectErr: false,
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.Multiline = tokenize.MultilineConfig{
+					cfg.Multiline = split.MultilineConfig{
 						LineEndPattern: "Start",
 					}
 					return cfg
@@ -348,7 +348,7 @@ func TestUnmarshal(t *testing.T) {
 				ExpectErr: false,
 				Expect: func() *Config {
 					cfg := NewConfig()
-					cfg.Multiline = tokenize.MultilineConfig{
+					cfg.Multiline = split.MultilineConfig{
 						LineEndPattern: "%",
 					}
 					return cfg
@@ -476,7 +476,7 @@ func TestBuild(t *testing.T) {
 		{
 			"MultilineConfiguredStartAndEndPatterns",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineEndPattern:   "Exists",
 					LineStartPattern: "Exists",
 				}
@@ -487,7 +487,7 @@ func TestBuild(t *testing.T) {
 		{
 			"MultilineConfiguredStartPattern",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineStartPattern: "START.*",
 				}
 			},
@@ -497,7 +497,7 @@ func TestBuild(t *testing.T) {
 		{
 			"MultilineConfiguredEndPattern",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineEndPattern: "END.*",
 				}
 			},
@@ -515,7 +515,7 @@ func TestBuild(t *testing.T) {
 		{
 			"LineStartAndEnd",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineStartPattern: ".*",
 					LineEndPattern:   ".*",
 				}
@@ -526,7 +526,7 @@ func TestBuild(t *testing.T) {
 		{
 			"NoLineStartOrEnd",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{}
+				f.Multiline = split.MultilineConfig{}
 			},
 			require.NoError,
 			func(t *testing.T, f *Input) {},
@@ -534,7 +534,7 @@ func TestBuild(t *testing.T) {
 		{
 			"InvalidLineStartRegex",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineStartPattern: "(",
 				}
 			},
@@ -544,7 +544,7 @@ func TestBuild(t *testing.T) {
 		{
 			"InvalidLineEndRegex",
 			func(f *Config) {
-				f.Multiline = tokenize.MultilineConfig{
+				f.Multiline = split.MultilineConfig{
 					LineEndPattern: "(",
 				}
 			},

--- a/pkg/stanza/operator/input/syslog/config_test.go
+++ b/pkg/stanza/operator/input/syslog/config_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/tcp"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/udp"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -38,7 +38,7 @@ func TestUnmarshal(t *testing.T) {
 					cfg.TCP.ListenAddress = "10.0.0.1:9000"
 					cfg.TCP.AddAttributes = true
 					cfg.TCP.Encoding = "utf-16"
-					cfg.TCP.Multiline = tokenize.NewMultilineConfig()
+					cfg.TCP.Multiline = split.NewMultilineConfig()
 					cfg.TCP.Multiline.LineStartPattern = "ABC"
 					cfg.TCP.TLS = &configtls.TLSServerSetting{
 						TLSSetting: configtls.TLSSetting{
@@ -62,7 +62,7 @@ func TestUnmarshal(t *testing.T) {
 					cfg.UDP.ListenAddress = "10.0.0.1:9000"
 					cfg.UDP.AddAttributes = true
 					cfg.UDP.Encoding = "utf-16"
-					cfg.UDP.Multiline = tokenize.NewMultilineConfig()
+					cfg.UDP.Multiline = split.NewMultilineConfig()
 					cfg.UDP.Multiline.LineStartPattern = "ABC"
 					return cfg
 				}(),

--- a/pkg/stanza/operator/input/syslog/syslog_test.go
+++ b/pkg/stanza/operator/input/syslog/syslog_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/udp"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/syslog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/pipeline"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split/splittest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize/tokenizetest"
 )
 
 var (
@@ -182,7 +182,7 @@ func NewConfigWithUDP(syslogCfg *syslog.BaseConfig) *Config {
 }
 
 func TestOctetFramingSplitFunc(t *testing.T) {
-	testCases := []tokenizetest.TestCase{
+	testCases := []splittest.TestCase{
 		{
 			Name:  "OneLogSimple",
 			Input: []byte(`17 my log LOGEND 123`),
@@ -216,34 +216,34 @@ func TestOctetFramingSplitFunc(t *testing.T) {
 		{
 			Name: "HugeLog100",
 			Input: func() []byte {
-				newRaw := tokenizetest.GenerateBytes(100)
+				newRaw := splittest.GenerateBytes(100)
 				newRaw = append([]byte(`100 `), newRaw...)
 				return newRaw
 			}(),
 			ExpectedTokens: []string{
-				`100 ` + string(tokenizetest.GenerateBytes(100)),
+				`100 ` + string(splittest.GenerateBytes(100)),
 			},
 		},
 		{
 			Name: "maxCapacity",
 			Input: func() []byte {
-				newRaw := tokenizetest.GenerateBytes(4091)
+				newRaw := splittest.GenerateBytes(4091)
 				newRaw = append([]byte(`4091 `), newRaw...)
 				return newRaw
 			}(),
 			ExpectedTokens: []string{
-				`4091 ` + string(tokenizetest.GenerateBytes(4091)),
+				`4091 ` + string(splittest.GenerateBytes(4091)),
 			},
 		},
 		{
 			Name: "over capacity",
 			Input: func() []byte {
-				newRaw := tokenizetest.GenerateBytes(4092)
+				newRaw := splittest.GenerateBytes(4092)
 				newRaw = append([]byte(`5000 `), newRaw...)
 				return newRaw
 			}(),
 			ExpectedTokens: []string{
-				`5000 ` + string(tokenizetest.GenerateBytes(4091)),
+				`5000 ` + string(splittest.GenerateBytes(4091)),
 				`j`,
 			},
 		},

--- a/pkg/stanza/operator/input/tcp/config_test.go
+++ b/pkg/stanza/operator/input/tcp/config_test.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -32,7 +32,7 @@ func TestUnmarshal(t *testing.T) {
 					cfg.ListenAddress = "10.0.0.1:9000"
 					cfg.AddAttributes = true
 					cfg.Encoding = "utf-8"
-					cfg.Multiline = tokenize.NewMultilineConfig()
+					cfg.Multiline = split.NewMultilineConfig()
 					cfg.Multiline.LineStartPattern = "ABC"
 					cfg.TLS = &configtls.TLSServerSetting{
 						TLSSetting: configtls.TLSSetting{

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -24,7 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
@@ -55,7 +55,7 @@ func NewConfigWithID(operatorID string) *Config {
 		InputConfig: helper.NewInputConfig(operatorID, operatorType),
 		BaseConfig: BaseConfig{
 			OneLogPerPacket: false,
-			Multiline:       tokenize.NewMultilineConfig(),
+			Multiline:       split.NewMultilineConfig(),
 			Encoding:        "utf-8",
 		},
 	}
@@ -75,7 +75,7 @@ type BaseConfig struct {
 	AddAttributes    bool                        `mapstructure:"add_attributes,omitempty"`
 	OneLogPerPacket  bool                        `mapstructure:"one_log_per_packet,omitempty"`
 	Encoding         string                      `mapstructure:"encoding,omitempty"`
-	Multiline        tokenize.MultilineConfig    `mapstructure:"multiline,omitempty"`
+	Multiline        split.MultilineConfig       `mapstructure:"multiline,omitempty"`
 	TrimConfig       trim.Config                 `mapstructure:",squash"`
 	MultiLineBuilder MultiLineBuilderFunc
 }

--- a/pkg/stanza/operator/input/udp/config_test.go
+++ b/pkg/stanza/operator/input/udp/config_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -29,7 +29,7 @@ func TestUnmarshal(t *testing.T) {
 					cfg.ListenAddress = "10.0.0.1:9000"
 					cfg.AddAttributes = true
 					cfg.Encoding = "utf-8"
-					cfg.Multiline = tokenize.NewMultilineConfig()
+					cfg.Multiline = split.NewMultilineConfig()
 					cfg.Multiline.LineStartPattern = "ABC"
 					return cfg
 				}(),

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -18,7 +18,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
@@ -45,7 +45,7 @@ func NewConfigWithID(operatorID string) *Config {
 		BaseConfig: BaseConfig{
 			Encoding:        "utf-8",
 			OneLogPerPacket: false,
-			Multiline: tokenize.MultilineConfig{
+			Multiline: split.MultilineConfig{
 				LineStartPattern: "",
 				LineEndPattern:   ".^", // Use never matching regex to not split data by default
 			},
@@ -61,12 +61,12 @@ type Config struct {
 
 // BaseConfig is the details configuration of a udp input operator.
 type BaseConfig struct {
-	ListenAddress   string                   `mapstructure:"listen_address,omitempty"`
-	OneLogPerPacket bool                     `mapstructure:"one_log_per_packet,omitempty"`
-	AddAttributes   bool                     `mapstructure:"add_attributes,omitempty"`
-	Encoding        string                   `mapstructure:"encoding,omitempty"`
-	Multiline       tokenize.MultilineConfig `mapstructure:"multiline,omitempty"`
-	TrimConfig      trim.Config              `mapstructure:",squash"`
+	ListenAddress   string                `mapstructure:"listen_address,omitempty"`
+	OneLogPerPacket bool                  `mapstructure:"one_log_per_packet,omitempty"`
+	AddAttributes   bool                  `mapstructure:"add_attributes,omitempty"`
+	Encoding        string                `mapstructure:"encoding,omitempty"`
+	Multiline       split.MultilineConfig `mapstructure:"multiline,omitempty"`
+	TrimConfig      trim.Config           `mapstructure:",squash"`
 }
 
 // Build will build a udp input operator.

--- a/pkg/stanza/split/multiline.go
+++ b/pkg/stanza/split/multiline.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package tokenize // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
+package split // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 
 import (
 	"bufio"

--- a/pkg/stanza/split/multiline_test.go
+++ b/pkg/stanza/split/multiline_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package tokenize
+package split
 
 import (
 	"bufio"
@@ -15,12 +15,12 @@ import (
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/unicode"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize/tokenizetest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split/splittest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
 func TestLineStartSplitFunc(t *testing.T) {
-	testCases := []tokenizetest.TestCase{
+	testCases := []splittest.TestCase{
 		{
 			Name:    "OneLogSimple",
 			Pattern: `LOGSTART \d+ `,
@@ -66,12 +66,12 @@ func TestLineStartSplitFunc(t *testing.T) {
 			Pattern: `LOGSTART \d+ `,
 			Input: func() []byte {
 				newInput := []byte(`LOGSTART 123 `)
-				newInput = append(newInput, tokenizetest.GenerateBytes(100)...)
+				newInput = append(newInput, splittest.GenerateBytes(100)...)
 				newInput = append(newInput, []byte(`LOGSTART 234 endlog`)...)
 				return newInput
 			}(),
 			ExpectedTokens: []string{
-				`LOGSTART 123 ` + string(tokenizetest.GenerateBytes(100)),
+				`LOGSTART 123 ` + string(splittest.GenerateBytes(100)),
 			},
 		},
 		{
@@ -79,12 +79,12 @@ func TestLineStartSplitFunc(t *testing.T) {
 			Pattern: `LOGSTART \d+ `,
 			Input: func() []byte {
 				newInput := []byte(`LOGSTART 123 `)
-				newInput = append(newInput, tokenizetest.GenerateBytes(10000)...)
+				newInput = append(newInput, splittest.GenerateBytes(10000)...)
 				newInput = append(newInput, []byte(`LOGSTART 234 endlog`)...)
 				return newInput
 			}(),
 			ExpectedTokens: []string{
-				`LOGSTART 123 ` + string(tokenizetest.GenerateBytes(10000)),
+				`LOGSTART 123 ` + string(splittest.GenerateBytes(10000)),
 			},
 		},
 		{
@@ -92,7 +92,7 @@ func TestLineStartSplitFunc(t *testing.T) {
 			Pattern: `LOGSTART \d+ `,
 			Input: func() []byte {
 				newInput := []byte(`LOGSTART 123 `)
-				newInput = append(newInput, tokenizetest.GenerateBytes(1000000)...)
+				newInput = append(newInput, splittest.GenerateBytes(1000000)...)
 				newInput = append(newInput, []byte(`LOGSTART 234 endlog`)...)
 				return newInput
 			}(),
@@ -149,7 +149,7 @@ func TestLineStartSplitFunc(t *testing.T) {
 }
 
 func TestLineEndSplitFunc(t *testing.T) {
-	testCases := []tokenizetest.TestCase{
+	testCases := []splittest.TestCase{
 		{
 			Name:    "OneLogSimple",
 			Pattern: `LOGEND \d+`,
@@ -193,31 +193,31 @@ func TestLineEndSplitFunc(t *testing.T) {
 			Name:    "HugeLog100",
 			Pattern: `LOGEND \d`,
 			Input: func() []byte {
-				newInput := tokenizetest.GenerateBytes(100)
+				newInput := splittest.GenerateBytes(100)
 				newInput = append(newInput, []byte(`LOGEND 1 `)...)
 				return newInput
 			}(),
 			ExpectedTokens: []string{
-				string(tokenizetest.GenerateBytes(100)) + `LOGEND 1`,
+				string(splittest.GenerateBytes(100)) + `LOGEND 1`,
 			},
 		},
 		{
 			Name:    "HugeLog10000",
 			Pattern: `LOGEND \d`,
 			Input: func() []byte {
-				newInput := tokenizetest.GenerateBytes(10000)
+				newInput := splittest.GenerateBytes(10000)
 				newInput = append(newInput, []byte(`LOGEND 1 `)...)
 				return newInput
 			}(),
 			ExpectedTokens: []string{
-				string(tokenizetest.GenerateBytes(10000)) + `LOGEND 1`,
+				string(splittest.GenerateBytes(10000)) + `LOGEND 1`,
 			},
 		},
 		{
 			Name:    "HugeLog1000000",
 			Pattern: `LOGEND \d`,
 			Input: func() []byte {
-				newInput := tokenizetest.GenerateBytes(1000000)
+				newInput := splittest.GenerateBytes(1000000)
 				newInput = append(newInput, []byte(`LOGEND 1 `)...)
 				return newInput
 			}(),
@@ -255,7 +255,7 @@ func TestLineEndSplitFunc(t *testing.T) {
 }
 
 func TestNewlineSplitFunc(t *testing.T) {
-	testCases := []tokenizetest.TestCase{
+	testCases := []splittest.TestCase{
 		{
 			Name:  "OneLogSimple",
 			Input: []byte("my log\n"),
@@ -293,29 +293,29 @@ func TestNewlineSplitFunc(t *testing.T) {
 		{
 			Name: "HugeLog100",
 			Input: func() []byte {
-				newInput := tokenizetest.GenerateBytes(100)
+				newInput := splittest.GenerateBytes(100)
 				newInput = append(newInput, '\n')
 				return newInput
 			}(),
 			ExpectedTokens: []string{
-				string(tokenizetest.GenerateBytes(100)),
+				string(splittest.GenerateBytes(100)),
 			},
 		},
 		{
 			Name: "HugeLog10000",
 			Input: func() []byte {
-				newInput := tokenizetest.GenerateBytes(10000)
+				newInput := splittest.GenerateBytes(10000)
 				newInput = append(newInput, '\n')
 				return newInput
 			}(),
 			ExpectedTokens: []string{
-				string(tokenizetest.GenerateBytes(10000)),
+				string(splittest.GenerateBytes(10000)),
 			},
 		},
 		{
 			Name: "HugeLog1000000",
 			Input: func() []byte {
-				newInput := tokenizetest.GenerateBytes(1000000)
+				newInput := splittest.GenerateBytes(1000000)
 				newInput = append(newInput, '\n')
 				return newInput
 			}(),
@@ -384,7 +384,7 @@ func TestNewlineSplitFunc(t *testing.T) {
 
 func TestNoSplitFunc(t *testing.T) {
 	const largeLogSize = 100
-	testCases := []tokenizetest.TestCase{
+	testCases := []splittest.TestCase{
 		{
 			Name:           "OneLogSimple",
 			Input:          []byte("my log\n"),
@@ -408,14 +408,14 @@ func TestNoSplitFunc(t *testing.T) {
 		{
 			Name: "HugeLog100",
 			Input: func() []byte {
-				return tokenizetest.GenerateBytes(largeLogSize)
+				return splittest.GenerateBytes(largeLogSize)
 			}(),
-			ExpectedTokens: []string{string(tokenizetest.GenerateBytes(largeLogSize))},
+			ExpectedTokens: []string{string(splittest.GenerateBytes(largeLogSize))},
 		},
 		{
 			Name: "HugeLog300",
 			Input: func() []byte {
-				return tokenizetest.GenerateBytes(largeLogSize * 3)
+				return splittest.GenerateBytes(largeLogSize * 3)
 			}(),
 			ExpectedTokens: []string{
 				"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv",
@@ -426,7 +426,7 @@ func TestNoSplitFunc(t *testing.T) {
 		{
 			Name: "EOFBeforeMaxLogSize",
 			Input: func() []byte {
-				return tokenizetest.GenerateBytes(largeLogSize * 3.5)
+				return splittest.GenerateBytes(largeLogSize * 3.5)
 			}(),
 			ExpectedTokens: []string{
 				"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuv",

--- a/pkg/stanza/split/splittest/splittest.go
+++ b/pkg/stanza/split/splittest/splittest.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package tokenizetest // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize/tokenizetest"
+package splittest // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split/splittest"
 
 import (
 	"bufio"

--- a/receiver/otlpjsonfilereceiver/file_test.go
+++ b/receiver/otlpjsonfilereceiver/file_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/matcher"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/tokenize"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver/internal/metadata"
 )
 
@@ -124,7 +124,7 @@ func testdataConfigYamlAsMap() *Config {
 			IncludeFileNameResolved: false,
 			IncludeFilePathResolved: false,
 			PollInterval:            200 * time.Millisecond,
-			Multiline:               tokenize.NewMultilineConfig(),
+			Multiline:               split.NewMultilineConfig(),
 			Encoding:                "utf-8",
 			StartAt:                 "end",
 			FingerprintSize:         1000,


### PR DESCRIPTION
Another subset of #26241.

This renames the `tokenize` package to `split`. The `tokenize` package was created by isolating several related concerns into a single package. However, at this point, each of those concerns has been moved into a very specific package. e.g. `decode`, `flush`, `trim`, `split`.

What remains of the tokenize package is only concerned with split functions, so the name is more appropriate going forward. Future PRs will rename some of the structs and functions in and relating to this package.