### PR TITLE
[chore] update otelcol_version

### DIFF
--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   name: otelcontribcol
   description: Local OpenTelemetry Collector Contrib binary, testing only.
   version: 0.85.0-dev
-  otelcol_version: 0.84.0
+  otelcol_version: 0.85.0
 
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.85.1-0.20230919160920-512b9c3c8fec

--- a/cmd/oteltestbedcol/builder-config.yaml
+++ b/cmd/oteltestbedcol/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   name: oteltestbedcol
   description: OpenTelemetry Collector binary for testbed only tests.
   version: 0.85.0-dev
-  otelcol_version: 0.84.0
+  otelcol_version: 0.85.0
 
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.85.1-0.20230919160920-512b9c3c8fec


### PR DESCRIPTION
This was missed in the last release. It's only used for local builds.
