### PR TITLE
[pkg/stanza] SplitFunc naming cleanup

### DIFF
--- a/.chloggen/pkg-stanza-split-func-factory.yaml
+++ b/.chloggen/pkg-stanza-split-func-factory.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename syslog and tcp MultilineBuilders
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26631]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Rename syslog.OctetMultiLineBuilder to syslog.OctetSplitFuncBuilder
+  - Rename tc.MultilineBuilder to tcp.SplitFuncBuilder
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -101,7 +101,7 @@ func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback) (*Manager, 
 
 	// Ensure that splitter is buildable
 	factory := splitter.NewSplitFuncFactory(c.SplitConfig, enc, int(c.MaxLogSize), c.TrimConfig.Func(), c.FlushPeriod)
-	if _, err := factory.Build(); err != nil {
+	if _, err := factory.SplitFunc(); err != nil {
 		return nil, err
 	}
 
@@ -120,7 +120,7 @@ func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit emit.Callback
 
 	// Ensure that splitter is buildable
 	factory := splitter.NewCustomFactory(splitFunc, c.FlushPeriod)
-	if _, err := factory.Build(); err != nil {
+	if _, err := factory.SplitFunc(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -100,7 +100,7 @@ func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback) (*Manager, 
 	}
 
 	// Ensure that splitter is buildable
-	factory := splitter.NewMultilineFactory(c.SplitConfig, enc, int(c.MaxLogSize), c.TrimConfig.Func(), c.FlushPeriod)
+	factory := splitter.NewSplitFuncFactory(c.SplitConfig, enc, int(c.MaxLogSize), c.TrimConfig.Func(), c.FlushPeriod)
 	if _, err := factory.Build(); err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/fileconsumer/internal/splitter/custom.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/custom.go
@@ -25,7 +25,7 @@ func NewCustomFactory(splitFunc bufio.SplitFunc, flushPeriod time.Duration) Fact
 	}
 }
 
-// Build builds Multiline Splitter struct
-func (f *customFactory) Build() (bufio.SplitFunc, error) {
+// SplitFunc builds a bufio.SplitFunc based on the configuration
+func (f *customFactory) SplitFunc() (bufio.SplitFunc, error) {
 	return flush.WithPeriod(f.splitFunc, trim.Nop, f.flushPeriod), nil
 }

--- a/pkg/stanza/fileconsumer/internal/splitter/custom_test.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/custom_test.go
@@ -30,7 +30,7 @@ func TestCustomFactory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			factory := NewCustomFactory(tt.splitter, tt.flushPeriod)
-			got, err := factory.Build()
+			got, err := factory.SplitFunc()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Build() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/stanza/fileconsumer/internal/splitter/factory.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/factory.go
@@ -8,5 +8,5 @@ import (
 )
 
 type Factory interface {
-	Build() (bufio.SplitFunc, error)
+	SplitFunc() (bufio.SplitFunc, error)
 }

--- a/pkg/stanza/fileconsumer/internal/splitter/multiline.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/multiline.go
@@ -14,35 +14,35 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
-type multilineFactory struct {
-	multilineCfg split.Config
-	encoding     encoding.Encoding
-	maxLogSize   int
-	trimFunc     trim.Func
-	flushPeriod  time.Duration
+type splitFuncFactory struct {
+	splitConfig split.Config
+	encoding    encoding.Encoding
+	maxLogSize  int
+	trimFunc    trim.Func
+	flushPeriod time.Duration
 }
 
-var _ Factory = (*multilineFactory)(nil)
+var _ Factory = (*splitFuncFactory)(nil)
 
-func NewMultilineFactory(
-	multilineCfg split.Config,
+func NewSplitFuncFactory(
+	splitConfig split.Config,
 	encoding encoding.Encoding,
 	maxLogSize int,
 	trimFunc trim.Func,
 	flushPeriod time.Duration,
 ) Factory {
-	return &multilineFactory{
-		multilineCfg: multilineCfg,
-		encoding:     encoding,
-		maxLogSize:   maxLogSize,
-		trimFunc:     trimFunc,
-		flushPeriod:  flushPeriod,
+	return &splitFuncFactory{
+		splitConfig: splitConfig,
+		encoding:    encoding,
+		maxLogSize:  maxLogSize,
+		trimFunc:    trimFunc,
+		flushPeriod: flushPeriod,
 	}
 }
 
 // Build builds Multiline Splitter struct
-func (f *multilineFactory) Build() (bufio.SplitFunc, error) {
-	splitFunc, err := f.multilineCfg.Func(f.encoding, false, f.maxLogSize, f.trimFunc)
+func (f *splitFuncFactory) Build() (bufio.SplitFunc, error) {
+	splitFunc, err := f.splitConfig.Func(f.encoding, false, f.maxLogSize, f.trimFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/fileconsumer/internal/splitter/multiline.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/multiline.go
@@ -40,8 +40,8 @@ func NewSplitFuncFactory(
 	}
 }
 
-// Build builds Multiline Splitter struct
-func (f *splitFuncFactory) Build() (bufio.SplitFunc, error) {
+// SplitFunc builds a bufio.SplitFunc based on the configuration
+func (f *splitFuncFactory) SplitFunc() (bufio.SplitFunc, error) {
 	splitFunc, err := f.splitConfig.Func(f.encoding, false, f.maxLogSize, f.trimFunc)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/fileconsumer/internal/splitter/multiline_test.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/multiline_test.go
@@ -18,7 +18,7 @@ import (
 func TestSplitFuncFactory(t *testing.T) {
 	tests := []struct {
 		name        string
-		splitFunc   split.Config
+		splitConfig split.Config
 		encoding    encoding.Encoding
 		maxLogSize  int
 		flushPeriod time.Duration
@@ -32,8 +32,8 @@ func TestSplitFuncFactory(t *testing.T) {
 			wantErr:     false,
 		},
 		{
-			name: "Multiline  error",
-			splitFunc: split.Config{
+			name: "split config  error",
+			splitConfig: split.Config{
 				LineStartPattern: "START",
 				LineEndPattern:   "END",
 			},
@@ -45,10 +45,10 @@ func TestSplitFuncFactory(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			factory := NewSplitFuncFactory(tt.splitFunc, tt.encoding, tt.maxLogSize, trim.Nop, tt.flushPeriod)
-			got, err := factory.Build()
+			factory := NewSplitFuncFactory(tt.splitConfig, tt.encoding, tt.maxLogSize, trim.Nop, tt.flushPeriod)
+			got, err := factory.SplitFunc()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Build() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("SplitFunc() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if err == nil {

--- a/pkg/stanza/fileconsumer/internal/splitter/multiline_test.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/multiline_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
-func TestMultilineBuild(t *testing.T) {
+func TestSplitFuncFactory(t *testing.T) {
 	tests := []struct {
-		name         string
-		multilineCfg split.Config
-		encoding     encoding.Encoding
-		maxLogSize   int
-		flushPeriod  time.Duration
-		wantErr      bool
+		name        string
+		splitFunc   split.Config
+		encoding    encoding.Encoding
+		maxLogSize  int
+		flushPeriod time.Duration
+		wantErr     bool
 	}{
 		{
 			name:        "default configuration",
@@ -33,7 +33,7 @@ func TestMultilineBuild(t *testing.T) {
 		},
 		{
 			name: "Multiline  error",
-			multilineCfg: split.Config{
+			splitFunc: split.Config{
 				LineStartPattern: "START",
 				LineEndPattern:   "END",
 			},
@@ -45,7 +45,7 @@ func TestMultilineBuild(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			factory := NewMultilineFactory(tt.multilineCfg, tt.encoding, tt.maxLogSize, trim.Nop, tt.flushPeriod)
+			factory := NewSplitFuncFactory(tt.splitFunc, tt.encoding, tt.maxLogSize, trim.Nop, tt.flushPeriod)
 			got, err := factory.Build()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Build() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/stanza/fileconsumer/reader_factory.go
+++ b/pkg/stanza/fileconsumer/reader_factory.go
@@ -29,7 +29,7 @@ type readerFactory struct {
 }
 
 func (f *readerFactory) newReader(file *os.File, fp *fingerprint.Fingerprint) (*reader, error) {
-	lineSplitFunc, err := f.splitterFactory.Build()
+	lineSplitFunc, err := f.splitterFactory.SplitFunc()
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (f *readerFactory) copy(old *reader, newFile *os.File) (*reader, error) {
 	var err error
 	lineSplitFunc := old.lineSplitFunc
 	if lineSplitFunc == nil {
-		lineSplitFunc, err = f.splitterFactory.Build()
+		lineSplitFunc, err = f.splitterFactory.SplitFunc()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -226,7 +226,6 @@ func TestHeaderFingerprintIncluded(t *testing.T) {
 func testReaderFactory(t *testing.T, sCfg split.Config, maxLogSize int, flushPeriod time.Duration) (*readerFactory, chan *emitParams) {
 	emitChan := make(chan *emitParams, 100)
 	enc, err := decode.LookupEncoding(defaultEncoding)
-	trimFunc := trim.Whitespace
 	require.NoError(t, err)
 	return &readerFactory{
 		SugaredLogger: testutil.Logger(t),
@@ -236,7 +235,7 @@ func testReaderFactory(t *testing.T, sCfg split.Config, maxLogSize int, flushPer
 			emit:            testEmitFunc(emitChan),
 		},
 		fromBeginning:   true,
-		splitterFactory: splitter.NewSplitFuncFactory(sCfg, enc, maxLogSize, trimFunc, flushPeriod),
+		splitterFactory: splitter.NewSplitFuncFactory(sCfg, enc, maxLogSize, trim.Whitespace, flushPeriod),
 		encoding:        enc,
 	}, emitChan
 }

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -236,7 +236,7 @@ func testReaderFactory(t *testing.T, sCfg split.Config, maxLogSize int, flushPer
 			emit:            testEmitFunc(emitChan),
 		},
 		fromBeginning:   true,
-		splitterFactory: splitter.NewMultilineFactory(sCfg, enc, maxLogSize, trimFunc, flushPeriod),
+		splitterFactory: splitter.NewSplitFuncFactory(sCfg, enc, maxLogSize, trimFunc, flushPeriod),
 		encoding:        enc,
 	}, emitChan
 }

--- a/pkg/stanza/operator/input/syslog/syslog.go
+++ b/pkg/stanza/operator/input/syslog/syslog.go
@@ -64,7 +64,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		tcpInputCfg := tcp.NewConfigWithID(inputBase.ID() + "_internal_tcp")
 		tcpInputCfg.BaseConfig = *c.TCP
 		if syslogParserCfg.EnableOctetCounting {
-			tcpInputCfg.MultiLineBuilder = OctetMultiLineBuilder
+			tcpInputCfg.SplitFuncBuilder = OctetSplitFuncBuilder
 		}
 
 		tcpInput, err := tcpInputCfg.Build(logger)
@@ -144,7 +144,7 @@ func (t *Input) SetOutputs(operators []operator.Operator) error {
 	return t.parser.SetOutputs(operators)
 }
 
-func OctetMultiLineBuilder(_ encoding.Encoding) (bufio.SplitFunc, error) {
+func OctetSplitFuncBuilder(_ encoding.Encoding) (bufio.SplitFunc, error) {
 	return newOctetFrameSplitFunc(true), nil
 }
 

--- a/pkg/stanza/operator/input/syslog/syslog_test.go
+++ b/pkg/stanza/operator/input/syslog/syslog_test.go
@@ -249,10 +249,8 @@ func TestOctetFramingSplitFunc(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		splitFunc, err := OctetMultiLineBuilder(nil)
+		splitFunc, err := OctetSplitFuncBuilder(nil)
 		require.NoError(t, err)
 		t.Run(tc.Name, tc.Run(splitFunc))
 	}
 }
-
-// TODO refactor test dependency away from internal?

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -76,10 +76,10 @@ type BaseConfig struct {
 	Encoding         string                      `mapstructure:"encoding,omitempty"`
 	SplitConfig      split.Config                `mapstructure:"multiline,omitempty"`
 	TrimConfig       trim.Config                 `mapstructure:",squash"`
-	MultiLineBuilder MultiLineBuilderFunc
+	SplitFuncBuilder SplitFuncBuilder
 }
 
-type MultiLineBuilderFunc func(enc encoding.Encoding) (bufio.SplitFunc, error)
+type SplitFuncBuilder func(enc encoding.Encoding) (bufio.SplitFunc, error)
 
 func (c Config) defaultMultilineBuilder(enc encoding.Encoding) (bufio.SplitFunc, error) {
 	trimFunc := c.TrimConfig.Func()
@@ -120,12 +120,12 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		return nil, err
 	}
 
-	if c.MultiLineBuilder == nil {
-		c.MultiLineBuilder = c.defaultMultilineBuilder
+	if c.SplitFuncBuilder == nil {
+		c.SplitFuncBuilder = c.defaultMultilineBuilder
 	}
 
-	// Build multiline
-	splitFunc, err := c.MultiLineBuilder(enc)
+	// Build split func
+	splitFunc, err := c.SplitFuncBuilder(enc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -89,9 +89,8 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		return nil, err
 	}
 
-	// Build multiline
-	trimFunc := c.TrimConfig.Func()
-	splitFunc, err := c.SplitConfig.Func(enc, true, MaxUDPSize, trimFunc)
+	// Build SplitFunc
+	splitFunc, err := c.SplitConfig.Func(enc, true, MaxUDPSize, c.TrimConfig.Func())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Another few remaining parts of #26241. This basically follows up on renaming the `multiline` package by renaming a few remaining to "multiline" throughout the codebase.