### PR TITLE
[pkg/ottl] Add new TruncateTime function

### DIFF
--- a/.chloggen/ottl-truncate-function.yaml
+++ b/.chloggen/ottl-truncate-function.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add new `TruncateTime` function to help with manipulation of timestamps
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26696]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -299,6 +299,8 @@ Available Converters:
 - [Split](#split)
 - [Substring](#substring)
 - [Time](#time)
+- [TraceID](#traceid)
+- [TruncateTime](#truncatetime)
 - [UnixMicro](#unixmicro)
 - [UnixMilli](#unixmilli)
 - [UnixNano](#unixnano)
@@ -750,6 +752,20 @@ The `TraceID` Converter returns a `pdata.TraceID` struct from the given byte sli
 Examples:
 
 - `TraceID(0x00000000000000000000000000000000)`
+
+### TruncateTime
+
+`TruncateTime(time, duration)`
+
+The `TruncateTime` Converter returns the given time rounded down to a multiple of the given duration. The Converter [uses the `time.Truncate` function](https://pkg.go.dev/time#Time.Truncate).
+
+`time` is a `time.Time`. `duration` is a `time.Duration`. If `time` is not a `time.Time` or if `duration` is not a `time.Duration`, an error will be returned. 
+
+While some common paths can return a `time.Time` object, you will most like need to use the [Duration Converter](#duration) to create a `time.Duration`.
+
+Examples:
+
+- `TruncateTime(start_time, Duration("1s"))`
 
 ### UnixMicro
 

--- a/pkg/ottl/ottlfuncs/func_truncate_time.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_time.go
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type TruncateTimeArguments[K any] struct {
+	Time     ottl.TimeGetter[K]
+	Duration ottl.DurationGetter[K]
+}
+
+func NewTruncateTimeFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("TruncateTime", &TruncateTimeArguments[K]{}, createTruncateTimeFunction[K])
+}
+func createTruncateTimeFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*TruncateTimeArguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("TimeFactory args must be of type *TruncateTimeArguments[K]")
+	}
+
+	return TruncateTime(args.Time, args.Duration)
+}
+
+func TruncateTime[K any](inputTime ottl.TimeGetter[K], inputDuration ottl.DurationGetter[K]) (ottl.ExprFunc[K], error) {
+	return func(ctx context.Context, tCtx K) (interface{}, error) {
+		t, err := inputTime.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		d, err := inputDuration.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		return t.Truncate(d), nil
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_truncate_time_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_time_test.go
@@ -51,6 +51,21 @@ func Test_TruncateTime(t *testing.T) {
 			},
 			expected: time.Date(2022, 1, 1, 1, 1, 1, 999000000, time.Local),
 		},
+		{
+			name: "truncate old time",
+			time: &ottl.StandardTimeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return time.Date(1980, 9, 9, 9, 59, 59, 999999999, time.Local), nil
+				},
+			},
+			duration: &ottl.StandardDurationGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					d, _ := time.ParseDuration("1h")
+					return d, nil
+				},
+			},
+			expected: time.Date(1980, 9, 9, 9, 0, 0, 0, time.Local),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ottl/ottlfuncs/func_truncate_time_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_time_test.go
@@ -1,0 +1,111 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_TruncateTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		time     ottl.TimeGetter[interface{}]
+		duration ottl.DurationGetter[interface{}]
+		expected time.Time
+	}{
+		{
+			name: "truncate to 1s",
+			time: &ottl.StandardTimeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return time.Date(2022, 1, 1, 1, 1, 1, 999999999, time.Local), nil
+				},
+			},
+			duration: &ottl.StandardDurationGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					d, _ := time.ParseDuration("1s")
+					return d, nil
+				},
+			},
+			expected: time.Date(2022, 1, 1, 1, 1, 1, 0, time.Local),
+		},
+		{
+			name: "truncate to 1ms",
+			time: &ottl.StandardTimeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return time.Date(2022, 1, 1, 1, 1, 1, 999999999, time.Local), nil
+				},
+			},
+			duration: &ottl.StandardDurationGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					d, _ := time.ParseDuration("1ms")
+					return d, nil
+				},
+			},
+			expected: time.Date(2022, 1, 1, 1, 1, 1, 999000000, time.Local),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := TruncateTime(tt.time, tt.duration)
+			assert.NoError(t, err)
+			result, err := exprFunc(context.Background(), nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected.UnixNano(), result.(time.Time).UnixNano())
+		})
+	}
+}
+
+func Test_TruncateTimeError(t *testing.T) {
+	tests := []struct {
+		name          string
+		time          ottl.TimeGetter[interface{}]
+		duration      ottl.DurationGetter[interface{}]
+		expectedError string
+	}{
+		{
+			name: "not a time",
+			time: &ottl.StandardTimeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "11/11/11", nil
+				},
+			},
+			duration: &ottl.StandardDurationGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					d, _ := time.ParseDuration("1ms")
+					return d, nil
+				},
+			},
+			expectedError: "expected time but got string",
+		},
+		{
+			name: "not a duration",
+			time: &ottl.StandardTimeGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return time.Now(), nil
+				},
+			},
+			duration: &ottl.StandardDurationGetter[interface{}]{
+				Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+					return "string", nil
+				},
+			},
+			expectedError: "expected duration but got string",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := TruncateTime[any](tt.time, tt.duration)
+			require.NoError(t, err)
+			_, err = exprFunc(context.Background(), nil)
+			assert.ErrorContains(t, err, tt.expectedError)
+		})
+	}
+}

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -58,6 +58,7 @@ func converters[K any]() []ottl.Factory[K] {
 		NewSplitFactory[K](),
 		NewSubstringFactory[K](),
 		NewTimeFactory[K](),
+		NewTruncateTimeFactory[K](),
 		NewTraceIDFactory[K](),
 		NewUnixMicroFactory[K](),
 		NewUnixMilliFactory[K](),


### PR DESCRIPTION
**Description:** 
To facilitate more time manipulation scenarios, this PR adds a new `TruncateTime` function that exposes Go's [`time.Truncate` function ](https://pkg.go.dev/time#Time.Truncate).

**Link to tracking Issue:** 
Related to:
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16067
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16562

**Testing:**
Added new unit tests

**Documentation:** <Describe the documentation added.>
Updated ottlfunc readme