### PR TITLE
[receiver/k8sobjects] Extract resource attributes from payload for events

### DIFF
--- a/.chloggen/k8sobjects-extract-attributes.yaml
+++ b/.chloggen/k8sobjects-extract-attributes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/k8sobjects
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add automatic resource attribute extraction for k8s events
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27069]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: For k8s events, extracts the k8s.namespace.name, k8s.{kind}.name, and k8s.{kind}.uid of the object associated to the event
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/k8sobjectsreceiver/receiver.go
+++ b/receiver/k8sobjectsreceiver/receiver.go
@@ -216,8 +216,6 @@ func (kr *k8sobjectsreceiver) doWatch(ctx context.Context, config *K8sObjectsCon
 				continue
 			}
 
-			kr.setting.Logger.Info("gvr)", zap.Any("gvr)", config.gvr))
-
 			logs, err := watchObjectsToLogData(&data, time.Now(), config)
 			if err != nil {
 				kr.setting.Logger.Error("error converting objects to log data", zap.Error(err))

--- a/receiver/k8sobjectsreceiver/receiver.go
+++ b/receiver/k8sobjectsreceiver/receiver.go
@@ -216,6 +216,8 @@ func (kr *k8sobjectsreceiver) doWatch(ctx context.Context, config *K8sObjectsCon
 				continue
 			}
 
+			kr.setting.Logger.Info("gvr)", zap.Any("gvr)", config.gvr))
+
 			logs, err := watchObjectsToLogData(&data, time.Now(), config)
 			if err != nil {
 				kr.setting.Logger.Error("error converting objects to log data", zap.Error(err))

--- a/receiver/k8sobjectsreceiver/unstructured_to_logdata.go
+++ b/receiver/k8sobjectsreceiver/unstructured_to_logdata.go
@@ -60,10 +60,12 @@ func unstructuredListToLogData(event *unstructured.UnstructuredList, observedAt 
 				resourceAttrs.PutStr(semconv.AttributeK8SNamespaceName, namespace)
 			}
 
-			if config.gvr.Version == "events.k8s.io/v1" {
-				extractResourceAttributes(resourceAttrs, e.Object, "regarding")
-			} else {
-				extractResourceAttributes(resourceAttrs, e.Object, "involvedObject")
+			if config.gvr.Resource == "events" {
+				if config.gvr.Group == "events.k8s.io" {
+					extractResourceAttributesFromEvent(resourceAttrs, e.Object, "regarding")
+				} else {
+					extractResourceAttributesFromEvent(resourceAttrs, e.Object, "involvedObject")
+				}
 			}
 
 			sl := rl.ScopeLogs().AppendEmpty()
@@ -88,7 +90,7 @@ func unstructuredListToLogData(event *unstructured.UnstructuredList, observedAt 
 	return out
 }
 
-func extractResourceAttributes(resourceAttrs pcommon.Map, object map[string]any, location string) {
+func extractResourceAttributesFromEvent(resourceAttrs pcommon.Map, object map[string]any, location string) {
 	objKind, ok, _ := unstructured.NestedString(object, "object", "kind")
 	if ok && objKind == "Event" {
 		namespace, ok, _ := unstructured.NestedString(object, "object", location, "namespace")

--- a/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
+++ b/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
@@ -188,8 +188,8 @@ func TestUnstructuredListToLogData(t *testing.T) {
 		objects.Items = append(objects.Items, object)
 		config := &K8sObjectsConfig{
 			gvr: &schema.GroupVersionResource{
-				Group:    "",
-				Version:  "events.k8s.io/v1",
+				Group:    "events.k8s.io",
+				Version:  "v1",
 				Resource: "events",
 			},
 		}

--- a/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
+++ b/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
@@ -169,4 +169,44 @@ func TestUnstructuredListToLogData(t *testing.T) {
 		assert.Equal(t, logRecords.At(0).ObservedTimestamp().AsTime().Unix(), observedAt.Unix())
 	})
 
+	t.Run("Test object with regarding", func(t *testing.T) {
+		objects := unstructured.UnstructuredList{
+			Items: []unstructured.Unstructured{},
+		}
+		object := unstructured.Unstructured{}
+		object.Object = map[string]any{
+			"object": map[string]any{
+				"kind": "Event",
+				"regarding": map[string]any{
+					"kind":      "Pod",
+					"name":      "my-pod-name",
+					"uid":       "12345",
+					"namespace": "my-namespace",
+				},
+			},
+		}
+		objects.Items = append(objects.Items, object)
+		config := &K8sObjectsConfig{
+			gvr: &schema.GroupVersionResource{
+				Group:    "",
+				Version:  "events.k8s.io",
+				Resource: "events",
+			},
+		}
+		logs := pullObjectsToLogData(&objects, time.Now(), config)
+
+		assert.Equal(t, logs.LogRecordCount(), 1)
+
+		resourceLogs := logs.ResourceLogs()
+		assert.Equal(t, resourceLogs.Len(), 1)
+
+		rl := resourceLogs.At(0)
+		resourceAttributes := rl.Resource().Attributes()
+		podName, _ := resourceAttributes.Get(semconv.AttributeK8SPodName)
+		assert.Equal(t, "my-pod-name", podName.AsString())
+		podUID, _ := resourceAttributes.Get(semconv.AttributeK8SPodUID)
+		assert.Equal(t, "12345", podUID.AsString())
+		podNamespace, _ := resourceAttributes.Get(semconv.AttributeK8SNamespaceName)
+		assert.Equal(t, "my-namespace", podNamespace.AsString())
+	})
 }


### PR DESCRIPTION
**Description:**
Updates the k8sobjects recevier to be able to extract meaningful kubernetes resource attributes from events.

**Link to tracking Issue:** <Issue number if applicable>

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24242

**Testing:** <Describe what testing was performed and which tests were added.>

Added unit tests and tested locally

**Documentation:** <Describe the documentation added.>
