### PR TITLE
[chore] [exporter/signalfx] Remove dependency on signalfx-agent

### DIFF
--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -169,7 +169,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.85.0 // indirect
 	github.com/samber/lo v1.37.0 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
-	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 // indirect
 	go.opentelemetry.io/collector/exporter v0.85.1-0.20230919160920-512b9c3c8fec // indirect
 	go.opentelemetry.io/collector/receiver v0.85.1-0.20230919160920-512b9c3c8fec // indirect
 )

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -3102,8 +3102,6 @@ github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8
 github.com/signalfx/sapm-proto v0.7.2/go.mod h1:HLufOh6Gd2altGxbeve+s6hh0EWCWoOM7MmuYuvs5PI=
 github.com/signalfx/sapm-proto v0.13.0 h1:yEkp1+MAU4vZvnJMp56uhVlRjlvCK7KQjBg0g2Apw8k=
 github.com/signalfx/sapm-proto v0.13.0/go.mod h1:C72HjeCW5v0Llk6pIVJ/ZH8A5GbiZpCCSkE1dSlpWxY=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 h1:FCyZbLP9tqrwca1CLRxosGCbBXzaL7oFXmEbrUbiwSM=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1/go.mod h1:92AQ/lCA08Aw2Eg8mgdIAak7IWyTbV5PZHocEO7vH0g=
 github.com/sijms/go-ora/v2 v2.7.17 h1:M/pYIqjaMUeBxyzOWp2oj4ntF6fHSBloJWGNH9vbmsU=
 github.com/sijms/go-ora/v2 v2.7.17/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -586,7 +586,6 @@ require (
 	github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 // indirect
 	github.com/signalfx/golib/v3 v3.3.47 // indirect
 	github.com/signalfx/sapm-proto v0.13.0 // indirect
-	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 // indirect
 	github.com/sijms/go-ora/v2 v2.7.17 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/snowflakedb/gosnowflake v1.6.24 // indirect

--- a/cmd/otelcontribcol/go.sum
+++ b/cmd/otelcontribcol/go.sum
@@ -3017,8 +3017,6 @@ github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8
 github.com/signalfx/sapm-proto v0.7.2/go.mod h1:HLufOh6Gd2altGxbeve+s6hh0EWCWoOM7MmuYuvs5PI=
 github.com/signalfx/sapm-proto v0.13.0 h1:yEkp1+MAU4vZvnJMp56uhVlRjlvCK7KQjBg0g2Apw8k=
 github.com/signalfx/sapm-proto v0.13.0/go.mod h1:C72HjeCW5v0Llk6pIVJ/ZH8A5GbiZpCCSkE1dSlpWxY=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 h1:FCyZbLP9tqrwca1CLRxosGCbBXzaL7oFXmEbrUbiwSM=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1/go.mod h1:92AQ/lCA08Aw2Eg8mgdIAak7IWyTbV5PZHocEO7vH0g=
 github.com/sijms/go-ora/v2 v2.7.17 h1:M/pYIqjaMUeBxyzOWp2oj4ntF6fHSBloJWGNH9vbmsU=
 github.com/sijms/go-ora/v2 v2.7.17/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=

--- a/cmd/oteltestbedcol/go.mod
+++ b/cmd/oteltestbedcol/go.mod
@@ -211,7 +211,6 @@ require (
 	github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 // indirect
 	github.com/signalfx/golib/v3 v3.3.47 // indirect
 	github.com/signalfx/sapm-proto v0.13.0 // indirect
-	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/cmd/oteltestbedcol/go.sum
+++ b/cmd/oteltestbedcol/go.sum
@@ -2476,8 +2476,6 @@ github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8
 github.com/signalfx/sapm-proto v0.7.2/go.mod h1:HLufOh6Gd2altGxbeve+s6hh0EWCWoOM7MmuYuvs5PI=
 github.com/signalfx/sapm-proto v0.13.0 h1:yEkp1+MAU4vZvnJMp56uhVlRjlvCK7KQjBg0g2Apw8k=
 github.com/signalfx/sapm-proto v0.13.0/go.mod h1:C72HjeCW5v0Llk6pIVJ/ZH8A5GbiZpCCSkE1dSlpWxY=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 h1:FCyZbLP9tqrwca1CLRxosGCbBXzaL7oFXmEbrUbiwSM=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1/go.mod h1:92AQ/lCA08Aw2Eg8mgdIAak7IWyTbV5PZHocEO7vH0g=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	apmcorrelation "github.com/signalfx/signalfx-agent/pkg/apm/correlations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
@@ -21,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.uber.org/zap"
 
+	apmcorrelation "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/correlations"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/correlation"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/translation"

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx v0.85.0
 	github.com/shirou/gopsutil/v3 v3.23.8
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.3
-	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1
+	github.com/signalfx/golib/v3 v3.3.47
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector/component v0.85.1-0.20230919160920-512b9c3c8fec
 	go.opentelemetry.io/collector/config/confighttp v0.85.1-0.20230919160920-512b9c3c8fec
@@ -63,7 +63,6 @@ require (
 	github.com/rs/cors v1.10.0 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 // indirect
-	github.com/signalfx/golib/v3 v3.3.47 // indirect
 	github.com/signalfx/sapm-proto v0.13.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect

--- a/exporter/signalfxexporter/go.sum
+++ b/exporter/signalfxexporter/go.sum
@@ -2357,8 +2357,6 @@ github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8
 github.com/signalfx/sapm-proto v0.7.2/go.mod h1:HLufOh6Gd2altGxbeve+s6hh0EWCWoOM7MmuYuvs5PI=
 github.com/signalfx/sapm-proto v0.13.0 h1:yEkp1+MAU4vZvnJMp56uhVlRjlvCK7KQjBg0g2Apw8k=
 github.com/signalfx/sapm-proto v0.13.0/go.mod h1:C72HjeCW5v0Llk6pIVJ/ZH8A5GbiZpCCSkE1dSlpWxY=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 h1:FCyZbLP9tqrwca1CLRxosGCbBXzaL7oFXmEbrUbiwSM=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1/go.mod h1:92AQ/lCA08Aw2Eg8mgdIAak7IWyTbV5PZHocEO7vH0g=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/exporter/signalfxexporter/internal/apm/correlations/client.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/client.go
@@ -1,0 +1,392 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/correlations/client.go
+
+package correlations // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/correlations"
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/signalfx/golib/v3/datapoint"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/log"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/requests"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/requests/requestcounter"
+)
+
+var ErrChFull = errors.New("request channel full")
+var errRetryChFull = errors.New("retry channel full")
+var errMaxAttempts = errors.New("maximum attempts exceeded")
+var errRequestCancelled = errors.New("request cancelled")
+
+// ErrMaxEntries is an error returned when the correlation endpoint returns a 418 http status
+// code indicating that the set of services or environments is too large to add another value
+type ErrMaxEntries struct {
+	MaxEntries int64 `json:"max,omitempty"`
+}
+
+func (m *ErrMaxEntries) Error() string {
+	return fmt.Sprintf("max entries %d", m.MaxEntries)
+}
+
+var _ error = (*ErrMaxEntries)(nil)
+
+// CorrelationClient is an interface for correlations.Client
+type CorrelationClient interface {
+	Correlate(*Correlation, CorrelateCB)
+	Delete(*Correlation, SuccessfulDeleteCB)
+	Get(dimName string, dimValue string, cb SuccessfulGetCB)
+	InternalMetrics() []*datapoint.Datapoint
+	Start()
+}
+
+type request struct {
+	*Correlation
+	ctx       context.Context
+	cancel    context.CancelFunc
+	operation string
+	callback  func(body []byte, statuscode int, err error)
+	sendAt    time.Time
+}
+
+// Client is a client for making dimensional correlations
+type Client struct {
+	sync.RWMutex
+	log           log.Logger
+	ctx           context.Context
+	wg            sync.WaitGroup
+	Token         string
+	APIURL        *url.URL
+	client        *http.Client
+	requestSender *requests.ReqSender
+	requestChan   chan *request
+	retryChan     chan *request
+	dedup         *deduplicator
+
+	// For easier unit testing
+	now        func() time.Time
+	logUpdates bool
+
+	retryDelay  time.Duration
+	maxAttempts uint32
+
+	TotalClientError4xxResponses int64
+	TotalRetriedUpdates          int64
+	TotalInvalidDimensions       int64
+	dedupCleanupInterval         time.Duration
+}
+
+// Config defines configuration for correlation settings.
+type Config struct {
+	MaxRequests     uint          `mapstructure:"max_requests"`
+	MaxBuffered     uint          `mapstructure:"max_buffered"`
+	MaxRetries      uint          `mapstructure:"max_retries"`
+	LogUpdates      bool          `mapstructure:"log_updates"`
+	RetryDelay      time.Duration `mapstructure:"retry_delay"`
+	CleanupInterval time.Duration `mapstructure:"cleanup_interval"`
+}
+
+// ClientConfig for correlation client.
+type ClientConfig struct {
+	Config
+	AccessToken string
+	URL         *url.URL
+}
+
+// NewCorrelationClient returns a new Client
+func NewCorrelationClient(log log.Logger, ctx context.Context, client *http.Client, conf ClientConfig) (CorrelationClient, error) {
+	sender := requests.NewReqSender(ctx, client, conf.MaxRequests, "correlation")
+	return &Client{
+		log:                  log,
+		ctx:                  ctx,
+		Token:                conf.AccessToken,
+		APIURL:               conf.URL,
+		requestSender:        sender,
+		client:               client,
+		now:                  time.Now,
+		logUpdates:           conf.LogUpdates,
+		requestChan:          make(chan *request, conf.MaxBuffered),
+		retryChan:            make(chan *request, conf.MaxBuffered),
+		dedup:                newDeduplicator(int(conf.MaxBuffered)),
+		retryDelay:           conf.RetryDelay,
+		maxAttempts:          uint32(conf.MaxRetries) + 1,
+		dedupCleanupInterval: conf.CleanupInterval,
+	}, nil
+}
+
+func (cc *Client) putRequestOnChan(r *request) error {
+	// prevent requests against empty dimension names and values
+	if r.DimName == "" || r.DimValue == "" {
+		// logging this as debug because this means there's no actual dimension to correlate with
+		// and because this isn't being taken off on the request sender and subject to retries, this could
+		// potentially spam the logs
+		atomic.AddInt64(&cc.TotalInvalidDimensions, int64(1))
+		r.Logger(cc.log).WithFields(log.Fields{"method": r.operation}).Debug("No dimension key or value to correlate to")
+		return nil
+	}
+
+	r.ctx, r.cancel = context.WithCancel(requestcounter.ContextWithRequestCounter(context.Background()))
+
+	var err error
+	select {
+	case cc.requestChan <- r:
+	case <-cc.ctx.Done():
+		err = context.DeadlineExceeded
+	default:
+		err = ErrChFull
+	}
+	return err
+}
+
+func (cc *Client) putRequestOnRetryChan(r *request) error {
+	// handle request counter
+	if requestcounter.GetRequestCount(r.ctx) == cc.maxAttempts {
+		return errMaxAttempts
+	}
+	requestcounter.IncrementRequestCount(r.ctx)
+
+	// set the time to retry
+	r.sendAt = cc.now().Add(cc.retryDelay)
+
+	if r.ctx.Err() != nil {
+		return errRequestCancelled
+	}
+
+	var err error
+	select {
+	case <-r.ctx.Done():
+		err = errRequestCancelled
+	case cc.retryChan <- r:
+	case <-cc.ctx.Done():
+		err = context.DeadlineExceeded
+	default:
+		err = errRetryChFull
+	}
+
+	return err
+}
+
+// CorrelateCB is a call back invoked with Correlate requests
+// it is not invoked if the reqeust is deduplicated, cancelled, or the client context is cancelled
+type CorrelateCB func(cor *Correlation, err error)
+
+// Correlate
+func (cc *Client) Correlate(cor *Correlation, cb CorrelateCB) {
+	err := cc.putRequestOnChan(&request{
+		Correlation: cor,
+		operation:   http.MethodPut,
+		callback: func(body []byte, statuscode int, err error) {
+			switch statuscode {
+			case http.StatusOK:
+				if cc.logUpdates {
+					cor.Logger(cc.log).WithFields(log.Fields{"method": http.MethodPut}).Info("Updated dimension")
+				}
+			case http.StatusTeapot:
+				max := &ErrMaxEntries{}
+				err = json.Unmarshal(body, max)
+				if err == nil {
+					err = max
+				}
+			}
+			if err != nil {
+				cor.Logger(cc.log).WithError(err).WithFields(log.Fields{"method": http.MethodPut}).Error("Unable to update dimension, not retrying")
+			}
+			cb(cor, err)
+		}})
+	if err != nil {
+		cor.Logger(cc.log).WithError(err).WithFields(log.Fields{"method": http.MethodPut}).Debug("Unable to update dimension, not retrying")
+	}
+}
+
+// SuccessfulDeleteCB is a call back that is only invoked on successful Deletion operations
+type SuccessfulDeleteCB func(cor *Correlation)
+
+// Delete removes a correlation
+func (cc *Client) Delete(cor *Correlation, callback SuccessfulDeleteCB) {
+	err := cc.putRequestOnChan(&request{
+		Correlation: cor,
+		operation:   http.MethodDelete,
+		callback: func(_ []byte, statuscode int, err error) {
+			switch statuscode {
+			case http.StatusOK:
+				callback(cor)
+				if cc.logUpdates {
+					cor.Logger(cc.log).WithFields(log.Fields{"method": http.MethodDelete}).Info("Updated dimension")
+				}
+			default:
+				cc.log.WithError(err).Error("Unable to update dimension, not retrying")
+			}
+		}})
+	if err != nil {
+		cor.Logger(cc.log).WithError(err).WithFields(log.Fields{"method": http.MethodDelete}).Debug("Unable to update dimension, not retrying")
+	}
+}
+
+// SuccessfulGetCB
+type SuccessfulGetCB func(map[string][]string)
+
+// Get
+func (cc *Client) Get(dimName string, dimValue string, callback SuccessfulGetCB) {
+	err := cc.putRequestOnChan(&request{
+		Correlation: &Correlation{
+			DimName:  dimName,
+			DimValue: dimValue,
+		},
+		operation: http.MethodGet,
+		callback: func(body []byte, statuscode int, err error) {
+			switch statuscode {
+			case http.StatusOK:
+				var response = map[string][]string{}
+				err = json.Unmarshal(body, &response)
+				if err != nil {
+					cc.log.WithError(err).WithFields(log.Fields{"dim": dimName, "value": dimValue}).Error("Unable to unmarshall correlations for dimension")
+					return
+				}
+				callback(response)
+			case http.StatusNotFound:
+				// only log this as debug because we do a blanket fetch of correlations on the backend
+				// and if the backend fails to find anything this isn't really an error for us
+				cc.log.WithError(err).Debug("Unable to update dimension, not retrying")
+			default:
+				cc.log.WithError(err).Error("Unable to update dimension, not retrying")
+			}
+		},
+	})
+	if err != nil {
+		cc.log.WithError(err).WithFields(log.Fields{"dimensionName": dimName, "dimensionValue": dimValue}).Debug("Unable to retrieve correlations for dimension, not retrying")
+	}
+}
+
+func (cc *Client) makeRequest(r *request) {
+	var (
+		req *http.Request
+		err error
+	)
+
+	// build endpoint url
+	endpoint := fmt.Sprintf("%s/v2/apm/correlate/%s/%s", cc.APIURL, url.PathEscape(r.DimName), url.PathEscape(r.DimValue))
+
+	switch r.operation {
+	case http.MethodGet:
+		req, err = http.NewRequest(r.operation, endpoint, nil)
+	case http.MethodPut:
+		// TODO: pool the reader
+		endpoint = fmt.Sprintf("%s/%s", endpoint, r.Type)
+		req, err = http.NewRequest(r.operation, endpoint, strings.NewReader(r.Value))
+		req.Header.Add("Content-Type", "text/plain")
+	case http.MethodDelete:
+		endpoint = fmt.Sprintf("%s/%s/%s", endpoint, r.Type, url.PathEscape(r.Value))
+		req, err = http.NewRequest(r.operation, endpoint, nil)
+	default:
+		err = fmt.Errorf("unknown operation")
+	}
+
+	if err != nil {
+		// logging this as debug because this means there's something fundamentally wrong with the request
+		// and because this isn't being taken off on the request sender and subject to retries, this could
+		// potentially spam the logs long term.  This would be a really good candidate for a throttled error logger
+		r.Correlation.Logger(cc.log).WithError(err).WithFields(log.Fields{"method": r.operation}).Debug("Unable to make request, not retrying")
+		r.cancel()
+		return
+	}
+
+	req.Header.Add("X-SF-TOKEN", cc.Token)
+
+	req = req.WithContext(
+		context.WithValue(req.Context(), requests.RequestFailedCallbackKey, requests.RequestFailedCallback(func(body []byte, statusCode int, err error) {
+			// retry if the http status code is not 4XX. A 4xx or http client error implies
+			// an error that is not going to be remedied by retrying.
+			if statusCode < 400 || statusCode >= 500 {
+				// The retry (for non 400 errors) is meant to provide some measure of robustness against
+				// temporary API failures.  If the API is down for significant
+				// periods of time, correlation updates will probably eventually back
+				// up beyond conf.MaxBuffered and start dropping.
+				retryErr := cc.putRequestOnRetryChan(r)
+				if retryErr == nil {
+					r.Correlation.Logger(cc.log).WithError(err).WithFields(log.Fields{"method": req.Method}).Debug("Unable to update dimension, retrying")
+					return
+				}
+			} else {
+				atomic.AddInt64(&cc.TotalClientError4xxResponses, int64(1))
+			}
+
+			// invoke the callback
+			r.callback(body, statusCode, err)
+
+			// cancel the request context
+			r.cancel()
+		})))
+
+	req = req.WithContext(
+		context.WithValue(req.Context(), requests.RequestSuccessCallbackKey, requests.RequestSuccessCallback(func(body []byte) {
+			r.callback(body, http.StatusOK, nil)
+			// close the request context
+			r.cancel()
+		})))
+
+	// This will block if we don't have enough requests
+	cc.requestSender.Send(req)
+}
+
+// routines
+// processChan processes incoming requests, drops duplicates, and cancels conflicting requests
+func (cc *Client) processChan() {
+	defer cc.wg.Done()
+	purgeDeduper := time.NewTimer(cc.dedupCleanupInterval)
+	defer purgeDeduper.Stop()
+	for {
+		select {
+		case <-cc.ctx.Done():
+			return
+		case <-purgeDeduper.C:
+			cc.dedup.purge()
+			purgeDeduper.Reset(cc.dedupCleanupInterval)
+		case r := <-cc.requestChan:
+			if cc.dedup.isDup(r) {
+				r.cancel()
+				continue
+			}
+			cc.makeRequest(r)
+		}
+	}
+}
+
+// processRetryChan is a routine that drains the retry channel and waits until the appropriate time to retry the request
+func (cc *Client) processRetryChan() {
+	defer cc.wg.Done()
+	for {
+		select {
+		case <-cc.ctx.Done(): // client is shutdown
+			return
+		case r := <-cc.retryChan:
+			if r.ctx.Err() != nil {
+				continue
+			}
+			select {
+			case <-time.After(time.Until(r.sendAt)): // wait and resend the request
+				atomic.AddInt64(&cc.TotalRetriedUpdates, int64(1))
+				cc.makeRequest(r)
+			case <-r.ctx.Done(): // request is cancelled
+				continue
+			case <-cc.ctx.Done(): // client is shutdown
+				return
+			}
+		}
+	}
+}
+
+// Start the client's processing queue
+func (cc *Client) Start() {
+	cc.wg.Add(2)
+	go cc.processChan()
+	go cc.processRetryChan()
+}

--- a/exporter/signalfxexporter/internal/apm/correlations/client.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/client.go
@@ -103,7 +103,7 @@ type ClientConfig struct {
 }
 
 // NewCorrelationClient returns a new Client
-func NewCorrelationClient(log log.Logger, ctx context.Context, client *http.Client, conf ClientConfig) (CorrelationClient, error) {
+func NewCorrelationClient(ctx context.Context, log log.Logger, client *http.Client, conf ClientConfig) (CorrelationClient, error) {
 	sender := requests.NewReqSender(ctx, client, conf.MaxRequests, "correlation")
 	return &Client{
 		log:                  log,

--- a/exporter/signalfxexporter/internal/apm/correlations/client_test.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/client_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -83,7 +83,7 @@ func makeHandler(t *testing.T, corCh chan<- *request, forcedRespCode *atomic.Val
 				return
 			}
 
-			body, err := ioutil.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				rw.WriteHeader(400)
 				return
@@ -170,7 +170,7 @@ func setup(t *testing.T) (CorrelationClient, chan *request, *atomic.Value, *atom
 		},
 	}
 
-	client, err := NewCorrelationClient(log.Nil, ctx, httpClient, conf)
+	client, err := NewCorrelationClient(ctx, log.Nil, httpClient, conf)
 	if err != nil {
 		panic("could not make correlation client: " + err.Error())
 	}
@@ -205,7 +205,7 @@ func TestCorrelationClient(t *testing.T) {
 		forcedRespCode.Store(200)
 		respPayload := map[string][]string{"sf_services": {"testService1"}}
 		respJSON, err := json.Marshal(&respPayload)
-		require.Nil(t, err, "json marshalling failed in test")
+		require.Nil(t, err, "json marshaling failed in test")
 		forcedRespPayload.Store(respJSON)
 
 		var wg sync.WaitGroup

--- a/exporter/signalfxexporter/internal/apm/correlations/client_test.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/client_test.go
@@ -1,0 +1,256 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/correlations/client_test.go
+
+package correlations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/log"
+)
+
+var getPathRegexp = regexp.MustCompile(`/v2/apm/correlate/([^/]+)/([^/]+)`)                    // /dimName/dimVal
+var putPathRegexp = regexp.MustCompile(`/v2/apm/correlate/([^/]+)/([^/]+)/([^/]+)`)            // /dimName/dimVal/{service,environment}
+var deletePathRegexp = regexp.MustCompile(`/v2/apm/correlate/([^/]+)/([^/]+)/([^/]+)/([^/]+)`) // /dimName/dimValue/{service,environment}/value
+
+func waitForCors(corCh <-chan *request, count, waitSeconds int) []*request { // nolint: unparam
+	cors := make([]*request, 0, count)
+	timeout := time.After(time.Duration(waitSeconds) * time.Second)
+
+loop:
+	for {
+		select {
+		case cor := <-corCh:
+			cors = append(cors, cor)
+			if len(cors) >= count {
+				break loop
+			}
+		case <-timeout:
+			break loop
+		}
+	}
+
+	return cors
+}
+
+func makeHandler(t *testing.T, corCh chan<- *request, forcedRespCode *atomic.Value, forcedRespPayload *atomic.Value) http.HandlerFunc {
+	forcedRespCode.Store(200)
+
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		forcedRespInt := forcedRespCode.Load().(int)
+		if forcedRespInt != 200 {
+			rw.WriteHeader(forcedRespInt)
+			return
+		}
+
+		t.Logf("Test server got %s request: %s", r.Method, r.URL.Path)
+		var cor *request
+		switch r.Method {
+		case http.MethodGet:
+			match := getPathRegexp.FindStringSubmatch(r.URL.Path)
+			if match == nil || len(match) < 3 {
+				rw.WriteHeader(404)
+				return
+			}
+			corCh <- &request{
+				operation: r.Method,
+				Correlation: &Correlation{
+					DimName:  match[1],
+					DimValue: match[2],
+				},
+			}
+			_, _ = rw.Write(forcedRespPayload.Load().([]byte))
+			return
+		case http.MethodPut:
+			match := putPathRegexp.FindStringSubmatch(r.URL.Path)
+			if match == nil || len(match) < 4 {
+				rw.WriteHeader(404)
+				return
+			}
+
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				rw.WriteHeader(400)
+				return
+			}
+			cor = &request{
+				operation: r.Method,
+				Correlation: &Correlation{
+					DimName:  match[1],
+					DimValue: match[2],
+					Type:     Type(match[3]),
+					Value:    string(body),
+				},
+			}
+
+		case http.MethodDelete:
+			match := deletePathRegexp.FindStringSubmatch(r.URL.Path)
+			if match == nil || len(match) < 5 {
+				rw.WriteHeader(404)
+				return
+			}
+			cor = &request{
+				operation: r.Method,
+				Correlation: &Correlation{
+					DimName:  match[1],
+					DimValue: match[2],
+					Type:     Type(match[3]),
+					Value:    match[4],
+				},
+			}
+		default:
+			rw.WriteHeader(404)
+			return
+		}
+
+		corCh <- cor
+
+		rw.WriteHeader(200)
+	})
+}
+
+func setup(t *testing.T) (CorrelationClient, chan *request, *atomic.Value, *atomic.Value, context.CancelFunc) {
+	serverCh := make(chan *request, 100)
+
+	var forcedRespCode atomic.Value
+	var forcedRespPayload atomic.Value
+	server := httptest.NewServer(makeHandler(t, serverCh, &forcedRespCode, &forcedRespPayload))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-ctx.Done()
+		server.Close()
+	}()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		panic(err)
+	}
+
+	conf := ClientConfig{
+		Config: Config{
+			MaxRequests:     10,
+			MaxBuffered:     10,
+			MaxRetries:      4,
+			LogUpdates:      true,
+			RetryDelay:      0,
+			CleanupInterval: 0,
+		},
+		AccessToken: "",
+		URL:         serverURL,
+	}
+
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   5 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			MaxIdleConns:        int(conf.MaxRequests),
+			MaxIdleConnsPerHost: int(conf.MaxRequests),
+			IdleConnTimeout:     30 * time.Second,
+			TLSHandshakeTimeout: 10 * time.Second,
+		},
+	}
+
+	client, err := NewCorrelationClient(log.Nil, ctx, httpClient, conf)
+	if err != nil {
+		panic("could not make correlation client: " + err.Error())
+	}
+	client.Start()
+
+	return client, serverCh, &forcedRespCode, &forcedRespPayload, cancel
+}
+
+func TestCorrelationClient(t *testing.T) {
+	client, serverCh, forcedRespCode, forcedRespPayload, cancel := setup(t)
+	defer close(serverCh)
+	defer cancel()
+
+	for _, correlationType := range []Type{Service, Environment} {
+		for _, op := range []string{http.MethodPut, http.MethodDelete} {
+			op := op
+			correlationType := correlationType
+			t.Run(fmt.Sprintf("%v %v", op, correlationType), func(t *testing.T) {
+				testData := &Correlation{Type: correlationType, DimName: "host", DimValue: "test-box", Value: "test-service"}
+				switch op {
+				case http.MethodPut:
+					client.Correlate(testData, CorrelateCB(func(_ *Correlation, _ error) {}))
+				case http.MethodDelete:
+					client.Delete(testData, SuccessfulDeleteCB(func(_ *Correlation) {}))
+				}
+				cors := waitForCors(serverCh, 1, 5)
+				require.Equal(t, []*request{{operation: op, Correlation: testData}}, cors)
+			})
+		}
+	}
+	t.Run("GET returns expected payload and 200 response", func(t *testing.T) {
+		forcedRespCode.Store(200)
+		respPayload := map[string][]string{"sf_services": {"testService1"}}
+		respJSON, err := json.Marshal(&respPayload)
+		require.Nil(t, err, "json marshalling failed in test")
+		forcedRespPayload.Store(respJSON)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		var receivedPayload map[string][]string
+		client.Get("host", "test-box", SuccessfulGetCB(func(resp map[string][]string) {
+			receivedPayload = resp
+			wg.Done()
+		}))
+		wg.Wait()
+
+		require.Equal(t, respPayload, receivedPayload)
+
+		cors := waitForCors(serverCh, 1, 3)
+		require.Len(t, cors, 1)
+	})
+	t.Run("does not retry 4xx responses", func(t *testing.T) {
+		forcedRespCode.Store(400)
+
+		testData := &Correlation{Type: Service, DimName: "host", DimValue: "test-box", Value: "test-service"}
+		client.Correlate(testData, CorrelateCB(func(_ *Correlation, _ error) {}))
+
+		cors := waitForCors(serverCh, 1, 3)
+		require.Len(t, cors, 0)
+
+		forcedRespCode.Store(200)
+		cors = waitForCors(serverCh, 1, 3)
+		require.Len(t, cors, 0)
+	})
+	t.Run("does retry 500 responses", func(t *testing.T) {
+		forcedRespCode.Store(500)
+		require.Equal(t, int64(0), atomic.LoadInt64(&client.(*Client).TotalRetriedUpdates), "test cleaned up correctly")
+		testData := &Correlation{Type: Service, DimName: "host", DimValue: "test-box", Value: "test-service"}
+		client.Correlate(testData, CorrelateCB(func(_ *Correlation, _ error) {}))
+		// sending the testData twice tests deduplication, since the 500 status
+		// will trigger retries, and the requests should be deduped and the
+		// TotalRertriedUpdates should still only be 5
+		client.Correlate(testData, CorrelateCB(func(_ *Correlation, _ error) {}))
+
+		cors := waitForCors(serverCh, 1, 4)
+		require.Len(t, cors, 0)
+		require.Equal(t, int64(5), atomic.LoadInt64(&client.(*Client).TotalRetriedUpdates))
+
+		forcedRespCode.Store(200)
+		cors = waitForCors(serverCh, 1, 2)
+		require.Equal(t, []*request{}, cors)
+	})
+}

