### PR TITLE
checkapi fixes for probabilisticsamplerprocess

### DIFF
--- a/.chloggen/26304-probablisticsamplingprocessor-checkapi.yaml
+++ b/.chloggen/26304-probablisticsamplingprocessor-checkapi.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: probabilisticsamplerprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:  Unexport `SamplingProcessorMetricViews` to comply with checkapi 
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26304]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -13,7 +13,6 @@ extension/observer/ecsobserver
 extension/observer
 processor/groupbyattrsprocessor
 processor/groupbytraceprocessor
-processor/probabilisticsamplerprocessor
 processor/servicegraphprocessor
 receiver/carbonreceiver
 receiver/collectdreceiver

--- a/processor/probabilisticsamplerprocessor/factory.go
+++ b/processor/probabilisticsamplerprocessor/factory.go
@@ -24,7 +24,7 @@ var onceMetrics sync.Once
 func NewFactory() processor.Factory {
 	onceMetrics.Do(func() {
 		// TODO: Handle this err
-		_ = view.Register(SamplingProcessorMetricViews(configtelemetry.LevelNormal)...)
+		_ = view.Register(samplingProcessorMetricViews(configtelemetry.LevelNormal)...)
 	})
 
 	return processor.NewFactory(

--- a/processor/probabilisticsamplerprocessor/metrics.go
+++ b/processor/probabilisticsamplerprocessor/metrics.go
@@ -22,8 +22,8 @@ var (
 	statCountLogsSampled   = stats.Int64("count_logs_sampled", "Count of logs that were sampled or not", stats.UnitDimensionless)
 )
 
-// SamplingProcessorMetricViews return the metrics views according to given telemetry level.
-func SamplingProcessorMetricViews(level configtelemetry.Level) []*view.View {
+// samplingProcessorMetricViews return the metrics views according to given telemetry level.
+func samplingProcessorMetricViews(level configtelemetry.Level) []*view.View {
 	if level == configtelemetry.LevelNone {
 		return nil
 	}


### PR DESCRIPTION
**Description:** 
Rename  and stop  exporting `SamplingProcessorMetricViews`

**Link to tracking Issue:** 26304

**Testing:** 
`go run cmd/checkapi/main.go .`
`go test ./...` for `probabilisticsamplerprocessor`

**Documentation:** <Describe the documentation added.>