### PR TITLE
Remove line causing container already existed

### DIFF
--- a/examples/demo/docker-compose.yaml
+++ b/examples/demo/docker-compose.yaml
@@ -59,7 +59,6 @@ services:
       - otel-collector
 
   prometheus:
-    container_name: prometheus
     image: prom/prometheus:latest
     restart: always
     volumes:


### PR DESCRIPTION
Remove container naming so newly created container will not overlap existing container on host.

**Description:** <Describe what has changed.>
Newly created container should have name generated automatically by Docker compose, so that existing container with the same name will not need to be deleted

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>