### PR TITLE
[exporter/pulsar] do not expose method

### DIFF
--- a/.chloggen/pulsarexporter-checkapi-26304.yaml
+++ b/.chloggen/pulsarexporter-checkapi-26304.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'breaking'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pulsarexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not export function WithTracesMarshalers, add test for that and pass checkapi
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26304]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -1,6 +1,5 @@
 connector/servicegraphconnector
 exporter/kafkaexporter
-exporter/pulsarexporter
 extension/observer
 processor/servicegraphprocessor
 receiver/carbonreceiver

--- a/exporter/pulsarexporter/factory.go
+++ b/exporter/pulsarexporter/factory.go
@@ -28,8 +28,8 @@ const (
 // FactoryOption applies changes to pulsarExporterFactory.
 type FactoryOption func(factory *pulsarExporterFactory)
 
-// WithTracesMarshalers adds tracesMarshalers.
-func WithTracesMarshalers(tracesMarshalers ...TracesMarshaler) FactoryOption {
+// withTracesMarshalers adds tracesMarshalers.
+func withTracesMarshalers(tracesMarshalers ...TracesMarshaler) FactoryOption {
 	return func(factory *pulsarExporterFactory) {
 		for _, marshaler := range tracesMarshalers {
 			factory.tracesMarshalers[marshaler.Encoding()] = marshaler

--- a/exporter/pulsarexporter/factory_test.go
+++ b/exporter/pulsarexporter/factory_test.go
@@ -31,6 +31,18 @@ func Test_createDefaultConfig(t *testing.T) {
 	})
 }
 
+func TestWithTracesMarshalers_err(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Endpoint = ""
+
+	tracesMarshaler := &customTraceMarshaler{encoding: "unknown"}
+	f := NewFactory(withTracesMarshalers(tracesMarshaler))
+	r, err := f.CreateTracesExporter(context.Background(), exportertest.NewNopCreateSettings(), cfg)
+	// no available broker
+	require.Error(t, err)
+	assert.Nil(t, r)
+}
+
 func TestCreateTracesExporter_err(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Endpoint = ""


### PR DESCRIPTION
**Description:** 
Do not export function WithTracesMarshalers, add test for that and pass checkapi

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26304

**Testing:** 
make chlog-validate
go run cmd/checkapi/main.go .
go test for pulsarexporter

**Documentation:**