--- a/exporter/signalfxexporter/internal/apm/correlations/correlation.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/correlation.go
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/correlations/correlation.go
+
+package correlations // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/correlations"
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/log"
+)
+
+// Type is the type of correlation
+type Type string
+
+const (
+	// Service is for correlating services
+	Service Type = "service"
+	// Environment is for correlating environments
+	Environment Type = "environment"
+)
+
+// Correlation is a struct referencing
+type Correlation struct {
+	// Type is the type of correlation
+	Type Type
+	// DimName is the dimension name
+	DimName string
+	// DimValue is the dimension value
+	DimValue string
+	// Value is the value to makeRequest with the DimName and DimValue
+	Value string
+}
+
+func (c *Correlation) Logger(l log.Logger) log.Logger {
+	return l.WithFields(log.Fields{
+		"correlation.type":     c.Type,
+		"correlation.dimName":  c.DimName,
+		"correlation.dimValue": c.DimValue,
+		"correlation.value":    c.Value,
+	})
+}

--- a/exporter/signalfxexporter/internal/apm/correlations/dedup.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/dedup.go
@@ -1,0 +1,164 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/correlations/dedup.go
+
+package correlations // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/correlations"
+
+import (
+	"container/list"
+	"net/http"
+)
+
+// deduplicator deduplicates requests and cancels pending conflicting requests and deduplicates
+// this is not threadsafe
+type deduplicator struct {
+	// maps for deduplicating requests
+	maxSize           int
+	pendingCreates    *list.List
+	pendingCreateKeys map[Correlation]*list.Element
+	pendingDeletes    *list.List
+	pendingDeleteKeys map[Correlation]*list.Element
+}
+
+func (d *deduplicator) purgeCreates() {
+	var elem = d.pendingCreates.Front()
+	for {
+		if elem == nil {
+			return
+		}
+		if elem.Value.(*request).ctx.Err() != nil {
+			toDelete := elem
+			elem = elem.Next()
+			d.pendingCreates.Remove(toDelete)
+			delete(d.pendingCreateKeys, *toDelete.Value.(*request).Correlation)
+		} else {
+			elem = elem.Next()
+		}
+	}
+}
+
+func (d *deduplicator) purgeDeletes() {
+	var elem = d.pendingDeletes.Front()
+	for {
+		if elem == nil {
+			return
+		}
+		if elem.Value.(*request).ctx.Err() != nil {
+			toDelete := elem
+			elem = elem.Next()
+			d.pendingDeletes.Remove(toDelete)
+			delete(d.pendingDeleteKeys, *toDelete.Value.(*request).Correlation)
+		} else {
+			elem = elem.Next()
+		}
+	}
+}
+
+func (d *deduplicator) purge() {
+	d.purgeCreates()
+	d.purgeDeletes()
+}
+
+func (d *deduplicator) evictPendingDelete() {
+	var elem = d.pendingDeletes.Back()
+	if elem != nil {
+		req, ok := elem.Value.(*request)
+		if ok {
+			req.cancel()
+			d.pendingDeletes.Remove(elem)
+			delete(d.pendingDeleteKeys, *req.Correlation)
+		}
+	}
+}
+
+func (d *deduplicator) evictPendingCreate() {
+	var elem = d.pendingCreates.Back()
+	if elem != nil {
+		req, ok := elem.Value.(*request)
+		if ok {
+			req.cancel()
+			d.pendingCreates.Remove(elem)
+			delete(d.pendingCreateKeys, *req.Correlation)
+
+		}
+	}
+}
+
+func (d *deduplicator) dedupCorrelate(r *request) bool {
+	// look for duplicate pending creates
+	pendingCreate, ok := d.pendingCreateKeys[*r.Correlation]
+	if ok && pendingCreate.Value.(*request).ctx.Err() == nil {
+		// return true if there is a context for the key and the context has not expired
+		return true
+	}
+
+	// make room if necessary
+	if len(d.pendingCreateKeys) >= d.maxSize {
+		d.evictPendingCreate()
+	}
+
+	// insert the request into the pendingCreates
+	elem := d.pendingCreates.PushFront(r)
+	d.pendingCreateKeys[*r.Correlation] = elem
+
+	// cancel any pending delete operations
+	deleteElem, pendindgDelete := d.pendingDeleteKeys[*r.Correlation]
+	if pendindgDelete {
+		deleteElem.Value.(*request).cancel()
+		d.pendingDeletes.Remove(deleteElem)
+		delete(d.pendingDeleteKeys, *deleteElem.Value.(*request).Correlation)
+	}
+
+	return false
+}
+
+func (d *deduplicator) dedupDelete(r *request) bool {
+	// look for duplicate pending creates
+	pendingDelete, ok := d.pendingDeleteKeys[*r.Correlation]
+	if ok && pendingDelete.Value.(*request).ctx.Err() == nil {
+		// return true if there is a context for the key and the context has not expired
+		return true
+	}
+
+	// make room if necessary
+	if len(d.pendingDeleteKeys) >= d.maxSize {
+		d.evictPendingDelete()
+	}
+
+	// insert the request into the pendingDeletes
+	elem := d.pendingDeletes.PushFront(r)
+	d.pendingDeleteKeys[*r.Correlation] = elem
+
+	// cancel any pending create operations
+	createElem, pendindgCreate := d.pendingCreateKeys[*r.Correlation]
+	if pendindgCreate {
+		createElem.Value.(*request).cancel()
+		d.pendingCreates.Remove(createElem)
+		delete(d.pendingCreateKeys, *createElem.Value.(*request).Correlation)
+	}
+
+	return false
+}
+
+// isDup returns true if the request is a duplicate
+func (d *deduplicator) isDup(r *request) (isDup bool) {
+	switch r.operation {
+	case http.MethodPut:
+		return d.dedupCorrelate(r)
+	case http.MethodDelete:
+		return d.dedupDelete(r)
+	default:
+		return
+	}
+}
+
+// newDeduplicator returns a new instance
+func newDeduplicator(size int) *deduplicator {
+	return &deduplicator{
+		maxSize:           size,
+		pendingCreates:    list.New(),
+		pendingCreateKeys: make(map[Correlation]*list.Element),
+		pendingDeletes:    list.New(),
+		pendingDeleteKeys: make(map[Correlation]*list.Element),
+	}
+}

