### PR TITLE
[processor/k8sattributes] allow metadata extractions to be empty list

### DIFF
--- a/.chloggen/k8sattribute-processor-null-metadata.yaml
+++ b/.chloggen/k8sattribute-processor-null-metadata.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/k8sattributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: allow metadata extractions to be null
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [14452]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/k8sattribute-processor-null-metadata.yaml
+++ b/.chloggen/k8sattribute-processor-null-metadata.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: processor/k8sattributes
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: allow metadata extractions to be null
+note: allow metadata extractions to be set to empty list
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [14452]

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -29,6 +29,9 @@ func TestLoadConfig(t *testing.T) {
 			expected: &Config{
 				APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
 				Exclude:   ExcludeConfig{Pods: []ExcludePodConfig{{Name: "jaeger-agent"}, {Name: "jaeger-collector"}}},
+				Extract: ExtractConfig{
+					Metadata: enabledAttributes(),
+				},
 			},
 		},
 		{
@@ -114,6 +117,7 @@ func TestLoadConfig(t *testing.T) {
 					Labels: []FieldExtractConfig{
 						{KeyRegex: "opentel.*", From: kube.MetadataFromPod},
 					},
+					Metadata: enabledAttributes(),
 				},
 				Exclude: ExcludeConfig{
 					Pods: []ExcludePodConfig{

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -35,6 +35,9 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		APIConfig: k8sconfig.APIConfig{AuthType: k8sconfig.AuthTypeServiceAccount},
 		Exclude:   defaultExcludes,
+		Extract: ExtractConfig{
+			Metadata: enabledAttributes(),
+		},
 	}
 }
 

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -125,12 +125,6 @@ func enabledAttributes() (attributes []string) {
 // If no fields explicitly provided, the defaults are pulled from metadata.yaml.
 func withExtractMetadata(fields ...string) option {
 	return func(p *kubernetesprocessor) error {
-		if fields == nil {
-			return nil
-		}
-		if len(fields) == 0 {
-			fields = enabledAttributes()
-		}
 		for _, field := range fields {
 			switch field {
 			case conventions.AttributeK8SNamespaceName:

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -125,6 +125,9 @@ func enabledAttributes() (attributes []string) {
 // If no fields explicitly provided, the defaults are pulled from metadata.yaml.
 func withExtractMetadata(fields ...string) option {
 	return func(p *kubernetesprocessor) error {
+		if fields == nil {
+			return nil
+		}
 		if len(fields) == 0 {
 			fields = enabledAttributes()
 		}

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -284,7 +284,7 @@ func TestWithExtractLabels(t *testing.T) {
 
 func TestWithExtractMetadata(t *testing.T) {
 	p := &kubernetesprocessor{}
-	assert.NoError(t, withExtractMetadata()(p))
+	assert.NoError(t, withExtractMetadata(enabledAttributes()...)(p))
 	assert.True(t, p.rules.Namespace)
 	assert.True(t, p.rules.PodName)
 	assert.True(t, p.rules.PodUID)


### PR DESCRIPTION
**Description:** 
Allow metadata extractions to be null

After this is merged, user is allow to specify the metadata to be null like following

```
    processors:
      k8sattributes:
        extract:
          annotations:
          - from: pod
            key: workload
            tag_name: k8s.annotations.workload
          labels:
          - from: pod
            key: app
            tag_name: k8s.labels.app
          metadata: []
```

and the trace is like 
![image](https://github.com/open-telemetry/opentelemetry-collector-contrib/assets/11855957/1720cfe0-670b-4cb3-ad3a-c62f14926fa1)


**Link to tracking Issue:** <Issue number if applicable>

fix #14452 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>