### PR TITLE
[chore][pkg/stanza] Migrate flush func tests

### DIFF
--- a/pkg/stanza/flush/flush_test.go
+++ b/pkg/stanza/flush/flush_test.go
@@ -8,93 +8,48 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split/splittest"
 )
 
-func TestFlusher(t *testing.T) {
+func TestNewlineSplitFunc(t *testing.T) {
+	testCases := []struct {
+		name        string
+		flushPeriod time.Duration
+		baseFunc    bufio.SplitFunc
+		input       []byte
+		steps       []splittest.Step
+	}{
+		{
+			name:     "FlushNoPeriod",
+			input:    []byte("complete line\nincomplete"),
+			baseFunc: scanLinesStrict,
+			steps: []splittest.Step{
+				splittest.ExpectAdvanceToken(len("complete line\n"), "complete line"),
+			},
+		},
+		{
+			name:        "FlushIncompleteLineAfterPeriod",
+			input:       []byte("complete line\nincomplete"),
+			baseFunc:    scanLinesStrict,
+			flushPeriod: 100 * time.Millisecond,
+			steps: []splittest.Step{
+				splittest.ExpectAdvanceToken(len("complete line\n"), "complete line"),
+				splittest.ExpectReadMore(),
+				splittest.Eventually(splittest.ExpectToken("incomplete"), 150*time.Millisecond, 10*time.Millisecond),
+			},
+		},
+	}
 
-	// bufio.ScanWords is a simple split function which with tokenize based on newlines.
-	// It will return a partial token if atEOF=true. In order to test the flusher,
-	// we don't want the split func to return partial tokens on its own. Instead, we only
-	// want the flusher to force the partial out based on its own behavior. Therefore, we
-	// always use atEOF=false.
-
-	flushPeriod := 100 * time.Millisecond
-	f := WithPeriod(bufio.ScanWords, flushPeriod)
-
-	content := []byte("foo bar hellowo")
-
-	// The first token is complete
-	advance, token, err := f(content, false)
-	assert.NoError(t, err)
-	assert.Equal(t, 4, advance)
-	assert.Equal(t, []byte("foo"), token)
-
-	// The second token is also complete
-	advance, token, err = f(content[4:], false)
-	assert.NoError(t, err)
-	assert.Equal(t, 4, advance)
-	assert.Equal(t, []byte("bar"), token)
-
-	// We find a partial token, but we just updated, so don't flush it yet
-	advance, token, err = f(content[8:], false)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, advance)
-	assert.Equal(t, []byte(nil), token)
-
-	// We find the same partial token, but we updated quite recently, so still don't flush it yet
-	advance, token, err = f(content[8:], false)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, advance)
-	assert.Equal(t, []byte(nil), token)
-
-	time.Sleep(2 * flushPeriod)
-
-	// Now it's been a while, so we should just flush the partial token
-	advance, token, err = f(content[8:], false)
-	assert.NoError(t, err)
-	assert.Equal(t, 7, advance)
-	assert.Equal(t, []byte("hellowo"), token)
+	for _, tc := range testCases {
+		splitFunc := WithPeriod(tc.baseFunc, tc.flushPeriod)
+		t.Run(tc.name, splittest.New(splitFunc, tc.input, tc.steps...))
+	}
 }
 
-func TestNoFlushPeriod(t *testing.T) {
-	// Same test as above, but with a flush period of 0 we should never force flush.
-	// In other words, we should expect exactly the behavior of bufio.ScanWords.
-
-	flushPeriod := time.Duration(0)
-	f := WithPeriod(bufio.ScanWords, flushPeriod)
-
-	content := []byte("foo bar hellowo")
-
-	// The first token is complete
-	advance, token, err := f(content, false)
-	assert.NoError(t, err)
-	assert.Equal(t, 4, advance)
-	assert.Equal(t, []byte("foo"), token)
-
-	// The second token is also complete
-	advance, token, err = f(content[4:], false)
-	assert.NoError(t, err)
-	assert.Equal(t, 4, advance)
-	assert.Equal(t, []byte("bar"), token)
-
-	// We find a partial token, but we're using flushPeriod = 0 so we should never flush
-	advance, token, err = f(content[8:], false)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, advance)
-	assert.Equal(t, []byte(nil), token)
-
-	// We find the same partial token, but we're using flushPeriod = 0 so we should never flush
-	advance, token, err = f(content[8:], false)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, advance)
-	assert.Equal(t, []byte(nil), token)
-
-	time.Sleep(2 * flushPeriod)
-
-	// Now it's been a while, but we are using flushPeriod=0, so we should never not flush
-	advance, token, err = f(content[8:], false)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, advance)
-	assert.Equal(t, []byte(nil), token)
+func scanLinesStrict(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	advance, token, err = bufio.ScanLines(data, atEOF)
+	if advance == len(token) {
+		return 0, nil, nil
+	}
+	return
 }


### PR DESCRIPTION
This PR migrates `flush` package tests to the new split func framework. It includes timing-based enhancements to the framework as well.