### PR TITLE
[processor/tailsampling] Allow sub-second decision wait times

### DIFF
--- a/.chloggen/26354-allow-subsecond-decisionwait.yaml
+++ b/.chloggen/26354-allow-subsecond-decisionwait.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/tailsampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow sub-second decision wait time
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26354]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -6,6 +6,7 @@ package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry
 import (
 	"context"
 	"fmt"
+	"math"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -71,8 +72,8 @@ func newTracesProcessor(ctx context.Context, settings component.TelemetrySetting
 		return nil, component.ErrNilNextConsumer
 	}
 
-	numDecisionBatches := uint64(cfg.DecisionWait.Seconds())
-	inBatcher, err := idbatcher.New(numDecisionBatches, cfg.ExpectedNewTracesPerSec, uint64(2*runtime.NumCPU()))
+	numDecisionBatches := math.Max(1, cfg.DecisionWait.Seconds())
+	inBatcher, err := idbatcher.New(uint64(numDecisionBatches), cfg.ExpectedNewTracesPerSec, uint64(2*runtime.NumCPU()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR changes the tail-sampling processor to allow sub-second decision wait times. Before this PR, the batcher size would be determined based on the decision time, which would be 0 for sub-second values. This has now a minimum value of 1.

Fixes #26354

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

