### PR TITLE
Add an optional argument to converters to support hashing

### DIFF
--- a/.chloggen/ottl-replace-pattern.yaml
+++ b/.chloggen/ottl-replace-pattern.yaml
@@ -16,8 +16,11 @@ issues: [27235]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  The `ottl.Optional` type can now be used in a converter's `Arguments` struct
-  to indicate that a parameter is optional. Hashing functions are passed as optional parameters to converters.
+  Hashing functions are passed as optional arguments to the following converters:
+  - `replace_pattern`
+  - `replace_all_patterns`
+  - `replace_match`
+  - `replace_all_matches`
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/ottl-replace-pattern.yaml
+++ b/.chloggen/ottl-replace-pattern.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add optional parameters to converters
+note: Add optional Converter parameters to replacement Editors
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [27235]
@@ -16,7 +16,7 @@ issues: [27235]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  Hashing functions are passed as optional arguments to the following converters:
+  Functions to modify matched text during replacement can now be passed as optional arguments to the following Editors:
   - `replace_pattern`
   - `replace_all_patterns`
   - `replace_match`

--- a/.chloggen/ottl-replace-pattern.yaml
+++ b/.chloggen/ottl-replace-pattern.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add optional parameters to converters
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27235]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `ottl.Optional` type can now be used in a converter's `Arguments` struct
+  to indicate that a parameter is optional. Hashing functions are passed as optional parameters to converters.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -254,8 +254,8 @@ type FunctionGetter[K any] interface {
 
 // StandardFunctionGetter is a basic implementation of FunctionGetter.
 type StandardFunctionGetter[K any] struct {
-	fCtx FunctionContext
-	fact Factory[K]
+	FCtx FunctionContext
+	Fact Factory[K]
 }
 
 // Get takes an Arguments struct containing arguments the caller wants passed to the
@@ -263,12 +263,12 @@ type StandardFunctionGetter[K any] struct {
 // If there is a mismatch between the function's signature and the arguments the caller
 // wants to pass to the function, an error is returned.
 func (g StandardFunctionGetter[K]) Get(args Arguments) (Expr[K], error) {
-	if g.fact == nil {
+	if g.Fact == nil {
 		return Expr[K]{}, fmt.Errorf("undefined function")
 	}
-	fArgs := g.fact.CreateDefaultArguments()
+	fArgs := g.Fact.CreateDefaultArguments()
 	if reflect.TypeOf(fArgs).Kind() != reflect.Pointer {
-		return Expr[K]{}, fmt.Errorf("factory for %q must return a pointer to an Arguments value in its CreateDefaultArguments method", g.fact.Name())
+		return Expr[K]{}, fmt.Errorf("factory for %q must return a pointer to an Arguments value in its CreateDefaultArguments method", g.Fact.Name())
 	}
 	if reflect.TypeOf(args).Kind() != reflect.Pointer {
 		return Expr[K]{}, fmt.Errorf("%q must be pointer to an Arguments value", reflect.TypeOf(args).Kind())
@@ -282,7 +282,7 @@ func (g StandardFunctionGetter[K]) Get(args Arguments) (Expr[K], error) {
 		field := argsVal.Field(i)
 		fArgsVal.Field(i).Set(field)
 	}
-	fn, err := g.fact.CreateFunction(g.fCtx, fArgs)
+	fn, err := g.Fact.CreateFunction(g.FCtx, fArgs)
 	if err != nil {
 		return Expr[K]{}, fmt.Errorf("couldn't create function: %w", err)
 	}

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -720,7 +720,7 @@ func Test_FunctionGetter(t *testing.T) {
 					return "str", nil
 				},
 			},
-			function: StandardFunctionGetter[any]{fCtx: FunctionContext{Set: componenttest.NewNopTelemetrySettings()}, fact: functions["SHA256"]},
+			function: StandardFunctionGetter[any]{FCtx: FunctionContext{Set: componenttest.NewNopTelemetrySettings()}, Fact: functions["SHA256"]},
 			want:     "anything",
 			valid:    true,
 		},
@@ -731,7 +731,7 @@ func Test_FunctionGetter(t *testing.T) {
 					return nil, nil
 				},
 			},
-			function:         StandardFunctionGetter[any]{fCtx: FunctionContext{Set: componenttest.NewNopTelemetrySettings()}, fact: functions["SHA250"]},
+			function:         StandardFunctionGetter[any]{FCtx: FunctionContext{Set: componenttest.NewNopTelemetrySettings()}, Fact: functions["SHA250"]},
 			want:             "anything",
 			valid:            false,
 			expectedErrorMsg: "undefined function",
@@ -743,7 +743,7 @@ func Test_FunctionGetter(t *testing.T) {
 					return nil, nil
 				},
 			},
-			function:         StandardFunctionGetter[any]{fCtx: FunctionContext{Set: componenttest.NewNopTelemetrySettings()}, fact: functions["test_arg_mismatch"]},
+			function:         StandardFunctionGetter[any]{FCtx: FunctionContext{Set: componenttest.NewNopTelemetrySettings()}, Fact: functions["test_arg_mismatch"]},
 			want:             "anything",
 			valid:            false,
 			expectedErrorMsg: "incorrect number of arguments. Expected: 4 Received: 1",
@@ -755,7 +755,7 @@ func Test_FunctionGetter(t *testing.T) {
 					return nil, nil
 				},
 			},
