### PR TITLE
Fix error on build-test-windows workflow

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -3,10 +3,19 @@
 # otherwise in the example command pipe, only the exit code of `tee` is recorded instead of `go test` which can cause
 # test to pass in CI when they should not.
 SHELL = /bin/bash
-ifeq ($(shell uname -s),Windows)
-	.SHELLFLAGS = /o pipefile /c
+.SHELLFLAGS = -o pipefail -c
+
+SHELL_CASE_EXP = case "$$(uname -s)" in CYGWIN*|MINGW*|MSYS*) echo "true";; esac;
+UNIX_SHELL_ON_WINDOWS := $(shell $(SHELL_CASE_EXP))
+
+ifeq ($(UNIX_SHELL_ON_WINDOWS),true)
+	# The "sed" transformation below is needed on Windows, since commands like `go list -f '{{ .Dir }}'`
+	# return Windows paths and such paths are incompatible with other *nix tools, like `find`,
+	# used by the Makefile shell.
+	# The backslash needs to be doubled so its passed correctly to the shell. 
+	NORMALIZE_DIRS = sed -e 's/^/\\//' -e 's/://' -e 's/\\\\/\\//g' | sort
 else
-	.SHELLFLAGS = -o pipefail -c
+	NORMALIZE_DIRS = sort
 endif
 
 # SRC_ROOT is the top of the source tree.
@@ -63,7 +72,7 @@ GOVULNCHECK         := $(TOOLS_BIN_DIR)/govulncheck
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
 
-ALL_PKG_DIRS := $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | sort)
+ALL_PKG_DIRS := $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | $(NORMALIZE_DIRS))
 
 ALL_SRC := $(shell find $(ALL_PKG_DIRS) -name '*.go' \
                                 -not -path '*/third_party/*' \


### PR DESCRIPTION
**Description:**

Fix #25843

The issue is that the `go` tool generates directories as per its build OS, so on Windows, `go list -f '{{ .Dir }}' ./...` outputs paths in Windows format, e.g.: "c:\src\otel-col-contrib", however, the tools used by the make expect paths to be in Unix format. This change adds a `sed` expression to convert the Windows paths to Unix paths so they can be passed to tools like `find`.
 
**Link to tracking Issue:** 

#25843

**Testing:** 

Run of the change on my repo https://github.com/pjanotti/opentelemetry-service-contrib/actions/runs/6331612383

**Documentation:**

 N/A