### PR TITLE
[chore] update examples to use debugexporter

### DIFF
--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -619,6 +619,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.86.0 // indirect
 	go.opentelemetry.io/collector/connector v0.86.0 // indirect
 	go.opentelemetry.io/collector/consumer v0.86.0 // indirect
+	go.opentelemetry.io/collector/exporter/debugexporter v0.86.0 // indirect
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0 // indirect
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.86.0 // indirect
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.86.0 // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -1686,6 +1686,8 @@ go.opentelemetry.io/collector/consumer v0.86.0 h1:8AL9I30tJV01KfcSaa+8DTiARIiUDA
 go.opentelemetry.io/collector/consumer v0.86.0/go.mod h1:SvoV1eto4VZzQ3ILKQ1rv4qgN8rUMJqupn78hoXLHRw=
 go.opentelemetry.io/collector/exporter v0.86.0 h1:LFmBb7S4Fkj5fv/nrUkLOy50GT6s4R/BLrv6uTb+GNo=
 go.opentelemetry.io/collector/exporter v0.86.0/go.mod h1:+PKZrFV4sVgS2TVFnfZ+RCJqXexEENjW1riWaqkxsN4=
+go.opentelemetry.io/collector/exporter/debugexporter v0.86.0 h1:F76S/yAJg6f2CgdOJJ6BDSEYkG87xgqkBsWSQWKghts=
+go.opentelemetry.io/collector/exporter/debugexporter v0.86.0/go.mod h1:bdgxipCPu/81HPS9x6CMmd3IW2BbnjMGyanD4DLveRs=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0 h1:cS8w7CSZ6cy8Q4qMec291fxihj41zLrV103ABfJf/F8=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0/go.mod h1:T9YhRZ/9ZfT8Hf0etTpwkbBx5yS+wg5RKrk8TSDXV3A=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.86.0 h1:xngHj6dvluhl5JgLtmyQ56OXGZEDwmcg4roYcA6freM=

--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -31,6 +31,7 @@ extensions:
     import: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/dbstorage
 
 exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.86.0
   - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.86.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.86.0

