### PR TITLE
fixes for checkapi

### DIFF
--- a/.chloggen/checkapi-fluentforwarder-26304.yaml
+++ b/.chloggen/checkapi-fluentforwarder-26304.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component:  fluentforwardreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "rename `Logs` and `DetermineNextEventMode` functions and all usage to lowercase to stop exporting method and pass checkapi"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26304]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -21,7 +21,6 @@ processor/tailsamplingprocessor
 receiver/carbonreceiver
 receiver/collectdreceiver
 receiver/dockerstatsreceiver
-receiver/fluentforwardreceiver
 receiver/jaegerreceiver
 receiver/journaldreceiver
 receiver/kafkareceiver

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -23,7 +23,7 @@ func TestMessageEventConversion(t *testing.T) {
 	err := event.DecodeMsg(reader)
 	require.Nil(t, err)
 
-	expectedLog := Logs(
+	expectedLog := logs(
 		Log{
 			Timestamp: 1593031012000000000,
 			Body:      pcommon.NewValueStr("..."),
@@ -90,7 +90,7 @@ func TestAttributeTypeConversion(t *testing.T) {
 
 	le := event.LogRecords().At(0)
 
-	require.NoError(t, plogtest.CompareLogRecord(Logs(
+	require.NoError(t, plogtest.CompareLogRecord(logs(
 		Log{
 			Timestamp: 5000000000000,
 			Body:      pcommon.NewValueEmpty(),
@@ -236,7 +236,7 @@ func TestBodyConversion(t *testing.T) {
 	cv := body.Map().PutEmptyMap("c")
 	cv.PutInt("d", 24)
 
-	require.NoError(t, plogtest.CompareLogRecord(Logs(
+	require.NoError(t, plogtest.CompareLogRecord(logs(
 		Log{
 			Timestamp: 5000000000000,
 			Body:      body,

--- a/receiver/fluentforwardreceiver/receiver_test.go
+++ b/receiver/fluentforwardreceiver/receiver_test.go
@@ -108,7 +108,7 @@ func TestMessageEvent(t *testing.T) {
 		return len(converted) == 1
 	}, 5*time.Second, 10*time.Millisecond)
 
-	require.NoError(t, plogtest.CompareLogs(Logs(Log{
+	require.NoError(t, plogtest.CompareLogs(logs(Log{
 		Timestamp: 1593031012000000000,
 		Body:      pcommon.NewValueStr("..."),
 		Attributes: map[string]interface{}{
@@ -138,7 +138,7 @@ func TestForwardEvent(t *testing.T) {
 		return len(converted) == 1
 	}, 5*time.Second, 10*time.Millisecond)
 
-	require.NoError(t, plogtest.CompareLogs(Logs(
+	require.NoError(t, plogtest.CompareLogs(logs(
 		Log{
 			Timestamp: 1593032377776693638,
 			Body:      pcommon.NewValueEmpty(),
@@ -217,7 +217,7 @@ func TestForwardPackedEvent(t *testing.T) {
 		return len(converted) == 1
 	}, 5*time.Second, 10*time.Millisecond)
 
-	require.NoError(t, plogtest.CompareLogs(Logs(
+	require.NoError(t, plogtest.CompareLogs(logs(
 		Log{
 			Timestamp: 1593032517024597622,
 			Body:      pcommon.NewValueStr("starting fluentd worker pid=17 ppid=7 worker=0"),
@@ -279,7 +279,7 @@ func TestForwardPackedCompressedEvent(t *testing.T) {
 		return len(converted) == 1
 	}, 5*time.Second, 10*time.Millisecond)
 
-	require.NoError(t, plogtest.CompareLogs(Logs(
+	require.NoError(t, plogtest.CompareLogs(logs(
 		Log{
 			Timestamp: 1593032426012197420,
 			Body:      pcommon.NewValueStr("starting fluentd worker pid=17 ppid=7 worker=0"),

--- a/receiver/fluentforwardreceiver/server.go
+++ b/receiver/fluentforwardreceiver/server.go
@@ -81,7 +81,7 @@ func (s *server) handleConn(ctx context.Context, conn net.Conn) error {
 	reader := msgp.NewReaderSize(conn, readBufferSize)
 
 	for {
-		mode, err := DetermineNextEventMode(reader.R)
+		mode, err := determineNextEventMode(reader.R)
 		if err != nil {
 			return err
 		}
@@ -125,13 +125,13 @@ func (s *server) handleConn(ctx context.Context, conn net.Conn) error {
 	}
 }
 
-// DetermineNextEventMode inspects the next bit of data from the given peeker
+// determineNextEventMode inspects the next bit of data from the given peeker
 // reader to determine which type of event mode it is.  According to the
 // forward protocol spec: "Server MUST detect the carrier mode by inspecting
 // the second element of the array."  It is assumed that peeker is aligned at
 // the start of a new event, otherwise the result is undefined and will
 // probably error.
-func DetermineNextEventMode(peeker Peeker) (EventMode, error) {
+func determineNextEventMode(peeker Peeker) (EventMode, error) {
 	var chunk []byte
 	var err error
 	chunk, err = peeker.Peek(2)

--- a/receiver/fluentforwardreceiver/server_test.go
+++ b/receiver/fluentforwardreceiver/server_test.go
@@ -105,7 +105,7 @@ func TestDetermineNextEventMode(t *testing.T) {
 		c := cases[i]
 		t.Run(c.name, func(t *testing.T) {
 			peeker := bufio.NewReaderSize(bytes.NewReader(c.event()), 1024*100)
-			mode, err := DetermineNextEventMode(peeker)
+			mode, err := determineNextEventMode(peeker)
 			if c.expectedError != nil {
 				require.Equal(t, c.expectedError, err)
 			} else {

--- a/receiver/fluentforwardreceiver/util_test.go
+++ b/receiver/fluentforwardreceiver/util_test.go
@@ -16,11 +16,11 @@ type Log struct {
 	Attributes map[string]interface{}
 }
 
-// Logs is a convenience function for constructing logs for tests in a way that is
+// logs is a convenience function for constructing logs for tests in a way that is
 // relatively easy to read and write declaratively compared to the highly
 // imperative and verbose method of using pdata directly.
 // Attributes are sorted by key name.
-func Logs(recs ...Log) plog.Logs {
+func logs(recs ...Log) plog.Logs {
 	out := plog.NewLogs()
 	logSlice := out.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords()
 	logSlice.EnsureCapacity(len(recs))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Stop exporting `Logs` and `DetermineNextEventMode` to align with  `checkapi`  standards as related to issue #26304 

**Link to tracking Issue:**  #26304 

**Testing:** 
-  `go run cmd/checkapi/main.go .`
- `go test`  for `fluentforwardreceiver`

**Documentation:** 