### PR TITLE
[chore] Update approver auto assign config

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -18,8 +18,8 @@ assigneeGroups:
     - songy23
     - fatsheep9146
     # Maintainers
-    - codeboten
     - bogdandrutu
+    - codeboten
     - djaglowski
     - dmitryax
     - evan-bradley

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -11,8 +11,8 @@ useAssigneeGroups: true
 assigneeGroups:
   approvers_maintainers:
     # Approvers
-    - astencel-sumo
     - Aneurysm9
+    - astencel-sumo
     - atoulme
     - dashpole
     - songy23

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -24,8 +24,8 @@ assigneeGroups:
     - dmitryax
     - evan-bradley
     - jpkrohling
-    - mx-psi
     - MovieStoreGuy
+    - mx-psi
     - TylerHelmuth
 
 # A number of assignees added to the pull request

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -11,19 +11,21 @@ useAssigneeGroups: true
 assigneeGroups:
   approvers_maintainers:
     # Approvers
+    - astencel-sumo
     - Aneurysm9
     - atoulme
     - dashpole
+    - songy23
     - fatsheep9146
     # Maintainers
-    - bogdandrutu
     - codeboten
+    - bogdandrutu
     - djaglowski
     - dmitryax
     - evan-bradley
     - jpkrohling
-    - MovieStoreGuy
     - mx-psi
+    - MovieStoreGuy
     - TylerHelmuth
 
 # A number of assignees added to the pull request


### PR DESCRIPTION
**Description:** Add missing approvers to the auto assign config. I also reorganized the maintainers list to match the ordering of names in the README. Small nit, but it made it easier to compare. 