### PR TITLE
fix(stanza/converter): handle syslogrecevier attributes correctly

### DIFF
--- a/.chloggen/drosiek-syslog-receiver-attributes.yaml
+++ b/.chloggen/drosiek-syslog-receiver-attributes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: syslogparser
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: return correct structure from syslog parser
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27414]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/stanza/adapter/converter.go
+++ b/pkg/stanza/adapter/converter.go
@@ -302,6 +302,14 @@ func upsertToAttributeVal(value interface{}, dest pcommon.Value) {
 		dest.SetDouble(float64(t))
 	case map[string]interface{}:
 		upsertToMap(t, dest.SetEmptyMap())
+	case map[string]map[string]string: // output from syslog receiver
+		d := dest.SetEmptyMap()
+		for k, v := range t {
+			dd := d.PutEmptyMap(k)
+			for kk, vv := range v {
+				upsertToAttributeVal(vv, dd.PutEmpty(kk))
+			}
+		}
 	case []interface{}:
 		upsertToSlice(t, dest.SetEmptySlice())
 	default:

--- a/pkg/stanza/adapter/converter.go
+++ b/pkg/stanza/adapter/converter.go
@@ -302,14 +302,6 @@ func upsertToAttributeVal(value interface{}, dest pcommon.Value) {
 		dest.SetDouble(float64(t))
 	case map[string]interface{}:
 		upsertToMap(t, dest.SetEmptyMap())
-	case map[string]map[string]string: // output from syslog receiver
-		d := dest.SetEmptyMap()
-		for k, v := range t {
-			dd := d.PutEmptyMap(k)
-			for kk, vv := range v {
-				upsertToAttributeVal(vv, dd.PutEmpty(kk))
-			}
-		}
 	case []interface{}:
 		upsertToSlice(t, dest.SetEmptySlice())
 	default:

--- a/pkg/stanza/operator/input/syslog/syslog_test.go
+++ b/pkg/stanza/operator/input/syslog/syslog_test.go
@@ -49,8 +49,8 @@ var (
 				"msg_id":   "ID52020",
 				"priority": 86,
 				"proc_id":  "23108",
-				"structured_data": map[string]map[string]string{
-					"SecureAuth@27389": {
+				"structured_data": map[string]interface{}{
+					"SecureAuth@27389": map[string]interface{}{
 						"PEN":             "27389",
 						"Realm":           "SecureAuth0",
 						"UserHostAddress": "192.168.2.132",

--- a/pkg/stanza/operator/parser/syslog/data.go
+++ b/pkg/stanza/operator/parser/syslog/data.go
@@ -159,8 +159,8 @@ func CreateCases(basicConfig func() *Config) ([]Case, error) {
 					"msg_id":   "ID52020",
 					"priority": 86,
 					"proc_id":  "23108",
-					"structured_data": map[string]map[string]string{
-						"SecureAuth@27389": {
+					"structured_data": map[string]interface{}{
+						"SecureAuth@27389": map[string]interface{}{
 							"PEN":             "27389",
 							"Realm":           "SecureAuth0",
 							"UserHostAddress": "192.168.2.132",
@@ -197,8 +197,8 @@ func CreateCases(basicConfig func() *Config) ([]Case, error) {
 					"msg_id":   "ID52020",
 					"priority": 86,
 					"proc_id":  "23108",
-					"structured_data": map[string]map[string]string{
-						"SecureAuth@27389": {
+					"structured_data": map[string]interface{}{
+						"SecureAuth@27389": map[string]interface{}{
 							"PEN":             "27389",
 							"Realm":           "SecureAuth0",
 							"UserHostAddress": "192.168.2.132",
@@ -235,8 +235,8 @@ func CreateCases(basicConfig func() *Config) ([]Case, error) {
 					"msg_id":   "ID52020",
 					"priority": 86,
 					"proc_id":  "23108",
-					"structured_data": map[string]map[string]string{
-						"SecureAuth@27389": {
+					"structured_data": map[string]interface{}{
+						"SecureAuth@27389": map[string]interface{}{
 							"PEN":             "27389",
 							"Realm":           "SecureAuth0",
 							"UserHostAddress": "192.168.2.132",

--- a/pkg/stanza/operator/parser/syslog/syslog.go
+++ b/pkg/stanza/operator/parser/syslog/syslog.go
@@ -253,6 +253,7 @@ func (s *Parser) toSafeMap(message map[string]interface{}) (map[string]interface
 }
 
 // convertMap converts map[string]map[string]string to map[string]interface{}
+// which is expected by stanza converter
 func convertMap(data map[string]map[string]string) map[string]interface{} {
 	ret := map[string]interface{}{}
 	for key, value := range data {

--- a/pkg/stanza/operator/parser/syslog/syslog.go
+++ b/pkg/stanza/operator/parser/syslog/syslog.go
@@ -243,13 +243,28 @@ func (s *Parser) toSafeMap(message map[string]interface{}) (map[string]interface
 				delete(message, key)
 				continue
 			}
-			message[key] = *v
+			message[key] = convertMap(*v)
 		default:
 			return nil, fmt.Errorf("key %s has unknown field of type %T", key, v)
 		}
 	}
 
 	return message, nil
+}
+
+// convertMap converts map[string]map[string]string to map[string]interface{}
+func convertMap(data map[string]map[string]string) map[string]interface{} {
+	ret := map[string]interface{}{}
+	for key, value := range data {
+		ret[key] = map[string]interface{}{}
+		r := ret[key].(map[string]interface{})
+
+		for k, v := range value {
+			r[k] = v
+		}
+	}
+
+	return ret
 }
 
 func toBytes(value interface{}) ([]byte, error) {


### PR DESCRIPTION
**Description:**

Syslog receiver produces attribute (`structured_data`) which is a stringified map. This PR fixes it. See Issue for more details

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27414

**Testing:**

UT

**Documentation:**

In code comments