### PR TITLE
[pkg/ottl] ottlarg struct tag  cleanup

### DIFF
--- a/.chloggen/ottl-structtag-cleanup.yaml
+++ b/.chloggen/ottl-structtag-cleanup.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove support for `ottlarg`. The struct's field order is now the function parameter order.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [25705]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -70,8 +70,8 @@ func dropFn[K any]() (ottl.ExprFunc[K], error) {
 }
 
 type hasAttributeOnDatapointArguments struct {
-	Key         string `ottlarg:"0"`
-	ExpectedVal string `ottlarg:"1"`
+	Key         string
+	ExpectedVal string
 }
 
 func newHasAttributeOnDatapointFactory() ottl.Factory[ottlmetric.TransformContext] {
@@ -95,7 +95,7 @@ func hasAttributeOnDatapoint(key string, expectedVal string) (ottl.ExprFunc[ottl
 }
 
 type hasAttributeKeyOnDatapointArguments struct {
-	Key string `ottlarg:"0"`
+	Key string
 }
 
 func newHasAttributeKeyOnDatapointFactory() ottl.Factory[ottlmetric.TransformContext] {

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -703,7 +703,7 @@ func Test_FunctionGetter(t *testing.T) {
 		Function    FunctionGetter[any]
 	}
 	type FuncArgs struct {
-		Input StringGetter[any] `ottlarg:"0"`
+		Input StringGetter[any]
 	}
 	tests := []struct {
 		name             string

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -1191,7 +1191,7 @@ func functionWithErr() (ExprFunc[any], error) {
 }
 
 type stringSliceArguments struct {
-	Strings []string `ottlarg:"0"`
+	Strings []string
 }
 
 func functionWithStringSlice(strs []string) (ExprFunc[any], error) {
@@ -1201,7 +1201,7 @@ func functionWithStringSlice(strs []string) (ExprFunc[any], error) {
 }
 
 type floatSliceArguments struct {
-	Floats []float64 `ottlarg:"0"`
+	Floats []float64
 }
 
 func functionWithFloatSlice(floats []float64) (ExprFunc[interface{}], error) {
@@ -1211,7 +1211,7 @@ func functionWithFloatSlice(floats []float64) (ExprFunc[interface{}], error) {
 }
 
 type intSliceArguments struct {
-	Ints []int64 `ottlarg:"0"`
+	Ints []int64
 }
 
 func functionWithIntSlice(ints []int64) (ExprFunc[interface{}], error) {
@@ -1221,7 +1221,7 @@ func functionWithIntSlice(ints []int64) (ExprFunc[interface{}], error) {
 }
 
 type byteSliceArguments struct {
-	Bytes []byte `ottlarg:"0"`
+	Bytes []byte
 }
 
 func functionWithByteSlice(bytes []byte) (ExprFunc[interface{}], error) {
@@ -1231,7 +1231,7 @@ func functionWithByteSlice(bytes []byte) (ExprFunc[interface{}], error) {
 }
 
 type getterSliceArguments struct {
-	Getters []Getter[any] `ottlarg:"0"`
+	Getters []Getter[any]
 }
 
 func functionWithGetterSlice(getters []Getter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1241,7 +1241,7 @@ func functionWithGetterSlice(getters []Getter[interface{}]) (ExprFunc[interface{
 }
 
 type stringGetterSliceArguments struct {
-	StringGetters []StringGetter[any] `ottlarg:"0"`
+	StringGetters []StringGetter[any]
 }
 
 func functionWithStringGetterSlice(getters []StringGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1251,7 +1251,7 @@ func functionWithStringGetterSlice(getters []StringGetter[interface{}]) (ExprFun
 }
 
 type durationGetterSliceArguments struct {
-	DurationGetters []DurationGetter[any] `ottlarg:"0"`
+	DurationGetters []DurationGetter[any]
 }
 
 func functionWithDurationGetterSlice(_ []DurationGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1261,7 +1261,7 @@ func functionWithDurationGetterSlice(_ []DurationGetter[interface{}]) (ExprFunc[
 }
 
 type timeGetterSliceArguments struct {
-	TimeGetters []TimeGetter[any] `ottlarg:"0"`
+	TimeGetters []TimeGetter[any]
 }
 
 func functionWithTimeGetterSlice(_ []TimeGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1271,7 +1271,7 @@ func functionWithTimeGetterSlice(_ []TimeGetter[interface{}]) (ExprFunc[interfac
 }
 
 type floatGetterSliceArguments struct {
-	FloatGetters []FloatGetter[any] `ottlarg:"0"`
+	FloatGetters []FloatGetter[any]
 }
 
 func functionWithFloatGetterSlice(getters []FloatGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1281,7 +1281,7 @@ func functionWithFloatGetterSlice(getters []FloatGetter[interface{}]) (ExprFunc[
 }
 
 type intGetterSliceArguments struct {
-	IntGetters []IntGetter[any] `ottlarg:"0"`
+	IntGetters []IntGetter[any]
 }
 
 func functionWithIntGetterSlice(getters []IntGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1291,7 +1291,7 @@ func functionWithIntGetterSlice(getters []IntGetter[interface{}]) (ExprFunc[inte
 }
 
 type pMapGetterSliceArguments struct {
-	PMapGetters []PMapGetter[any] `ottlarg:"0"`
+	PMapGetters []PMapGetter[any]
 }
 
 func functionWithPMapGetterSlice(getters []PMapGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1301,7 +1301,7 @@ func functionWithPMapGetterSlice(getters []PMapGetter[interface{}]) (ExprFunc[in
 }
 
 type stringLikeGetterSliceArguments struct {
-	StringLikeGetters []StringLikeGetter[any] `ottlarg:"0"`
+	StringLikeGetters []StringLikeGetter[any]
 }
 
 func functionWithStringLikeGetterSlice(getters []StringLikeGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1311,7 +1311,7 @@ func functionWithStringLikeGetterSlice(getters []StringLikeGetter[interface{}]) 
 }
 
 type floatLikeGetterSliceArguments struct {
-	FloatLikeGetters []FloatLikeGetter[any] `ottlarg:"0"`
+	FloatLikeGetters []FloatLikeGetter[any]
 }
 
 func functionWithFloatLikeGetterSlice(getters []FloatLikeGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1321,7 +1321,7 @@ func functionWithFloatLikeGetterSlice(getters []FloatLikeGetter[interface{}]) (E
 }
 
 type intLikeGetterSliceArguments struct {
-	IntLikeGetters []IntLikeGetter[any] `ottlarg:"0"`
+	IntLikeGetters []IntLikeGetter[any]
 }
 
 func functionWithIntLikeGetterSlice(getters []IntLikeGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1331,7 +1331,7 @@ func functionWithIntLikeGetterSlice(getters []IntLikeGetter[interface{}]) (ExprF
 }
 
 type setterArguments struct {
-	SetterArg Setter[any] `ottlarg:"0"`
+	SetterArg Setter[any]
 }
 
 func functionWithSetter(Setter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1341,7 +1341,7 @@ func functionWithSetter(Setter[interface{}]) (ExprFunc[interface{}], error) {
 }
 
 type getSetterArguments struct {
-	GetSetterArg GetSetter[any] `ottlarg:"0"`
+	GetSetterArg GetSetter[any]
 }
 
 func functionWithGetSetter(GetSetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1351,7 +1351,7 @@ func functionWithGetSetter(GetSetter[interface{}]) (ExprFunc[interface{}], error
 }
 
 type getterArguments struct {
-	GetterArg Getter[any] `ottlarg:"0"`
+	GetterArg Getter[any]
 }
 
 func functionWithGetter(Getter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1361,7 +1361,7 @@ func functionWithGetter(Getter[interface{}]) (ExprFunc[interface{}], error) {
 }
 
 type stringGetterArguments struct {
-	StringGetterArg StringGetter[any] `ottlarg:"0"`
+	StringGetterArg StringGetter[any]
 }
 
 func functionWithStringGetter(StringGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1371,7 +1371,7 @@ func functionWithStringGetter(StringGetter[interface{}]) (ExprFunc[interface{}],
 }
 
 type durationGetterArguments struct {
-	DurationGetterArg DurationGetter[any] `ottlarg:"0"`
+	DurationGetterArg DurationGetter[any]
 }
 
 func functionWithDurationGetter(DurationGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1381,7 +1381,7 @@ func functionWithDurationGetter(DurationGetter[interface{}]) (ExprFunc[interface
 }
 
 type timeGetterArguments struct {
-	TimeGetterArg TimeGetter[any] `ottlarg:"0"`
+	TimeGetterArg TimeGetter[any]
 }
 
 func functionWithTimeGetter(TimeGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1391,7 +1391,7 @@ func functionWithTimeGetter(TimeGetter[interface{}]) (ExprFunc[interface{}], err
 }
 
 type functionGetterArguments struct {
-	FunctionGetterArg FunctionGetter[any] `ottlarg:"0"`
+	FunctionGetterArg FunctionGetter[any]
 }
 
 func functionWithFunctionGetter(FunctionGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1401,7 +1401,7 @@ func functionWithFunctionGetter(FunctionGetter[interface{}]) (ExprFunc[interface
 }
 
 type stringLikeGetterArguments struct {
-	StringLikeGetterArg StringLikeGetter[any] `ottlarg:"0"`
+	StringLikeGetterArg StringLikeGetter[any]
 }
 
 func functionWithStringLikeGetter(StringLikeGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1411,7 +1411,7 @@ func functionWithStringLikeGetter(StringLikeGetter[interface{}]) (ExprFunc[inter
 }
 
 type floatGetterArguments struct {
-	FloatGetterArg FloatGetter[any] `ottlarg:"0"`
+	FloatGetterArg FloatGetter[any]
 }
 
 func functionWithFloatGetter(FloatGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1421,7 +1421,7 @@ func functionWithFloatGetter(FloatGetter[interface{}]) (ExprFunc[interface{}], e
 }
 
 type floatLikeGetterArguments struct {
-	FloatLikeGetterArg FloatLikeGetter[any] `ottlarg:"0"`
+	FloatLikeGetterArg FloatLikeGetter[any]
 }
 
 func functionWithFloatLikeGetter(FloatLikeGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1431,7 +1431,7 @@ func functionWithFloatLikeGetter(FloatLikeGetter[interface{}]) (ExprFunc[interfa
 }
 
 type intGetterArguments struct {
-	IntGetterArg IntGetter[any] `ottlarg:"0"`
+	IntGetterArg IntGetter[any]
 }
 
 func functionWithIntGetter(IntGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1441,7 +1441,7 @@ func functionWithIntGetter(IntGetter[interface{}]) (ExprFunc[interface{}], error
 }
 
 type intLikeGetterArguments struct {
-	IntLikeGetterArg IntLikeGetter[any] `ottlarg:"0"`
+	IntLikeGetterArg IntLikeGetter[any]
 }
 
 func functionWithIntLikeGetter(IntLikeGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1451,7 +1451,7 @@ func functionWithIntLikeGetter(IntLikeGetter[interface{}]) (ExprFunc[interface{}
 }
 
 type pMapGetterArguments struct {
-	PMapArg PMapGetter[any] `ottlarg:"0"`
+	PMapArg PMapGetter[any]
 }
 
 func functionWithPMapGetter(PMapGetter[interface{}]) (ExprFunc[interface{}], error) {
@@ -1461,7 +1461,7 @@ func functionWithPMapGetter(PMapGetter[interface{}]) (ExprFunc[interface{}], err
 }
 
 type stringArguments struct {
-	StringArg string `ottlarg:"0"`
+	StringArg string
 }
 
 func functionWithString(string) (ExprFunc[interface{}], error) {
@@ -1471,7 +1471,7 @@ func functionWithString(string) (ExprFunc[interface{}], error) {
 }
 
 type floatArguments struct {
-	FloatArg float64 `ottlarg:"0"`
+	FloatArg float64
 }
 
 func functionWithFloat(float64) (ExprFunc[interface{}], error) {
@@ -1481,7 +1481,7 @@ func functionWithFloat(float64) (ExprFunc[interface{}], error) {
 }
 
 type intArguments struct {
-	IntArg int64 `ottlarg:"0"`
+	IntArg int64
 }
 
 func functionWithInt(int64) (ExprFunc[interface{}], error) {
@@ -1491,7 +1491,7 @@ func functionWithInt(int64) (ExprFunc[interface{}], error) {
 }
 
 type boolArguments struct {
-	BoolArg bool `ottlarg:"0"`
+	BoolArg bool
 }
 
 func functionWithBool(bool) (ExprFunc[interface{}], error) {
@@ -1501,10 +1501,10 @@ func functionWithBool(bool) (ExprFunc[interface{}], error) {
 }
 
 type multipleArgsArguments struct {
-	GetSetterArg GetSetter[any] `ottlarg:"0"`
-	StringArg    string         `ottlarg:"1"`
-	FloatArg     float64        `ottlarg:"2"`
-	IntArg       int64          `ottlarg:"3"`
+	GetSetterArg GetSetter[any]
+	StringArg    string
+	FloatArg     float64
+	IntArg       int64
 }
 
 func functionWithMultipleArgs(GetSetter[interface{}], string, float64, int64) (ExprFunc[interface{}], error) {
@@ -1523,7 +1523,7 @@ func functionThatHasAnError() (ExprFunc[interface{}], error) {
 }
 
 type enumArguments struct {
-	EnumArg Enum `ottlarg:"0"`
+	EnumArg Enum
 }
 
 func functionWithEnum(Enum) (ExprFunc[interface{}], error) {

--- a/pkg/ottl/math_test.go
+++ b/pkg/ottl/math_test.go
@@ -83,7 +83,7 @@ func testDuration[K any](duration string) (ExprFunc[K], error) {
 }
 
 type sumArguments struct {
-	Ints []int64 `ottlarg:"0"`
+	Ints []int64
 }
 
 //nolint:unparam
@@ -514,11 +514,11 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 		createFactory("threePointOne", &struct{}{}, threePointOne[any]),
 		createFactory("sum", &sumArguments{}, sum[any]),
 		createFactory("Time", &struct {
-			Time   string `ottlarg:"0"`
-			Format string `ottlarg:"1"`
+			Time   string
+			Format string
 		}{}, testTime[any]),
 		createFactory("Duration", &struct {
-			Duration string `ottlarg:"0"`
+			Duration string
 		}{}, testDuration[any]),
 	)
 
@@ -564,11 +564,11 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 	functions := CreateFactoryMap(
 		createFactory("Time", &struct {
-			Time   string `ottlarg:"0"`
-			Format string `ottlarg:"1"`
+			Time   string
+			Format string
 		}{}, testTime[any]),
 		createFactory("Duration", &struct {
-			Duration string `ottlarg:"0"`
+			Duration string
 		}{}, testDuration[any]),
 	)
 

--- a/pkg/ottl/ottlfuncs/func_extract_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_extract_patterns.go
@@ -14,8 +14,8 @@ import (
 )
 
 type ExtractPatternsArguments[K any] struct {
-	Target  ottl.StringGetter[K] `ottlarg:"0"`
-	Pattern string               `ottlarg:"1"`
+	Target  ottl.StringGetter[K]
+	Pattern string
 }
 
 func NewExtractPatternsFactory[K any]() ottl.Factory[K] {

--- a/pkg/ottl/ottlfuncs/func_hours.go
+++ b/pkg/ottl/ottlfuncs/func_hours.go
@@ -11,7 +11,7 @@ import (
 )
 
 type HoursArguments[K any] struct {
-	Duration ottl.DurationGetter[K] `ottlarg:"0"`
+	Duration ottl.DurationGetter[K]
 }
 
 func NewHoursFactory[K any]() ottl.Factory[K] {

--- a/pkg/ottl/ottlfuncs/func_microseconds.go
+++ b/pkg/ottl/ottlfuncs/func_microseconds.go
@@ -11,7 +11,7 @@ import (
 )
 
 type MicrosecondsArguments[K any] struct {
-	Duration ottl.DurationGetter[K] `ottlarg:"0"`
+	Duration ottl.DurationGetter[K]
 }
 
 func NewMicrosecondsFactory[K any]() ottl.Factory[K] {

--- a/pkg/ottl/ottlfuncs/func_milliseconds.go
+++ b/pkg/ottl/ottlfuncs/func_milliseconds.go
@@ -11,7 +11,7 @@ import (
 )
 
 type MillisecondsArguments[K any] struct {
-	Duration ottl.DurationGetter[K] `ottlarg:"0"`
+	Duration ottl.DurationGetter[K]
 }
 
 func NewMillisecondsFactory[K any]() ottl.Factory[K] {

--- a/pkg/ottl/ottlfuncs/func_minutes.go
+++ b/pkg/ottl/ottlfuncs/func_minutes.go
@@ -11,7 +11,7 @@ import (
 )
 
 type MinutesArguments[K any] struct {
-	Duration ottl.DurationGetter[K] `ottlarg:"0"`
+	Duration ottl.DurationGetter[K]
 }
 
 func NewMinutesFactory[K any]() ottl.Factory[K] {

--- a/pkg/ottl/ottlfuncs/func_nanoseconds.go
+++ b/pkg/ottl/ottlfuncs/func_nanoseconds.go
@@ -11,7 +11,7 @@ import (
 )
 
 type NanosecondsArguments[K any] struct {
-	Duration ottl.DurationGetter[K] `ottlarg:"0"`
+	Duration ottl.DurationGetter[K]
 }
 
 func NewNanosecondsFactory[K any]() ottl.Factory[K] {

--- a/pkg/ottl/ottlfuncs/func_seconds.go
+++ b/pkg/ottl/ottlfuncs/func_seconds.go
@@ -11,7 +11,7 @@ import (
 )
 
 type SecondsArguments[K any] struct {
-	Duration ottl.DurationGetter[K] `ottlarg:"0"`
+	Duration ottl.DurationGetter[K]
 }
 
 func NewSecondsFactory[K any]() ottl.Factory[K] {

--- a/pkg/ottl/ottlfuncs/func_unix_micro.go
+++ b/pkg/ottl/ottlfuncs/func_unix_micro.go
@@ -11,7 +11,7 @@ import (
 )
 
 type UnixMicroArguments[K any] struct {
-	Time ottl.TimeGetter[K] `ottlarg:"0"`
+	Time ottl.TimeGetter[K]
 }
 
 func NewUnixMicroFactory[K any]() ottl.Factory[K] {

--- a/pkg/ottl/ottlfuncs/func_unix_milli.go
+++ b/pkg/ottl/ottlfuncs/func_unix_milli.go
@@ -11,7 +11,7 @@ import (
 )
 
 type UnixMilliArguments[K any] struct {
-	Time ottl.TimeGetter[K] `ottlarg:"0"`
+	Time ottl.TimeGetter[K]
 }
 
 func NewUnixMilliFactory[K any]() ottl.Factory[K] {

--- a/pkg/ottl/ottlfuncs/func_unix_nano.go
+++ b/pkg/ottl/ottlfuncs/func_unix_nano.go
@@ -11,7 +11,7 @@ import (
 )
 
 type UnixNanoArguments[K any] struct {
-	Time ottl.TimeGetter[K] `ottlarg:"0"`
+	Time ottl.TimeGetter[K]
 }
 
 func NewUnixNanoFactory[K any]() ottl.Factory[K] {

--- a/pkg/ottl/ottlfuncs/func_unix_seconds.go
+++ b/pkg/ottl/ottlfuncs/func_unix_seconds.go
@@ -11,7 +11,7 @@ import (
 )
 
 type UnixSecondsArguments[K any] struct {
-	Time ottl.TimeGetter[K] `ottlarg:"0"`
+	Time ottl.TimeGetter[K]
 }
 
 func NewUnixSecondsFactory[K any]() ottl.Factory[K] {

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum.go
@@ -14,8 +14,8 @@ import (
 )
 
 type convertGaugeToSumArguments struct {
-	StringAggTemp string `ottlarg:"0"`
-	Monotonic     bool   `ottlarg:"1"`
+	StringAggTemp string
+	Monotonic     bool
 }
 
 func newConvertGaugeToSumFactory() ottl.Factory[ottldatapoint.TransformContext] {

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum.go
@@ -14,8 +14,8 @@ import (
 )
 
 type convertSummaryCountValToSumArguments struct {
-	StringAggTemp string `ottlarg:"0"`
-	Monotonic     bool   `ottlarg:"1"`
+	StringAggTemp string
+	Monotonic     bool
 }
 
 func newConvertSummaryCountValToSumFactory() ottl.Factory[ottldatapoint.TransformContext] {

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum.go
@@ -14,8 +14,8 @@ import (
 )
 
 type convertSummarySumValToSumArguments struct {
-	StringAggTemp string `ottlarg:"0"`
-	Monotonic     bool   `ottlarg:"1"`
+	StringAggTemp string
+	Monotonic     bool
 }
 
 func newConvertSummarySumValToSumFactory() ottl.Factory[ottldatapoint.TransformContext] {

--- a/processor/transformprocessor/internal/metrics/func_extract_count_metric.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_count_metric.go
@@ -14,7 +14,7 @@ import (
 )
 
 type extractCountMetricArguments struct {
-	Monotonic bool `ottlarg:"0"`
+	Monotonic bool
 }
 
 func newExtractCountMetricFactory() ottl.Factory[ottlmetric.TransformContext] {

--- a/processor/transformprocessor/internal/metrics/func_extract_sum_metric.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_sum_metric.go
@@ -15,7 +15,7 @@ import (
 )
 
 type extractSumMetricArguments struct {
-	Monotonic bool `ottlarg:"0"`
+	Monotonic bool
 }
 
 func newExtractSumMetricFactory() ottl.Factory[ottlmetric.TransformContext] {


### PR DESCRIPTION
**Description:** 
Removes all instances of `ottlarg`. Followup to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/25705

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24874
