### PR TITLE
Increase spanner receiver resiliency when a metrics, database or project is not found

### DIFF
--- a/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/receiver/scrapererror"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/datasource"
@@ -70,17 +72,24 @@ func (databaseReader *DatabaseReader) Read(ctx context.Context) ([]*metadata.Met
 	databaseReader.logger.Debug("Executing read method for database",
 		zap.String("database", databaseReader.database.DatabaseID().ID()))
 
-	var result []*metadata.MetricsDataPoint
+	var (
+		result []*metadata.MetricsDataPoint
+		err    error
+	)
 
 	for _, reader := range databaseReader.readers {
 		dataPoints, err := reader.Read(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("cannot read data for data points databaseReader %q because of an error: %w",
-				reader.Name(), err)
+			err = multierr.Combine(err, fmt.Errorf("cannot read data for data points databaseReader %q because of an error: %w",
+				reader.Name(), err))
+		} else {
+			result = append(result, dataPoints...)
 		}
-
-		result = append(result, dataPoints...)
 	}
 
-	return result, nil
+	if len(result) > 0 {
+		err = scrapererror.NewPartialScrapeError(err, len(multierr.Errors(err)))
+	}
+
+	return result, err
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.--> Enable retrieval of metric if a systems metrics, database or project is not found.
In many cases, 1 of those could fail due to a delete outside of the receiver configuration update. However, all the other part of the configuration could still be valid and we should still collect the other metrics. 

**Link to tracking Issue:** <Issue number if applicable> https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26732

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>