--- a/cmd/otelcontribcol/components.go
+++ b/cmd/otelcontribcol/components.go
@@ -6,6 +6,7 @@ import (
 	"go.opentelemetry.io/collector/connector"
 	forwardconnector "go.opentelemetry.io/collector/connector/forwardconnector"
 	"go.opentelemetry.io/collector/exporter"
+	debugexporter "go.opentelemetry.io/collector/exporter/debugexporter"
 	loggingexporter "go.opentelemetry.io/collector/exporter/loggingexporter"
 	otlpexporter "go.opentelemetry.io/collector/exporter/otlpexporter"
 	otlphttpexporter "go.opentelemetry.io/collector/exporter/otlphttpexporter"
@@ -321,6 +322,7 @@ func components() (otelcol.Factories, error) {
 	}
 
 	factories.Exporters, err = exporter.MakeFactoryMap(
+		debugexporter.NewFactory(),
 		loggingexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),

--- a/cmd/otelcontribcol/exporters_test.go
+++ b/cmd/otelcontribcol/exporters_test.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -105,8 +104,10 @@ func TestDefaultExporters(t *testing.T) {
 			},
 		},
 		{
-			exporter:      "logging",
-			skipLifecycle: runtime.GOOS == "darwin", // TODO: investigate why this fails on darwin.
+			exporter: "debug",
+		},
+		{
+			exporter: "logging",
 		},
 		{
 			exporter: "opencensus",

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -191,6 +191,7 @@ require (
 	go.opentelemetry.io/collector/connector/forwardconnector v0.86.0
 	go.opentelemetry.io/collector/consumer v0.86.0
 	go.opentelemetry.io/collector/exporter v0.86.0
+	go.opentelemetry.io/collector/exporter/debugexporter v0.86.0
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.86.0
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.86.0

--- a/cmd/otelcontribcol/go.sum
+++ b/cmd/otelcontribcol/go.sum
@@ -2170,6 +2170,8 @@ go.opentelemetry.io/collector/consumer v0.86.0 h1:8AL9I30tJV01KfcSaa+8DTiARIiUDA
 go.opentelemetry.io/collector/consumer v0.86.0/go.mod h1:SvoV1eto4VZzQ3ILKQ1rv4qgN8rUMJqupn78hoXLHRw=
 go.opentelemetry.io/collector/exporter v0.86.0 h1:LFmBb7S4Fkj5fv/nrUkLOy50GT6s4R/BLrv6uTb+GNo=
 go.opentelemetry.io/collector/exporter v0.86.0/go.mod h1:+PKZrFV4sVgS2TVFnfZ+RCJqXexEENjW1riWaqkxsN4=
+go.opentelemetry.io/collector/exporter/debugexporter v0.86.0 h1:F76S/yAJg6f2CgdOJJ6BDSEYkG87xgqkBsWSQWKghts=
+go.opentelemetry.io/collector/exporter/debugexporter v0.86.0/go.mod h1:bdgxipCPu/81HPS9x6CMmd3IW2BbnjMGyanD4DLveRs=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0 h1:cS8w7CSZ6cy8Q4qMec291fxihj41zLrV103ABfJf/F8=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0/go.mod h1:T9YhRZ/9ZfT8Hf0etTpwkbBx5yS+wg5RKrk8TSDXV3A=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.86.0 h1:xngHj6dvluhl5JgLtmyQ56OXGZEDwmcg4roYcA6freM=

--- a/cmd/oteltestbedcol/builder-config.yaml
+++ b/cmd/oteltestbedcol/builder-config.yaml
@@ -13,6 +13,7 @@ extensions:
     import: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
 
 exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.86.0
   - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.86.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.86.0

--- a/cmd/oteltestbedcol/components.go
+++ b/cmd/oteltestbedcol/components.go
@@ -5,6 +5,7 @@ package main
 import (
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/exporter"
+	debugexporter "go.opentelemetry.io/collector/exporter/debugexporter"
 	loggingexporter "go.opentelemetry.io/collector/exporter/loggingexporter"
 	otlpexporter "go.opentelemetry.io/collector/exporter/otlpexporter"
 	otlphttpexporter "go.opentelemetry.io/collector/exporter/otlphttpexporter"
@@ -80,6 +81,7 @@ func components() (otelcol.Factories, error) {
 	}
 
 	factories.Exporters, err = exporter.MakeFactoryMap(
+		debugexporter.NewFactory(),
 		loggingexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),

--- a/cmd/oteltestbedcol/go.mod
+++ b/cmd/oteltestbedcol/go.mod
@@ -34,6 +34,7 @@ require (
 	go.opentelemetry.io/collector/component v0.86.0
 	go.opentelemetry.io/collector/connector v0.86.0
 	go.opentelemetry.io/collector/exporter v0.86.0
+	go.opentelemetry.io/collector/exporter/debugexporter v0.86.0
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.86.0
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.86.0

--- a/cmd/oteltestbedcol/go.sum
+++ b/cmd/oteltestbedcol/go.sum
@@ -1263,6 +1263,8 @@ go.opentelemetry.io/collector/consumer v0.86.0 h1:8AL9I30tJV01KfcSaa+8DTiARIiUDA
 go.opentelemetry.io/collector/consumer v0.86.0/go.mod h1:SvoV1eto4VZzQ3ILKQ1rv4qgN8rUMJqupn78hoXLHRw=
 go.opentelemetry.io/collector/exporter v0.86.0 h1:LFmBb7S4Fkj5fv/nrUkLOy50GT6s4R/BLrv6uTb+GNo=
 go.opentelemetry.io/collector/exporter v0.86.0/go.mod h1:+PKZrFV4sVgS2TVFnfZ+RCJqXexEENjW1riWaqkxsN4=
+go.opentelemetry.io/collector/exporter/debugexporter v0.86.0 h1:F76S/yAJg6f2CgdOJJ6BDSEYkG87xgqkBsWSQWKghts=
+go.opentelemetry.io/collector/exporter/debugexporter v0.86.0/go.mod h1:bdgxipCPu/81HPS9x6CMmd3IW2BbnjMGyanD4DLveRs=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0 h1:cS8w7CSZ6cy8Q4qMec291fxihj41zLrV103ABfJf/F8=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0/go.mod h1:T9YhRZ/9ZfT8Hf0etTpwkbBx5yS+wg5RKrk8TSDXV3A=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.86.0 h1:xngHj6dvluhl5JgLtmyQ56OXGZEDwmcg4roYcA6freM=

--- a/cmd/telemetrygen/README.md
+++ b/cmd/telemetrygen/README.md
@@ -38,7 +38,7 @@ receivers:
 processors:
 
 exporters:
-  logging:
+  debug:
 
 service:
   pipelines:
@@ -47,7 +47,7 @@ service:
       - otlp
       processors: []
       exporters:
-      - logging
+      - debug
 ```
 
 Once the OpenTelemetry Collector instance is up and running, run `telemetrygen` for your desired telemetry:

--- a/confmap/provider/s3provider/testdata/otel-config.yaml
+++ b/confmap/provider/s3provider/testdata/otel-config.yaml
@@ -20,18 +20,18 @@ processors:
     check_interval: 5s
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [logging]
+      exporters: [debug]
 
   extensions: [memory_ballast, zpages]

--- a/examples/demo/otel-collector-config.yaml
+++ b/examples/demo/otel-collector-config.yaml
@@ -9,7 +9,7 @@ exporters:
     const_labels:
       label1: value1
 
-  logging:
+  debug:
 
   zipkin:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
@@ -36,8 +36,8 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, zipkin, otlp]
+      exporters: [debug, zipkin, otlp]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, prometheus]
+      exporters: [debug, prometheus]

--- a/examples/kubernetes/otel-collector-config.yml
+++ b/examples/kubernetes/otel-collector-config.yml
@@ -74,10 +74,10 @@ receivers:
         from: attributes.uid
         to: resource["k8s.pod.uid"]
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 service:
   pipelines:
     logs:
       receivers: [filelog]
-      exporters: [logging]
+      exporters: [debug]

--- a/examples/kubernetes/otel-collector.yaml
+++ b/examples/kubernetes/otel-collector.yaml
@@ -113,14 +113,14 @@ data:
           - from: connection
 
     exporters:
-      logging:
-        loglevel: debug
+      debug:
+        verbosity: detailed
     service:
       pipelines:
         logs:
           receivers: [filelog]
           processors: [k8sattributes]
-          exporters: [logging]
+          exporters: [debug]
 
 ---
 apiVersion: apps/v1

--- a/examples/nomad/otel-collector.nomad
+++ b/examples/nomad/otel-collector.nomad
@@ -96,14 +96,14 @@ processors:
     check_interval: 5s
 
 exporters:
-  logging:
-    logLevel: debug
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
 
 EOH
 

--- a/exporter/fileexporter/README.md
+++ b/exporter/fileexporter/README.md
@@ -125,7 +125,7 @@ spec:
     processors:
 
     exporters:
-      logging:
+      debug:
       file:
         path: /data/metrics.json
 
@@ -134,7 +134,7 @@ spec:
         metrics:
           receivers: [otlp]
           processors: []
-          exporters: [logging,file]
+          exporters: [debug,file]
   volumes:
     - name: file
       emptyDir: {}

--- a/exporter/instanaexporter/README.md
+++ b/exporter/instanaexporter/README.md
@@ -62,8 +62,6 @@ receivers:
 processors:
   batch:
 exporters:
-  logging:
-    loglevel: debug
   instana:
     endpoint: ${env:INSTANA_ENDPOINT_URL}
     agent_key: ${env:INSTANA_AGENT_KEY}

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -79,7 +79,6 @@ receivers:
 processors:
 
 exporters:
-  logging:
   loadbalancing:
     routing_key: "service"
     protocol:
@@ -122,7 +121,6 @@ receivers:
 processors:
 
 exporters:
-  logging:
   loadbalancing:
     routing_key: "service"
     protocol:
@@ -181,7 +179,7 @@ receivers:
 processors:
 
 exporters:
-  logging:
+  debug:
   loadbalancing:
     protocol:
       otlp:
@@ -210,28 +208,28 @@ service:
         - otlp/backend-1
       processors: []
       exporters:
-        - logging
+        - debug
 
     traces/backend-2:
       receivers:
         - otlp/backend-2
       processors: []
       exporters:
-        - logging
+        - debug
 
     traces/backend-3:
       receivers:
         - otlp/backend-3
       processors: []
       exporters:
-        - logging
+        - debug
 
     traces/backend-4:
       receivers:
         - otlp/backend-4
       processors: []
       exporters:
-        - logging
+        - debug
 
     logs/loadbalancer:
       receivers:
@@ -244,25 +242,25 @@ service:
         - otlp/backend-1
       processors: []
       exporters:
-        - logging
+        - debug
     logs/backend-2:
       receivers:
         - otlp/backend-2
       processors: []
       exporters:
-        - logging
+        - debug
     logs/backend-3:
       receivers:
         - otlp/backend-3
       processors: []
       exporters:
-        - logging
+        - debug
     logs/backend-4:
       receivers:
         - otlp/backend-4
       processors: []
       exporters:
-        - logging
+        - debug
 ```
 
 ## Metrics

--- a/exporter/loadbalancingexporter/example/k8s-resolver/README.md
+++ b/exporter/loadbalancingexporter/example/k8s-resolver/README.md
@@ -101,7 +101,7 @@ spec:
     processors:
 
     exporters:
-      logging:
+      debug:
 
     service:
       pipelines:
@@ -110,7 +110,7 @@ spec:
             - otlp
           processors: []
           exporters:
-            - logging
+            - debug
 EOF
 ```
 

--- a/exporter/loadbalancingexporter/example/otel-agent-config.yaml
+++ b/exporter/loadbalancingexporter/example/otel-agent-config.yaml
@@ -6,8 +6,8 @@ processors:
   batch:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
   loadbalancing:
     protocol:
       otlp:
@@ -32,4 +32,4 @@ service:
     logs:
       receivers: [fluentforward]
       processors: [batch]
-      exporters: [loadbalancing, logging]
+      exporters: [loadbalancing, debug]

--- a/exporter/loadbalancingexporter/example/otel-collector-config.yaml
+++ b/exporter/loadbalancingexporter/example/otel-collector-config.yaml
@@ -7,8 +7,8 @@ processors:
   batch:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
 extensions:
   health_check:
@@ -21,4 +21,4 @@ service:
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]

--- a/exporter/lokiexporter/example/otelcol.yaml
+++ b/exporter/lokiexporter/example/otelcol.yaml
@@ -3,8 +3,8 @@ receivers:
     directory: /var/log/journal/a04e3a44cdd740f88d6a7ae3bb8c70cf
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
   loki:
     endpoint: http://localhost:3100/loki/api/v1/push
     tls:
@@ -46,4 +46,4 @@ service:
     logs:
       receivers: [journald]
       processors: [resource, attributes]
-      exporters: [logging, loki]
+      exporters: [debug, loki]

--- a/extension/oidcauthextension/README.md
+++ b/extension/oidcauthextension/README.md
@@ -36,8 +36,8 @@ receivers:
 processors:
 
 exporters:
-  logging:
-    logLevel: debug
+  debug:
+    verbosity: detailed
 
 service:
   extensions: [oidc]
@@ -45,5 +45,5 @@ service:
     traces:
       receivers: [otlp]
       processors: []
-      exporters: [logging]
+      exporters: [debug]
 ```

--- a/go.mod
+++ b/go.mod
@@ -166,6 +166,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.86.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.86.0
 	go.opentelemetry.io/collector/exporter v0.86.0
+	go.opentelemetry.io/collector/exporter/debugexporter v0.86.0
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.86.0
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.86.0

--- a/go.sum
+++ b/go.sum
@@ -1690,6 +1690,8 @@ go.opentelemetry.io/collector/consumer v0.86.0 h1:8AL9I30tJV01KfcSaa+8DTiARIiUDA
 go.opentelemetry.io/collector/consumer v0.86.0/go.mod h1:SvoV1eto4VZzQ3ILKQ1rv4qgN8rUMJqupn78hoXLHRw=
 go.opentelemetry.io/collector/exporter v0.86.0 h1:LFmBb7S4Fkj5fv/nrUkLOy50GT6s4R/BLrv6uTb+GNo=
 go.opentelemetry.io/collector/exporter v0.86.0/go.mod h1:+PKZrFV4sVgS2TVFnfZ+RCJqXexEENjW1riWaqkxsN4=
+go.opentelemetry.io/collector/exporter/debugexporter v0.86.0 h1:F76S/yAJg6f2CgdOJJ6BDSEYkG87xgqkBsWSQWKghts=
+go.opentelemetry.io/collector/exporter/debugexporter v0.86.0/go.mod h1:bdgxipCPu/81HPS9x6CMmd3IW2BbnjMGyanD4DLveRs=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0 h1:cS8w7CSZ6cy8Q4qMec291fxihj41zLrV103ABfJf/F8=
 go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0/go.mod h1:T9YhRZ/9ZfT8Hf0etTpwkbBx5yS+wg5RKrk8TSDXV3A=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.86.0 h1:xngHj6dvluhl5JgLtmyQ56OXGZEDwmcg4roYcA6freM=

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -5,6 +5,7 @@ package components // import "github.com/open-telemetry/opentelemetry-collector-
 
 import (
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/debugexporter"
 	"go.opentelemetry.io/collector/exporter/loggingexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
@@ -319,6 +320,7 @@ func Components() (otelcol.Factories, error) {
 		coralogixexporter.NewFactory(),
 		datadogexporter.NewFactory(),
 		datasetexporter.NewFactory(),
+		debugexporter.NewFactory(),
 		dynatraceexporter.NewFactory(),
 		elasticsearchexporter.NewFactory(),
 		f5cloudexporter.NewFactory(),

--- a/pkg/stanza/docs/types/timestamp.md
+++ b/pkg/stanza/docs/types/timestamp.md
@@ -53,8 +53,8 @@ Since the timestamp is a part of the log's body, it needs to be extracted from t
 
 ```yaml
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 receivers:
   filelog:
     include:
@@ -72,7 +72,7 @@ service:
       receivers:
       - filelog
       exporters:
-      - logging
+      - debug
 ```
 
 Note that this configuration has a side effect of creating a `timestamp_field` attribute for each log record.
@@ -80,8 +80,8 @@ To get rid of the attribute, use the `remove` operator:
 
 ```yaml
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 receivers:
   filelog:
     include:
@@ -101,7 +101,7 @@ service:
       receivers:
       - filelog
       exporters:
-      - logging
+      - debug
 ```
 
 #### Parse timestamps from JSON logs
@@ -118,8 +118,8 @@ Use [json_parser](../operators/json_parser.md) to parse the log body into JSON a
 
 ```yaml
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 receivers:
   filelog:
     include:
@@ -137,7 +137,7 @@ service:
       receivers:
       - filelog
       exporters:
-      - logging
+      - debug
 ```
 
 The above example uses a standalone [time_parser](../operators/time_parser.md) operator to parse the timestamp,

--- a/receiver/awscloudwatchmetricsreceiver/README.md
+++ b/receiver/awscloudwatchmetricsreceiver/README.md
@@ -102,7 +102,7 @@ receivers:
 processors:
 
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 
 service:
@@ -110,7 +110,7 @@ service:
     metrics:
       receivers: [awscloudwatchmetrics]
       processors: []
-      exporters: [logging]
+      exporters: [debug]
 ```
 
 ## AWS Costs

--- a/receiver/awscontainerinsightreceiver/README.md
+++ b/receiver/awscontainerinsightreceiver/README.md
@@ -218,8 +218,8 @@ data:
               - namespace_number_of_running_pods
 
 
-      logging:
-        loglevel: debug
+      debug:
+        verbosity: detailed
 
     service:
       pipelines:
@@ -729,14 +729,14 @@ exporters:
           - instance_cpu_limit
           - instance_memory_working_set
           - instance_memory_limit
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 service:
   pipelines:
     metrics:
       receivers: [awscontainerinsightreceiver]
       processors: [batch/metrics]
-      exporters: [awsemf,logging]
+      exporters: [awsemf,debug]
 ```
 To deploy to an ECS cluster check this [doc](https://aws-otel.github.io/docs/setup/ecs#3-setup-the-aws-otel-collector-for-ecs-ec2-instance-metrics) for details
 

--- a/receiver/hostmetricsreceiver/example_config.yaml
+++ b/receiver/hostmetricsreceiver/example_config.yaml
@@ -16,7 +16,7 @@ receivers:
       processes:
 
 exporters:
-  logging:
+  debug:
   prometheus:
     endpoint: 0.0.0.0:8889
 
@@ -24,6 +24,6 @@ service:
   pipelines:
     metrics:
       receivers: [hostmetrics]
-      exporters: [prometheus, logging]
+      exporters: [prometheus, debug]
 
   extensions: [zpages]

--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -137,7 +137,7 @@ for the format of emitted log records.
 ## Example
 
 Here is an example deployment of the collector that sets up this receiver along with
-the logging exporter.
+the debug exporter.
 
 Follow the below sections to setup various Kubernetes resources required for the deployment.
 
@@ -159,15 +159,15 @@ data:
       k8s_cluster:
         collection_interval: 10s
     exporters:
-      logging:
+      debug:
     service:
       pipelines:
         metrics:
           receivers: [k8s_cluster]
-          exporters: [logging]
+          exporters: [debug]
         logs/entity_events:
           receivers: [k8s_cluster]
-          exporters: [logging]
+          exporters: [debug]
 EOF
 ```
 

--- a/receiver/simpleprometheusreceiver/examples/federation/otel-collector-config.yml
+++ b/receiver/simpleprometheusreceiver/examples/federation/otel-collector-config.yml
@@ -13,8 +13,8 @@ receivers:
       grpc:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
 processors:
   batch:
@@ -35,4 +35,4 @@ service:
     metrics:
       receivers: [prometheus_simple]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]

--- a/receiver/windowsperfcountersreceiver/example_config.yaml
+++ b/receiver/windowsperfcountersreceiver/example_config.yaml
@@ -19,7 +19,7 @@ receivers:
           - "% Idle Time"
 
 exporters:
-  logging:
+  debug:
   prometheus:
     endpoint: 0.0.0.0:8889
 
@@ -27,6 +27,6 @@ service:
   pipelines:
     metrics:
       receivers: [windowsperfcounters]
-      exporters: [prometheus, logging]
+      exporters: [prometheus, debug]
 
   extensions: [zpages]

--- a/testbed/tests/testdata/agent-config.yaml
+++ b/testbed/tests/testdata/agent-config.yaml
@@ -9,7 +9,7 @@ exporters:
     endpoint: "127.0.0.1:55680"
     tls:
       insecure: true
-  logging:
+  debug:
     loglevel: info
 
 processors:
@@ -20,8 +20,8 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp, logging]
+      exporters: [otlp, debug]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp, logging]
+      exporters: [otlp, debug]


### PR DESCRIPTION
This updates the code examples to use the debug exporter instead of the logging exporter. This change will need to be merged after the v0.86.0 release.
