### PR TITLE
[pkg/stanza] propagate globbing io errors for logging

### DIFF
--- a/.chloggen/filelogreceiver_log_globing_io_errors.yaml
+++ b/.chloggen/filelogreceiver_log_globing_io_errors.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Log the globbing IO errors
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23768]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
+++ b/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
@@ -20,10 +20,13 @@ func Validate(globs []string) error {
 }
 
 // FindFiles gets a list of paths given an array of glob patterns to include and exclude
-func FindFiles(includes []string, excludes []string) []string {
+func FindFiles(includes []string, excludes []string) ([]string, error) {
 	all := make([]string, 0, len(includes))
 	for _, include := range includes {
-		matches, _ := doublestar.FilepathGlob(include, doublestar.WithFilesOnly()) // compile error checked in build
+		matches, err := doublestar.FilepathGlob(include, doublestar.WithFilesOnly(), doublestar.WithFailOnIOErrors())
+		if err != nil {
+			return all, err
+		}
 	INCLUDE:
 		for _, match := range matches {
 			for _, exclude := range excludes {
@@ -42,5 +45,5 @@ func FindFiles(includes []string, excludes []string) []string {
 		}
 	}
 
-	return all
+	return all, nil
 }

--- a/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
+++ b/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
@@ -28,6 +28,7 @@ func FindFiles(includes []string, excludes []string) ([]string, error) {
 		matches, err := doublestar.FilepathGlob(include, doublestar.WithFilesOnly(), doublestar.WithFailOnIOErrors())
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("find files with '%s' pattern: %w", include, err))
+			matches, _ = doublestar.FilepathGlob(include, doublestar.WithFilesOnly())
 		}
 	INCLUDE:
 		for _, match := range matches {

--- a/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
+++ b/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
@@ -4,6 +4,7 @@
 package finder // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/matcher/internal/finder"
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -21,11 +22,12 @@ func Validate(globs []string) error {
 
 // FindFiles gets a list of paths given an array of glob patterns to include and exclude
 func FindFiles(includes []string, excludes []string) ([]string, error) {
+	var errs error
 	all := make([]string, 0, len(includes))
 	for _, include := range includes {
 		matches, err := doublestar.FilepathGlob(include, doublestar.WithFilesOnly(), doublestar.WithFailOnIOErrors())
 		if err != nil {
-			return all, err
+			errs = errors.Join(errs, fmt.Errorf("find files with '%s' pattern: %w", include, err))
 		}
 	INCLUDE:
 		for _, match := range matches {
@@ -45,5 +47,5 @@ func FindFiles(includes []string, excludes []string) ([]string, error) {
 		}
 	}
 
-	return all, nil
+	return all, errs
 }

--- a/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
+++ b/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
@@ -28,6 +28,8 @@ func FindFiles(includes []string, excludes []string) ([]string, error) {
 		matches, err := doublestar.FilepathGlob(include, doublestar.WithFilesOnly(), doublestar.WithFailOnIOErrors())
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("find files with '%s' pattern: %w", include, err))
+			// the same pattern could cause an IO error due to one file or directory,
+			// but also could still find files without `doublestar.WithFailOnIOErrors()`.
 			matches, _ = doublestar.FilepathGlob(include, doublestar.WithFilesOnly())
 		}
 	INCLUDE:

--- a/pkg/stanza/fileconsumer/matcher/internal/finder/finder_test.go
+++ b/pkg/stanza/fileconsumer/matcher/internal/finder/finder_test.go
@@ -177,14 +177,17 @@ func TestFindFiles(t *testing.T) {
 			for _, f := range tc.files {
 				require.NoError(t, os.MkdirAll(filepath.Dir(f), 0700))
 
-				file, err := os.OpenFile(f, os.O_CREATE|os.O_RDWR, 0600)
+				var file *os.File
+				file, err = os.OpenFile(f, os.O_CREATE|os.O_RDWR, 0600)
 				require.NoError(t, err)
 
 				_, err = file.WriteString(filepath.Base(f))
 				require.NoError(t, err)
 				require.NoError(t, file.Close())
 			}
-			assert.Equal(t, tc.expected, FindFiles(tc.include, tc.exclude))
+			files, err := FindFiles(tc.include, tc.exclude)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, files)
 		})
 	}
 }

--- a/pkg/stanza/fileconsumer/matcher/matcher.go
+++ b/pkg/stanza/fileconsumer/matcher/matcher.go
@@ -124,7 +124,7 @@ func (m Matcher) MatchFiles() ([]string, error) {
 
 	result, err := filter.Filter(files, m.regex, m.filterOpts...)
 	if len(result) == 0 {
-		return result, errors.Join(errs, err)
+		return result, errors.Join(err, errs)
 	}
 
 	// Return only the first item.

--- a/pkg/stanza/fileconsumer/matcher/matcher.go
+++ b/pkg/stanza/fileconsumer/matcher/matcher.go
@@ -109,7 +109,10 @@ type Matcher struct {
 
 // MatchFiles gets a list of paths given an array of glob patterns to include and exclude
 func (m Matcher) MatchFiles() ([]string, error) {
-	files := finder.FindFiles(m.include, m.exclude)
+	files, err := finder.FindFiles(m.include, m.exclude)
+	if err != nil {
+		return files, err
+	}
 	if len(files) == 0 {
 		return files, fmt.Errorf("no files match the configured criteria")
 	}

--- a/pkg/stanza/fileconsumer/matcher/matcher.go
+++ b/pkg/stanza/fileconsumer/matcher/matcher.go
@@ -129,5 +129,5 @@ func (m Matcher) MatchFiles() ([]string, error) {
 
 	// Return only the first item.
 	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23788
-	return result[:1], errors.Join(errs, err)
+	return result[:1], errors.Join(err, errs)
 }

--- a/pkg/stanza/fileconsumer/matcher/matcher.go
+++ b/pkg/stanza/fileconsumer/matcher/matcher.go
@@ -116,7 +116,7 @@ func (m Matcher) MatchFiles() ([]string, error) {
 		errs = errors.Join(errs, err)
 	}
 	if len(files) == 0 {
-		return files, errors.Join(errs, fmt.Errorf("no files match the configured criteria"))
+		return files, errors.Join(fmt.Errorf("no files match the configured criteria"), errs)
 	}
 	if len(m.filterOpts) == 0 {
 		return files, errs


### PR DESCRIPTION
**Description:**
Set `WithFailOnIOErrors` option and propagate the globbing io errors for logging.

**Link to tracking Issue:**
resolve #23768