--- a/exporter/signalfxexporter/internal/apm/correlations/diagnostics.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/diagnostics.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/correlations/diagnostics.go
+
+package correlations // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/correlations"
+
+import (
+	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/signalfx/golib/v3/sfxclient"
+)
+
+// InternalMetrics returns datapoints that describe the current state of the
+// dimension update client
+func (cc *Client) InternalMetrics() []*datapoint.Datapoint {
+	dps := []*datapoint.Datapoint{
+		sfxclient.CumulativeP("sfxagent.correlation_updates_invalid", nil, &cc.TotalInvalidDimensions),
+		// All 4xx HTTP responses that are not retried except 404 (which is retried)
+		sfxclient.CumulativeP("sfxagent.correlation_updates_client_errors", nil, &cc.TotalClientError4xxResponses),
+		sfxclient.CumulativeP("sfxagent.correlation_updates_retries", nil, &cc.TotalRetriedUpdates),
+	}
+	return append(dps, cc.requestSender.InternalMetrics()...)
+}

--- a/exporter/signalfxexporter/internal/apm/log/log.go
+++ b/exporter/signalfxexporter/internal/apm/log/log.go
@@ -1,0 +1,50 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/log/log.go
+
+package log // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/log"
+
+// Fields is a map that is used to populated logging context.
+type Fields map[string]interface{}
+
+type nilLogger struct {
+}
+
+func (n nilLogger) Debug(msg string) {
+}
+
+func (n nilLogger) Warn(msg string) {
+}
+
+func (n nilLogger) Error(msg string) {
+}
+
+func (n nilLogger) Info(msg string) {
+}
+
+func (n nilLogger) Panic(msg string) {
+}
+
+func (n nilLogger) WithFields(fields Fields) Logger {
+	return nilLogger{}
+}
+
+func (n nilLogger) WithError(err error) Logger {
+	return nilLogger{}
+}
+
+// Nil logger is a silent logger interface.
+var Nil = nilLogger{}
+
+var _ Logger = (*nilLogger)(nil)
+
+// Logger is generic logging interface.
+type Logger interface {
+	Debug(msg string)
+	Warn(msg string)
+	Error(msg string)
+	Info(msg string)
+	Panic(msg string)
+	WithFields(fields Fields) Logger
+	WithError(err error) Logger
+}

