### PR TITLE
[processor/metricstransformprocessor] fix copy exponential histogram

### DIFF
--- a/.chloggen/fix-metricstransformprocessor-copy-exponential-histogram.yaml
+++ b/.chloggen/fix-metricstransformprocessor-copy-exponential-histogram.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'metricstransformprocessor'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Fixes a nil pointer dereference when copying an exponential histogram'
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27409]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
@@ -454,7 +454,7 @@ func copyMetricDetails(from, to pmetric.Metric) {
 	case pmetric.MetricTypeHistogram:
 		to.SetEmptyHistogram().SetAggregationTemporality(from.Histogram().AggregationTemporality())
 	case pmetric.MetricTypeExponentialHistogram:
-		to.SetEmptyExponentialHistogram().SetAggregationTemporality(from.Histogram().AggregationTemporality())
+		to.SetEmptyExponentialHistogram().SetAggregationTemporality(from.ExponentialHistogram().AggregationTemporality())
 	case pmetric.MetricTypeSummary:
 		to.SetEmptySummary()
 	}

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -1162,6 +1162,23 @@ var (
 			},
 		},
 		{
+			name: "combine_exponential_histogram",
+			transforms: []internalTransform{
+				{
+					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric(?P<namedsubmatch>[12])$")},
+					Action:              Combine,
+					NewName:             "new",
+				},
+			},
+			in: []pmetric.Metric{
+				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric1").build(),
+				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric2").build(),
+			},
+			out: []pmetric.Metric{
+				metricBuilder(pmetric.MetricTypeExponentialHistogram, "new", "namedsubmatch").build(),
+			},
+		},
+		{
 			name: "combine_error_type",
 			transforms: []internalTransform{
 				{

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -1165,9 +1165,11 @@ var (
 			name: "combine_exponential_histogram",
 			transforms: []internalTransform{
 				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric(?P<namedsubmatch>[12])$")},
-					Action:              Combine,
-					NewName:             "new",
+					MetricIncludeFilter: internalFilterRegexp{
+						include: regexp.MustCompile("^metric(?P<namedsubmatch>[12])$"),
+					},
+					Action:  Combine,
+					NewName: "new",
 				},
 			},
 			in: []pmetric.Metric{


### PR DESCRIPTION
**Description:**
Fixes a bug where the wrong function was called for the exponential histogram type during the copy operation. 

**Link to tracking Issue:** 
Fixes #27409

**Testing:** 
Added a test for `combine` that covers the failing code path. 

**Documentation:** 
No documentation added as this is a simple bug fix. 