### PR TITLE
Revert "[tiny][pkg/stanza] Name Windows event provider on error msg"

### DIFF
--- a/pkg/stanza/operator/input/windows/publisher.go
+++ b/pkg/stanza/operator/input/windows/publisher.go
@@ -24,12 +24,12 @@ func (p *Publisher) Open(provider string) error {
 
 	utf16, err := syscall.UTF16PtrFromString(provider)
 	if err != nil {
-		return fmt.Errorf("failed to convert the provider name %q to utf16: %w", provider, err)
+		return fmt.Errorf("failed to convert provider to utf16: %w", err)
 	}
 
 	handle, err := evtOpenPublisherMetadata(0, utf16, nil, 0, 0)
 	if err != nil {
-		return fmt.Errorf("failed to open the metadata for the %q provider: %w", provider, err)
+		return fmt.Errorf("failed to open publisher handle: %w", err)
 	}
 
 	p.handle = handle


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#27286

This is failing tests on main. I apologize for not enabling Windows tests on the PR. @pjanotti, would you mind updating tests and resubmitting?