--- a/exporter/signalfxexporter/internal/apm/log/log.go
+++ b/exporter/signalfxexporter/internal/apm/log/log.go
@@ -10,26 +10,26 @@ type Fields map[string]interface{}
 type nilLogger struct {
 }
 
-func (n nilLogger) Debug(msg string) {
+func (n nilLogger) Debug(string) {
 }
 
-func (n nilLogger) Warn(msg string) {
+func (n nilLogger) Warn(string) {
 }
 
-func (n nilLogger) Error(msg string) {
+func (n nilLogger) Error(string) {
 }
 
-func (n nilLogger) Info(msg string) {
+func (n nilLogger) Info(string) {
 }
 
-func (n nilLogger) Panic(msg string) {
+func (n nilLogger) Panic(string) {
 }
 
-func (n nilLogger) WithFields(fields Fields) Logger {
+func (n nilLogger) WithFields(Fields) Logger {
 	return nilLogger{}
 }
 
-func (n nilLogger) WithError(err error) Logger {
+func (n nilLogger) WithError(error) Logger {
 	return nilLogger{}
 }
 

--- a/exporter/signalfxexporter/internal/apm/requests/diagnostics.go
+++ b/exporter/signalfxexporter/internal/apm/requests/diagnostics.go
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/requests/diagnostics.go
+
+package requests // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/requests"
+
+import (
+	"sync/atomic"
+
+	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/signalfx/golib/v3/sfxclient"
+)
+
+// InternalMetrics returns datapoints that describe the current state of the
+// dimension update client
+func (rs *ReqSender) InternalMetrics() []*datapoint.Datapoint {
+	return []*datapoint.Datapoint{
+		sfxclient.CumulativeP("sfxagent.dim_updates_started", map[string]string{"client": rs.clientName}, &rs.TotalRequestsStarted),
+		sfxclient.CumulativeP("sfxagent.dim_updates_completed", map[string]string{"client": rs.clientName}, &rs.TotalRequestsCompleted),
+		sfxclient.CumulativeP("sfxagent.dim_updates_failed", map[string]string{"client": rs.clientName}, &rs.TotalRequestsFailed),
+		sfxclient.Gauge("sfxagent.dim_request_senders", map[string]string{"client": rs.clientName}, atomic.LoadInt64(&rs.RunningWorkers)),
+	}
+}

--- a/exporter/signalfxexporter/internal/apm/requests/requestcounter/counter.go
+++ b/exporter/signalfxexporter/internal/apm/requests/requestcounter/counter.go
@@ -1,0 +1,67 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/requests/requestcounter/counter.go
+
+package requestcounter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/requests/requestcounter"
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type key int
+
+const (
+	getRequestCountKey       key = 1
+	incrementRequestCountKey key = 2
+	resetRequestCountKey     key = 3
+)
+
+type getRequestCount func() uint32
+type incrementRequestCount func()
+type resetRequestCount func()
+
+// checks if a counter already exists on the context
+func counterExists(ctx context.Context) (exists bool) {
+	if _, exists = ctx.Value(getRequestCountKey).(getRequestCount); !exists {
+		if _, exists = ctx.Value(incrementRequestCountKey).(incrementRequestCount); !exists {
+			_, exists = ctx.Value(resetRequestCountKey).(resetRequestCount)
+		}
+	}
+	return exists
+}
+
+// ContextWithRequestCounter adds a counter to the context if one does not already exist
+func ContextWithRequestCounter(ctx context.Context) context.Context {
+	if counterExists(ctx) {
+		// don't create a new context with counter if a counter already exists on the counter
+		return ctx
+	}
+	var c uint32
+	newCtx := context.WithValue(ctx, getRequestCountKey, getRequestCount(func() uint32 { return atomic.LoadUint32(&c) }))
+	newCtx = context.WithValue(newCtx, incrementRequestCountKey, incrementRequestCount(func() { atomic.AddUint32(&c, 1) }))
+	return context.WithValue(newCtx, resetRequestCountKey, resetRequestCount(func() { atomic.StoreUint32(&c, 0) }))
+}
+
+// ResetRequestCount resets the request counter on the provided context if the context has one
+func ResetRequestCount(ctx context.Context) {
+	if res, ok := ctx.Value(resetRequestCountKey).(resetRequestCount); ok {
+		res()
+	}
+}
+
+// IncrementRequestCount increments the request counter on the provided context if the context has one
+func IncrementRequestCount(ctx context.Context) {
+	if inc, ok := ctx.Value(incrementRequestCountKey).(incrementRequestCount); ok {
+		inc()
+	}
+}
+
+// GetRequestCount retrieves the current request count on the provided context.  It returns 0 if the context does not
+// have a request counter
+func GetRequestCount(ctx context.Context) (count uint32) {
+	if get, ok := ctx.Value(getRequestCountKey).(getRequestCount); ok {
+		count = get()
+	}
+	return count
+}

--- a/exporter/signalfxexporter/internal/apm/requests/requestcounter/counter_test.go
+++ b/exporter/signalfxexporter/internal/apm/requests/requestcounter/counter_test.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/requests/requestcounter/counter_test.go
+
+package requestcounter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContextWithRequestCounter(t *testing.T) {
+	parent := ContextWithRequestCounter(context.Background())
+	assert.True(t, counterExists(parent), "parent context contains counter")
+	assert.Equal(t, uint32(0), GetRequestCount(parent), "parent context with counter is initialized to 0")
+
+	// ensure counter can be incremented
+	IncrementRequestCount(parent)
+	assert.Equal(t, uint32(1), GetRequestCount(parent), "parent context is incremented")
+
+	// ensure child contexts retains the counter
+	child, _ := context.WithCancel(parent)
+	assert.True(t, counterExists(parent), "child context contains counter")
+	assert.Equal(t, uint32(1), GetRequestCount(child), "child context carried over parent count")
+
+	// ensure increment on child also increments parent
+	IncrementRequestCount(child)
+	assert.Equal(t, uint32(2), GetRequestCount(child), "child context can be incremented")
+	assert.Equal(t, uint32(2), GetRequestCount(parent), "parent context was incremented when child was incremented")
+
+	// ensure increment on parent also increments child
+	IncrementRequestCount(parent)
+	assert.Equal(t, uint32(3), GetRequestCount(parent), "parent context can still still increment counter")
+	assert.Equal(t, uint32(3), GetRequestCount(child), "child context counter was incremented when parent was incremented")
+
+	assert.Equal(t, uint32(3), GetRequestCount(ContextWithRequestCounter(parent)), "trying to get a context with a counter shouldn't not overwrite an existing counter")
+
+	// ensure counter can be reset
+	ResetRequestCount(child)
+	assert.Equal(t, uint32(0), GetRequestCount(parent), "parent context counter was reset")
+	assert.Equal(t, uint32(0), GetRequestCount(child), "child context counter was reset")
+
+	// ensure no error when context with out counter is passed in to functions
+	todo := context.TODO()
+	assert.False(t, counterExists(todo), "plain context shouldn't have a counter")
+	assert.Equal(t, uint32(0), GetRequestCount(todo), "plain context should return count of 0")
+	assert.NotPanics(t, func() { IncrementRequestCount(todo) }, todo, "incrementing a plain counter should not panic")
+	assert.Equal(t, uint32(0), GetRequestCount(todo), "incrementing a plain counter should do nothing")
+}

--- a/exporter/signalfxexporter/internal/apm/requests/requestcounter/counter_test.go
+++ b/exporter/signalfxexporter/internal/apm/requests/requestcounter/counter_test.go
@@ -21,7 +21,7 @@ func TestContextWithRequestCounter(t *testing.T) {
 	assert.Equal(t, uint32(1), GetRequestCount(parent), "parent context is incremented")
 
 	// ensure child contexts retains the counter
-	child, _ := context.WithCancel(parent)
+	child, _ := context.WithCancel(parent) //nolint:govet
 	assert.True(t, counterExists(parent), "child context contains counter")
 	assert.Equal(t, uint32(1), GetRequestCount(child), "child context carried over parent count")
 

--- a/exporter/signalfxexporter/internal/apm/requests/sender.go
+++ b/exporter/signalfxexporter/internal/apm/requests/sender.go
@@ -1,0 +1,129 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/requests/sender.go
+
+package requests // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/requests"
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync/atomic"
+)
+
+type ReqSender struct {
+	client      *http.Client
+	requests    chan *http.Request
+	workerCount uint32
+	ctx         context.Context
+	clientName  string
+
+	RunningWorkers         int64
+	TotalRequestsStarted   int64
+	TotalRequestsCompleted int64
+	TotalRequestsFailed    int64
+}
+
+func NewReqSender(ctx context.Context, client *http.Client, workerCount uint, clientName string) *ReqSender {
+	return &ReqSender{
+		client:     client,
+		clientName: clientName,
+		// Unbuffered so that it blocks clients
+		requests:    make(chan *http.Request),
+		workerCount: uint32(workerCount),
+		ctx:         ctx,
+	}
+}
+
+func (rs *ReqSender) Send(req *http.Request) {
+	// Slight optimization to avoid spinning up unnecessary workers if there
+	// aren't ever that many dim updates. Once workers start, they remain for the
+	// duration of the agent.
+	select {
+	case rs.requests <- req:
+		return
+	default:
+		if atomic.LoadInt64(&rs.RunningWorkers) < int64(atomic.LoadUint32(&rs.workerCount)) {
+			go rs.processRequests()
+		}
+
+		// Block until we can get through a request
+		rs.requests <- req
+	}
+}
+
+func (rs *ReqSender) processRequests() {
+	atomic.AddInt64(&rs.RunningWorkers, int64(1))
+	defer atomic.AddInt64(&rs.RunningWorkers, int64(-1))
+
+	for {
+		select {
+		case <-rs.ctx.Done():
+			return
+		case req := <-rs.requests:
+			atomic.AddInt64(&rs.TotalRequestsStarted, int64(1))
+			if err := rs.sendRequest(req); err != nil {
+				atomic.AddInt64(&rs.TotalRequestsFailed, int64(1))
+				continue
+			}
+			atomic.AddInt64(&rs.TotalRequestsCompleted, int64(1))
+		}
+	}
+}
+
+func (rs *ReqSender) sendRequest(req *http.Request) error {
+	body, statusCode, err := sendRequest(rs.client, req)
+	// If it was successful there is nothing else to do.
+	if statusCode == 200 {
+		onRequestSuccess(req, body)
+		return nil
+	}
+
+	if err != nil {
+		err = fmt.Errorf("error making HTTP request to %s: %v", req.URL.String(), err)
+	} else {
+		err = fmt.Errorf("unexpected status code %d on response for request to %s: %s", statusCode, req.URL.String(), string(body))
+	}
+
+	onRequestFailed(req, body, statusCode, err)
+
+	return err
+}
+
+type key int
+
+const RequestFailedCallbackKey key = 1
+const RequestSuccessCallbackKey key = 2
+
+type RequestFailedCallback func(body []byte, statusCode int, err error)
+type RequestSuccessCallback func([]byte)
+
+func onRequestSuccess(req *http.Request, body []byte) {
+	ctx := req.Context()
+	cb, ok := ctx.Value(RequestSuccessCallbackKey).(RequestSuccessCallback)
+	if !ok {
+		return
+	}
+	cb(body)
+}
+func onRequestFailed(req *http.Request, body []byte, statusCode int, err error) {
+	ctx := req.Context()
+	cb, ok := ctx.Value(RequestFailedCallbackKey).(RequestFailedCallback)
+	if !ok {
+		return
+	}
+	cb(body, statusCode, err)
+}
+
+func sendRequest(client *http.Client, req *http.Request) ([]byte, int, error) {
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	return body, resp.StatusCode, err
+}

--- a/exporter/signalfxexporter/internal/apm/requests/sender.go
+++ b/exporter/signalfxexporter/internal/apm/requests/sender.go
@@ -7,7 +7,7 @@ package requests // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync/atomic"
 )
@@ -81,7 +81,7 @@ func (rs *ReqSender) sendRequest(req *http.Request) error {
 	}
 
 	if err != nil {
-		err = fmt.Errorf("error making HTTP request to %s: %v", req.URL.String(), err)
+		err = fmt.Errorf("error making HTTP request to %s: %w", req.URL.String(), err)
 	} else {
 		err = fmt.Errorf("unexpected status code %d on response for request to %s: %s", statusCode, req.URL.String(), string(body))
 	}
@@ -124,6 +124,6 @@ func sendRequest(client *http.Client, req *http.Request) ([]byte, int, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	return body, resp.StatusCode, err
 }

--- a/exporter/signalfxexporter/internal/apm/tracetracker/cache.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/cache.go
@@ -1,0 +1,188 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/tracetracker/cache.go
+
+package tracetracker // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/tracetracker"
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+type CacheKey struct {
+	dimName  string
+	dimValue string
+	value    string
+}
+
+type cacheElem struct {
+	LastSeen time.Time
+	Obj      *CacheKey
+}
+
+type TimeoutCache struct {
+	sync.Mutex
+
+	// How long to keep sending metrics for a particular service name after it
+	// is last seen
+	timeout time.Duration
+	// A linked list of keys sorted by time last seen
+	keysByTime *list.List
+	// Which keys are active currently.  The value is an entry in the
+	// keysByTime linked list so that it can be quickly accessed and
+	// moved to the back of the list.
+	keysActive map[CacheKey]*list.Element
+
+	// Internal metrics
+	ActiveCount int64
+	PurgedCount int64
+
+	maxSize         int64
+	maxSizeExpiryTS time.Time
+}
+
+// returns whether the cache is full
+func (t *TimeoutCache) IsFull() bool {
+	t.Lock()
+	defer t.Unlock()
+	if time.Now().Before(t.maxSizeExpiryTS) {
+		return int64(len(t.keysActive)) >= t.maxSize
+	}
+	return false
+}
+
+func (t *TimeoutCache) SetMaxSize(max int64, now time.Time) {
+	t.Lock()
+	defer t.Unlock()
+	t.maxSize = max
+	t.maxSizeExpiryTS = now.Add(time.Hour * 1)
+}
+
+// RunIfKeyDoesNotExist locks and runs the supplied function if the key does not exist.
+// Be careful not to perform cache operations inside of this function because they will deadlock
+func (t *TimeoutCache) RunIfKeyDoesNotExist(o *CacheKey, fn func()) {
+	t.Lock()
+	defer t.Unlock()
+	if _, ok := t.keysActive[*o]; ok {
+		return
+	}
+	fn()
+}
+
+// UpdateOrCreate
+func (t *TimeoutCache) UpdateOrCreate(o *CacheKey, now time.Time) (isNew bool) {
+	t.Lock()
+	defer t.Unlock()
+	if timeElm, ok := t.keysActive[*o]; ok {
+		if timeElm.Value.(*cacheElem).LastSeen.Before(now) {
+			timeElm.Value.(*cacheElem).LastSeen = now
+			t.keysByTime.MoveToFront(timeElm)
+		}
+	} else {
+		isNew = true
+		elm := t.keysByTime.PushFront(&cacheElem{
+			LastSeen: now,
+			Obj:      o,
+		})
+		t.keysActive[*o] = elm
+		t.ActiveCount++
+	}
+	return
+}
+
+// UpdateIfExists
+func (t *TimeoutCache) UpdateIfExists(o *CacheKey, now time.Time) bool {
+	t.Lock()
+	defer t.Unlock()
+	var timeElm *list.Element
+	var exists bool
+	if timeElm, exists = t.keysActive[*o]; exists {
+		timeElm.Value.(*cacheElem).LastSeen = now
+		t.keysByTime.MoveToFront(timeElm)
+	}
+	return exists
+}
+
+func (t *TimeoutCache) GetPurgeable(now time.Time) []*CacheKey {
+	t.Lock()
+	defer t.Unlock()
+
+	var candidates []*CacheKey
+	elm := t.keysByTime.Back()
+	for {
+		if elm == nil {
+			break
+		}
+
+		e := elm.Value.(*cacheElem)
+		// If this one isn't timed out, nothing else in the list is either.
+		if now.Sub(e.LastSeen) < t.timeout {
+			break
+		}
+
+		candidates = append(candidates, e.Obj)
+
+		elm = elm.Prev()
+	}
+
+	return candidates
+}
+
+func (t *TimeoutCache) Delete(key *CacheKey) {
+	t.Lock()
+	defer t.Unlock()
+
+	elem, ok := t.keysActive[*key]
+	if ok {
+		t.keysByTime.Remove(elem)
+		delete(t.keysActive, *key)
+
+		t.ActiveCount--
+		t.PurgedCount++
+	}
+}
+
+// PurgeOld
+func (t *TimeoutCache) PurgeOld(now time.Time, onPurge func(*CacheKey)) {
+	t.Lock()
+	defer t.Unlock()
+	for {
+		elm := t.keysByTime.Back()
+		if elm == nil {
+			break
+		}
+		e := elm.Value.(*cacheElem)
+		// If this one isn't timed out, nothing else in the list is either.
+		if now.Sub(e.LastSeen) < t.timeout {
+			break
+		}
+
+		t.keysByTime.Remove(elm)
+		delete(t.keysActive, *e.Obj)
+		onPurge(e.Obj)
+
+		t.ActiveCount--
+		t.PurgedCount++
+	}
+}
+
+func (t *TimeoutCache) GetActiveCount() int64 {
+	t.Lock()
+	defer t.Unlock()
+	return t.ActiveCount
+}
+
+func (t *TimeoutCache) GetPurgedCount() int64 {
+	t.Lock()
+	defer t.Unlock()
+	return t.PurgedCount
+}
+
+func NewTimeoutCache(timeout time.Duration) *TimeoutCache {
+	return &TimeoutCache{
+		timeout:    timeout,
+		keysByTime: list.New(),
+		keysActive: make(map[CacheKey]*list.Element),
+	}
+}

--- a/exporter/signalfxexporter/internal/apm/tracetracker/shims.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/shims.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/tracetracker/shims.go
+
+package tracetracker // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/tracetracker"
+
+import (
+	"github.com/signalfx/golib/v3/trace"
+)
+
+var (
+	_ SpanList = (*spanListWrap)(nil)
+	_ Span     = (*spanWrap)(nil)
+)
+
+// Span is a generic interface for accessing span metadata.
+type Span interface {
+	Environment() (string, bool)
+	ServiceName() (string, bool)
+	Tag(string) (string, bool)
+	NumTags() int
+}
+
+// SpanList is a generic interface for accessing a list of spans.
+type SpanList interface {
+	Len() int
+	At(i int) Span
+}
+
+type spanWrap struct {
+	*trace.Span
+}
+
+func (s spanWrap) Environment() (string, bool) {
+	env, ok := s.Tags["environment"]
+	return env, ok
+}
+
+func (s spanWrap) ServiceName() (string, bool) {
+	if s.LocalEndpoint == nil || s.LocalEndpoint.ServiceName == nil || *s.LocalEndpoint.ServiceName == "" {
+		return "", false
+	}
+	return *s.LocalEndpoint.ServiceName, true
+}
+
+func (s spanWrap) Tag(tag string) (string, bool) {
+	t, ok := s.Tags[tag]
+	return t, ok
+}
+
+func (s spanWrap) NumTags() int {
+	return len(s.Tags)
+}
+
+type spanListWrap struct {
+	spans []*trace.Span
+}
+
+func (s spanListWrap) Len() int {
+	return len(s.spans)
+}
+
+func (s spanListWrap) At(i int) Span {
+	return spanWrap{Span: s.spans[i]}
+}

--- a/exporter/signalfxexporter/internal/apm/tracetracker/tracker.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/tracker.go
@@ -1,0 +1,439 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/tracetracker/tracker.go
+
+package tracetracker // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/tracetracker"
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/signalfx/golib/v3/sfxclient"
+	"github.com/signalfx/golib/v3/trace"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/correlations"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/log"
+)
+
+const spanCorrelationMetricName = "sf.int.service.heartbeat"
+
+// DefaultDimsToSyncSource are the default dimensions to sync correlated environment and services onto.
+var DefaultDimsToSyncSource = map[string]string{
+	"container_id":       "container_id",
+	"kubernetes_pod_uid": "kubernetes_pod_uid",
+}
+
+// ActiveServiceTracker keeps track of which services are seen in the trace
+// spans passed through ProcessSpans.  It supports expiry of service names if
+// they are not seen for a certain amount of time.
+type ActiveServiceTracker struct {
+	dpCacheLock sync.Mutex
+
+	log log.Logger
+
+	// hostIDDims is the map of key/values discovered by the agent that identify the host
+	hostIDDims map[string]string
+
+	// sendTraceHostCorrelationMetrics turns metric emission on and off
+	sendTraceHostCorrelationMetrics bool
+
+	// hostServiceCache is a cache of services associated with the host
+	hostServiceCache *TimeoutCache
+
+	// hostEnvironmentCache is a cache of environments associated with the host
+	hostEnvironmentCache *TimeoutCache
+
+	// tenantServiceCache is the cache for services related to containers/pods
+	tenantServiceCache *TimeoutCache
+
+	// tenantEnvironmentCache is the cache for environments related to containers/pods
+	tenantEnvironmentCache *TimeoutCache
+
+	// tenantEnvironmentEmptyCache is the cache to make sure we don't send multiple requests to mitigate a very
+	// specific corner case.  This is a separate cache so we don't impact metrics.  See the note in processEnvironment()
+	// for more information
+	tenantEmptyEnvironmentCache *TimeoutCache
+
+	// cache of service names to generate datapoints for
+	dpCache map[string]struct{}
+
+	// A callback that gets called with the correlation datapoint when a
+	// service is first seen
+	newServiceCallback func(dp *datapoint.Datapoint)
+	timeNow            func() time.Time
+
+	// correlationClient is the client used for updating infrastructure correlation properties
+	correlationClient correlations.CorrelationClient
+
+	// Internal metrics
+	spansProcessed int64
+
+	// Map of dimensions to sync to with the key being the span attribute to lookup and the value being
+	// the dimension to sync to.
+	dimsToSyncSource map[string]string
+}
+
+// dpForService actually makes the datapoint that is put into the dp cache
+func dpForService(service string) *datapoint.Datapoint {
+	return sfxclient.Gauge(spanCorrelationMetricName, map[string]string{
+		"sf_hasService": service,
+		// Host dimensions get added in the writer just like datapoints
+	}, 0)
+}
+
+// addServiceToDPCache creates a datapoint for the given service in the dpCache.
+func (a *ActiveServiceTracker) addServiceToDPCache(service string) {
+	a.dpCacheLock.Lock()
+	defer a.dpCacheLock.Unlock()
+
+	a.dpCache[service] = struct{}{}
+
+	if a.newServiceCallback != nil {
+		a.newServiceCallback(dpForService(service))
+	}
+}
+
+// removeServiceFromDPCache removes the datapoint for the given service from the dpCache
+func (a *ActiveServiceTracker) removeServiceFromDPCache(service string) {
+	a.dpCacheLock.Lock()
+	delete(a.dpCache, service)
+	a.dpCacheLock.Unlock()
+}
+
+// CorrelationDatapoints returns a list of host correlation datapoints based on
+// the spans sent through ProcessSpans
+func (a *ActiveServiceTracker) CorrelationDatapoints() []*datapoint.Datapoint {
+	a.dpCacheLock.Lock()
+	defer a.dpCacheLock.Unlock()
+
+	out := make([]*datapoint.Datapoint, 0, len(a.dpCache))
+	for service := range a.dpCache {
+		out = append(out, dpForService(service))
+	}
+	return out
+}
+
+// LoadHostIDDimCorrelations asynchronously retrieves all known correlations from the backend
+// for all known hostIDDims.  This allows the agent to timeout and manage correlation
+// deletions on restart.
+func (a *ActiveServiceTracker) LoadHostIDDimCorrelations() {
+	// asynchronously fetch all services and environments for each hostIDDim at startup
+	for dimName, dimValue := range a.hostIDDims {
+		dimName := dimName
+		dimValue := dimValue
+		a.correlationClient.Get(dimName, dimValue, func(correlations map[string][]string) {
+			if services, ok := correlations["sf_services"]; ok {
+				for _, service := range services {
+					// Note that only the value is set for the host service cache because we only track services for the host
+					// therefore there we don't need to include the dim key and value on the cache key
+					if isNew := a.hostServiceCache.UpdateOrCreate(&CacheKey{value: service}, a.timeNow()); isNew {
+						if a.sendTraceHostCorrelationMetrics {
+							// create datapoint for service
+							a.addServiceToDPCache(service)
+						}
+
+						a.log.WithFields(log.Fields{"service": service}).Debug("Tracking service name from trace span")
+					}
+				}
+			}
+			if environments, ok := correlations["sf_environments"]; ok {
+				// Note that only the value is set for the host environment cache because we only track environments for the host
+				// therefore there we don't need to include the dim key and value on the cache key
+				for _, environment := range environments {
+					if isNew := a.hostEnvironmentCache.UpdateOrCreate(&CacheKey{value: environment}, a.timeNow()); isNew {
+						a.log.WithFields(log.Fields{"environment": environment}).Debug("Tracking environment name from trace span")
+					}
+				}
+			}
+		})
+	}
+}
+
+// New creates a new initialized service tracker
+func New(
+	log log.Logger,
+	timeout time.Duration,
+	correlationClient correlations.CorrelationClient,
+	hostIDDims map[string]string,
+	sendTraceHostCorrelationMetrics bool,
+	newServiceCallback func(dp *datapoint.Datapoint),
+	dimsToSyncSource map[string]string,
+) *ActiveServiceTracker {
+	a := &ActiveServiceTracker{
+		log:                             log,
+		hostIDDims:                      hostIDDims,
+		hostServiceCache:                NewTimeoutCache(timeout),
+		hostEnvironmentCache:            NewTimeoutCache(timeout),
+		tenantServiceCache:              NewTimeoutCache(timeout),
+		tenantEnvironmentCache:          NewTimeoutCache(timeout),
+		tenantEmptyEnvironmentCache:     NewTimeoutCache(timeout),
+		dpCache:                         make(map[string]struct{}),
+		newServiceCallback:              newServiceCallback,
+		correlationClient:               correlationClient,
+		sendTraceHostCorrelationMetrics: sendTraceHostCorrelationMetrics,
+		timeNow:                         time.Now,
+		dimsToSyncSource:                dimsToSyncSource,
+	}
+	a.LoadHostIDDimCorrelations()
+
+	return a
+}
+
+// AddSpans wraps given SignalFx spans for use by AddSpansGeneric.
+func (a *ActiveServiceTracker) AddSpans(ctx context.Context, spans []*trace.Span) {
+	a.AddSpansGeneric(ctx, spanListWrap{spans: spans})
+}
+
+// AddSpansGeneric accepts a list of trace spans and uses them to update the
+// current list of active services.  This is thread-safe.
+func (a *ActiveServiceTracker) AddSpansGeneric(ctx context.Context, spans SpanList) {
+	// Take current time once since this is a system call.
+	now := a.timeNow()
+
+	for i := 0; i < spans.Len(); i++ {
+		a.processEnvironment(spans.At(i), now)
+		a.processService(spans.At(i), now)
+	}
+
+	// Protected by lock above
+	atomic.AddInt64(&a.spansProcessed, int64(spans.Len()))
+}
+
+func (a *ActiveServiceTracker) processEnvironment(span Span, now time.Time) {
+	if span.NumTags() == 0 {
+		return
+	}
+	environment, environmentFound := span.Environment()
+
+	if !environmentFound || strings.TrimSpace(environment) == "" {
+		// The following is ONLY to mitigate a corner case scenario where the environment for a container/pod is set on
+		// the backend with an old default environment set by the agent, and the agent has been restarted with no
+		// default environment. On restart, the agent only fetches existing environment values for hostIDDims, and does
+		// not fetch for containers/pod dims. If a container/pod is emitting spans without an environment value, then
+		// the agent won't be able to overwrite the value. The agent is also unable to age out environment values for
+		// containers/pods from startup.
+		//
+		// Under that VERY specific circumstance, we need to fetch and delete the environment values for each
+		// pod/container that we have not already scraped an environment off of this agent runtime.
+		for sourceAttr, dimName := range a.dimsToSyncSource {
+			sourceAttr := sourceAttr
+			dimName := dimName
+			if dimValue, ok := span.Tag(sourceAttr); ok {
+				// look up the dimension / value in the environment cache to ensure it doesn't already exist
+				// if it does exist, this means we've already scraped and overwritten what was on the backend
+				// probably from another span. This also implies that some spans for the tenant have an environment
+				// and some do not.
+				a.tenantEnvironmentCache.RunIfKeyDoesNotExist(&CacheKey{dimName: dimName, dimValue: dimValue}, func() {
+					// create a cache key ensuring that we don't fetch environment values multiple times for spans with
+					// empty environments
+					if isNew := a.tenantEmptyEnvironmentCache.UpdateOrCreate(&CacheKey{dimName: dimName, dimValue: dimValue}, now); isNew {
+						// get the existing value from the backend
+						a.correlationClient.Get(dimName, dimValue, func(response map[string][]string) {
+							if len(response) == 0 {
+								return
+							}
+
+							// look for the existing environment value
+							environments, ok := response["sf_environments"]
+							if !ok || len(environments) == 0 {
+								return
+							}
+
+							// Note: This cache operation is OK to execute inside of the encapsulating
+							// tenantEnvironmentCache.RunIfKeyDoesNotExist() because it is actually inside an
+							// asynchronous callback to the correlation client's Get(). So... by the time the callback
+							// is actually executed, the parent RunIfKeyDoesNotExist will have already released the lock
+							// on the cache
+							a.tenantEnvironmentCache.RunIfKeyDoesNotExist(&CacheKey{dimName: dimName, dimValue: dimValue}, func() {
+								a.correlationClient.Delete(&correlations.Correlation{
+									Type:     correlations.Environment,
+									DimName:  dimName,
+									DimValue: dimValue,
+									Value:    environments[0], // We already checked for empty, and backend enforces 1 value max.
+								}, func(_ *correlations.Correlation) {})
+							})
+						})
+					}
+				})
+			}
+		}
+
+		// return so we don't set empty string or spaces as an environment value
+		return
+	}
+
+	// update the environment for the hostIDDims
+	// Note that only the value is set for the host environment cache because we only track environments for the host
+	// therefore there we don't need to include the dim key and value on the cache key
+	if exists := a.hostEnvironmentCache.UpdateIfExists(&CacheKey{value: environment}, now); !exists {
+		if !a.hostEnvironmentCache.IsFull() {
+			for dimName, dimValue := range a.hostIDDims {
+				a.correlationClient.Correlate(&correlations.Correlation{
+					Type:     correlations.Environment,
+					DimName:  dimName,
+					DimValue: dimValue,
+					Value:    environment,
+				}, func(cor *correlations.Correlation, err error) {
+					if err == nil {
+						a.hostEnvironmentCache.UpdateOrCreate(&CacheKey{value: environment}, now)
+					}
+					if max, ok := err.(*correlations.ErrMaxEntries); ok && max.MaxEntries > 0 {
+						a.hostEnvironmentCache.SetMaxSize(max.MaxEntries, now)
+					}
+				})
+			}
+		}
+		a.log.WithFields(log.Fields{"environment": environment}).Debug("Tracking environment name from trace span")
+	}
+
+	// container / pod level stuff
+	// this cache is necessary to identify environments associated with a kubernetes pod or container id
+	for sourceAttr, dimName := range a.dimsToSyncSource {
+		sourceAttr := sourceAttr
+		dimName := dimName
+		if dimValue, ok := span.Tag(sourceAttr); ok {
+			// Note that the value is not set on the cache key.  We only send the first environment received for a
+			// given pod/container, and we never delete the values set on the container/pod dimension.
+			// So we only need to cache the dim name and dim value that have been associated with an environment.
+			if exists := a.tenantEnvironmentCache.UpdateIfExists(&CacheKey{dimName: dimName, dimValue: dimValue}, now); !exists {
+				a.correlationClient.Correlate(&correlations.Correlation{
+					Type:     correlations.Environment,
+					DimName:  dimName,
+					DimValue: dimValue,
+					Value:    environment,
+				}, func(cor *correlations.Correlation, err error) {
+					if err == nil {
+						a.tenantEnvironmentCache.UpdateOrCreate(&CacheKey{dimName: dimName, dimValue: dimValue}, now)
+					}
+				})
+			}
+		}
+	}
+}
+
+func (a *ActiveServiceTracker) processService(span Span, now time.Time) {
+	// Can't do anything if the spans don't have a local service name
+	service, ok := span.ServiceName()
+	if !ok || service == "" {
+		return
+	}
+
+	// Handle host level service and environment correlation
+	// Note that only the value is set for the host service cache because we only track services for the host
+	// therefore there we don't need to include the dim key and value on the cache key
+	if exists := a.hostServiceCache.UpdateIfExists(&CacheKey{value: service}, now); !exists {
+		// all of the host id dims need to be correlated with the service
+		for dimName, dimValue := range a.hostIDDims {
+			if !a.hostServiceCache.IsFull() {
+				a.correlationClient.Correlate(&correlations.Correlation{
+					Type:     correlations.Service,
+					DimName:  dimName,
+					DimValue: dimValue,
+					Value:    service,
+				}, func(cor *correlations.Correlation, err error) {
+					if err == nil {
+						a.hostServiceCache.UpdateOrCreate(&CacheKey{value: service}, now)
+					}
+					if max, ok := err.(*correlations.ErrMaxEntries); ok && max.MaxEntries > 0 {
+						a.hostServiceCache.SetMaxSize(max.MaxEntries, now)
+					}
+				})
+			}
+		}
+
+		if a.sendTraceHostCorrelationMetrics {
+			// create datapoint for service
+			a.addServiceToDPCache(service)
+		}
+
+		a.log.WithFields(log.Fields{"service": service}).Debug("Tracking service name from trace span")
+	}
+
+	// container / pod level stuff (this should not directly affect the active service count)
+	// this cache is necessary to identify services associated with a kubernetes pod or container id
+	for sourceAttr, dimName := range a.dimsToSyncSource {
+		sourceAttr := sourceAttr
+		dimName := dimName
+		if dimValue, ok := span.Tag(sourceAttr); ok {
+			// Note that the value is not set on the cache key.  We only send the first service received for a
+			// given pod/container, and we never delete the values set on the container/pod dimension.
+			// So we only need to cache the dim name and dim value that have been associated with a service.
+			if exists := a.tenantServiceCache.UpdateIfExists(&CacheKey{dimName: dimName, dimValue: dimValue}, now); !exists {
+				a.correlationClient.Correlate(&correlations.Correlation{
+					Type:     correlations.Service,
+					DimName:  dimName,
+					DimValue: dimValue,
+					Value:    service,
+				}, func(cor *correlations.Correlation, err error) {
+					if err == nil {
+						a.tenantServiceCache.UpdateOrCreate(&CacheKey{dimName: dimName, dimValue: dimValue}, now)
+					}
+				})
+			}
+		}
+	}
+}
+
+// Purges caches on the ActiveServiceTracker
+func (a *ActiveServiceTracker) Purge() {
+	now := a.timeNow()
+
+	for _, purged := range a.hostServiceCache.GetPurgeable(now) {
+		// delete the correlation from all host id dims
+		for dimName, dimValue := range a.hostIDDims {
+			purged := purged
+			a.correlationClient.Delete(&correlations.Correlation{
+				Type:     correlations.Service,
+				DimName:  dimName,
+				DimValue: dimValue,
+				Value:    purged.value,
+			}, func(cor *correlations.Correlation) {
+				a.hostServiceCache.Delete(purged)
+			})
+		}
+		// remove host/service correlation metric from tracker
+		if a.sendTraceHostCorrelationMetrics {
+			a.removeServiceFromDPCache(purged.value)
+		}
+
+		a.log.WithFields(log.Fields{"serviceName": purged.value}).Debug("No longer tracking service name from trace span")
+	}
+
+	for _, purged := range a.hostEnvironmentCache.GetPurgeable(now) {
+		// delete the correlation from all host id dims
+		for dimName, dimValue := range a.hostIDDims {
+			purged := purged
+			a.correlationClient.Delete(&correlations.Correlation{
+				Type:     correlations.Environment,
+				DimName:  dimName,
+				DimValue: dimValue,
+				Value:    purged.value,
+			}, func(cor *correlations.Correlation) {
+				a.hostEnvironmentCache.Delete(purged)
+				a.log.WithFields(log.Fields{"environmentName": purged.value}).Debug("No longer tracking environment name from trace span")
+			})
+		}
+	}
+
+	// Purge the caches for containers and pods, but don't do the deletions.
+	// These values aren't expected to change, and can be overwritten.
+	// The onPurge() function doesn't need to do anything
+	a.tenantServiceCache.PurgeOld(now, func(_ *CacheKey) {})
+	a.tenantEnvironmentCache.PurgeOld(now, func(_ *CacheKey) {})
+	a.tenantEmptyEnvironmentCache.PurgeOld(now, func(_ *CacheKey) {})
+}
+
+// InternalMetrics returns datapoint describing the status of the tracker
+func (a *ActiveServiceTracker) InternalMetrics() []*datapoint.Datapoint {
+	return []*datapoint.Datapoint{
+		sfxclient.Gauge("sfxagent.tracing_active_services", nil, a.hostServiceCache.GetActiveCount()),
+		sfxclient.Cumulative("sfxagent.tracing_purged_services", nil, a.hostServiceCache.GetPurgedCount()),
+		sfxclient.Gauge("sfxagent.tracing_active_environments", nil, a.hostEnvironmentCache.GetActiveCount()),
+		sfxclient.Cumulative("sfxagent.tracing_purged_environments", nil, a.hostEnvironmentCache.GetPurgedCount()),
+		sfxclient.CumulativeP("sfxagent.tracing_spans_processed", nil, &a.spansProcessed),
+	}
+}

--- a/exporter/signalfxexporter/internal/apm/tracetracker/tracker.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/tracker.go
@@ -190,7 +190,7 @@ func (a *ActiveServiceTracker) AddSpans(ctx context.Context, spans []*trace.Span
 
 // AddSpansGeneric accepts a list of trace spans and uses them to update the
 // current list of active services.  This is thread-safe.
-func (a *ActiveServiceTracker) AddSpansGeneric(ctx context.Context, spans SpanList) {
+func (a *ActiveServiceTracker) AddSpansGeneric(_ context.Context, spans SpanList) {
 	// Take current time once since this is a system call.
 	now := a.timeNow()
 
@@ -281,6 +281,7 @@ func (a *ActiveServiceTracker) processEnvironment(span Span, now time.Time) {
 					if err == nil {
 						a.hostEnvironmentCache.UpdateOrCreate(&CacheKey{value: environment}, now)
 					}
+					// nolint:errorlint
 					if max, ok := err.(*correlations.ErrMaxEntries); ok && max.MaxEntries > 0 {
 						a.hostEnvironmentCache.SetMaxSize(max.MaxEntries, now)
 					}
@@ -338,6 +339,7 @@ func (a *ActiveServiceTracker) processService(span Span, now time.Time) {
 					if err == nil {
 						a.hostServiceCache.UpdateOrCreate(&CacheKey{value: service}, now)
 					}
+					// nolint:errorlint
 					if max, ok := err.(*correlations.ErrMaxEntries); ok && max.MaxEntries > 0 {
 						a.hostServiceCache.SetMaxSize(max.MaxEntries, now)
 					}

--- a/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
@@ -1,0 +1,305 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+// Originally copied from https://github.com/signalfx/signalfx-agent/blob/fbc24b0fdd3884bd0bbfbd69fe3c83f49d4c0b77/pkg/apm/tracetracker/tracker_test.go
+
+package tracetracker
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/signalfx/golib/v3/pointer"
+	"github.com/signalfx/golib/v3/trace"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/correlations"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/log"
+)
+
+func setTime(a *ActiveServiceTracker, t time.Time) {
+	a.timeNow = func() time.Time { return t }
+}
+
+func advanceTime(a *ActiveServiceTracker, minutes int64) {
+	newNow := a.timeNow().Add(time.Duration(minutes) * time.Minute)
+	a.timeNow = func() time.Time { return newNow }
+}
+
+// mergeStringMaps merges n maps with a later map's keys overriding earlier maps
+func mergeStringMaps(maps ...map[string]string) map[string]string {
+	ret := map[string]string{}
+
+	for _, m := range maps {
+		for k, v := range m {
+			ret[k] = v
+		}
+	}
+
+	return ret
+}
+
+func TestDatapointsAreGenerated(t *testing.T) {
+	correlationClient := &correlationTestClient{}
+
+	a := New(log.Nil, 5*time.Minute, correlationClient, nil, true, nil, DefaultDimsToSyncSource)
+
+	a.AddSpans(context.Background(), []*trace.Span{
+		{
+			LocalEndpoint: &trace.Endpoint{
+				ServiceName: pointer.String("one"),
+			},
+			Tags: map[string]string{"host": "test"},
+		},
+		{
+			LocalEndpoint: &trace.Endpoint{
+				ServiceName: pointer.String("two"),
+			},
+			Tags: map[string]string{"host": "test"},
+		},
+	})
+
+	a.Purge()
+	dps := a.CorrelationDatapoints()
+	assert.Len(t, dps, 2, "Expected two datapoints")
+
+	var serviceDims []string
+	for _, dp := range dps {
+		serviceDims = append(serviceDims, dp.Dimensions["sf_hasService"])
+	}
+	assert.ElementsMatch(t, serviceDims, []string{"one", "two"}, "expected service names 'one' and 'two'")
+
+	assert.Equal(t, dps[0].Value.(datapoint.IntValue).Int(), int64(0), "Expected dp value to be 0")
+}
+
+func TestExpiration(t *testing.T) {
+	correlationClient := &correlationTestClient{}
+
+	hostIDDims := map[string]string{"host": "test", "AWSUniqueId": "randomAWSUniqueId"}
+	a := New(log.Nil, 5*time.Minute, correlationClient, hostIDDims, true, nil, DefaultDimsToSyncSource)
+	setTime(a, time.Unix(100, 0))
+
+	a.AddSpans(context.Background(), []*trace.Span{
+		{
+			LocalEndpoint: &trace.Endpoint{
+				ServiceName: pointer.String("one"),
+			},
+			Tags: mergeStringMaps(hostIDDims, map[string]string{"environment": "environment1"}),
+		},
+		{
+			LocalEndpoint: &trace.Endpoint{
+				ServiceName: pointer.String("two"),
+			},
+			Tags: mergeStringMaps(hostIDDims, map[string]string{"environment": "environment2"}),
+		},
+		{
+			LocalEndpoint: &trace.Endpoint{
+				ServiceName: pointer.String("three"),
+			},
+			Tags: mergeStringMaps(hostIDDims, map[string]string{"environment": "environment3"}),
+		},
+	})
+
+	assert.Equal(t, int64(3), a.hostServiceCache.ActiveCount, "activeServiceCount is not properly tracked")
+	assert.Equal(t, int64(3), a.hostEnvironmentCache.ActiveCount, "activeEnvironmentCount is not properly tracked")
+
+	advanceTime(a, 4)
+
+	a.AddSpans(context.Background(), []*trace.Span{
+		{
+			LocalEndpoint: &trace.Endpoint{
+				ServiceName: pointer.String("two"),
+			},
+			Tags: mergeStringMaps(hostIDDims, map[string]string{"environment": "environment2"}),
+		},
+	})
+
+	advanceTime(a, 2)
+	a.Purge()
+	dps := a.CorrelationDatapoints()
+	assert.Len(t, dps, 1, "Expected one datapoint")
+	assert.Equal(t, dps[0].Dimensions["sf_hasService"], "two", "expected service two to still be active")
+
+	assert.Equal(t, int64(1), a.hostServiceCache.ActiveCount, "activeServiceCount is not properly tracked")
+	assert.Equal(t, int64(1), a.hostEnvironmentCache.ActiveCount, "activeEnvironmentCount is not properly tracked")
+	assert.Equal(t, int64(2), a.hostServiceCache.PurgedCount, "purgedServiceCount is not properly tracked")
+	assert.Equal(t, int64(2), a.hostEnvironmentCache.PurgedCount, "activeEnvironmentCount is not properly tracked")
+
+	advanceTime(a, 4)
+	a.Purge()
+	assert.Len(t, a.CorrelationDatapoints(), 0, "Expected all datapoints to be expired")
+}
+
+type correlationTestClient struct {
+	sync.Mutex
+	cors             []*correlations.Correlation
+	getPayload       map[string]map[string][]string
+	getCallback      func()
+	getCounter       int64
+	deleteCounter    int64
+	correlateCounter int64
+}
+
+func (c *correlationTestClient) Start() { /*no-op*/ }
+func (c *correlationTestClient) Get(dimName string, dimValue string, cb correlations.SuccessfulGetCB) {
+	atomic.AddInt64(&c.getCounter, 1)
+	go func() {
+		cb(c.getPayload[dimValue])
+		if c.getCallback != nil {
+			c.getCallback()
+		}
+	}()
+}
+func (c *correlationTestClient) Correlate(cl *correlations.Correlation, cb correlations.CorrelateCB) {
+	c.Lock()
+	defer c.Unlock()
+	c.cors = append(c.cors, cl)
+	cb(cl, nil)
+	atomic.AddInt64(&c.correlateCounter, 1)
+}
+func (c *correlationTestClient) Delete(cl *correlations.Correlation, cb correlations.SuccessfulDeleteCB) {
+	c.Lock()
+	defer c.Unlock()
+	c.cors = append(c.cors, cl)
+	cb(cl)
+	atomic.AddInt64(&c.deleteCounter, 1)
+}
+func (c *correlationTestClient) InternalMetrics() []*datapoint.Datapoint {
+	return nil
+}
+func (c *correlationTestClient) getCorrelations() []*correlations.Correlation {
+	c.Lock()
+	defer c.Unlock()
+	return c.cors
+}
+
+var _ correlations.CorrelationClient = &correlationTestClient{}
+
+func TestCorrelationEmptyEnvironment(t *testing.T) {
+	var wg sync.WaitGroup
+	correlationClient := &correlationTestClient{
+		getPayload: map[string]map[string][]string{
+			"testk8sPodUID": {
+				"sf_services":     {"one"},
+				"sf_environments": {"environment1"},
+			},
+			"testContainerID": {
+				"sf_services":     {"one"},
+				"sf_environments": {"environment1"},
+			},
+		},
+		getCallback: func() {
+			wg.Done()
+		},
+	}
+
+	hostIDDims := map[string]string{"host": "test", "AWSUniqueId": "randomAWSUniqueId"}
+	wg.Add(len(hostIDDims))
+	containerLevelIDDims := map[string]string{"kubernetes_pod_uid": "testk8sPodUID", "container_id": "testContainerID"}
+	a := New(log.Nil, 5*time.Minute, correlationClient, hostIDDims, true, nil, DefaultDimsToSyncSource)
+	wg.Wait() // wait for the initial fetch of hostIDDims to complete
+
+	// for each container level ID we're going to perform a GET to check for an environment
+	wg.Add(len(containerLevelIDDims))
+	a.AddSpans(context.Background(), []*trace.Span{
+		{
+			LocalEndpoint: &trace.Endpoint{},
+			Tags:          mergeStringMaps(hostIDDims, containerLevelIDDims),
+		},
+		{
+			LocalEndpoint: &trace.Endpoint{},
+			Tags:          mergeStringMaps(hostIDDims, containerLevelIDDims),
+		},
+		{
+			LocalEndpoint: &trace.Endpoint{},
+			Tags:          mergeStringMaps(hostIDDims, containerLevelIDDims),
+		},
+	})
+
+	wg.Wait() // wait for the gets to complete to check for existing tenant environment values
+
+	// there shouldn't be any active tenant environments.  None of the spans had environments on them,
+	// and we don't actively fetch and store environments from the back end.  That's kind of the whole point of this
+	// the workaround this is testing.
+	assert.Equal(t, int64(0), a.tenantEnvironmentCache.ActiveCount, "tenantEnvironmentCache is not properly tracked")
+	// ensure we only have 1 entry per container / pod id
+	assert.Equal(t, int64(len(containerLevelIDDims)), a.tenantEmptyEnvironmentCache.ActiveCount, "tenantEmptyEnvironmentCount is not properly tracked")
+	// len(hostIDDims) * len(containerLevelIDDims)
+	assert.Equal(t, int64(len(containerLevelIDDims)+len(hostIDDims)), atomic.LoadInt64(&correlationClient.getCounter), "")
+	// 1 DELETE * len(containerLevelIDDims)
+	assert.Equal(t, len(containerLevelIDDims), len(correlationClient.getCorrelations()), "")
+}
+
+func TestCorrelationUpdates(t *testing.T) {
+	var wg sync.WaitGroup
+	correlationClient := &correlationTestClient{
+		getPayload: map[string]map[string][]string{
+			"test": {
+				"sf_services":     {"one"},
+				"sf_environments": {"environment1"},
+			},
+		},
+		getCallback: func() {
+			wg.Done()
+		},
+	}
+
+	hostIDDims := map[string]string{"host": "test", "AWSUniqueId": "randomAWSUniqueId"}
+	wg.Add(len(hostIDDims))
+	containerLevelIDDims := map[string]string{"kubernetes_pod_uid": "testk8sPodUID", "container_id": "testContainerID"}
+	a := New(log.Nil, 5*time.Minute, correlationClient, hostIDDims, true, nil, DefaultDimsToSyncSource)
+	wg.Wait()
+	assert.Equal(t, int64(1), a.hostServiceCache.ActiveCount, "activeServiceCount is not properly tracked")
+	assert.Equal(t, int64(1), a.hostEnvironmentCache.ActiveCount, "activeEnvironmentCount is not properly tracked")
+	advanceTime(a, 6)
+	a.Purge()
+	assert.Equal(t, int64(0), a.hostServiceCache.ActiveCount, "activeServiceCount is not properly tracked")
+	assert.Equal(t, int64(0), a.hostEnvironmentCache.ActiveCount, "activeEnvironmentCount is not properly tracked")
+	assert.Equal(t, int64(1), a.hostServiceCache.PurgedCount, "hostServiceCache purged count is not properly tracked")
+	assert.Equal(t, int64(1), a.hostEnvironmentCache.PurgedCount, "hostEnvironmentCache purged count is not properly tracked")
+
+	setTime(a, time.Unix(100, 0))
+
+	a.AddSpans(context.Background(), []*trace.Span{
+		{
+			LocalEndpoint: &trace.Endpoint{
+				ServiceName: pointer.String("one"),
+			},
+			Tags: mergeStringMaps(hostIDDims, mergeStringMaps(containerLevelIDDims, map[string]string{"environment": "environment1"})),
+		},
+		{
+			LocalEndpoint: &trace.Endpoint{
+				ServiceName: pointer.String("two"),
+			},
+			Tags: mergeStringMaps(hostIDDims, mergeStringMaps(containerLevelIDDims, map[string]string{"environment": "environment2"})),
+		},
+		{
+			LocalEndpoint: &trace.Endpoint{
+				ServiceName: pointer.String("three"),
+			},
+			Tags: mergeStringMaps(hostIDDims, mergeStringMaps(containerLevelIDDims, map[string]string{"environment": "environment3"})),
+		},
+	})
+
+	assert.Equal(t, int64(3), a.hostServiceCache.ActiveCount, "activeServiceCount is not properly tracked")
+	assert.Equal(t, int64(3), a.hostEnvironmentCache.ActiveCount, "activeEnvironmentCount is not properly tracked")
+
+	numEnvironments := 3
+	numServices := 3
+	numHostIDDimCorrelations := len(hostIDDims)*(numEnvironments+numServices) + 4 /* 4 deletes for service & environment fetched at startup */
+	numContainerLevelCorrelations := 2 * len(containerLevelIDDims)
+	totalExpectedCorrelations := numHostIDDimCorrelations + numContainerLevelCorrelations
+	assert.Equal(t, totalExpectedCorrelations, len(correlationClient.getCorrelations()), "# of correlation requests do not match")
+
+	advanceTime(a, 6)
+	a.Purge()
+	dps := a.CorrelationDatapoints()
+	assert.Len(t, dps, 0, "Expected all datapoints to be expired")
+	assert.Equal(t, int64(0), a.hostServiceCache.ActiveCount, "activeServiceCount is not properly tracked")
+	assert.Equal(t, int64(0), a.hostEnvironmentCache.ActiveCount, "activeEnvironmentCount is not properly tracked")
+	assert.Equal(t, int64(4), a.hostServiceCache.PurgedCount, "purgedServiceCount is not properly tracked")
+	assert.Equal(t, int64(4), a.hostEnvironmentCache.PurgedCount, "activeEnvironmentCount is not properly tracked")
+}

--- a/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
@@ -144,7 +144,7 @@ type correlationTestClient struct {
 }
 
 func (c *correlationTestClient) Start() { /*no-op*/ }
-func (c *correlationTestClient) Get(dimName string, dimValue string, cb correlations.SuccessfulGetCB) {
+func (c *correlationTestClient) Get(_ string, dimValue string, cb correlations.SuccessfulGetCB) {
 	atomic.AddInt64(&c.getCounter, 1)
 	go func() {
 		cb(c.getPayload[dimValue])

--- a/exporter/signalfxexporter/internal/correlation/config.go
+++ b/exporter/signalfxexporter/internal/correlation/config.go
@@ -8,9 +8,10 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/signalfx/signalfx-agent/pkg/apm/correlations"
 	"go.opentelemetry.io/collector/config/confighttp"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/correlations"
 )
 
 // DefaultConfig returns default configuration correlation values.

--- a/exporter/signalfxexporter/internal/correlation/correlation.go
+++ b/exporter/signalfxexporter/internal/correlation/correlation.go
@@ -9,14 +9,14 @@ import (
 	"net/url"
 	"sync"
 
-	"github.com/signalfx/signalfx-agent/pkg/apm/correlations"
-	"github.com/signalfx/signalfx-agent/pkg/apm/tracetracker"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/correlations"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/tracetracker"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )

--- a/exporter/signalfxexporter/internal/correlation/correlation.go
+++ b/exporter/signalfxexporter/internal/correlation/correlation.go
@@ -63,7 +63,7 @@ func newCorrelationClient(cfg *Config, accessToken configopaque.String, params e
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	client, err := correlations.NewCorrelationClient(newZapShim(params.Logger), ctx, httpClient, correlations.ClientConfig{
+	client, err := correlations.NewCorrelationClient(ctx, newZapShim(params.Logger), httpClient, correlations.ClientConfig{
 		Config:      cfg.Config,
 		AccessToken: string(accessToken),
 		URL:         corrURL,

--- a/exporter/signalfxexporter/internal/correlation/logshims.go
+++ b/exporter/signalfxexporter/internal/correlation/logshims.go
@@ -4,9 +4,10 @@
 package correlation // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/correlation"
 
 import (
-	"github.com/signalfx/signalfx-agent/pkg/apm/log"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/log"
 )
 
 type zapShim struct {

--- a/exporter/signalfxexporter/internal/correlation/logshims_test.go
+++ b/exporter/signalfxexporter/internal/correlation/logshims_test.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/signalfx/signalfx-agent/pkg/apm/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/log"
 )
 
 func newShimTest() (*observer.ObservedLogs, zapShim) {

--- a/exporter/signalfxexporter/internal/correlation/spanshims.go
+++ b/exporter/signalfxexporter/internal/correlation/spanshims.go
@@ -4,9 +4,10 @@
 package correlation // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/correlation"
 
 import (
-	"github.com/signalfx/signalfx-agent/pkg/apm/tracetracker"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/signalfxexporter/internal/apm/tracetracker"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -566,7 +566,6 @@ require (
 	github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 // indirect
 	github.com/signalfx/golib/v3 v3.3.47 // indirect
 	github.com/signalfx/sapm-proto v0.13.0 // indirect
-	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 // indirect
 	github.com/sijms/go-ora/v2 v2.7.17 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/snowflakedb/gosnowflake v1.6.24 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3104,8 +3104,6 @@ github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8
 github.com/signalfx/sapm-proto v0.7.2/go.mod h1:HLufOh6Gd2altGxbeve+s6hh0EWCWoOM7MmuYuvs5PI=
 github.com/signalfx/sapm-proto v0.13.0 h1:yEkp1+MAU4vZvnJMp56uhVlRjlvCK7KQjBg0g2Apw8k=
 github.com/signalfx/sapm-proto v0.13.0/go.mod h1:C72HjeCW5v0Llk6pIVJ/ZH8A5GbiZpCCSkE1dSlpWxY=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 h1:FCyZbLP9tqrwca1CLRxosGCbBXzaL7oFXmEbrUbiwSM=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1/go.mod h1:92AQ/lCA08Aw2Eg8mgdIAak7IWyTbV5PZHocEO7vH0g=
 github.com/sijms/go-ora/v2 v2.7.17 h1:M/pYIqjaMUeBxyzOWp2oj4ntF6fHSBloJWGNH9vbmsU=
 github.com/sijms/go-ora/v2 v2.7.17/go.mod h1:EHxlY6x7y9HAsdfumurRfTd+v8NrEOTR3Xl4FWlH6xk=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=

--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -67,7 +67,6 @@ require (
 	github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 // indirect
 	github.com/signalfx/golib/v3 v3.3.47 // indirect
 	github.com/signalfx/sapm-proto v0.13.0 // indirect
-	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect

--- a/receiver/signalfxreceiver/go.sum
+++ b/receiver/signalfxreceiver/go.sum
@@ -2358,8 +2358,6 @@ github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8
 github.com/signalfx/sapm-proto v0.7.2/go.mod h1:HLufOh6Gd2altGxbeve+s6hh0EWCWoOM7MmuYuvs5PI=
 github.com/signalfx/sapm-proto v0.13.0 h1:yEkp1+MAU4vZvnJMp56uhVlRjlvCK7KQjBg0g2Apw8k=
 github.com/signalfx/sapm-proto v0.13.0/go.mod h1:C72HjeCW5v0Llk6pIVJ/ZH8A5GbiZpCCSkE1dSlpWxY=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 h1:FCyZbLP9tqrwca1CLRxosGCbBXzaL7oFXmEbrUbiwSM=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1/go.mod h1:92AQ/lCA08Aw2Eg8mgdIAak7IWyTbV5PZHocEO7vH0g=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -205,7 +205,6 @@ require (
 	github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 // indirect
 	github.com/signalfx/golib/v3 v3.3.47 // indirect
 	github.com/signalfx/sapm-proto v0.13.0 // indirect
-	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -2560,8 +2560,6 @@ github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8
 github.com/signalfx/sapm-proto v0.7.2/go.mod h1:HLufOh6Gd2altGxbeve+s6hh0EWCWoOM7MmuYuvs5PI=
 github.com/signalfx/sapm-proto v0.13.0 h1:yEkp1+MAU4vZvnJMp56uhVlRjlvCK7KQjBg0g2Apw8k=
 github.com/signalfx/sapm-proto v0.13.0/go.mod h1:C72HjeCW5v0Llk6pIVJ/ZH8A5GbiZpCCSkE1dSlpWxY=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1 h1:FCyZbLP9tqrwca1CLRxosGCbBXzaL7oFXmEbrUbiwSM=
-github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-20230214151822-6a6813cf5bf1/go.mod h1:92AQ/lCA08Aw2Eg8mgdIAak7IWyTbV5PZHocEO7vH0g=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=


### PR DESCRIPTION
https://github.com/signalfx/signalfx-agent is marked as EOS. In order to remove the dependency, this change brings code from https://github.com/signalfx/signalfx-agent/tree/main/pkg/apm module needed for the exporter without any modifications other than linter fixes. Exporter uses only part of that code. We can remove unused parts in the next steps to cut the dependency tree.
