### PR TITLE
[chore] checkapi fixes for servicegraphprocessor

### DIFF
--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -14,7 +14,6 @@ extension/observer
 processor/groupbyattrsprocessor
 processor/groupbytraceprocessor
 processor/probabilisticsamplerprocessor
-processor/servicegraphprocessor
 receiver/carbonreceiver
 receiver/collectdreceiver
 receiver/dockerstatsreceiver

--- a/processor/servicegraphprocessor/config_test.go
+++ b/processor/servicegraphprocessor/config_test.go
@@ -69,5 +69,5 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func newConnectorFactory() connector.Factory {
-	return NewConnectorFactoryFunc("servicegraph", component.StabilityLevelAlpha)()
+	return newConnectorFactoryFunc("servicegraph", component.StabilityLevelAlpha)()
 }

--- a/processor/servicegraphprocessor/factory.go
+++ b/processor/servicegraphprocessor/factory.go
@@ -54,8 +54,8 @@ func NewFactory() processor.Factory {
 	)
 }
 
-// NewConnectorFactoryFunc creates a function that returns a factory for the servicegraph connector.
-func NewConnectorFactoryFunc(cfgType component.Type, tracesToMetricsStability component.StabilityLevel) func() connector.Factory {
+// newConnectorFactoryFunc creates a function that returns a factory for the servicegraph connector.
+func newConnectorFactoryFunc(cfgType component.Type, tracesToMetricsStability component.StabilityLevel) func() connector.Factory {
 	return func() connector.Factory {
 		// TODO: Handle this err
 		_ = view.Register(serviceGraphProcessorViews()...)


### PR DESCRIPTION
**Description:** 
Rename and stop exporting `NewConnnectorFactoryFunc` to `newConnnectorFactoryFunc` for checkapi standards.
No breaking changes only used in tests

**Link to tracking Issue:** 26304

**Testing:** 
`go run cmd/checkapi/main.go .`
`go test ./...` for `servicegraphprocessor`
