### PR TITLE
[chore] re-add myself as awsemfexporter codeowner. 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,7 @@ examples/demo/                                                          @open-te
 
 exporter/alibabacloudlogserviceexporter/                                @open-telemetry/collector-contrib-approvers @shabicheng @kongluoxing @qiansheng91
 exporter/awscloudwatchlogsexporter/                                     @open-telemetry/collector-contrib-approvers @boostchicken @bryan-aguilar @rapphil
-exporter/awsemfexporter/                                                @open-telemetry/collector-contrib-approvers @Aneurysm9 @shaochengwang @mxiamxia
+exporter/awsemfexporter/                                                @open-telemetry/collector-contrib-approvers @Aneurysm9 @shaochengwang @mxiamxia @bryan-aguilar
 exporter/awskinesisexporter/                                            @open-telemetry/collector-contrib-approvers @Aneurysm9 @MovieStoreGuy
 exporter/awss3exporter/                                                 @open-telemetry/collector-contrib-approvers @atoulme @pdelewski
 exporter/awsxrayexporter/                                               @open-telemetry/collector-contrib-approvers @wangzlei @srprash


### PR DESCRIPTION
**Description:** Original merged approval PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26100

PR that inadvertantly removed me: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26556

