### PR TITLE
[pkg/stanza] add buildInfo for operator(#21794)

### DIFF
--- a/pkg/stanza/adapter/benchmark_test.go
+++ b/pkg/stanza/adapter/benchmark_test.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -162,8 +161,8 @@ type BenchOpConfig struct {
 }
 
 // Build will build a noop operator.
-func (c BenchOpConfig) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c BenchOpConfig) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/adapter/integration_test.go
+++ b/pkg/stanza/adapter/integration_test.go
@@ -31,7 +31,9 @@ func createNoopReceiver(nextConsumer consumer.Logs) (*receiver, error) {
 				Builder: noop.NewConfig(),
 			},
 		},
-	}.Build(zap.NewNop().Sugar())
+	}.Build(&operator.BuildInfoInternal{
+		Logger: zap.NewNop().Sugar(),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/adapter/mocks_test.go
+++ b/pkg/stanza/adapter/mocks_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/collector/component"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -41,8 +40,8 @@ func NewUnstartableConfig() operator.Config {
 }
 
 // Build will build an unstartable operator
-func (c *UnstartableConfig) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	o, _ := c.OutputConfig.Build(logger)
+func (c *UnstartableConfig) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	o, _ := c.OutputConfig.Build(buildInfo.Logger)
 	return &UnstartableOperator{OutputOperator: o}, nil
 }
 

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -138,7 +138,7 @@ func BenchmarkReadLine(b *testing.B) {
 	pipe, err := pipeline.Config{
 		Operators:     operatorCfgs,
 		DefaultOutput: emitter,
-	}.Build(zap.NewNop().Sugar())
+	}.Build(&operator.BuildInfoInternal{Logger: zap.NewNop().Sugar()})
 	require.NoError(b, err)
 
 	// Populate the file that will be consumed
@@ -203,7 +203,7 @@ func BenchmarkParseAndMap(b *testing.B) {
 	pipe, err := pipeline.Config{
 		Operators:     operatorCfgs,
 		DefaultOutput: emitter,
-	}.Build(zap.NewNop().Sugar())
+	}.Build(&operator.BuildInfoInternal{Logger: zap.NewNop().Sugar()})
 	require.NoError(b, err)
 
 	// Populate the file that will be consumed

--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -147,7 +148,7 @@ func BenchmarkFileInput(b *testing.B) {
 
 			received := make(chan []byte)
 
-			op, err := cfg.Build(testutil.Logger(b), emitOnChan(received))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(b)}, emitOnChan(received))
 			require.NoError(b, err)
 
 			// write half the lines before starting

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -619,7 +619,7 @@ func TestBuild(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			input, err := cfg.Build(testutil.Logger(t), nopEmitFunc)
+			input, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)}, nopEmitFunc)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return
@@ -785,7 +785,7 @@ func TestBuildWithHeader(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			input, err := cfg.Build(testutil.Logger(t), nopEmitFunc)
+			input, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)}, nopEmitFunc)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -45,6 +45,8 @@ type Manager struct {
 	seenPaths  map[string]struct{}
 
 	currentFps []*fingerprint.Fingerprint
+
+	telemetry *fileConsumerTelemetry
 }
 
 func (m *Manager) Start(persister operator.Persister) error {

--- a/pkg/stanza/fileconsumer/internal/header/config.go
+++ b/pkg/stanza/fileconsumer/internal/header/config.go
@@ -38,7 +38,7 @@ func NewConfig(matchRegex string, metadataOperators []operator.Config, enc encod
 	p, err := pipeline.Config{
 		Operators:     metadataOperators,
 		DefaultOutput: newPipelineOutput(nopLogger),
-	}.Build(nopLogger)
+	}.Build(&operator.BuildInfoInternal{Logger: nopLogger})
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to build pipelines: %w", err)

--- a/pkg/stanza/fileconsumer/internal/header/reader.go
+++ b/pkg/stanza/fileconsumer/internal/header/reader.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/pipeline"
 )
 
@@ -31,7 +32,7 @@ func NewReader(logger *zap.SugaredLogger, cfg Config) (*Reader, error) {
 	r.pipeline, err = pipeline.Config{
 		Operators:     cfg.metadataOperators,
 		DefaultOutput: r.output,
-	}.Build(logger)
+	}.Build(&operator.BuildInfoInternal{Logger: logger})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build pipeline: %w", err)
 	}

