### PR TITLE
[chore][pkg/stanza] Extract max length trimming responsibility into trim package

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -113,7 +113,7 @@ func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback) (*Manager, 
 	}
 
 	// Ensure that splitter is buildable
-	factory := splitter.NewFactory(splitFunc, trimFunc, c.FlushPeriod)
+	factory := splitter.NewFactory(splitFunc, trimFunc, c.FlushPeriod, int(c.MaxLogSize))
 	return c.buildManager(logger, emit, factory)
 }
 
@@ -124,7 +124,7 @@ func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit emit.Callback
 	}
 
 	// Ensure that splitter is buildable
-	factory := splitter.NewFactory(splitFunc, c.TrimConfig.Func(), c.FlushPeriod)
+	factory := splitter.NewFactory(splitFunc, c.TrimConfig.Func(), c.FlushPeriod, int(c.MaxLogSize))
 	return c.buildManager(logger, emit, factory)
 }
 

--- a/pkg/stanza/fileconsumer/internal/scanner/scanner.go
+++ b/pkg/stanza/fileconsumer/internal/scanner/scanner.go
@@ -25,14 +25,6 @@ func New(r io.Reader, maxLogSize int, bufferSize int, startOffset int64, splitFu
 	s.Buffer(make([]byte, 0, bufferSize), maxLogSize)
 	scanFunc := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		advance, token, err = splitFunc(data, atEOF)
-		if (advance == 0 && token == nil && err == nil) && len(data) >= maxLogSize {
-			// reference: https://pkg.go.dev/bufio#SplitFunc
-			// splitFunc returns (0, nil, nil) to signal the Scanner to read more data but the buffer is full.
-			// Truncate the log entry.
-			advance, token, err = maxLogSize, data[:maxLogSize], nil
-		} else if len(token) > maxLogSize {
-			advance, token = maxLogSize, token[:maxLogSize]
-		}
 		s.pos += int64(advance)
 		return
 	}

--- a/pkg/stanza/fileconsumer/internal/scanner/scanner_test.go
+++ b/pkg/stanza/fileconsumer/internal/scanner/scanner_test.go
@@ -73,30 +73,6 @@ func TestScanner(t *testing.T) {
 				[]byte(""),
 			},
 		},
