### PR TITLE
[chore] Update k8s example to tail files

### DIFF
--- a/examples/kubernetes/otel-collector-config.yml
+++ b/examples/kubernetes/otel-collector-config.yml
@@ -5,7 +5,7 @@ receivers:
     exclude:
       # Exclude logs from all containers named otel-collector
       - /var/log/pods/*/otel-collector/*.log
-    start_at: beginning
+    start_at: end
     include_file_path: true
     include_file_name: false
     operators:

--- a/examples/kubernetes/otel-collector.yaml
+++ b/examples/kubernetes/otel-collector.yaml
@@ -12,7 +12,7 @@ data:
         exclude:
           # Exclude logs from all containers named otel-collector
           - /var/log/pods/*/otel-collector/*.log
-        start_at: beginning
+        start_at: end
         include_file_path: true
         include_file_name: false
         operators:


### PR DESCRIPTION
**Description:** 
The existing k8s example configures the filelog receiver to `start_at: beginning`.  This results in a significant amount of data to be ingested on startup, and significant duplicate data on a collector restart.  I propose we recommend using `start_at:end` for default k8s log ingestion.