### PR TITLE
[pkg/ottl] add Now() function

### DIFF
--- a/.chloggen/feat_ottl-now.yaml
+++ b/.chloggen/feat_ottl-now.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'pkg/ottl'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add a Now() function to ottl that returns the current system time ()"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27038, 26507]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: ['user']

--- a/.chloggen/feat_ottl-now.yaml
+++ b/.chloggen/feat_ottl-now.yaml
@@ -7,7 +7,7 @@ change_type: 'enhancement'
 component: 'pkg/ottl'
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Add a Now() function to ottl that returns the current system time ()"
+note: "Add a Now() function to ottl that returns the current system time"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [27038, 26507]

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -291,6 +291,7 @@ Available Converters:
 - [Milliseconds](#milliseconds)
 - [Minutes](#minutes)
 - [Nanoseconds](#nanoseconds)
+- [Now](#now)
 - [ParseJSON](#parsejson)
 - [Seconds](#seconds)
 - [SHA1](#sha1)
@@ -597,6 +598,18 @@ The returned type is `int64`.
 Examples:
 
 - `Nanoseconds(Duration("1h"))`
+
+### Now
+
+`Now()`
+
+The `Now` function returns the current time as represented by `time.Now()` in Go.
+
+The returned type is `time.Time`.
+
+Examples:
+
+- `UnixSeconds(Now())`
 
 ### ParseJSON
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -610,6 +610,7 @@ The returned type is `time.Time`.
 Examples:
 
 - `UnixSeconds(Now())`
+- `set(start_time, Now())`
 
 ### ParseJSON
 

--- a/pkg/ottl/ottlfuncs/func_now.go
+++ b/pkg/ottl/ottlfuncs/func_now.go
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func now[K any]() (ottl.ExprFunc[K], error) {
+	return func(ctx context.Context, tCtx K) (interface{}, error) {
+		return time.Now(), nil
+	}, nil
+}
+
+func createNowFunction[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
+	return now[K]()
+}
+
+func NewNowFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("Now", nil, createNowFunction[K])
+}

--- a/pkg/ottl/ottlfuncs/func_now_test.go
+++ b/pkg/ottl/ottlfuncs/func_now_test.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Now(t *testing.T) {
+	exprFunc, err := now[interface{}]()
+	assert.NoError(t, err)
+
+	value, err := exprFunc(nil, nil)
+	assert.NoError(t, err)
+	// There should be basically no difference between the value of time.Now() returned by the ottlfunc vs time.Now() run in the test.
+	n := time.Now()
+	assert.LessOrEqual(t, n.Sub(value.(time.Time)).Seconds(), 1.0)
+}

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -50,6 +50,7 @@ func converters[K any]() []ottl.Factory[K] {
 		NewMillisecondsFactory[K](),
 		NewMinutesFactory[K](),
 		NewNanosecondsFactory[K](),
+		NewNowFactory[K](),
 		NewParseJSONFactory[K](),
 		NewSecondsFactory[K](),
 		NewSHA1Factory[K](),


### PR DESCRIPTION
Implement a new OTTL function that takes no inputs and returns the current time.

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Adds a simple OTTL function that returns the current system time.

**Link to tracking Issue:** Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26507

**Testing:** Added tests to confirm that function returns no errors and returns a time that is consistent. 

**Documentation:** Updated OTTL Functions README.