-		{
-			name:       "overflow_maxlogsize",
-			stream:     []byte("testlog1islongerthanmaxlogsize\n"),
-			delimiter:  []byte("\n"),
-			maxSize:    20,
-			bufferSize: DefaultBufferSize,
-			expected: [][]byte{
-				[]byte("testlog1islongerthan"),
-				[]byte("maxlogsize"),
-			},
-			skipFirstDelimiter: true,
-		},
-		{
-			name:       "overflow_buffer",
-			stream:     []byte("testlog1islongerthanbuffer\n"),
-			delimiter:  []byte("\n"),
-			maxSize:    20,
-			bufferSize: 20,
-			expected: [][]byte{
-				[]byte("testlog1islongerthan"),
-				[]byte("buffer"),
-			},
-			skipFirstDelimiter: true,
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/stanza/fileconsumer/internal/splitter/factory.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/factory.go
@@ -19,19 +19,29 @@ type factory struct {
 	splitFunc   bufio.SplitFunc
 	trimFunc    trim.Func
 	flushPeriod time.Duration
+	maxLength   int
 }
 
 var _ Factory = (*factory)(nil)
 
-func NewFactory(splitFunc bufio.SplitFunc, trimFunc trim.Func, flushPeriod time.Duration) Factory {
+func NewFactory(splitFunc bufio.SplitFunc, trimFunc trim.Func, flushPeriod time.Duration, maxLength int) Factory {
 	return &factory{
 		splitFunc:   splitFunc,
 		trimFunc:    trimFunc,
 		flushPeriod: flushPeriod,
+		maxLength:   maxLength,
 	}
 }
 
 // SplitFunc builds a bufio.SplitFunc based on the configuration
 func (f *factory) SplitFunc() bufio.SplitFunc {
-	return trim.WithFunc(flush.WithPeriod(f.splitFunc, f.flushPeriod), f.trimFunc)
+	// First apply the base splitFunc.
+	// If no token is found, we may still flush one based on timing.
+	// If a token is emitted for any reason, we must then apply trim rules.
+	// We must trim to max length _before_ trimming whitespace because otherwise we
+	// cannot properly keep track of the number of bytes to advance.
+	// For instance, if we have advance: 5, token: []byte(" foo "):
+	//   Trimming whitespace first would result in advance: 5, token: []byte("foo")
+	//   Then if we trim to max length of 2, we don't know whether or not to reduce advance.
+	return trim.WithFunc(trim.ToLength(flush.WithPeriod(f.splitFunc, f.flushPeriod), f.maxLength), f.trimFunc)
 }

--- a/pkg/stanza/fileconsumer/internal/splitter/factory_test.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/factory_test.go
@@ -16,67 +16,125 @@ func TestFactorySplitFunc(t *testing.T) {
 	testCases := []struct {
 		name        string
 		baseFunc    bufio.SplitFunc
-		trimFunc    trim.Func
 		flushPeriod time.Duration
+		maxLength   int
+		trimFunc    trim.Func
 		input       []byte
 		steps       []splittest.Step
 	}{
 		{
-			name:        "ScanLinesStrict",
-			input:       []byte(" hello \n world \n extra "),
-			baseFunc:    splittest.ScanLinesStrict,
-			trimFunc:    trim.Nop,
-			flushPeriod: 0,
+			name:     "ScanLinesStrict",
+			input:    []byte(" hello \n world \n extra "),
+			baseFunc: splittest.ScanLinesStrict,
 			steps: []splittest.Step{
 				splittest.ExpectAdvanceToken(len(" hello \n"), " hello "),
 				splittest.ExpectAdvanceToken(len(" world \n"), " world "),
-			},
-		},
-		{
-			name:        "ScanLinesStrictWithTrim",
-			input:       []byte(" hello \n world \n extra "),
-			baseFunc:    splittest.ScanLinesStrict,
-			trimFunc:    trim.Whitespace,
-			flushPeriod: 0,
-			steps: []splittest.Step{
-				splittest.ExpectAdvanceToken(len(" hello \n"), "hello"),
-				splittest.ExpectAdvanceToken(len(" world \n"), "world"),
 			},
 		},
 		{
 			name:        "ScanLinesStrictWithFlush",
 			input:       []byte(" hello \n world \n extra "),
 			baseFunc:    splittest.ScanLinesStrict,
-			trimFunc:    trim.Nop,
 			flushPeriod: 100 * time.Millisecond,
 			steps: []splittest.Step{
 				splittest.ExpectAdvanceToken(len(" hello \n"), " hello "),
 				splittest.ExpectAdvanceToken(len(" world \n"), " world "),
 				splittest.ExpectReadMore(),
-				splittest.Eventually(
-					splittest.ExpectAdvanceToken(len(" extra "), " extra "), 200*time.Millisecond, 10*time.Millisecond,
-				),
+				splittest.Eventually(splittest.ExpectAdvanceToken(len(" extra "), " extra "),
+					200*time.Millisecond, 10*time.Millisecond),
 			},
 		},
 		{
-			name:        "ScanLinesStrictWithTrimAndFlush",
+			name:      "ScanLinesStrictWithMaxLength",
+			input:     []byte(" hello \n world \n extra "),
+			baseFunc:  splittest.ScanLinesStrict,
+			maxLength: 4,
+			steps: []splittest.Step{
+				splittest.ExpectAdvanceToken(4, " hel"),
+				splittest.ExpectAdvanceToken(4, "lo "),
+				splittest.ExpectAdvanceToken(4, " wor"),
+				splittest.ExpectAdvanceToken(4, "ld "),
+				splittest.ExpectAdvanceToken(4, " ext"),
+			},
+		},
+		{
+			name:     "ScanLinesStrictWithTrim",
+			input:    []byte(" hello \n world \n extra "),
+			baseFunc: splittest.ScanLinesStrict,
+			trimFunc: trim.Whitespace,
+			steps: []splittest.Step{
+				splittest.ExpectAdvanceToken(len(" hello \n"), "hello"),
+				splittest.ExpectAdvanceToken(len(" world \n"), "world"),
+			},
+		},
+		{
+			name:        "ScanLinesStrictWithFlushAndMaxLength",
 			input:       []byte(" hello \n world \n extra "),
 			baseFunc:    splittest.ScanLinesStrict,
-			trimFunc:    trim.Whitespace,
 			flushPeriod: 100 * time.Millisecond,
+			maxLength:   4,
+			steps: []splittest.Step{
+				splittest.ExpectAdvanceToken(4, " hel"),
+				splittest.ExpectAdvanceToken(4, "lo "),
+				splittest.ExpectAdvanceToken(4, " wor"),
+				splittest.ExpectAdvanceToken(4, "ld "),
+				splittest.ExpectAdvanceToken(4, " ext"),
+				splittest.ExpectReadMore(),
+				splittest.Eventually(splittest.ExpectAdvanceToken(3, "ra "),
+					200*time.Millisecond, 10*time.Millisecond),
+			},
+		},
+		{
+			name:        "ScanLinesStrictWithFlushAndTrim",
+			input:       []byte(" hello \n world \n extra "),
+			baseFunc:    splittest.ScanLinesStrict,
+			flushPeriod: 100 * time.Millisecond,
+			trimFunc:    trim.Whitespace,
 			steps: []splittest.Step{
 				splittest.ExpectAdvanceToken(len(" hello \n"), "hello"),
 				splittest.ExpectAdvanceToken(len(" world \n"), "world"),
 				splittest.ExpectReadMore(),
-				splittest.Eventually(
-					splittest.ExpectAdvanceToken(len(" extra "), "extra"), 200*time.Millisecond, 10*time.Millisecond,
-				),
+				splittest.Eventually(splittest.ExpectAdvanceToken(len(" extra "), "extra"),
+					200*time.Millisecond, 10*time.Millisecond),
+			},
+		},
+		{
+			name:        "ScanLinesStrictWithMaxLengthAndTrim",
+			input:       []byte(" hello \n world \n extra "),
+			baseFunc:    splittest.ScanLinesStrict,
+			flushPeriod: 0,
+			maxLength:   4,
+			trimFunc:    trim.Whitespace,
+			steps: []splittest.Step{
+				splittest.ExpectAdvanceToken(4, "hel"), // trimmed to length before whitespace
+				splittest.ExpectAdvanceToken(4, "lo"),
+				splittest.ExpectAdvanceToken(4, "wor"),
+				splittest.ExpectAdvanceToken(4, "ld"),
+				splittest.ExpectAdvanceToken(4, "ext"),
+			},
+		},
+		{
+			name:        "ScanLinesStrictWithFlushAndMaxLengthAndTrim",
+			input:       []byte(" hello \n world \n extra "),
+			baseFunc:    splittest.ScanLinesStrict,
+			flushPeriod: 100 * time.Millisecond,
+			maxLength:   4,
+			trimFunc:    trim.Whitespace,
+			steps: []splittest.Step{
+				splittest.ExpectAdvanceToken(4, "hel"),
+				splittest.ExpectAdvanceToken(4, "lo"),
+				splittest.ExpectAdvanceToken(4, "wor"),
+				splittest.ExpectAdvanceToken(4, "ld"),
+				splittest.ExpectAdvanceToken(4, "ext"),
+				splittest.ExpectReadMore(),
+				splittest.Eventually(splittest.ExpectAdvanceToken(3, "ra"),
+					200*time.Millisecond, 10*time.Millisecond),
 			},
 		},
 	}
 
 	for _, tc := range testCases {
-		factory := NewFactory(tc.baseFunc, tc.trimFunc, tc.flushPeriod)
+		factory := NewFactory(tc.baseFunc, tc.trimFunc, tc.flushPeriod, tc.maxLength)
 		t.Run(tc.name, splittest.New(factory.SplitFunc(), tc.input, tc.steps...))
 	}
 }

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -239,7 +239,7 @@ func testReaderFactory(t *testing.T, sCfg split.Config, maxLogSize int, flushPer
 			emit:            testEmitFunc(emitChan),
 		},
 		fromBeginning:   true,
-		splitterFactory: splitter.NewFactory(splitFunc, trim.Whitespace, flushPeriod),
+		splitterFactory: splitter.NewFactory(splitFunc, trim.Whitespace, flushPeriod, maxLogSize),
 		encoding:        enc,
 	}, emitChan
 }

