### PR TITLE
[chore] Update collector demo

### DIFF
--- a/examples/demo/.env
+++ b/examples/demo/.env
@@ -1,2 +1,2 @@
-OTELCOL_IMG=otel/opentelemetry-collector:0.67.0
+OTELCOL_IMG=otel/opentelemetry-collector:0.85.0
 OTELCOL_ARGS=

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -24,7 +24,7 @@ This demo uses `docker-compose` and by default runs against the
 to the `examples/demo` folder and run:
 
 ```shell
-docker-compose up -d
+docker compose up -d
 ```
 
 The demo exposes the following backends:

--- a/examples/demo/otel-collector-config.yaml
+++ b/examples/demo/otel-collector-config.yaml
@@ -15,8 +15,8 @@ exporters:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
     format: proto
 
-  jaeger:
-    endpoint: jaeger-all-in-one:14250
+  otlp:
+    endpoint: jaeger-all-in-one:4317
     tls:
       insecure: true
 
@@ -36,7 +36,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, zipkin, jaeger]
+      exporters: [logging, zipkin, otlp]
     metrics:
       receivers: [otlp]
       processors: [batch]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26546 removed the jaeger exporter, but the `build-and-test` workflow depended on that exporter since it uses the config in `examples/demo/otel-collector-config.yaml` for its test.

This PR updates the demo to use OTLP with jaeger, which also fixes the `rpm` and `deb` test job in `build-and-test`.