### PR TITLE
[chore] fix reference to obsreport

### DIFF
--- a/processor/tailsamplingprocessor/metrics.go
+++ b/processor/tailsamplingprocessor/metrics.go
@@ -90,7 +90,7 @@ func samplingProcessorMetricViews(level configtelemetry.Level) []*view.View {
 	}
 
 	countGlobalTracesSampledView := &view.View{
-		Name:        obsreport.BuildProcessorCustomMetricName(metadata.Type, statCountGlobalTracesSampled.Name()),
+		Name:        processorhelper.BuildCustomMetricName(metadata.Type, statCountGlobalTracesSampled.Name()),
 		Measure:     statCountGlobalTracesSampled,
 		Description: statCountGlobalTracesSampled.Description(),
 		TagKeys:     []tag.Key{tagSampledKey},


### PR DESCRIPTION
This was missed in a previous merge. Fixes #27245