--- a/pkg/stanza/trim/trim.go
+++ b/pkg/stanza/trim/trim.go
@@ -59,3 +59,21 @@ func Trailing(data []byte) []byte {
 func Whitespace(data []byte) []byte {
 	return Leading(Trailing(data))
 }
+
+func ToLength(splitFunc bufio.SplitFunc, maxLength int) bufio.SplitFunc {
+	if maxLength == 0 {
+		return splitFunc
+	}
+	return func(data []byte, atEOF bool) (int, []byte, error) {
+		advance, token, err := splitFunc(data, atEOF)
+		if (advance == 0 && token == nil && err == nil) && len(data) >= maxLength {
+			// No token was found, but we have enough data to return a token of max length.
+			return maxLength, data[:maxLength], nil
+		}
+		if len(token) > maxLength {
+			// A token was found but it is longer than the max length.
+			return maxLength, token[:maxLength], nil
+		}
+		return advance, token, err
+	}
+}


### PR DESCRIPTION
This extracts the "max length" responsibility from the scanner. A couple benefits of this:
1. The function can be applied _after_ the flush function. Previously, if a token was flushed due to timing, we were not enforcing the max length.
2. It makes the function directly testable.
4. We can simplify the scanner constructor, which previously had a parameter for the buffer size which was only used for testing the behavior of the extracted function. This is now tested within the trim function.