### PR TITLE
[k8sclusterreceiver] refactor k8s.container.restarts metric units

### DIFF
--- a/.chloggen/refactor.yaml
+++ b/.chloggen/refactor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sclusterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "change k8s.container.restarts unit from 1 to {restart}"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [10553]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/k8sclusterreceiver/documentation.md
+++ b/receiver/k8sclusterreceiver/documentation.md
@@ -74,7 +74,7 @@ How many times the container has restarted in the recent past. This value is pul
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| 1 | Gauge | Int |
+| {restart} | Gauge | Int |
 
 ### k8s.container.storage_limit
 

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
@@ -365,7 +365,7 @@ type metricK8sContainerRestarts struct {
 func (m *metricK8sContainerRestarts) init() {
 	m.data.SetName("k8s.container.restarts")
 	m.data.SetDescription("How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.")
-	m.data.SetUnit("1")
+	m.data.SetUnit("{restart}")
 	m.data.SetEmptyGauge()
 }
 

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_metrics_test.go
@@ -371,7 +371,7 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
 					assert.Equal(t, "How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.", ms.At(i).Description())
-					assert.Equal(t, "1", ms.At(i).Unit())
+					assert.Equal(t, "{restart}", ms.At(i).Unit())
 					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected.yaml
@@ -65,7 +65,7 @@ resourceMetrics:
               dataPoints:
                 - asInt: "3"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_evicted.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_evicted.yaml
@@ -71,7 +71,7 @@ resourceMetrics:
               dataPoints:
                 - asInt: "3"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -239,7 +239,7 @@ metrics:
   k8s.container.restarts:
     enabled: true
     description: How many times the container has restarted in the recent past. This value is pulled directly from the K8s API and the value can go indefinitely high and be reset to 0 at any time depending on how your kubelet is configured to prune dead containers. It is best to not depend too much on the exact value but rather look at it as either == 0, in which case you can conclude there were no restarts in the recent past, or > 0, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.
-    unit: 1
+    unit: "{restart}"
     gauge:
       value_type: int
   k8s.container.ready:

--- a/receiver/k8sclusterreceiver/testdata/e2e/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/expected.yaml
@@ -781,7 +781,7 @@ resourceMetrics:
                 - asInt: "0"
                   timeUnixNano: "1686772769034865545"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:
@@ -844,7 +844,7 @@ resourceMetrics:
                 - asInt: "0"
                   timeUnixNano: "1686772769034865545"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:
@@ -921,7 +921,7 @@ resourceMetrics:
                 - asInt: "0"
                   timeUnixNano: "1686772769034865545"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:
@@ -977,7 +977,7 @@ resourceMetrics:
                 - asInt: "0"
                   timeUnixNano: "1686772769034865545"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:
@@ -1033,7 +1033,7 @@ resourceMetrics:
                 - asInt: "0"
                   timeUnixNano: "1686772769034865545"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:
@@ -1089,7 +1089,7 @@ resourceMetrics:
                 - asInt: "0"
                   timeUnixNano: "1686772769034865545"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:
@@ -1138,7 +1138,7 @@ resourceMetrics:
                 - asInt: "0"
                   timeUnixNano: "1686772769034865545"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:
@@ -1208,7 +1208,7 @@ resourceMetrics:
                 - asInt: "0"
                   timeUnixNano: "1686772769034865545"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:
@@ -1285,7 +1285,7 @@ resourceMetrics:
                 - asInt: "0"
                   timeUnixNano: "1686772769034865545"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:
@@ -1334,7 +1334,7 @@ resourceMetrics:
                 - asInt: "0"
                   timeUnixNano: "1686772769034865545"
             name: k8s.container.restarts
-            unit: "1"
+            unit: "{restart}"
           - description: Whether a container has passed its readiness probe (0 for no, 1 for yes)
             gauge:
               dataPoints:


### PR DESCRIPTION
**Description:** 

Refactor k8s.container.restarts metric unit to be `{restart}`


**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10553

**Testing:** <Describe what testing was performed and which tests were added.>
- updated tests

**Documentation:** <Describe the documentation added.>
- generated