### PR TITLE
[chore][exporter/signalfx] Skip flaky TestCorrelationClient

### DIFF
--- a/exporter/signalfxexporter/internal/apm/correlations/client_test.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/client_test.go
@@ -180,6 +180,7 @@ func setup(t *testing.T) (CorrelationClient, chan *request, *atomic.Value, *atom
 }
 
 func TestCorrelationClient(t *testing.T) {
+	t.Skip("See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27059")
 	client, serverCh, forcedRespCode, forcedRespPayload, cancel := setup(t)
 	defer close(serverCh)
 	defer cancel()


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27059