### PR TITLE
[cmd/telemetrygen]set grpc logging to warn

### DIFF
--- a/.chloggen/set-warn-verbosity-grpc-telemetrygen.yaml
+++ b/.chloggen/set-warn-verbosity-grpc-telemetrygen.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: telemetrygen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Move the telemetrygen tool to use gRPC logging at warn level, in line with otlpgrpc.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26659]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/telemetrygen/internal/common/log.go
+++ b/cmd/telemetrygen/internal/common/log.go
@@ -16,8 +16,8 @@ func CreateLogger() (*zap.Logger, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to obtain logger: %w", err)
 	}
-	grpcZap.ReplaceGrpcLoggerV2(logger.WithOptions(
+	grpcZap.ReplaceGrpcLoggerV2WithVerbosity(logger.WithOptions(
 		zap.AddCallerSkip(3),
-	))
+	), 1) // set to warn verbosity to avoid copious logging from grpc framework
 	return logger, err
 }


### PR DESCRIPTION
**Description:**
Move the telemetrygen tool to use gRPC logging at warn level, in line with otlpgrpc.

See https://github.com/open-telemetry/opentelemetry-collector/blob/e116f8c928eb49ba6816751397f5e9e3cf867856/otelcol/internal/grpclog/logger.go#L15C9-L15C53 for how we mirror the behavior of setting the grpc logger.

**Link to tracking Issue:**
Fixes #26659