-			function:         StandardFunctionGetter[any]{fCtx: FunctionContext{Set: componenttest.NewNopTelemetrySettings()}, fact: functions["cannot_create_function"]},
+			function:         StandardFunctionGetter[any]{FCtx: FunctionContext{Set: componenttest.NewNopTelemetrySettings()}, Fact: functions["cannot_create_function"]},
 			want:             "anything",
 			valid:            false,
 			expectedErrorMsg: "couldn't create function: error",

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -381,25 +381,25 @@ type optionalManager interface {
 }
 
 type Optional[T any] struct {
-	Val      T
-	HasValue bool
+	val      T
+	hasValue bool
 }
 
 // This is called only by reflection.
 // nolint:unused
 func (o Optional[T]) set(val any) reflect.Value {
 	return reflect.ValueOf(Optional[T]{
-		Val:      val.(T),
-		HasValue: true,
+		val:      val.(T),
+		hasValue: true,
 	})
 }
 
 func (o Optional[T]) IsEmpty() bool {
-	return !o.HasValue
+	return !o.hasValue
 }
 
 func (o Optional[T]) Get() T {
-	return o.Val
+	return o.val
 }
 
 func (o Optional[T]) get() reflect.Value {
@@ -414,7 +414,7 @@ func (o Optional[T]) get() reflect.Value {
 // OTTL functions.
 func NewTestingOptional[T any](val T) Optional[T] {
 	return Optional[T]{
-		Val:      val,
-		HasValue: true,
+		val:      val,
+		hasValue: true,
 	}
 }

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -123,7 +123,7 @@ func (p *Parser[K]) buildArgs(ed editor, argsVal reflect.Value) error {
 			if !ok {
 				return fmt.Errorf("undefined function %s", name)
 			}
-			val = StandardFunctionGetter[K]{fCtx: FunctionContext{Set: p.telemetrySettings}, fact: f}
+			val = StandardFunctionGetter[K]{FCtx: FunctionContext{Set: p.telemetrySettings}, Fact: f}
 		case fieldType.Kind() == reflect.Slice:
 			val, err = p.buildSliceArg(arg.Value, fieldType)
 		default:
@@ -381,25 +381,25 @@ type optionalManager interface {
 }
 
 type Optional[T any] struct {
-	val      T
-	hasValue bool
+	Val      T
+	HasValue bool
 }
 
 // This is called only by reflection.
 // nolint:unused
 func (o Optional[T]) set(val any) reflect.Value {
 	return reflect.ValueOf(Optional[T]{
-		val:      val.(T),
-		hasValue: true,
+		Val:      val.(T),
+		HasValue: true,
 	})
 }
 
 func (o Optional[T]) IsEmpty() bool {
-	return !o.hasValue
+	return !o.HasValue
 }
 
 func (o Optional[T]) Get() T {
-	return o.val
+	return o.Val
 }
 
 func (o Optional[T]) get() reflect.Value {
@@ -414,7 +414,7 @@ func (o Optional[T]) get() reflect.Value {
 // OTTL functions.
 func NewTestingOptional[T any](val T) Optional[T] {
 	return Optional[T]{
-		val:      val,
-		hasValue: true,
+		Val:      val,
+		HasValue: true,
 	}
 }

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -57,6 +57,7 @@ The key will be deleted from the map.
 
 Examples:
 
+
 - `delete_key(attributes, "http.request.header.authorization")`
 
 - `delete_key(resource.attributes, "http.request.header.authorization")`
@@ -72,6 +73,7 @@ The `delete_matching_keys` function removes all keys from a `pdata.Map` that mat
 All keys that match the pattern will be deleted from the map.
 
 Examples:
+
 
 - `delete_key(attributes, "http.request.header.authorization")`
 
@@ -90,6 +92,7 @@ The map will be changed to only contain the keys specified by the list of string
 Examples:
 
 - `keep_keys(attributes, ["http.method"])`
+
 
 - `keep_keys(resource.attributes, ["http.method", "http.route", "http.url"])`
 
@@ -113,6 +116,7 @@ Examples:
 
 - `limit(attributes, 100, [])`
 
+
 - `limit(resource.attributes, 50, ["http.host", "http.method"])`
 
 ### merge_maps
@@ -135,18 +139,19 @@ Examples:
 
 - `merge_maps(attributes, ParseJSON(body), "upsert")`
 
+
 - `merge_maps(attributes, ParseJSON(attributes["kubernetes"]), "update")`
+
 
 - `merge_maps(attributes, resource.attributes, "insert")`
 
 ### replace_all_matches
 
-`replace_all_matches(target, pattern, replacement, hashFunction)`
+`replace_all_matches(target, pattern, replacement, function)`
 
 The `replace_all_matches` function replaces any matching string value with the replacement string.
 
-`target` is a path expression to a `pdata.Map` type field. `pattern` is a string following [filepath.Match syntax](https://pkg.go.dev/path/filepath#Match). `replacement` is either a path expression to a string telemetry field or a literal string. `hashFunction` is an optional argument
-that creates a hash of `replacement` and then replaces any matching string with the hash value.
+`target` is a path expression to a `pdata.Map` type field. `pattern` is a string following [filepath.Match syntax](https://pkg.go.dev/path/filepath#Match). `replacement` is either a path expression to a string telemetry field or a literal string. `function` is an optional argument that can take in any Converter that accepts a (`replacement`) string and returns a string. An example is a hash function that replaces any matching string with the hash value of `replacement`.
 
 Each string value in `target` that matches `pattern` will get replaced with `replacement`. Non-string values are ignored.
 
@@ -160,7 +165,7 @@ Examples:
 
 ### replace_all_patterns
 
-`replace_all_patterns(target, mode, regex, replacement, hashFunction)`
+`replace_all_patterns(target, mode, regex, replacement, function)`
 
 The `replace_all_patterns` function replaces any segments in a string value or key that match the regex pattern with the replacement string.
 
@@ -172,7 +177,7 @@ If one or more sections of `target` match `regex` they will get replaced with `r
 
 The `replacement` string can refer to matched groups using [regexp.Expand syntax](https://pkg.go.dev/regexp#Regexp.Expand).
 
-The `hashFunction` is an optional argument that creates a hash of `replacement` and then replaces the regex pattern with the hash value.
+The `function` is an optional argument that can take in any Converter that accepts a (`replacement`) string and returns a string. An example is a hash function that replaces any matching regex pattern with the hash value of `replacement`.
 
 There is currently a bug with OTTL that does not allow the pattern to end with `\\"`.
 If your pattern needs to end with backslashes, add something inconsequential to the end of the pattern such as `{1}`, `$`, or `.*`.
@@ -191,7 +196,7 @@ If using OTTL outside of collector configuration, `$` should not be escaped and 
 
 ### replace_match
 
-`replace_match(target, pattern, replacement, hashFunction)`
+`replace_match(target, pattern, replacement, function)`
 
 The `replace_match` function allows replacing entire strings if they match a glob pattern.
 
@@ -199,7 +204,7 @@ The `replace_match` function allows replacing entire strings if they match a glo
 
 If `target` matches `pattern` it will get replaced with `replacement`.
 
-The `hashFunction` is an optional argument that creates a hash of `replacement` and then replaces entire strings if they match a glob pattern with the hash value.
+The `function` is an optional argument that can take in any Converter that accepts a (`replacement`) string and returns a string. An example is a hash function that replaces any matching glob pattern with the hash value of `replacement`.
 
 There is currently a bug with OTTL that does not allow the pattern to end with `\\"`.
 [See Issue 23238 for details](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23238).
@@ -211,7 +216,7 @@ Examples:
 
 ### replace_pattern
 
-`replace_pattern(target, regex, replacement, hashFunction)`
+`replace_pattern(target, regex, replacement, function)`
 
 The `replace_pattern` function allows replacing all string sections that match a regex pattern with a new value.
 
@@ -221,7 +226,7 @@ If one or more sections of `target` match `regex` they will get replaced with `r
 
 The `replacement` string can refer to matched groups using [regexp.Expand syntax](https://pkg.go.dev/regexp#Regexp.Expand).
 
-The `hashFunction` is an optional argument that creates a hash of `replacement` and then replaces all string sections that match a regex pattern with the hash value.
+The `function` is an optional argument that can take in any Converter that accepts a (`replacement`) string and returns a string. An example is a hash function that replaces a matching regex pattern with the hash value of `replacement`.
 
 There is currently a bug with OTTL that does not allow the pattern to end with `\\"`.
 If your pattern needs to end with backslashes, add something inconsequential to the end of the pattern such as `{1}`, `$`, or `.*`.
@@ -251,9 +256,12 @@ Examples:
 
 - `set(attributes["http.path"], "/foo")`
 
+
 - `set(name, attributes["http.route"])`
 
+
 - `set(trace_state["svc"], "example")`
+
 
 - `set(attributes["source"], trace_state["source"])`
 
@@ -270,6 +278,7 @@ The map will be mutated such that the number of characters in all string values 
 Examples:
 
 - `truncate_all(attributes, 100)`
+
 
 - `truncate_all(resource.attributes, 50)`
 
@@ -327,7 +336,9 @@ Examples:
 
 - `Concat([attributes["http.method"], attributes["http.path"]], ": ")`
 
+
 - `Concat([name, 1], " ")`
+
 
 - `Concat(["HTTP method is: ", attributes["http.method"]], "")`
 
@@ -402,6 +413,7 @@ Examples:
 
 - `FNV(attributes["device.name"])`
 
+
 - `FNV("name")`
 
 ### Hours
@@ -441,6 +453,7 @@ Examples:
 
 - `Int(attributes["http.status_code"])`
 
+
 - `Int("2.0")`
 
 ### IsMap
@@ -456,6 +469,7 @@ If `value` is a `map[string]any` or a `pcommon.ValueTypeMap` then returns `true`
 Examples:
 
 - `IsMap(body)`
+
 
 - `IsMap(attributes["maybe a map"])`
 
@@ -484,6 +498,7 @@ There is currently a bug with OTTL that does not allow the target string to end 
 Examples:
 
 - `IsMatch(attributes["http.path"], "foo")`
+
 
 - `IsMatch("string", ".*ring")`
 
@@ -539,6 +554,7 @@ If target is nil an error is returned.
 Examples:
 
 - `Log(attributes["duration_ms"])`
+
 
 - `Int(Log(attributes["duration_ms"])`
 
@@ -636,7 +652,9 @@ Examples:
 
 - `ParseJSON("{\"attr\":true}")`
 
+
 - `ParseJSON(attributes["kubernetes"])`
+
 
 - `ParseJSON(body)`
 
@@ -670,6 +688,7 @@ Examples:
 
 - `SHA1(attributes["device.name"])`
 
+
 - `SHA1("name")`
 
 **Note:** According to the National Institute of Standards and Technology (NIST), SHA1 is no longer a recommended hash function. It should be avoided except when required for compatibility. New uses should prefer FNV whenever possible.
@@ -690,6 +709,7 @@ Examples:
 
 - `SHA256(attributes["device.name"])`
 
+
 - `SHA256("name")`
 
 **Note:** According to the National Institute of Standards and Technology (NIST), SHA256 is no longer a recommended hash function. It should be avoided except when required for compatibility. New uses should prefer FNV whenever possible.
@@ -708,7 +728,7 @@ Examples:
 
 ### Split
 
-`Split(target, delimiter)`
+```Split(target, delimiter)```
 
 The `Split` Converter separates a string by the delimiter, and returns an array of substrings.
 

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches.go
@@ -37,8 +37,6 @@ func createReplaceAllMatchesFunction[K any](_ ottl.FunctionContext, oArgs ottl.A
 func replaceAllMatches[K any](target ottl.PMapGetter[K], pattern string, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]]) (ottl.ExprFunc[K], error) {
 	glob, err := glob.Compile(pattern)
 	var replacementVal string
-	var replacementExpr ottl.Expr[K]
-	var replacementValRaw interface{}
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to replace_match is not a valid pattern: %w", err)
 	}
@@ -54,13 +52,13 @@ func replaceAllMatches[K any](target ottl.PMapGetter[K], pattern string, replace
 			}
 		} else {
 			fnVal := fn.Get()
-			replacementExpr, err = fnVal.Get(&FuncArgs[K]{Input: replacement})
-			if err != nil {
-				return nil, err
+			replacementExpr, errNew := fnVal.Get(&FuncArgs[K]{Input: replacement})
+			if errNew != nil {
+				return nil, errNew
 			}
-			replacementValRaw, err = replacementExpr.Eval(ctx, tCtx)
-			if err != nil {
-				return nil, err
+			replacementValRaw, errNew := replacementExpr.Eval(ctx, tCtx)
+			if errNew != nil {
+				return nil, errNew
 			}
 			replacementVal = replacementValRaw.(string)
 		}

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -43,8 +43,6 @@ func createReplaceAllPatternsFunction[K any](_ ottl.FunctionContext, oArgs ottl.
 func replaceAllPatterns[K any](target ottl.PMapGetter[K], mode string, regexPattern string, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]]) (ottl.ExprFunc[K], error) {
 	compiledPattern, err := regexp.Compile(regexPattern)
 	var replacementVal string
-	var replacementExpr ottl.Expr[K]
-	var replacementValRaw interface{}
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to replace_all_patterns is not a valid pattern: %w", err)
 	}
@@ -64,13 +62,13 @@ func replaceAllPatterns[K any](target ottl.PMapGetter[K], mode string, regexPatt
 			}
 		} else {
 			fnVal := fn.Get()
-			replacementExpr, err = fnVal.Get(&FuncArgs[K]{Input: replacement})
-			if err != nil {
-				return nil, err
+			replacementExpr, errNew := fnVal.Get(&FuncArgs[K]{Input: replacement})
+			if errNew != nil {
+				return nil, errNew
 			}
-			replacementValRaw, err = replacementExpr.Eval(ctx, tCtx)
-			if err != nil {
-				return nil, err
+			replacementValRaw, errNew := replacementExpr.Eval(ctx, tCtx)
+			if errNew != nil {
+				return nil, errNew
 			}
 			replacementVal = replacementValRaw.(string)
 		}

--- a/pkg/ottl/ottlfuncs/func_replace_match.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match.go
@@ -46,7 +46,6 @@ func replaceMatch[K any](target ottl.GetSetter[K], pattern string, replacement o
 		if err != nil {
 			return nil, err
 		}
-		//replacementVal, err := replacement.Get(ctx, tCtx)
 		if fn.IsEmpty() {
 			replacementVal, err = replacement.Get(ctx, tCtx)
 			if err != nil {

--- a/pkg/ottl/ottlfuncs/func_replace_match.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match.go
@@ -36,8 +36,6 @@ func createReplaceMatchFunction[K any](_ ottl.FunctionContext, oArgs ottl.Argume
 func replaceMatch[K any](target ottl.GetSetter[K], pattern string, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]]) (ottl.ExprFunc[K], error) {
 	glob, err := glob.Compile(pattern)
 	var replacementVal string
-	var replacementExpr ottl.Expr[K]
-	var replacementValRaw interface{}
 	if err != nil {
 		return nil, fmt.Errorf("the pattern supplied to replace_match is not a valid pattern: %w", err)
 	}
@@ -53,13 +51,13 @@ func replaceMatch[K any](target ottl.GetSetter[K], pattern string, replacement o
 			}
 		} else {
 			fnVal := fn.Get()
-			replacementExpr, err = fnVal.Get(&FuncArgs[K]{Input: replacement})
-			if err != nil {
-				return nil, err
+			replacementExpr, errNew := fnVal.Get(&FuncArgs[K]{Input: replacement})
+			if errNew != nil {
+				return nil, errNew
 			}
-			replacementValRaw, err = replacementExpr.Eval(ctx, tCtx)
-			if err != nil {
-				return nil, err
+			replacementValRaw, errNew := replacementExpr.Eval(ctx, tCtx)
+			if errNew != nil {
+				return nil, errNew
 			}
 			replacementVal = replacementValRaw.(string)
 		}

--- a/pkg/ottl/ottlfuncs/func_replace_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
@@ -128,6 +129,66 @@ func Test_replaceMatch_bad_input(t *testing.T) {
 	assert.Nil(t, result)
 
 	assert.Equal(t, pcommon.NewValueInt(1), input)
+}
+
+func Test_replaceMatch_bad_function_input(t *testing.T) {
+	input := pcommon.NewValueInt(1)
+	target := &ottl.StandardGetSetter[interface{}]{
+		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+			return tCtx, nil
+		},
+		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
+			t.Errorf("nothing should be set in this scenario")
+			return nil
+		},
+	}
+	replacement := &ottl.StandardStringGetter[interface{}]{
+		Getter: func(context.Context, interface{}) (interface{}, error) {
+			return nil, nil
+		},
+	}
+	function := ottl.Optional[ottl.FunctionGetter[interface{}]]{}
+
+	exprFunc, err := replaceMatch[interface{}](target, "regexp", replacement, function)
+	assert.NoError(t, err)
+
+	result, err := exprFunc(nil, input)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "expected string but got nil")
+	assert.Nil(t, result)
+}
+
+func Test_replaceMatch_bad_function_result(t *testing.T) {
+	input := pcommon.NewValueInt(1)
+	target := &ottl.StandardGetSetter[interface{}]{
+		Getter: func(ctx context.Context, tCtx interface{}) (interface{}, error) {
+			return tCtx, nil
+		},
+		Setter: func(ctx context.Context, tCtx interface{}, val interface{}) error {
+			t.Errorf("nothing should be set in this scenario")
+			return nil
+		},
+	}
+	replacement := &ottl.StandardStringGetter[interface{}]{
+		Getter: func(context.Context, interface{}) (interface{}, error) {
+			return nil, nil
+		},
+	}
+	ottlValue := ottl.StandardFunctionGetter[interface{}]{
+		FCtx: ottl.FunctionContext{
+			Set: componenttest.NewNopTelemetrySettings(),
+		},
+		Fact: StandardConverters[interface{}]()["IsString"],
+	}
+	function := ottl.NewTestingOptional[ottl.FunctionGetter[interface{}]](ottlValue)
+
+	exprFunc, err := replaceMatch[interface{}](target, "regexp", replacement, function)
+	assert.NoError(t, err)
+
+	result, err := exprFunc(nil, input)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "replacement value is not a string")
+	assert.Nil(t, result)
 }
 
 func Test_replaceMatch_get_nil(t *testing.T) {

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -38,8 +38,6 @@ func createReplacePatternFunction[K any](_ ottl.FunctionContext, oArgs ottl.Argu
 
 func replacePattern[K any](target ottl.GetSetter[K], regexPattern string, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]]) (ottl.ExprFunc[K], error) {
 	var replacementVal string
-	var replacementExpr ottl.Expr[K]
-	var replacementValRaw interface{}
 	compiledPattern, err := regexp.Compile(regexPattern)
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to replace_pattern is not a valid pattern: %w", err)
@@ -56,13 +54,13 @@ func replacePattern[K any](target ottl.GetSetter[K], regexPattern string, replac
 			}
 		} else {
 			fnVal := fn.Get()
-			replacementExpr, err = fnVal.Get(&FuncArgs[K]{Input: replacement})
-			if err != nil {
-				return nil, err
+			replacementExpr, errNew := fnVal.Get(&FuncArgs[K]{Input: replacement})
+			if errNew != nil {
+				return nil, errNew
 			}
-			replacementValRaw, err = replacementExpr.Eval(ctx, tCtx)
-			if err != nil {
-				return nil, err
+			replacementValRaw, errNew := replacementExpr.Eval(ctx, tCtx)
+			if errNew != nil {
+				return nil, errNew
 			}
 			replacementVal = replacementValRaw.(string)
 		}

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -64,7 +64,6 @@ func replacePattern[K any](target ottl.GetSetter[K], regexPattern string, replac
 			}
 			replacementVal = replacementValRaw.(string)
 		}
-		// replacementVal, err := replacement.Get(ctx, tCtx)
 		if originalVal == nil {
 			return nil, nil
 		}

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -38,6 +38,8 @@ func createReplacePatternFunction[K any](_ ottl.FunctionContext, oArgs ottl.Argu
 
 func replacePattern[K any](target ottl.GetSetter[K], regexPattern string, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]]) (ottl.ExprFunc[K], error) {
 	var replacementVal string
+	var replacementExpr ottl.Expr[K]
+	var replacementValRaw interface{}
 	compiledPattern, err := regexp.Compile(regexPattern)
 	if err != nil {
 		return nil, fmt.Errorf("the regex pattern supplied to replace_pattern is not a valid pattern: %w", err)
@@ -54,11 +56,11 @@ func replacePattern[K any](target ottl.GetSetter[K], regexPattern string, replac
 			}
 		} else {
 			fnVal := fn.Get()
-			replacementExpr, err := fnVal.Get(&FuncArgs[K]{Input: replacement})
+			replacementExpr, err = fnVal.Get(&FuncArgs[K]{Input: replacement})
 			if err != nil {
 				return nil, err
 			}
-			replacementValRaw, err := replacementExpr.Eval(ctx, tCtx)
+			replacementValRaw, err = replacementExpr.Eval(ctx, tCtx)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
@@ -68,12 +68,6 @@ func Test_replacePattern(t *testing.T) {
 				},
 			},
 			function: ottl.Optional[ottl.FunctionGetter[pcommon.Value]]{
-				Val: ottl.StandardFunctionGetter[pcommon.Value]{
-					FCtx: ottl.FunctionContext{
-						Set: componenttest.NewNopTelemetrySettings(),
-					},
-					Fact: StandardConverters[pcommon.Value]()["SHA256"],
-				},
 				HasValue: false,
 			},
 			want: func(expectedValue pcommon.Value) {
@@ -90,12 +84,6 @@ func Test_replacePattern(t *testing.T) {
 				},
 			},
 			function: ottl.Optional[ottl.FunctionGetter[pcommon.Value]]{
-				Val: ottl.StandardFunctionGetter[pcommon.Value]{
-					FCtx: ottl.FunctionContext{
-						Set: componenttest.NewNopTelemetrySettings(),
-					},
-					Fact: StandardConverters[pcommon.Value]()["SHA256"],
-				},
 				HasValue: false,
 			},
 			want: func(expectedValue pcommon.Value) {
@@ -112,12 +100,6 @@ func Test_replacePattern(t *testing.T) {
 				},
 			},
 			function: ottl.Optional[ottl.FunctionGetter[pcommon.Value]]{
-				Val: ottl.StandardFunctionGetter[pcommon.Value]{
-					FCtx: ottl.FunctionContext{
-						Set: componenttest.NewNopTelemetrySettings(),
-					},
-					Fact: StandardConverters[pcommon.Value]()["SHA256"],
-				},
 				HasValue: false,
 			},
 			want: func(expectedValue pcommon.Value) {
@@ -134,12 +116,6 @@ func Test_replacePattern(t *testing.T) {
 				},
 			},
 			function: ottl.Optional[ottl.FunctionGetter[pcommon.Value]]{
-				Val: ottl.StandardFunctionGetter[pcommon.Value]{
-					FCtx: ottl.FunctionContext{
-						Set: componenttest.NewNopTelemetrySettings(),
-					},
-					Fact: StandardConverters[pcommon.Value]()["SHA256"],
-				},
 				HasValue: false,
 			},
 			want: func(expectedValue pcommon.Value) {
@@ -182,12 +158,6 @@ func Test_replacePattern_bad_input(t *testing.T) {
 		},
 	}
 	function := ottl.Optional[ottl.FunctionGetter[interface{}]]{
-		Val: ottl.StandardFunctionGetter[interface{}]{
-			FCtx: ottl.FunctionContext{
-				Set: componenttest.NewNopTelemetrySettings(),
-			},
-			Fact: StandardConverters[interface{}]()["SHA256"],
-		},
 		HasValue: false,
 	}
 
@@ -216,12 +186,6 @@ func Test_replacePattern_get_nil(t *testing.T) {
 		},
 	}
 	function := ottl.Optional[ottl.FunctionGetter[interface{}]]{
-		Val: ottl.StandardFunctionGetter[interface{}]{
-			FCtx: ottl.FunctionContext{
-				Set: componenttest.NewNopTelemetrySettings(),
-			},
-			Fact: StandardConverters[interface{}]()["SHA256"],
-		},
 		HasValue: false,
 	}
 
@@ -250,12 +214,6 @@ func Test_replacePatterns_invalid_pattern(t *testing.T) {
 		},
 	}
 	function := ottl.Optional[ottl.FunctionGetter[interface{}]]{
-		Val: ottl.StandardFunctionGetter[interface{}]{
-			FCtx: ottl.FunctionContext{
-				Set: componenttest.NewNopTelemetrySettings(),
-			},
-			Fact: StandardConverters[interface{}]()["SHA256"],
-		},
 		HasValue: false,
 	}
 


### PR DESCRIPTION
**Description:** Functions to modify matched text during replacement can now be passed as optional arguments to the following Editors:
- replace_pattern
- replace_all_patterns
- replace_match
- replace_all_matches

**Documentation:**
https://github.com/rnishtala-sumo/opentelemetry-collector-contrib/blob/ottl-replace-pattern/pkg/ottl/ottlfuncs/README.md#replace_pattern

**Issue:**
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22787