### PR TITLE
Transform Example: Change `context` to `datapoint`

### DIFF
--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -85,12 +85,11 @@ This is not a common pattern, and we recommend copying the most common resource 
 processor:
   transform:
     metric_statements:
-      - context: metric
+      - context: datapoint
         statements:
-        - set(attributes["namespace"], resource.attributes["k8s_namespace_name"])
+        - set(attributes["k8s_namespace"], resource.attributes["k8s.namespace.name"])
         - set(attributes["container"], resource.attributes["k8s.container.name"])
         - set(attributes["pod"], resource.attributes["k8s.pod.name"])
-        - set(attributes["cluster"], resource.attributes["k8s.cluster.name"])
 ```
 
 After this, grouping or selecting becomes as simple as:

--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -87,7 +87,7 @@ processor:
     metric_statements:
       - context: datapoint
         statements:
-        - set(attributes["k8s_namespace"], resource.attributes["k8s.namespace.name"])
+        - set(attributes["namespace"], resource.attributes["k8s.namespace.name"])
         - set(attributes["container"], resource.attributes["k8s.container.name"])
         - set(attributes["pod"], resource.attributes["k8s.pod.name"])
 ```

--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -124,7 +124,7 @@ processor:
     metric_statements:
       - context: datapoint
         statements:
-        - set(attributes["k8s_namespace"], resource.attributes["k8s.namespace.name"])
+        - set(attributes["namespace"], resource.attributes["k8s.namespace.name"])
         - set(attributes["container"], resource.attributes["k8s.container.name"])
         - set(attributes["pod"], resource.attributes["k8s.pod.name"])
 ```

--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -122,12 +122,11 @@ This is not a common pattern, and we recommend copying the most common resource 
 processor:
   transform:
     metric_statements:
-      - context: metric
+      - context: datapoint
         statements:
-        - set(attributes["namespace"], resource.attributes["k8s_namespace_name"])
+        - set(attributes["k8s_namespace"], resource.attributes["k8s.namespace.name"])
         - set(attributes["container"], resource.attributes["k8s.container.name"])
         - set(attributes["pod"], resource.attributes["k8s.pod.name"])
-        - set(attributes["cluster"], resource.attributes["k8s.cluster.name"])
 ```
 
 After this, grouping or selecting becomes as simple as:


### PR DESCRIPTION
**Description:** 
- Fixing documentation for incorrect transform context.
- Correcting `resource.attributes["k8s_namespace_name"` to be correct `.` separated name.
- Removing `resource.attributes["k8s.cluster.name"]` as it's not an available attribute.  

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27012#issuecomment-1726766299

**Testing:** 
Works in my own otel-collector.

**Documentation:** 
All documentation updates here.