### PR TITLE
[processor/tailsampling] Duplicate policy names should yield an error

### DIFF
--- a/.chloggen/27016-duplicate-policy-names.yaml
+++ b/.chloggen/27016-duplicate-policy-names.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/tailsampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Prevent the tail-sampling from accepting duplicate policy names
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27016]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/27016-duplicate-policy-names.yaml
+++ b/.chloggen/27016-duplicate-policy-names.yaml
@@ -7,7 +7,7 @@ change_type: 'bug_fix'
 component: processor/tailsampling
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Prevent the tail-sampling from accepting duplicate policy names
+note: Prevent the tail-sampling processor from accepting duplicate policy names
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [27016]

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -72,15 +72,16 @@ func newTracesProcessor(ctx context.Context, settings component.TelemetrySetting
 		return nil, component.ErrNilNextConsumer
 	}
 
-	numDecisionBatches := math.Max(1, cfg.DecisionWait.Seconds())
-	inBatcher, err := idbatcher.New(uint64(numDecisionBatches), cfg.ExpectedNewTracesPerSec, uint64(2*runtime.NumCPU()))
-	if err != nil {
-		return nil, err
-	}
-
+	policyNames := map[string]bool{}
 	policies := make([]*policy, len(cfg.PolicyCfgs))
 	for i := range cfg.PolicyCfgs {
 		policyCfg := &cfg.PolicyCfgs[i]
+
+		if policyNames[policyCfg.Name] {
+			return nil, fmt.Errorf("duplicate policy name %q", policyCfg.Name)
+		}
+		policyNames[policyCfg.Name] = true
+
 		policyCtx, err := tag.New(ctx, tag.Upsert(tagPolicyKey, policyCfg.Name), tag.Upsert(tagSourceFormat, sourceFormat))
 		if err != nil {
 			return nil, err
@@ -95,6 +96,14 @@ func newTracesProcessor(ctx context.Context, settings component.TelemetrySetting
 			ctx:       policyCtx,
 		}
 		policies[i] = p
+	}
+
+	// this will start a goroutine in the background, so we run it only if everything went
+	// well in creating the policies
+	numDecisionBatches := math.Max(1, cfg.DecisionWait.Seconds())
+	inBatcher, err := idbatcher.New(uint64(numDecisionBatches), cfg.ExpectedNewTracesPerSec, uint64(2*runtime.NumCPU()))
+	if err != nil {
+		return nil, err
 	}
 
 	tsp := &tailSamplingSpanProcessor{


### PR DESCRIPTION
Fixes #27016

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
