### PR TITLE
[pkg/stanza] Further reduce "no file found" log message severity

### DIFF
--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -115,7 +115,7 @@ func (m *Manager) poll(ctx context.Context) {
 	// Get the list of paths on disk
 	matches, err := m.fileMatcher.MatchFiles()
 	if err != nil {
-		m.Infof("finding files: %v", err)
+		m.Debugf("finding files: %v", err)
 	}
 
 	for len(matches) > m.maxBatchFiles {


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27094

We still log this message if no files are found when the collector starts. However, the recurring message has proven to be a undesirable in many cases.