--- a/pkg/stanza/fileconsumer/metrics.go
+++ b/pkg/stanza/fileconsumer/metrics.go
@@ -1,0 +1,125 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
+
+import (
+	"context"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"go.opentelemetry.io/collector/config/configtelemetry"
+	rcvr "go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	scopeName   = "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
+	receiverKey = "receiver"
+	nameSep     = "_"
+	typeStr     = "filelog"
+)
+
+var (
+	receiverTagKey    = tag.MustNewKey(receiverKey)
+	statFileReadDelay = stats.Int64("file_read_delay", "the time it takes to read data from a file", stats.UnitMilliseconds)
+)
+
+func init() {
+	_ = view.Register(metricViews()...)
+}
+
+func BuildMetricName(typestr string, metric string) string {
+	return receiverKey + nameSep + typestr + nameSep + metric
+}
+
+// MetricViews returns the metrics views related to fileconsumer.
+func metricViews() []*view.View {
+	receiverTagKeys := []tag.Key{receiverTagKey}
+
+	distributionReadFileDelayView := &view.View{
+		Name:        BuildMetricName(typeStr, statFileReadDelay.Name()),
+		Measure:     statFileReadDelay,
+		Description: statFileReadDelay.Description(),
+		TagKeys:     receiverTagKeys,
+		Aggregation: view.Distribution(10, 25, 50, 75, 100, 250, 500, 750, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 20000, 30000, 50000,
+			100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000, 900_000,
+			1000_000, 2000_000, 3000_000, 4000_000, 5000_000, 6000_000, 7000_000, 8000_000, 9000_000),
+	}
+
+	return []*view.View{
+		distributionReadFileDelayView,
+	}
+}
+
+type fileConsumerTelemetry struct {
+	level    configtelemetry.Level
+	detailed bool
+	useOtel  bool
+
+	exportCtx context.Context
+
+	receiverAttr  []attribute.KeyValue
+	readFileDelay metric.Int64Histogram
+}
+
+func newFileConsumerTelemetry(set *rcvr.CreateSettings, useOtel bool) (*fileConsumerTelemetry, error) {
+	exportCtx, err := tag.New(context.Background(), tag.Insert(receiverTagKey, set.ID.String()))
+	if err != nil {
+		return nil, err
+	}
+
+	bpt := &fileConsumerTelemetry{
+		useOtel:      useOtel,
+		receiverAttr: []attribute.KeyValue{attribute.String(receiverKey, set.ID.String())},
+		exportCtx:    exportCtx,
+		level:        set.MetricsLevel,
+		detailed:     set.MetricsLevel == configtelemetry.LevelDetailed,
+	}
+
+	err = bpt.createOtelMetrics(set.MeterProvider)
+	if err != nil {
+		return nil, err
+	}
+	return bpt, nil
+}
+
+func (bpt *fileConsumerTelemetry) createOtelMetrics(mp metric.MeterProvider) error {
+	if !bpt.useOtel {
+		return nil
+	}
+
+	var err error
+	meter := mp.Meter(scopeName)
+	bpt.readFileDelay, err = meter.Int64Histogram(
+		BuildMetricName(typeStr, statFileReadDelay.Name()),
+		metric.WithDescription(statFileReadDelay.Description()),
+		metric.WithUnit("ms"),
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (bpt *fileConsumerTelemetry) record(delay int64) {
+	if bpt.useOtel {
+		bpt.recordWithOtel(delay)
+	} else {
+		bpt.recordWithOC(delay)
+	}
+}
+
+func (bpt *fileConsumerTelemetry) recordWithOC(delay int64) {
+	if bpt.detailed {
+		stats.Record(bpt.exportCtx, statFileReadDelay.M(delay))
+	}
+}
+
+func (bpt *fileConsumerTelemetry) recordWithOtel(delay int64) {
+	if bpt.detailed {
+		bpt.readFileDelay.Record(bpt.exportCtx, delay, metric.WithAttributes(bpt.receiverAttr...))
+	}
+}

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/observiq/nanojack"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -89,7 +88,7 @@ func buildTestManager(t *testing.T, cfg *Config, opts ...testManagerOption) (*Ma
 	for _, opt := range opts {
 		opt(tmc)
 	}
-	input, err := cfg.Build(testutil.Logger(t), testEmitFunc(tmc.emitChan))
+	input, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)}, testEmitFunc(tmc.emitChan))
 	require.NoError(t, err)
 	return input, tmc.emitChan
 }
