### PR TITLE
checkapi changes for azuremonitorexporter

### DIFF
--- a/.chloggen/26304-azuremonitor-exporter.yaml
+++ b/.chloggen/26304-azuremonitor-exporter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: changes for checkapi 
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26304]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/26304-azuremonitor-exporter.yaml
+++ b/.chloggen/26304-azuremonitor-exporter.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: azuremonitorexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: changes for checkapi 
+note: Unexport `Accept` to comply with checkapi 
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [26304]

--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -1,6 +1,5 @@
 connector/servicegraphconnector
 exporter/awskinesisexporter
-exporter/azuremonitorexporter
 exporter/coralogixexporter
 exporter/dynatraceexporter
 exporter/f5cloudexporter

--- a/exporter/azuremonitorexporter/traceexporter.go
+++ b/exporter/azuremonitorexporter/traceexporter.go
@@ -58,7 +58,7 @@ func (exporter *traceExporter) onTraceData(_ context.Context, traceData ptrace.T
 	}
 
 	visitor := &traceVisitor{exporter: exporter}
-	Accept(traceData, visitor)
+	accept(traceData, visitor)
 	return visitor.err
 }
 

--- a/exporter/azuremonitorexporter/traceiteration.go
+++ b/exporter/azuremonitorexporter/traceiteration.go
@@ -20,8 +20,8 @@ type TraceVisitor interface {
 	visit(resource pcommon.Resource, scope pcommon.InstrumentationScope, span ptrace.Span) (ok bool)
 }
 
-// Accept method is called to start the iteration process
-func Accept(traces ptrace.Traces, v TraceVisitor) {
+// accept method is called to start the iteration process
+func accept(traces ptrace.Traces, v TraceVisitor) {
 	resourceSpans := traces.ResourceSpans()
 
 	// Walk each ResourceSpans instance

--- a/exporter/azuremonitorexporter/traceiteration_test.go
+++ b/exporter/azuremonitorexporter/traceiteration_test.go
@@ -26,7 +26,7 @@ func TestTraceDataIterationNoResourceSpans(t *testing.T) {
 
 	visitor := getMockVisitor(true)
 
-	Accept(traces, visitor)
+	accept(traces, visitor)
 
 	visitor.AssertNumberOfCalls(t, "visit", 0)
 }
@@ -38,7 +38,7 @@ func TestTraceDataIterationResourceSpansIsEmpty(t *testing.T) {
 
 	visitor := getMockVisitor(true)
 
-	Accept(traces, visitor)
+	accept(traces, visitor)
 
 	visitor.AssertNumberOfCalls(t, "visit", 0)
 }
@@ -51,7 +51,7 @@ func TestTraceDataIterationScopeSpansIsEmpty(t *testing.T) {
 
 	visitor := getMockVisitor(true)
 
-	Accept(traces, visitor)
+	accept(traces, visitor)
 
 	visitor.AssertNumberOfCalls(t, "visit", 0)
 }
@@ -64,7 +64,7 @@ func TestTraceDataIterationNoSpans(t *testing.T) {
 
 	visitor := getMockVisitor(true)
 
-	Accept(traces, visitor)
+	accept(traces, visitor)
 
 	visitor.AssertNumberOfCalls(t, "visit", 0)
 }
@@ -79,7 +79,7 @@ func TestTraceDataIterationNoShortCircuit(t *testing.T) {
 
 	visitor := getMockVisitor(true)
 
-	Accept(traces, visitor)
+	accept(traces, visitor)
 
 	visitor.AssertNumberOfCalls(t, "visit", 2)
 }
@@ -94,7 +94,7 @@ func TestTraceDataIterationShortCircuit(t *testing.T) {
 
 	visitor := getMockVisitor(false)
 
-	Accept(traces, visitor)
+	accept(traces, visitor)
 
 	visitor.AssertNumberOfCalls(t, "visit", 1)
 }


### PR DESCRIPTION
**Description:** 
Rename `Accept` to `accept` to align with `checkapi` expectations

**Link to tracking Issue:** 26304

**Testing:**
`go run cmd/checkapi/main.go .`
`go test` for `azuremonitorexporter`
