### PR TITLE
[tiny][pkg/stanza] Name Windows event provider on error msg

### DIFF
--- a/pkg/stanza/operator/input/windows/publisher.go
+++ b/pkg/stanza/operator/input/windows/publisher.go
@@ -24,12 +24,12 @@ func (p *Publisher) Open(provider string) error {
 
 	utf16, err := syscall.UTF16PtrFromString(provider)
 	if err != nil {
-		return fmt.Errorf("failed to convert provider to utf16: %w", err)
+		return fmt.Errorf("failed to convert the provider name %q to utf16: %w", provider, err)
 	}
 
 	handle, err := evtOpenPublisherMetadata(0, utf16, nil, 0, 0)
 	if err != nil {
-		return fmt.Errorf("failed to open publisher handle: %w", err)
+		return fmt.Errorf("failed to open publisher for the %q provider: %w", provider, err)
 	}
 
 	p.handle = handle

--- a/pkg/stanza/operator/input/windows/publisher.go
+++ b/pkg/stanza/operator/input/windows/publisher.go
@@ -29,7 +29,7 @@ func (p *Publisher) Open(provider string) error {
 
 	handle, err := evtOpenPublisherMetadata(0, utf16, nil, 0, 0)
 	if err != nil {
-		return fmt.Errorf("failed to open publisher for the %q provider: %w", provider, err)
+		return fmt.Errorf("failed to open the metadata for the %q provider: %w", provider, err)
 	}
 
 	p.handle = handle


### PR DESCRIPTION
**Description:**
While reading #21491 the first thing that I wanted to know was the name of the affected provider. Unfortunately, the error message doesn't include that information. This PR changes that.

**Link to tracking Issue:**
Collateral to #21491

**Testing:**
N/A

**Documentation:**
N/A