@@ -238,6 +237,6 @@ func newMockOperatorConfig(cfg *Config) *mockOperatorConfig {
 
 // This function is impelmented for compatibility with operatortest
 // but is not meant to be used directly
-func (h *mockOperatorConfig) Build(*zap.SugaredLogger) (operator.Operator, error) {
+func (h *mockOperatorConfig) Build(*operator.BuildInfoInternal) (operator.Operator, error) {
 	panic("not impelemented")
 }

--- a/pkg/stanza/operator/config.go
+++ b/pkg/stanza/operator/config.go
@@ -6,14 +6,20 @@ package operator // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"encoding/json"
 	"fmt"
-
 	"go.opentelemetry.io/collector/confmap"
+	rcvr "go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 )
 
 // Config is the configuration of an operator
 type Config struct {
 	Builder
+}
+
+type BuildInfoInternal struct {
+	Logger           *zap.SugaredLogger
+	CreateSettings   *rcvr.CreateSettings
+	TelemetryUseOtel bool
 }
 
 // NewConfig wraps the builder interface in a concrete struct
@@ -25,7 +31,9 @@ func NewConfig(b Builder) Config {
 type Builder interface {
 	ID() string
 	Type() string
-	Build(*zap.SugaredLogger) (Operator, error)
+	// Build delivers the telemetrySettings and component.ID which contain the info that telemetry needs
+	// useOtel controls whether the collector uses open telemetrySettings for internal metrics
+	Build(*BuildInfoInternal) (Operator, error)
 	SetID(string)
 }
 

--- a/pkg/stanza/operator/config_test.go
+++ b/pkg/stanza/operator/config_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -18,7 +17,7 @@ type FakeBuilder struct {
 	Array        []string `json:"array" yaml:"array"`
 }
 
-func (f *FakeBuilder) Build(_ *zap.SugaredLogger) (Operator, error) {
+func (f *FakeBuilder) Build(_ *BuildInfoInternal) (Operator, error) {
 	return nil, nil
 }
 func (f *FakeBuilder) ID() string     { return "operator" }

--- a/pkg/stanza/operator/helper/helper_test.go
+++ b/pkg/stanza/operator/helper/helper_test.go
@@ -3,8 +3,6 @@
 package helper
 
 import (
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
@@ -35,6 +33,6 @@ func newHelpersConfig() *helpersConfig {
 
 // This function is impelmented for compatibility with operatortest
 // but is not meant to be used directly
-func (h *helpersConfig) Build(*zap.SugaredLogger) (operator.Operator, error) {
+func (h *helpersConfig) Build(*operator.BuildInfoInternal) (operator.Operator, error) {
 	panic("not impelemented")
 }

--- a/pkg/stanza/operator/input/file/config.go
+++ b/pkg/stanza/operator/input/file/config.go
@@ -4,8 +4,6 @@
 package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
 
 import (
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -38,8 +36,8 @@ type Config struct {
 }
 
 // Build will build a file input operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +58,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		toBody:        toBody,
 	}
 
-	input.fileConsumer, err = c.Config.Build(logger, input.emit)
+	input.fileConsumer, err = c.Config.Build(buildInfo, input.emit)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/file/config_test.go
+++ b/pkg/stanza/operator/input/file/config_test.go
@@ -560,7 +560,7 @@ func TestBuild(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return

--- a/pkg/stanza/operator/input/file/util_test.go
+++ b/pkg/stanza/operator/input/file/util_test.go
@@ -34,7 +34,7 @@ func newTestFileOperator(t *testing.T, cfgMod func(*Config)) (*Input, chan *entr
 	if cfgMod != nil {
 		cfgMod(cfg)
 	}
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 
 	err = op.SetOutputs([]operator.Operator{fakeOutput})

--- a/pkg/stanza/operator/input/generate/generate.go
+++ b/pkg/stanza/operator/input/generate/generate.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -36,8 +34,8 @@ type Config struct {
 }
 
 // Build will build a generate input operator.
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c *Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/generate/generate_test.go
+++ b/pkg/stanza/operator/input/generate/generate_test.go
@@ -21,7 +21,7 @@ func TestInputGenerate(t *testing.T) {
 		Body: "test message",
 	}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/input/journald/journald.go
+++ b/pkg/stanza/operator/input/journald/journald.go
@@ -67,8 +67,8 @@ type Config struct {
 type MatchConfig map[string]string
 
 // Build will build a journald input operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/stdin/stdin.go
+++ b/pkg/stanza/operator/input/stdin/stdin.go
@@ -34,8 +34,8 @@ type Config struct {
 }
 
 // Build will build a stdin input operator.
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c *Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/stdin/stdin_test.go
+++ b/pkg/stanza/operator/input/stdin/stdin_test.go
@@ -17,7 +17,7 @@ func TestStdin(t *testing.T) {
 	cfg := NewConfig("")
 	cfg.OutputIDs = []string{"fake"}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/input/syslog/syslog_test.go
+++ b/pkg/stanza/operator/input/syslog/syslog_test.go
@@ -87,7 +87,7 @@ func TestInput(t *testing.T) {
 }
 
 func InputTest(t *testing.T, cfg *Config, tc syslog.Case) {
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)
@@ -141,7 +141,7 @@ func TestSyslogIDs(t *testing.T) {
 
 	t.Run("TCP", func(t *testing.T) {
 		cfg := NewConfigWithTCP(basicConfig())
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 		syslogInputOp := op.(*Input)
 		require.Equal(t, "test_syslog_internal_tcp", syslogInputOp.tcp.ID())
@@ -152,7 +152,7 @@ func TestSyslogIDs(t *testing.T) {
 	})
 	t.Run("UDP", func(t *testing.T) {
 		cfg := NewConfigWithUDP(basicConfig())
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 		syslogInputOp := op.(*Input)
 		require.Equal(t, "test_syslog_internal_udp", syslogInputOp.udp.ID())

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -92,8 +92,8 @@ func (c Config) defaultMultilineBuilder(enc encoding.Encoding) (bufio.SplitFunc,
 }
 
 // Build will build a tcp input operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/tcp/tcp_test.go
+++ b/pkg/stanza/operator/input/tcp/tcp_test.go
@@ -78,7 +78,7 @@ func tcpInputTest(input []byte, expected []string) func(t *testing.T) {
 		cfg := NewConfigWithID("test_id")
 		cfg.ListenAddress = ":0"
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -127,7 +127,7 @@ func tcpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 		cfg.ListenAddress = ":0"
 		cfg.AddAttributes = true
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -213,7 +213,7 @@ func tlsInputTest(input []byte, expected []string) func(t *testing.T) {
 			},
 		}
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -343,7 +343,7 @@ func TestBuild(t *testing.T) {
 			cfg.ListenAddress = tc.inputBody.ListenAddress
 			cfg.MaxLogSize = tc.inputBody.MaxLogSize
 			cfg.TLS = tc.inputBody.TLS
-			_, err := cfg.Build(testutil.Logger(t))
+			_, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			if tc.expectErr {
 				require.Error(t, err)
 				return
@@ -388,7 +388,7 @@ func TestFailToBind(t *testing.T) {
 	var startTCP = func(int) (*Input, error) {
 		cfg := NewConfigWithID("test_id")
 		cfg.ListenAddress = net.JoinHostPort(ip, strconv.Itoa(port))
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 		mockOutput := testutil.Operator{}
 		tcpInput := op.(*Input)
@@ -415,7 +415,7 @@ func BenchmarkTCPInput(b *testing.B) {
 	cfg := NewConfigWithID("test_id")
 	cfg.ListenAddress = ":0"
 
-	op, err := cfg.Build(testutil.Logger(b))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(b)})
 	require.NoError(b, err)
 
 	fakeOutput := testutil.NewFakeOutput(b)

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -70,8 +70,8 @@ type BaseConfig struct {
 }
 
 // Build will build a udp input operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/udp/udp_test.go
+++ b/pkg/stanza/operator/input/udp/udp_test.go
@@ -23,7 +23,7 @@ func udpInputTest(input []byte, expected []string) func(t *testing.T) {
 		cfg := NewConfigWithID("test_input")
 		cfg.ListenAddress = ":0"
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -74,7 +74,7 @@ func udpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 		cfg.ListenAddress = ":0"
 		cfg.AddAttributes = true
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -172,7 +172,7 @@ func TestFailToBind(t *testing.T) {
 		cfg := NewConfigWithID("test_input")
 		cfg.ListenAddress = net.JoinHostPort(ip, strconv.Itoa(port))
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -204,7 +204,7 @@ func BenchmarkUDPInput(b *testing.B) {
 	cfg := NewConfigWithID("test_id")
 	cfg.ListenAddress = ":0"
 
-	op, err := cfg.Build(testutil.Logger(b))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(b)})
 	require.NoError(b, err)
 
 	fakeOutput := testutil.NewFakeOutput(b)

--- a/pkg/stanza/operator/output/drop/drop.go
+++ b/pkg/stanza/operator/output/drop/drop.go
@@ -6,8 +6,6 @@ package drop // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"context"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -30,8 +28,8 @@ type Config struct {
 }
 
 // Build will build a drop output operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	outputOperator, err := c.OutputConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	outputOperator, err := c.OutputConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/output/drop/drop_test.go
+++ b/pkg/stanza/operator/output/drop/drop_test.go
@@ -10,26 +10,27 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func TestBuildValid(t *testing.T) {
 	cfg := NewConfig("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	require.IsType(t, &Output{}, op)
 }
 
 func TestBuildIvalid(t *testing.T) {
 	cfg := NewConfig("test")
-	_, err := cfg.Build(nil)
+	_, err := cfg.Build(&operator.BuildInfoInternal{Logger: nil})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "build context is missing a logger")
 }
 
 func TestProcess(t *testing.T) {
 	cfg := NewConfig("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 
 	entry := entry.New()

--- a/pkg/stanza/operator/output/file/file.go
+++ b/pkg/stanza/operator/output/file/file.go
@@ -11,8 +11,6 @@ import (
 	"os"
 	"sync"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -38,8 +36,8 @@ type Config struct {
 }
 
 // Build will build a file output operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	outputOperator, err := c.OutputConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	outputOperator, err := c.OutputConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/output/stdout/stdout.go
+++ b/pkg/stanza/operator/output/stdout/stdout.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"sync"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -37,8 +35,8 @@ type Config struct {
 }
 
 // Build will build a stdout operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	outputOperator, err := c.OutputConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	outputOperator, err := c.OutputConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/output/stdout/stdout_test.go
+++ b/pkg/stanza/operator/output/stdout/stdout_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
@@ -27,7 +28,7 @@ func TestOperator(t *testing.T) {
 		},
 	}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 
 	var buf bytes.Buffer

--- a/pkg/stanza/operator/parser/csv/csv.go
+++ b/pkg/stanza/operator/parser/csv/csv.go
@@ -10,8 +10,6 @@ import (
 	"io"
 	"strings"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -48,8 +46,8 @@ type Config struct {
 }
 
 // Build will build a csv parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	parserOperator, err := c.ParserConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	parserOperator, err := c.ParserConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/csv/csv_test.go
+++ b/pkg/stanza/operator/parser/csv/csv_test.go
@@ -19,7 +19,7 @@ var testHeader = "name,sev,msg"
 func newTestParser(t *testing.T) *Parser {
 	cfg := NewConfigWithID("test")
 	cfg.Header = testHeader
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -28,7 +28,7 @@ func newTestParserIgnoreQuotes(t *testing.T) *Parser {
 	cfg := NewConfigWithID("test")
 	cfg.Header = testHeader
 	cfg.IgnoreQuotes = true
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -36,7 +36,7 @@ func newTestParserIgnoreQuotes(t *testing.T) *Parser {
 func TestParserBuildFailure(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -46,7 +46,7 @@ func TestParserBuildFailureLazyIgnoreQuotes(t *testing.T) {
 	cfg.Header = testHeader
 	cfg.LazyQuotes = true
 	cfg.IgnoreQuotes = true
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.Error(t, err)
 	require.ErrorContains(t, err, "only one of 'ignore_quotes' or 'lazy_quotes' can be true")
 }
@@ -55,7 +55,7 @@ func TestParserBuildFailureInvalidDelimiter(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.Header = testHeader
 	cfg.FieldDelimiter = ";;"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid 'delimiter': ';;'")
 }
@@ -64,7 +64,7 @@ func TestParserBuildFailureBadHeaderConfig(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.Header = "testheader"
 	cfg.HeaderAttribute = "testheader"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "only one header parameter can be set: 'header' or 'header_attribute'")
 }
@@ -793,7 +793,7 @@ func TestParserCSV(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			if tc.expectBuildErr {
 				require.Error(t, err)
 				return
@@ -1037,7 +1037,7 @@ cc""",dddd,eeee`,
 			cfg.OutputIDs = []string{"fake"}
 			cfg.Header = "A,B,C,D,E"
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)
@@ -1059,7 +1059,7 @@ func TestParserCSVInvalidJSONInput(t *testing.T) {
 		cfg.OutputIDs = []string{"fake"}
 		cfg.Header = testHeader
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 
 		fake := testutil.NewFakeOutput(t)
@@ -1084,21 +1084,21 @@ func TestBuildParserCSV(t *testing.T) {
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicParser()
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 	})
 
 	t.Run("MissingHeaderField", func(t *testing.T) {
 		c := newBasicParser()
 		c.Header = ""
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.Error(t, err)
 	})
 
 	t.Run("InvalidHeaderFieldMissingDelimiter", func(t *testing.T) {
 		c := newBasicParser()
 		c.Header = "name"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing field delimiter in header")
 	})
@@ -1106,7 +1106,7 @@ func TestBuildParserCSV(t *testing.T) {
 	t.Run("InvalidHeaderFieldWrongDelimiter", func(t *testing.T) {
 		c := newBasicParser()
 		c.Header = "name;position;number"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.Error(t, err)
 	})
 
@@ -1114,7 +1114,7 @@ func TestBuildParserCSV(t *testing.T) {
 		c := newBasicParser()
 		c.Header = "name,position,number"
 		c.FieldDelimiter = ":"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing field delimiter in header")
 	})

--- a/pkg/stanza/operator/parser/json/json.go
+++ b/pkg/stanza/operator/parser/json/json.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	jsoniter "github.com/json-iterator/go"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -39,8 +38,8 @@ type Config struct {
 }
 
 // Build will build a JSON parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	parserOperator, err := c.ParserConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	parserOperator, err := c.ParserConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/json/json_test.go
+++ b/pkg/stanza/operator/parser/json/json_test.go
@@ -18,14 +18,14 @@ import (
 
 func newTestParser(t *testing.T) *Parser {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	op, err := config.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	return op.(*Parser)
 }
 
 func TestConfigBuild(t *testing.T) {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	op, err := config.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	require.IsType(t, &Parser{}, op)
 }
@@ -33,7 +33,7 @@ func TestConfigBuild(t *testing.T) {
 func TestConfigBuildFailure(t *testing.T) {
 	config := NewConfigWithID("test")
 	config.OnError = "invalid_on_error"
-	_, err := config.Build(testutil.Logger(t))
+	_, err := config.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -143,7 +143,7 @@ func TestParser(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"go.uber.org/multierr"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -45,8 +44,8 @@ type Config struct {
 }
 
 // Build will build a key value parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	parserOperator, err := c.ParserConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	parserOperator, err := c.ParserConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
@@ -18,7 +18,7 @@ import (
 
 func newTestParser(t *testing.T) *Parser {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	op, err := config.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -31,7 +31,7 @@ func TestInit(t *testing.T) {
 
 func TestConfigBuild(t *testing.T) {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	op, err := config.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	require.IsType(t, &Parser{}, op)
 }
@@ -39,7 +39,7 @@ func TestConfigBuild(t *testing.T) {
 func TestConfigBuildFailure(t *testing.T) {
 	config := NewConfigWithID("test")
 	config.OnError = "invalid_on_error"
-	_, err := config.Build(testutil.Logger(t))
+	_, err := config.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -124,7 +124,7 @@ func TestBuild(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := tc.input
-			_, err := cfg.Build(testutil.Logger(t))
+			_, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			if tc.expectErr {
 				require.Error(t, err)
 				return
@@ -545,7 +545,7 @@ key=value`,
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			if tc.expectBuildErr {
 				require.Error(t, err)
 				return

--- a/pkg/stanza/operator/parser/regex/regex.go
+++ b/pkg/stanza/operator/parser/regex/regex.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -46,7 +44,8 @@ type Config struct {
 }
 
 // Build will build a regex parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	logger := buildInfo.Logger
 	parserOperator, err := c.ParserConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/regex/regex_test.go
+++ b/pkg/stanza/operator/parser/regex/regex_test.go
@@ -24,7 +24,7 @@ func newTestParser(t *testing.T, regex string, cacheSize uint16) *Parser {
 	if cacheSize > 0 {
 		cfg.Cache.Size = cacheSize
 	}
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -32,7 +32,7 @@ func newTestParser(t *testing.T, regex string, cacheSize uint16) *Parser {
 func TestParserBuildFailure(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -132,7 +132,7 @@ func TestParserRegex(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)
@@ -160,28 +160,28 @@ func TestBuildParserRegex(t *testing.T) {
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicParser()
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 	})
 
 	t.Run("MissingRegexField", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = ""
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.Error(t, err)
 	})
 
 	t.Run("InvalidRegexField", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = "())()"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.Error(t, err)
 	})
 
 	t.Run("NoNamedGroups", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = ".*"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no named capture groups")
 	})
@@ -189,7 +189,7 @@ func TestBuildParserRegex(t *testing.T) {
 	t.Run("NoNamedGroups", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = "(.*)"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no named capture groups")
 	})
@@ -224,7 +224,7 @@ func newTestBenchParser(t *testing.T, cacheSize uint16) *Parser {
 	cfg.Regex = benchParsePattern
 	cfg.Cache.Size = cacheSize
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	return op.(*Parser)
 }

--- a/pkg/stanza/operator/parser/scope/scope_name.go
+++ b/pkg/stanza/operator/parser/scope/scope_name.go
@@ -6,8 +6,6 @@ package scope // import "github.com/open-telemetry/opentelemetry-collector-contr
 import (
 	"context"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -39,8 +37,8 @@ type Config struct {
 }
 
 // Build will build a logger name parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/scope/scope_name_test.go
+++ b/pkg/stanza/operator/parser/scope/scope_name_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
@@ -92,7 +93,7 @@ func TestScopeNameParser(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			parser, err := tc.config.Build(testutil.Logger(t))
+			parser, err := tc.config.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			err = parser.Process(context.Background(), tc.input)

--- a/pkg/stanza/operator/parser/severity/severity.go
+++ b/pkg/stanza/operator/parser/severity/severity.go
@@ -6,8 +6,6 @@ package severity // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -39,7 +37,8 @@ type Config struct {
 }
 
 // Build will build a severity parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	logger := buildInfo.Logger
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/severity/severity_test.go
+++ b/pkg/stanza/operator/parser/severity/severity_test.go
@@ -222,7 +222,7 @@ func TestSeverityParser(t *testing.T) {
 
 func runSeverityParseTest(cfg *Config, ent *entry.Entry, buildErr bool, parseErr bool, expected entry.Severity) func(*testing.T) {
 	return func(t *testing.T) {
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		if buildErr {
 			require.Error(t, err, "expected error when configuring operator")
 			return

--- a/pkg/stanza/operator/parser/syslog/config_test.go
+++ b/pkg/stanza/operator/parser/syslog/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -126,7 +127,7 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestParserMissingProtocol(t *testing.T) {
-	_, err := NewConfig().Build(testutil.Logger(t))
+	_, err := NewConfig().Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing field 'protocol'")
 }
@@ -213,7 +214,7 @@ func TestRFC6587ConfigOptions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := tc.cfg.Build(testutil.Logger(t))
+			_, err := tc.cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			if tc.errContents != "" {
 				require.ErrorContains(t, err, tc.errContents)
 			} else {
@@ -228,7 +229,7 @@ func TestParserInvalidLocation(t *testing.T) {
 	config.Location = "not_a_location"
 	config.Protocol = RFC3164
 
-	_, err := config.Build(testutil.Logger(t))
+	_, err := config.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to load location "+config.Location)
 }

--- a/pkg/stanza/operator/parser/syslog/syslog.go
+++ b/pkg/stanza/operator/parser/syslog/syslog.go
@@ -15,7 +15,6 @@ import (
 	"github.com/influxdata/go-syslog/v3/octetcounting"
 	"github.com/influxdata/go-syslog/v3/rfc3164"
 	"github.com/influxdata/go-syslog/v3/rfc5424"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -63,7 +62,7 @@ type BaseConfig struct {
 }
 
 // Build will build a JSON parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
 	if c.ParserConfig.TimeParser == nil {
 		parseFromField := entry.NewAttributeField("timestamp")
 		c.ParserConfig.TimeParser = &helper.TimeParser{
@@ -72,7 +71,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		}
 	}
 
-	parserOperator, err := c.ParserConfig.Build(logger)
+	parserOperator, err := c.ParserConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/syslog/syslog_test.go
+++ b/pkg/stanza/operator/parser/syslog/syslog_test.go
@@ -27,7 +27,7 @@ func TestParser(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			op, err := tc.Config.Build(testutil.Logger(t))
+			op, err := tc.Config.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)
@@ -57,7 +57,7 @@ func TestSyslogParseRFC5424_SDNameTooLong(t *testing.T) {
 
 	body := `<86>1 2015-08-05T21:58:59.693Z 192.168.2.132 SecureAuth0 23108 ID52020 [verylongsdnamethatisgreaterthan32bytes@12345 UserHostAddress="192.168.2.132"] my message`
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/parser/time/time.go
+++ b/pkg/stanza/operator/parser/time/time.go
@@ -6,8 +6,6 @@ package time // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"context"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -39,8 +37,8 @@ type Config struct {
 }
 
 // Build will build a time parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/time/time_test.go
+++ b/pkg/stanza/operator/parser/time/time_test.go
@@ -63,7 +63,7 @@ func TestBuild(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := tc.input()
 			require.NoError(t, err, "expected nil error when running test cases input func")
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			if tc.expectErr {
 				require.Error(t, err, "expected error while building time_parser operator")
 				return
@@ -121,7 +121,7 @@ func TestProcess(t *testing.T) {
 				require.NoError(t, err)
 				return
 			}
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			if err != nil {
 				require.NoError(t, err)
 				return
@@ -501,7 +501,7 @@ func runTimeParseTest(t *testing.T, cfg *Config, ent *entry.Entry, buildErr bool
 
 func runLossyTimeParseTest(_ *testing.T, cfg *Config, ent *entry.Entry, buildErr bool, parseErr bool, expected time.Time, maxLoss time.Duration) func(*testing.T) {
 	return func(t *testing.T) {
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		if buildErr {
 			require.Error(t, err, "expected error when configuring operator")
 			return

--- a/pkg/stanza/operator/parser/trace/trace.go
+++ b/pkg/stanza/operator/parser/trace/trace.go
@@ -6,8 +6,6 @@ package trace // import "github.com/open-telemetry/opentelemetry-collector-contr
 import (
 	"context"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -39,8 +37,8 @@ type Config struct {
 }
 
 // Build will build a trace parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/trace/trace_test.go
+++ b/pkg/stanza/operator/parser/trace/trace_test.go
@@ -22,7 +22,7 @@ func TestInit(t *testing.T) {
 }
 func TestDefaultParser(t *testing.T) {
 	traceParserConfig := NewConfig()
-	_, err := traceParserConfig.Build(testutil.Logger(t))
+	_, err := traceParserConfig.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 }
 
@@ -83,7 +83,7 @@ func TestBuild(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := tc.input()
 			require.NoError(t, err, "expected nil error when running test cases input func")
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			if tc.expectErr {
 				require.Error(t, err, "expected error while building trace_parser operator")
 				return
@@ -109,7 +109,7 @@ func TestProcess(t *testing.T) {
 			"no-op",
 			func() (operator.Operator, error) {
 				cfg := NewConfigWithID("test_id")
-				return cfg.Build(testutil.Logger(t))
+				return cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			},
 			&entry.Entry{
 				Body: "https://google.com:443/path?user=dev",
@@ -128,7 +128,7 @@ func TestProcess(t *testing.T) {
 				cfg.SpanID.ParseFrom = &spanFrom
 				cfg.TraceID.ParseFrom = &traceFrom
 				cfg.TraceFlags.ParseFrom = &flagsFrom
-				return cfg.Build(testutil.Logger(t))
+				return cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			},
 			&entry.Entry{
 				Body: map[string]interface{}{
@@ -258,7 +258,7 @@ func TestTraceParserParse(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			traceParserConfig := NewConfigWithID("")
-			_, _ = traceParserConfig.Build(testutil.Logger(t))
+			_, _ = traceParserConfig.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			e := entry.New()
 			e.Body = tc.inputRecord
 			err := traceParserConfig.Parse(e)

--- a/pkg/stanza/operator/parser/uri/uri.go
+++ b/pkg/stanza/operator/parser/uri/uri.go
@@ -9,8 +9,6 @@ import (
 	"net/url"
 	"strings"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -40,8 +38,8 @@ type Config struct {
 }
 
 // Build will build a uri parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	parserOperator, err := c.ParserConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	parserOperator, err := c.ParserConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/uri/uri_test.go
+++ b/pkg/stanza/operator/parser/uri/uri_test.go
@@ -17,7 +17,7 @@ import (
 
 func newTestParser(t *testing.T) *Parser {
 	cfg := NewConfigWithID("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -31,7 +31,7 @@ func TestInit(t *testing.T) {
 func TestParserBuildFailure(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -68,7 +68,7 @@ func TestProcess(t *testing.T) {
 			"default",
 			func() (operator.Operator, error) {
 				cfg := NewConfigWithID("test_id")
-				return cfg.Build(testutil.Logger(t))
+				return cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			},
 			&entry.Entry{
 				Body: "https://google.com:443/path?user=dev",
@@ -94,7 +94,7 @@ func TestProcess(t *testing.T) {
 				cfg := NewConfigWithID("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
 				cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField("url2")}
-				return cfg.Build(testutil.Logger(t))
+				return cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			},
 			&entry.Entry{
 				Body: map[string]interface{}{
@@ -123,7 +123,7 @@ func TestProcess(t *testing.T) {
 			func() (operator.Operator, error) {
 				cfg := NewConfigWithID("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
-				return cfg.Build(testutil.Logger(t))
+				return cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			},
 			&entry.Entry{
 				Body: map[string]interface{}{
@@ -490,7 +490,7 @@ func TestBuildParserURL(t *testing.T) {
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicParser()
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 	})
 }

--- a/pkg/stanza/operator/transformer/add/add.go
+++ b/pkg/stanza/operator/transformer/add/add.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/antonmedv/expr/vm"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -42,8 +41,8 @@ type Config struct {
 }
 
 // Build will build an add operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/add/add_test.go
+++ b/pkg/stanza/operator/transformer/add/add_test.go
@@ -340,7 +340,7 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			add := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/copy/copy.go
+++ b/pkg/stanza/operator/transformer/copy/copy.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -40,8 +38,8 @@ type Config struct {
 }
 
 // Build will build a copy operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/copy/copy_test.go
+++ b/pkg/stanza/operator/transformer/copy/copy_test.go
@@ -287,7 +287,7 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			cp := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/filter/filter.go
+++ b/pkg/stanza/operator/transformer/filter/filter.go
@@ -49,8 +49,8 @@ type Config struct {
 }
 
 // Build will build a filter operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformer, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformer, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/filter/filter_test.go
+++ b/pkg/stanza/operator/transformer/filter/filter_test.go
@@ -159,7 +159,7 @@ func TestTransformer(t *testing.T) {
 			cfg := NewConfigWithID("test")
 			cfg.Expression = tc.expression
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			filtered := true
@@ -184,7 +184,7 @@ func TestFilterDropRatio(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.Expression = `body.message == "test_message"`
 	cfg.DropRatio = 0.5
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 
 	processedEntries := 0

--- a/pkg/stanza/operator/transformer/flatten/flatten.go
+++ b/pkg/stanza/operator/transformer/flatten/flatten.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -40,8 +38,8 @@ type Config struct {
 }
 
 // Build will build a Flatten operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/flatten/flatten_test.go
+++ b/pkg/stanza/operator/transformer/flatten/flatten_test.go
@@ -319,7 +319,7 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			if tc.expectErr && err != nil {
 				require.Error(t, err)
 				t.SkipNow()

--- a/pkg/stanza/operator/transformer/move/move.go
+++ b/pkg/stanza/operator/transformer/move/move.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -40,8 +38,8 @@ type Config struct {
 }
 
 // Build will build a Move operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/move/move_test.go
+++ b/pkg/stanza/operator/transformer/move/move_test.go
@@ -502,7 +502,7 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			move := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/noop/noop.go
+++ b/pkg/stanza/operator/transformer/noop/noop.go
@@ -6,8 +6,6 @@ package noop // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"context"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -37,8 +35,8 @@ type Config struct {
 }
 
 // Build will build a noop operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/noop/noop_test.go
+++ b/pkg/stanza/operator/transformer/noop/noop_test.go
@@ -16,14 +16,14 @@ import (
 
 func TestBuildValid(t *testing.T) {
 	cfg := NewConfigWithID("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	require.IsType(t, &Transformer{}, op)
 }
 
 func TestBuildInvalid(t *testing.T) {
 	cfg := NewConfigWithID("test")
-	_, err := cfg.Build(nil)
+	_, err := cfg.Build(&operator.BuildInfoInternal{Logger: nil})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "build context is missing a logger")
 }
@@ -31,7 +31,7 @@ func TestBuildInvalid(t *testing.T) {
 func TestProcess(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OutputIDs = []string{"fake"}
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/transformer/recombine/recombine.go
+++ b/pkg/stanza/operator/transformer/recombine/recombine.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/vm"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -62,8 +61,8 @@ type Config struct {
 }
 
 // Build creates a new Transformer from a config
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformer, err := c.TransformerConfig.Build(logger)
+func (c *Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformer, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build transformer config: %w", err)
 	}

--- a/pkg/stanza/operator/transformer/recombine/recombine_test.go
+++ b/pkg/stanza/operator/transformer/recombine/recombine_test.go
@@ -475,7 +475,7 @@ func TestTransformer(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			op, err := tc.config.Build(testutil.Logger(t))
+			op, err := tc.config.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 			require.NoError(t, op.Start(testutil.NewMockPersister("test")))
 			recombine := op.(*Transformer)
@@ -505,7 +505,7 @@ func TestTransformer(t *testing.T) {
 		cfg.CombineField = entry.NewBodyField()
 		cfg.IsFirstEntry = MatchAll
 		cfg.OutputIDs = []string{"fake"}
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 		require.NoError(t, err)
 		recombine := op.(*Transformer)
 
@@ -541,7 +541,7 @@ func BenchmarkRecombine(b *testing.B) {
 	cfg.IsFirstEntry = "body startsWith 'log-0'"
 	cfg.OutputIDs = []string{"fake"}
 	cfg.SourceIdentifier = entry.NewAttributeField("file.path")
-	op, err := cfg.Build(testutil.Logger(b))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(b)})
 	require.NoError(b, err)
 	recombine := op.(*Transformer)
 
@@ -584,7 +584,7 @@ func BenchmarkRecombineLimitTrigger(b *testing.B) {
 	cfg.IsFirstEntry = "body == 'start'"
 	cfg.MaxLogSize = 6
 	cfg.OutputIDs = []string{"fake"}
-	op, err := cfg.Build(testutil.Logger(b))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(b)})
 	require.NoError(b, err)
 	recombine := op.(*Transformer)
 
@@ -626,7 +626,7 @@ func TestTimeout(t *testing.T) {
 	cfg.IsFirstEntry = MatchAll
 	cfg.OutputIDs = []string{"fake"}
 	cfg.ForceFlushTimeout = 100 * time.Millisecond
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	recombine := op.(*Transformer)
 
@@ -669,7 +669,7 @@ func TestTimeoutWhenAggregationKeepHappen(t *testing.T) {
 	cfg.CombineWith = ""
 	cfg.OutputIDs = []string{"fake"}
 	cfg.ForceFlushTimeout = 100 * time.Millisecond
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	recombine := op.(*Transformer)
 
@@ -713,7 +713,7 @@ func TestSourceBatchDelete(t *testing.T) {
 	cfg.OutputIDs = []string{"fake"}
 	cfg.ForceFlushTimeout = 100 * time.Millisecond
 	cfg.MaxLogSize = 6
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	recombine := op.(*Transformer)
 

--- a/pkg/stanza/operator/transformer/remove/remove.go
+++ b/pkg/stanza/operator/transformer/remove/remove.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -40,8 +38,8 @@ type Config struct {
 }
 
 // Build will build a Remove operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/remove/remove_test.go
+++ b/pkg/stanza/operator/transformer/remove/remove_test.go
@@ -252,7 +252,7 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			remove := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/retain/retain.go
+++ b/pkg/stanza/operator/transformer/retain/retain.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -40,8 +38,8 @@ type Config struct {
 }
 
 // Build will build a retain operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/retain/retain_test.go
+++ b/pkg/stanza/operator/transformer/retain/retain_test.go
@@ -384,7 +384,7 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			retain := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/router/router.go
+++ b/pkg/stanza/operator/transformer/router/router.go
@@ -48,8 +48,8 @@ type RouteConfig struct {
 }
 
 // Build will build a router operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	basicOperator, err := c.BasicConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	basicOperator, err := c.BasicConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/router/router_test.go
+++ b/pkg/stanza/operator/transformer/router/router_test.go
@@ -183,7 +183,7 @@ func TestTransformer(t *testing.T) {
 			cfg.Routes = tc.routes
 			cfg.Default = tc.defaultOutput
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			results := map[string]int{}

--- a/pkg/stanza/operator/transformer/unquote/unquote.go
+++ b/pkg/stanza/operator/transformer/unquote/unquote.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -40,8 +38,8 @@ type Config struct {
 }
 
 // Build will build an unquote operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(buildInfo *operator.BuildInfoInternal) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(buildInfo.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/unquote/unquote_test.go
+++ b/pkg/stanza/operator/transformer/unquote/unquote_test.go
@@ -194,7 +194,7 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg := tc.cfg
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "send"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 
 			unqouteOp := op.(*Transformer)

--- a/pkg/stanza/pipeline/config_test.go
+++ b/pkg/stanza/pipeline/config_test.go
@@ -25,7 +25,7 @@ func TestBuildPipelineSuccess(t *testing.T) {
 		},
 	}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	pipe, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(pipe.Operators()))
 }
@@ -39,7 +39,7 @@ func TestBuildPipelineNoLogger(t *testing.T) {
 		},
 	}
 
-	pipe, err := cfg.Build(nil)
+	pipe, err := cfg.Build(&operator.BuildInfoInternal{Logger: nil})
 	require.EqualError(t, err, "logger must be provided")
 	require.Nil(t, pipe)
 }
@@ -47,7 +47,7 @@ func TestBuildPipelineNoLogger(t *testing.T) {
 func TestBuildPipelineNilOperators(t *testing.T) {
 	cfg := Config{}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	pipe, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.EqualError(t, err, "operators must be specified")
 	require.Nil(t, pipe)
 }
@@ -57,7 +57,7 @@ func TestBuildPipelineEmptyOperators(t *testing.T) {
 		Operators: []operator.Config{},
 	}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	pipe, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.EqualError(t, err, "empty pipeline not allowed")
 	require.Nil(t, pipe)
 }
@@ -75,7 +75,7 @@ func TestBuildAPipelineDefaultOperator(t *testing.T) {
 		DefaultOutput: testutil.NewFakeOutput(t),
 	}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	pipe, err := cfg.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 	require.NoError(t, err)
 
 	ops := pipe.Operators()
@@ -359,7 +359,7 @@ func TestUpdateOutputIDs(t *testing.T) {
 			pipeline, err := Config{
 				Operators:     tc.ops(),
 				DefaultOutput: tc.defaultOut,
-			}.Build(testutil.Logger(t))
+			}.Build(&operator.BuildInfoInternal{Logger: testutil.Logger(t)})
 			require.NoError(t, err)
 			ops := pipeline.Operators()
 

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -48,7 +48,7 @@ func newProcessor(config *Config, nextConsumer consumer.Logs, logger *zap.Logger
 	pipe, err := pipeline.Config{
 		Operators:     baseCfg.Operators,
 		DefaultOutput: p.emitter,
-	}.Build(p.logger.Sugar())
+	}.Build(&operator.BuildInfoInternal{Logger: p.logger.Sugar()})
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/otlpjsonfilereceiver/file.go
+++ b/receiver/otlpjsonfilereceiver/file.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver/internal/metadata"
 )
 
@@ -73,7 +74,7 @@ func createLogsReceiver(_ context.Context, settings receiver.CreateSettings, con
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(&operator.BuildInfoInternal{Logger: settings.Logger.Sugar()}, func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartLogsOp(ctx)
 		var l plog.Logs
 		l, err = logsUnmarshaler.UnmarshalLogs(token)
@@ -105,7 +106,7 @@ func createMetricsReceiver(_ context.Context, settings receiver.CreateSettings, 
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(&operator.BuildInfoInternal{Logger: settings.Logger.Sugar()}, func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartMetricsOp(ctx)
 		var m pmetric.Metrics
 		m, err = metricsUnmarshaler.UnmarshalMetrics(token)
@@ -137,7 +138,7 @@ func createTracesReceiver(_ context.Context, settings receiver.CreateSettings, c
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(&operator.BuildInfoInternal{Logger: settings.Logger.Sugar()}, func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartTracesOp(ctx)
 		var t ptrace.Traces
 		t, err = tracesUnmarshaler.UnmarshalTraces(token)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
For adding the telemetry for filelog receiver, the related info (CreateSettings) needs to be delivered from factory to operator. So I add a BuildInfoInternal struct to do this first. And then the operators have the ability to add the metrics themselves.

**Link to tracking Issue:** #21794