### PR TITLE
[chore][pkg/stanza] Decrease log level when reporting no files found

### DIFF
--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -115,7 +115,7 @@ func (m *Manager) poll(ctx context.Context) {
 	// Get the list of paths on disk
 	matches, err := m.fileMatcher.MatchFiles()
 	if err != nil {
-		m.Warnf("finding files: %v", err)
+		m.Infof("finding files: %v", err)
 	}
 
 	for len(matches) > m.maxBatchFiles {


### PR DESCRIPTION
When the component starts, if it finds no matching files, it reports a warning level message.

However, after the initial check, this may be too noisy because each poll result may report the same thing. Instead, report subsequent "no files found" as info level.