### PR TITLE
[prometheusreceiver] Enable proto negotiation

### DIFF
--- a/.chloggen/prometheus-receiver-proto-negotiation-option.yaml
+++ b/.chloggen/prometheus-receiver-proto-negotiation-option.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: prometheusreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: expose the EnableProtobufNegotiation flag
+note: add a new flag, enable_protobuf_negotiation, which enables protobuf negotiation when scraping prometheus clients
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [27027]

--- a/.chloggen/prometheus-receiver-proto-negotiation-option.yaml
+++ b/.chloggen/prometheus-receiver-proto-negotiation-option.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: expose the EnableProtobufNegotiation flag
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27027]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -52,6 +52,10 @@ type Config struct {
 	// that requires that all keys present in the config actually exist on the
 	// structure, ie.: it will error if an unknown key is present.
 	ConfigPlaceholder interface{} `mapstructure:"config"`
+
+	// EnableProtobufNegotiation allows the collector to set the scraper option for
+	// protobuf negotiation when conferring with a prometheus client.
+	EnableProtobufNegotiation bool `mapstructure:"enable_protobuf_negotiation"`
 }
 
 type targetAllocator struct {

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -41,6 +41,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, time.Duration(r1.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval), 5*time.Second)
 	assert.Equal(t, r1.UseStartTimeMetric, true)
 	assert.Equal(t, r1.TrimMetricSuffixes, true)
+	assert.Equal(t, r1.EnableProtobufNegotiation, true)
 	assert.Equal(t, r1.StartTimeMetricRegex, "^(.+_)*process_start_time_seconds$")
 	assert.True(t, r1.ReportExtraScrapeMetrics)
 

--- a/receiver/prometheusreceiver/metrics_receiver.go
+++ b/receiver/prometheusreceiver/metrics_receiver.go
@@ -267,8 +267,9 @@ func (r *pReceiver) initPrometheusComponents(ctx context.Context, host component
 	}
 
 	r.scrapeManager = scrape.NewManager(&scrape.Options{
-		PassMetadataInContext: true,
-		ExtraMetrics:          r.cfg.ReportExtraScrapeMetrics,
+		PassMetadataInContext:     true,
+		EnableProtobufNegotiation: r.cfg.EnableProtobufNegotiation,
+		ExtraMetrics:              r.cfg.ReportExtraScrapeMetrics,
 		HTTPClientOptions: []commonconfig.HTTPClientOption{
 			commonconfig.WithUserAgent(r.settings.BuildInfo.Command + "/" + r.settings.BuildInfo.Version),
 		},

--- a/receiver/prometheusreceiver/testdata/config.yaml
+++ b/receiver/prometheusreceiver/testdata/config.yaml
@@ -4,6 +4,7 @@ prometheus/customname:
   use_start_time_metric: true
   start_time_metric_regex: '^(.+_)*process_start_time_seconds$'
   report_extra_scrape_metrics: true
+  enable_protobuf_negotiation: true
   target_allocator:
     endpoint: http://my-targetallocator-service
     interval: 30s


### PR DESCRIPTION
**Description:** 

Exposes the protobuf negotiation flag for the scrape manager.

**Link to tracking Issue:** [issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27027)

**Testing:** tested locally that setting this flag indeed set this flag.

**Documentation:** Documented the flag in the prom receiver docs