### PR TITLE
[processor/probabilisticsampler] Allow non-bytes attributes

### DIFF
--- a/.chloggen/18222-probabilisticsampler-allow-non-bytes.yaml
+++ b/.chloggen/18222-probabilisticsampler-allow-non-bytes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/probabilisticsampler
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow non-bytes values to be used as the source for the sampling decision
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [18222]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/probabilisticsamplerprocessor/logsprocessor.go
+++ b/processor/probabilisticsamplerprocessor/logsprocessor.go
@@ -64,7 +64,7 @@ func (lsp *logSamplerProcessor) processLogs(ctx context.Context, ld plog.Logs) (
 				if lidBytes == nil && lsp.samplingSource != "" {
 					if value, ok := l.Attributes().Get(lsp.samplingSource); ok {
 						tagPolicyValue = lsp.samplingSource
-						lidBytes = value.Bytes().AsRaw()
+						lidBytes = getBytesFromValue(value)
 					}
 				}
 				priority := lsp.scaledSamplingRate
@@ -101,4 +101,11 @@ func (lsp *logSamplerProcessor) processLogs(ctx context.Context, ld plog.Logs) (
 		return ld, processorhelper.ErrSkipProcessingData
 	}
 	return ld, nil
+}
+
+func getBytesFromValue(value pcommon.Value) []byte {
+	if value.Type() == pcommon.ValueTypeBytes {
+		return value.Bytes().AsRaw()
+	}
+	return []byte(value.AsString())
 }

--- a/processor/probabilisticsamplerprocessor/logsprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/logsprocessor_test.go
@@ -162,7 +162,7 @@ func TestLogsSampling(t *testing.T) {
 				if i%2 == 0 {
 					b := record.Attributes().PutEmptyBytes("foo")
 					b.FromRaw(traceID[:])
-					record.Attributes().PutStr("bar", string(record.TraceID().String()))
+					record.Attributes().PutStr("bar", record.TraceID().String())
 				}
 				// set a fourth of records with a priority attribute
 				if i%4 == 0 {

--- a/processor/probabilisticsamplerprocessor/logsprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/logsprocessor_test.go
@@ -117,6 +117,15 @@ func TestLogsSampling(t *testing.T) {
 			received: 23,
 		},
 		{
+			name: "sampling_source sampling as string",
+			cfg: &Config{
+				SamplingPercentage: 50,
+				AttributeSource:    recordAttributeSource,
+				FromAttribute:      "bar",
+			},
+			received: 29, // probabilistic... doesn't yield the same results as foo
+		},
+		{
 			name: "sampling_priority",
 			cfg: &Config{
 				SamplingPercentage: 0,
@@ -149,10 +158,11 @@ func TestLogsSampling(t *testing.T) {
 				ib := byte(i)
 				traceID := [16]byte{0, 0, 0, 0, 0, 0, 0, 0, ib, ib, ib, ib, ib, ib, ib, ib}
 				record.SetTraceID(traceID)
-				// set half of records with a foo attribute
+				// set half of records with a foo (bytes) and a bar (string) attribute
 				if i%2 == 0 {
 					b := record.Attributes().PutEmptyBytes("foo")
 					b.FromRaw(traceID[:])
+					record.Attributes().PutStr("bar", string(record.TraceID().String()))
 				}
 				// set a fourth of records with a priority attribute
 				if i%4 == 0 {


### PR DESCRIPTION
When doing a probabilistic sampling for logs, the probabilistic sampler currently requires the source attribute to be of bytes value. This PR changes that to allow any value type to be used.

Fixes #18222

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
