### PR TITLE
[connector/routing] Change stability to alpha

### DIFF
--- a/.chloggen/routing_connector_alpha.yaml
+++ b/.chloggen/routing_connector_alpha.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: routingconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change routingconnector stability to alpha
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26495]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/routingconnector/README.md
+++ b/connector/routingconnector/README.md
@@ -7,16 +7,16 @@
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aconnector%2Frouting%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aconnector%2Frouting) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aconnector%2Frouting%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aconnector%2Frouting) |
 | [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@jpkrohling](https://www.github.com/jpkrohling), [@mwear](https://www.github.com/mwear) |
 
-[development]: https://github.com/open-telemetry/opentelemetry-collector#development
+[alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 
 ## Supported Pipeline Types
 
 | [Exporter Pipeline Type] | [Receiver Pipeline Type] | [Stability Level] |
 | ------------------------ | ------------------------ | ----------------- |
-| traces | traces | [development] |
-| metrics | metrics | [development] |
-| logs | logs | [development] |
+| traces | traces | [alpha] |
+| metrics | metrics | [alpha] |
+| logs | logs | [alpha] |
 
 [Exporter Pipeline Type]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md#exporter-pipeline-type
 [Receiver Pipeline Type]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md#receiver-pipeline-type

--- a/connector/routingconnector/internal/metadata/generated_status.go
+++ b/connector/routingconnector/internal/metadata/generated_status.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	Type                      = "routing"
-	TracesToTracesStability   = component.StabilityLevelDevelopment
-	MetricsToMetricsStability = component.StabilityLevelDevelopment
-	LogsToLogsStability       = component.StabilityLevelDevelopment
+	TracesToTracesStability   = component.StabilityLevelAlpha
+	MetricsToMetricsStability = component.StabilityLevelAlpha
+	LogsToLogsStability       = component.StabilityLevelAlpha
 )

--- a/connector/routingconnector/metadata.yaml
+++ b/connector/routingconnector/metadata.yaml
@@ -3,7 +3,7 @@ type: routing
 status:
   class: connector
   stability:
-    development: [traces_to_traces, metrics_to_metrics, logs_to_logs]
+    alpha: [traces_to_traces, metrics_to_metrics, logs_to_logs]
   distributions: [contrib]
   codeowners:
     active: [jpkrohling, mwear]


### PR DESCRIPTION
**Description:**
This PR changes the stability of the routing connector to alpha so that it will be included in the contrib images for usage by early adopters. The connector is not yet feature complete, but resource attribute based routing is. There are users interested in using it and potentially contributing additional functionality.

**Link to tracking Issue:** #26495
