### PR TITLE
[receiver/cloudflare] Make TLS config optional for cloudflarereceiver

### DIFF
--- a/.chloggen/tls-optional-cloudflare-receiver.yaml
+++ b/.chloggen/tls-optional-cloudflare-receiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cloudflarereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make TLS config optional for cloudflarereceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26562]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/cloudflarereceiver/README.md
+++ b/receiver/cloudflarereceiver/README.md
@@ -22,23 +22,27 @@ This Cloudflare receiver allows Cloudflare's [LogPush Jobs](https://developers.c
 To successfully operate this receiver, you must follow these steps in order:
 1. Have a Cloudflare site at the Enterprise plan level.
     - At the time the receiver was written, LogPush was available only for Enterprise sites.
-2. Receive a properly CA signed SSL certificate for use on the collector host.
-3. Configure the receiver using the previously acquired SSL certificate, and then start the collector.
-4. Create a LogPush HTTP destination job following the [directions](https://developers.cloudflare.com/logs/get-started/enable-destinations/http/) provided by Cloudflare. When the job is created, it will attempt to validate the connection to the receiver.
+1. Create a LogPush HTTP destination job following the [directions](https://developers.cloudflare.com/logs/get-started/enable-destinations/http/) provided by Cloudflare. When the job is created, it will attempt to validate the connection to the receiver.
     - If you've configured the receiver with a `secret` to validate requests, ensure you add the value to the `destination_conf` parameter of the LogPush job by adding its value as a query parameter under the `header_X-CF-Secret` parameter. For example, `"destination_conf": "https://example.com?header_X-CF-Secret=abcd1234"`.
     - If you want the receiver to parse one of the fields as the log record's timestamp (`EdgeStartTimestamp` is the default), the timestamp should be formatted RFC3339. This is not the default format, and must be explicitly specified in your job config.
       - If using the deprecated `logpull_options` parameter to configure your job, this can be explicitly specified by adding `&timestamps=rfc3339` to the `logpull_options` string when creating your LogPush job.
       - If using the `output_options` parameter to configure your job, this can be explicitly specified by setting the `timestamp_format` field of `output_options` to `"rfc3339"`
     - The receiver expects the uploaded logs to be in `ndjson` format with no template, prefix, suffix, or delimiter changes based on the options in `output_options`. The only [settings](https://developers.cloudflare.com/logs/reference/log-output-options/#output-types) supported by this receiver in `output_options` are `field_names`, `CVE-2021-44228`, and `sample_rate`.
-5. If the LogPush job creates successfully, the receiver is correctly configured and the LogPush job was able to send it a "test" message. If the job failed to create, the most likely issue is with the SSL configuration. Check both the LogPush API response and the receiver's logs for more details.
+1. If the LogPush job creates successfully, the receiver is correctly configured and the LogPush job was able to send it a "test" message. If the job failed to create, the most likely issue is with the SSL configuration. Check both the LogPush API response and the receiver's logs for more details.
+
+### Optional
+If the receiver will be handling TLS termination:
+
+1. Receive a properly CA signed SSL certificate for use on the collector host.
+1. Configure the receiver using the previously acquired SSL certificate, and then start the collector.
 
 ## Configuration
 
-- `tls` (Cloudflare requires TLS, and self-signed will not be sufficient)
-    - `cert_file` 
+- `tls` (Optional - Cloudflare requires TLS, and self-signed will not be sufficient)
+    - `cert_file`
        - You may need to append your CA certificate to the server's certificate, if it is not a CA known to the LogPush API.
     - `key_file`
-- `endpoint` 
+- `endpoint`
   - The endpoint on which the receiver will await requests from Cloudflare
 - `secret`
   - If this value is set, the receiver expects to see it in any valid requests under the `X-CF-Secret` header
@@ -64,5 +68,3 @@ receivers:
         ClientIP: http_request.client_ip
         ClientRequestURI: http_request.uri
 ```
-
-

--- a/receiver/cloudflarereceiver/config.go
+++ b/receiver/cloudflarereceiver/config.go
@@ -38,19 +38,19 @@ func (c *Config) Validate() error {
 		return errNoEndpoint
 	}
 
+	var errs error
 	if c.Logs.TLS != nil {
-		// When TLS cert is specified, but nothing for key
+		// Missing key
 		if c.Logs.TLS.KeyFile == "" {
 			errs = multierr.Append(errs, errNoKey)
 		}
 
-		// When TLS key is specified, but nothing for cert
+		// Missing cert
 		if c.Logs.TLS.CertFile == "" {
 			errs = multierr.Append(errs, errNoCert)
 		}
 	}
 
-	var errs error
 	_, _, err := net.SplitHostPort(c.Logs.Endpoint)
 	if err != nil {
 		errs = multierr.Append(errs, fmt.Errorf("failed to split endpoint into 'host:port' pair: %w", err))

--- a/receiver/cloudflarereceiver/config.go
+++ b/receiver/cloudflarereceiver/config.go
@@ -40,13 +40,13 @@ func (c *Config) Validate() error {
 
 	if c.Logs.TLS != nil {
 		// When TLS cert is specified, but nothing for key
-		if c.Logs.TLS.CertFile != "" && c.Logs.TLS.KeyFile == "" {
-			return errNoKey
+		if c.Logs.TLS.KeyFile == "" {
+			errs = multierr.Append(errs, errNoKey)
 		}
 
 		// When TLS key is specified, but nothing for cert
-		if c.Logs.TLS.CertFile == "" && c.Logs.TLS.KeyFile != "" {
-			return errNoCert
+		if c.Logs.TLS.CertFile == "" {
+			errs = multierr.Append(errs, errNoCert)
 		}
 	}
 

--- a/receiver/cloudflarereceiver/config.go
+++ b/receiver/cloudflarereceiver/config.go
@@ -27,7 +27,6 @@ type LogsConfig struct {
 
 var (
 	errNoEndpoint = errors.New("an endpoint must be specified")
-	errNoTLS      = errors.New("tls must be configured")
 	errNoCert     = errors.New("tls was configured, but no cert file was specified")
 	errNoKey      = errors.New("tls was configured, but no key file was specified")
 
@@ -39,22 +38,22 @@ func (c *Config) Validate() error {
 		return errNoEndpoint
 	}
 
-	if c.Logs.TLS == nil {
-		return errNoTLS
+	if c.Logs.TLS != nil {
+		// When TLS cert is specified, but nothing for key
+		if c.Logs.TLS.CertFile != "" && c.Logs.TLS.KeyFile == "" {
+			return errNoKey
+		}
+
+		// When TLS key is specified, but nothing for cert
+		if c.Logs.TLS.CertFile == "" && c.Logs.TLS.KeyFile != "" {
+			return errNoCert
+		}
 	}
 
 	var errs error
 	_, _, err := net.SplitHostPort(c.Logs.Endpoint)
 	if err != nil {
 		errs = multierr.Append(errs, fmt.Errorf("failed to split endpoint into 'host:port' pair: %w", err))
-	}
-
-	if c.Logs.TLS.CertFile == "" {
-		errs = multierr.Append(errs, errNoCert)
-	}
-
-	if c.Logs.TLS.KeyFile == "" {
-		errs = multierr.Append(errs, errNoKey)
 	}
 
 	return errs

--- a/receiver/cloudflarereceiver/config_test.go
+++ b/receiver/cloudflarereceiver/config_test.go
@@ -22,6 +22,14 @@ func TestValidate(t *testing.T) {
 		expectedErr string
 	}{
 		{
+			name: "Valid config",
+			config: Config{
+				Logs: LogsConfig{
+					Endpoint: "0.0.0.0:9999",
+				},
+			},
+		},
+		{
 			name: "Valid config with tls",
 			config: Config{
 				Logs: LogsConfig{
@@ -38,14 +46,7 @@ func TestValidate(t *testing.T) {
 		{
 			name: "missing endpoint",
 			config: Config{
-				Logs: LogsConfig{
-					TLS: &configtls.TLSServerSetting{
-						TLSSetting: configtls.TLSSetting{
-							CertFile: "some_cert_file",
-							KeyFile:  "some_key_file",
-						},
-					},
-				},
+				Logs: LogsConfig{},
 			},
 			expectedErr: errNoEndpoint.Error(),
 		},
@@ -54,12 +55,6 @@ func TestValidate(t *testing.T) {
 			config: Config{
 				Logs: LogsConfig{
 					Endpoint: "9999",
-					TLS: &configtls.TLSServerSetting{
-						TLSSetting: configtls.TLSSetting{
-							CertFile: "some_cert_file",
-							KeyFile:  "some_key_file",
-						},
-					},
 				},
 			},
 			expectedErr: "failed to split endpoint into 'host:port' pair",

--- a/receiver/cloudflarereceiver/factory.go
+++ b/receiver/cloudflarereceiver/factory.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
@@ -37,7 +36,6 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		Logs: LogsConfig{
 			TimestampField: defaultTimestampField,
-			TLS:            &configtls.TLSServerSetting{},
 		},
 	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Allow TLS for cloudflare receiver to be optional

**Link to tracking Issue:** <Issue number if applicable>

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26562

**Testing:** <Describe what testing was performed and which tests were added.>

* Added `Valid config` with empty TLS
* Updated `missing endpoint` to be an empty log config
* Updated `Invalid endpoint` to use empty TLS

**Documentation:** <Describe the documentation added.>

Moved mention of TLS to an optional sub header under `Getting Started`

