### PR TITLE
[receiver/httpcheck] add metrics check whether substring contains in response body

### DIFF
--- a/.chloggen/httpcheckreceiver-match-content.yaml
+++ b/.chloggen/httpcheckreceiver-match-content.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: httpcheckreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add metrics testing if the HTTP response body exact matches a specific string.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24913]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/httpcheckreceiver/README.md
+++ b/receiver/httpcheckreceiver/README.md
@@ -38,6 +38,7 @@ Each target has the following properties:
 - `endpoint` (required): the URL to be monitored
 - `method` (optional, default: `GET`): The HTTP method used to call the endpoint
 - `body` (optional, default: ""): If set, the receiver will emit metrics based on whether the response body exact matches this string.
+- `name` (optional, default: ""): If set, along with `httpcheck.body` metric attributes.
 
 Additionally, each target supports the client configuration options of [confighttp].
 

--- a/receiver/httpcheckreceiver/README.md
+++ b/receiver/httpcheckreceiver/README.md
@@ -38,7 +38,7 @@ Each target has the following properties:
 - `endpoint` (required): the URL to be monitored
 - `method` (optional, default: `GET`): The HTTP method used to call the endpoint
 - `body` (optional, default: ""): If set, the receiver will emit metrics based on whether the response body exact matches this string.
-- `name` (optional, default: ""): If set, along with `httpcheck.body` metric attributes.
+- `name` (optional, default: ""): The name of this receiver.
 
 Additionally, each target supports the client configuration options of [confighttp].
 

--- a/receiver/httpcheckreceiver/README.md
+++ b/receiver/httpcheckreceiver/README.md
@@ -37,6 +37,7 @@ Each target has the following properties:
 
 - `endpoint` (required): the URL to be monitored
 - `method` (optional, default: `GET`): The HTTP method used to call the endpoint
+- `body` (optional, default: ""): If set, the receiver will emit metrics based on whether the response body exact matches this string.
 
 Additionally, each target supports the client configuration options of [confighttp].
 

