### PR TITLE
[pkg/stanza] operators - make logging more verbose

### DIFF
--- a/pkg/stanza/operator/transformer/move/move.go
+++ b/pkg/stanza/operator/transformer/move/move.go
@@ -73,7 +73,7 @@ func (p *Transformer) Process(ctx context.Context, entry *entry.Entry) error {
 func (p *Transformer) Transform(e *entry.Entry) error {
 	val, exist := p.From.Delete(e)
 	if !exist {
-		return fmt.Errorf("move: field does not exist")
+		return fmt.Errorf("move: field does not exist: %s", p.From.String())
 	}
 	return p.To.Set(e, val)
 }

--- a/pkg/stanza/operator/transformer/remove/remove.go
+++ b/pkg/stanza/operator/transformer/remove/remove.go
@@ -81,7 +81,7 @@ func (p *Transformer) Transform(entry *entry.Entry) error {
 
 	_, exist := entry.Delete(p.Field.Field)
 	if !exist {
-		return fmt.Errorf("remove: field does not exist")
+		return fmt.Errorf("remove: field does not exist: %s", p.Field.Field.String())
 	}
 	return nil
 }


### PR DESCRIPTION
**Description:** If we have multiple move/remove operators in the pipeline, and if some of them fail, the error message isn't that much of a help because all it prints is:
`move: field does not exist`. 
Whereas, the `copy` operator's error message looks like this:
`copy: from field does not exist: FIELD_NAME`

Make logging sensible by including which field is missing while removing/moving