--- a/receiver/httpcheckreceiver/config.go
+++ b/receiver/httpcheckreceiver/config.go
@@ -31,6 +31,7 @@ type Config struct {
 type targetConfig struct {
 	confighttp.HTTPClientSettings `mapstructure:",squash"`
 	Method                        string `mapstructure:"method"`
+	Body                          string `mapstructure:"body"`
 }
 
 // Validate validates the configuration by checking for missing or invalid fields

--- a/receiver/httpcheckreceiver/config.go
+++ b/receiver/httpcheckreceiver/config.go
@@ -32,6 +32,7 @@ type targetConfig struct {
 	confighttp.HTTPClientSettings `mapstructure:",squash"`
 	Method                        string `mapstructure:"method"`
 	Body                          string `mapstructure:"body"`
+	Name                          string `mapstructure:"name"`
 }
 
 // Validate validates the configuration by checking for missing or invalid fields

--- a/receiver/httpcheckreceiver/documentation.md
+++ b/receiver/httpcheckreceiver/documentation.md
@@ -57,3 +57,27 @@ Records errors occurring during HTTP check.
 | http.status_code | HTTP response status code | Any Int |
 | http.method | HTTP request method | Any Str |
 | http.status_class | HTTP response status class | Any Str |
+
+## Optional Metrics
+
+The following metrics are not emitted by default. Each of them can be enabled by applying the following configuration:
+
+```yaml
+metrics:
+  <metric_name>:
+    enabled: true
+```
+
+### httpcheck.body
+
+Reports 1 if the HTTP response body exact matches the `body` configuration item, 0 otherwise.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| 1 | Sum | Int | Cumulative | false |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| http.url | Full HTTP request URL. | Any Str |

--- a/receiver/httpcheckreceiver/documentation.md
+++ b/receiver/httpcheckreceiver/documentation.md
@@ -81,4 +81,4 @@ Reports 1 if the HTTP response body exact matches the `body` configuration item,
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | http.url | Full HTTP request URL. | Any Str |
-| name | HTTP response body exact matches string | Any Str |
+| name | Optional name of this check. | Any Str |

--- a/receiver/httpcheckreceiver/documentation.md
+++ b/receiver/httpcheckreceiver/documentation.md
@@ -81,3 +81,4 @@ Reports 1 if the HTTP response body exact matches the `body` configuration item,
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | http.url | Full HTTP request URL. | Any Str |
+| name | HTTP response body exact matches string | Any Str |

--- a/receiver/httpcheckreceiver/internal/metadata/generated_config.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_config.go
@@ -25,6 +25,7 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for httpcheck metrics.
 type MetricsConfig struct {
+	HttpcheckBody     MetricConfig `mapstructure:"httpcheck.body"`
 	HttpcheckDuration MetricConfig `mapstructure:"httpcheck.duration"`
 	HttpcheckError    MetricConfig `mapstructure:"httpcheck.error"`
 	HttpcheckStatus   MetricConfig `mapstructure:"httpcheck.status"`
@@ -32,6 +33,9 @@ type MetricsConfig struct {
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
+		HttpcheckBody: MetricConfig{
+			Enabled: false,
+		},
 		HttpcheckDuration: MetricConfig{
 			Enabled: true,
 		},

--- a/receiver/httpcheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_config_test.go
@@ -26,6 +26,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					HttpcheckBody:     MetricConfig{Enabled: true},
 					HttpcheckDuration: MetricConfig{Enabled: true},
 					HttpcheckError:    MetricConfig{Enabled: true},
 					HttpcheckStatus:   MetricConfig{Enabled: true},
@@ -36,6 +37,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					HttpcheckBody:     MetricConfig{Enabled: false},
 					HttpcheckDuration: MetricConfig{Enabled: false},
 					HttpcheckError:    MetricConfig{Enabled: false},
 					HttpcheckStatus:   MetricConfig{Enabled: false},

--- a/receiver/httpcheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_metrics.go
@@ -28,7 +28,7 @@ func (m *metricHttpcheckBody) init() {
 	m.data.Sum().DataPoints().EnsureCapacity(m.capacity)
 }
 
-func (m *metricHttpcheckBody) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string) {
+func (m *metricHttpcheckBody) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64, httpURLAttributeValue string, nameAttributeValue string) {
 	if !m.config.Enabled {
 		return
 	}
@@ -37,6 +37,7 @@ func (m *metricHttpcheckBody) recordDataPoint(start pcommon.Timestamp, ts pcommo
 	dp.SetTimestamp(ts)
 	dp.SetIntValue(val)
 	dp.Attributes().PutStr("http.url", httpURLAttributeValue)
+	dp.Attributes().PutStr("name", nameAttributeValue)
 }
 
 // updateCapacity saves max length of data point slices that will be used for the slice capacity.
@@ -340,8 +341,8 @@ func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 }
 
 // RecordHttpcheckBodyDataPoint adds a data point to httpcheck.body metric.
-func (mb *MetricsBuilder) RecordHttpcheckBodyDataPoint(ts pcommon.Timestamp, val int64, httpURLAttributeValue string) {
-	mb.metricHttpcheckBody.recordDataPoint(mb.startTime, ts, val, httpURLAttributeValue)
+func (mb *MetricsBuilder) RecordHttpcheckBodyDataPoint(ts pcommon.Timestamp, val int64, httpURLAttributeValue string, nameAttributeValue string) {
+	mb.metricHttpcheckBody.recordDataPoint(mb.startTime, ts, val, httpURLAttributeValue, nameAttributeValue)
 }
 
 // RecordHttpcheckDurationDataPoint adds a data point to httpcheck.duration metric.

--- a/receiver/httpcheckreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_metrics_test.go
@@ -56,7 +56,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount := 0
 
 			allMetricsCount++
-			mb.RecordHttpcheckBodyDataPoint(ts, 1, "http.url-val")
+			mb.RecordHttpcheckBodyDataPoint(ts, 1, "http.url-val", "name-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -109,6 +109,9 @@ func TestMetricsBuilder(t *testing.T) {
 					attrVal, ok := dp.Attributes().Get("http.url")
 					assert.True(t, ok)
 					assert.EqualValues(t, "http.url-val", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("name")
+					assert.True(t, ok)
+					assert.EqualValues(t, "name-val", attrVal.Str())
 				case "httpcheck.duration":
 					assert.False(t, validatedMetrics["httpcheck.duration"], "Found a duplicate in the metrics slice: httpcheck.duration")
 					validatedMetrics["httpcheck.duration"] = true

--- a/receiver/httpcheckreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/httpcheckreceiver/internal/metadata/testdata/config.yaml
@@ -1,6 +1,8 @@
 default:
 all_set:
   metrics:
+    httpcheck.body:
+      enabled: true
     httpcheck.duration:
       enabled: true
     httpcheck.error:
@@ -9,6 +11,8 @@ all_set:
       enabled: true
 none_set:
   metrics:
+    httpcheck.body:
+      enabled: false
     httpcheck.duration:
       enabled: false
     httpcheck.error:

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -28,7 +28,7 @@ attributes:
     description: Error message recorded during check
     type: string
   name:
-    description: HTTP response body exact matches string
+    description: Optional name of this check.
     type: string
 
 metrics:

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -65,7 +65,7 @@ metrics:
       aggregation_temporality: cumulative
       monotonic: false
     unit: 1
-    attributes: [http.url]
+    attributes: [http.url, name]
 
 tests:
   config:

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -27,6 +27,9 @@ attributes:
   error.message:
     description: Error message recorded during check
     type: string
+  name:
+    description: HTTP response body exact matches string
+    type: string
 
 metrics:
   httpcheck.status:

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -54,6 +54,15 @@ metrics:
       monotonic: false
     unit: "{error}"
     attributes: [http.url, error.message]
+  httpcheck.body:
+    description: Reports 1 if the HTTP response body exact matches the `body` configuration item, 0 otherwise.
+    enabled: false
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+    unit: 1
+    attributes: [http.url]
 
 tests:
   config:

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -95,9 +95,9 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 					defer resp.Body.Close()
 
 					if strings.Contains(string(body), h.cfg.Targets[targetIndex].Body) {
-						h.mb.RecordHttpcheckBodyDataPoint(now, int64(1), h.cfg.Targets[targetIndex].Endpoint)
+						h.mb.RecordHttpcheckBodyDataPoint(now, int64(1), h.cfg.Targets[targetIndex].Endpoint, h.cfg.Targets[targetIndex].Name)
 					} else {
-						h.mb.RecordHttpcheckBodyDataPoint(now, int64(0), h.cfg.Targets[targetIndex].Endpoint)
+						h.mb.RecordHttpcheckBodyDataPoint(now, int64(0), h.cfg.Targets[targetIndex].Endpoint, h.cfg.Targets[targetIndex].Name)
 					}
 				}
 			}

--- a/receiver/httpcheckreceiver/scraper.go
+++ b/receiver/httpcheckreceiver/scraper.go
@@ -64,7 +64,7 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 
 			req, err := http.NewRequestWithContext(ctx, h.cfg.Targets[targetIndex].Method, h.cfg.Targets[targetIndex].Endpoint, http.NoBody)
 			if err != nil {
-				h.settings.Logger.Error("failed to create request", zap.Error(err))
+				h.settings.Logger.Error("failed to create request", zap.String("target endpoint", h.cfg.Targets[targetIndex].Endpoint), zap.Error(err))
 				return
 			}
 
@@ -90,7 +90,7 @@ func (h *httpcheckScraper) scrape(ctx context.Context) (pmetric.Metrics, error) 
 
 			if err == nil && len(h.cfg.Targets[targetIndex].Body) > 0 {
 				if body, err := io.ReadAll(resp.Body); err != nil {
-					h.settings.Logger.Error("failed to read response", zap.Error(err))
+					h.settings.Logger.Error("failed to read response", zap.String("target endpoint", h.cfg.Targets[targetIndex].Endpoint), zap.Error(err))
 				} else {
 					defer resp.Body.Close()
 

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -257,12 +257,14 @@ func TestScraperBody(t *testing.T) {
 			Endpoint: ms1.URL,
 		},
 		Body: "foo",
+		Name: "foo",
 	})
 	cfg.Targets = append(cfg.Targets, &targetConfig{
 		HTTPClientSettings: confighttp.HTTPClientSettings{
 			Endpoint: ms2.URL,
 		},
 		Body: "far",
+		Name: "",
 	})
 	cfg.MetricsBuilderConfig.Metrics.HttpcheckBody.Enabled = true
 

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/body.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/body.yaml
@@ -1,0 +1,208 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - description: Measures the duration of the HTTP check.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                - asInt: "0"
+                  attributes:
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+            name: httpcheck.duration
+            unit: ms
+          - description: 1 if the check resulted in status_code matching the status_class, otherwise 0.
+            name: httpcheck.status
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 1xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 1xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 2xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 2xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 3xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 3xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 4xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 4xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 5xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.method
+                      value:
+                        stringValue: GET
+                    - key: http.status_class
+                      value:
+                        stringValue: 5xx
+                    - key: http.status_code
+                      value:
+                        intValue: "200"
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: Reports 1 if the HTTP response body exact matches the `body` configuration item, 0 otherwise.
+            name: httpcheck.body
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: http.url
+                      value:
+                        stringValue: http://127.0.0.1:8000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+        scope:
+          name: otelcol/httpcheckreceiver
+          version: latest

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/body.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/body.yaml
@@ -193,6 +193,9 @@ resourceMetrics:
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
+                    - key: name
+                      value:
+                        stringValue: foo    
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "0"
@@ -200,6 +203,9 @@ resourceMetrics:
                     - key: http.url
                       value:
                         stringValue: http://127.0.0.1:8000
+                    - key: name
+                      value:
+                        stringValue: ""
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"


### PR DESCRIPTION
**Description:**
Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24913, add metrics check if substring contains in http check response body or not. When set `body` option and emit `httpcheck.body`,  testing substring contains or not in the response of HTTP Check. 

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24913

**Testing:**
make generate
make chlog-validate
go test for httpcheckreceiver

**Documentation:**
receiver/httpcheckreceiver/README.md  