### PR TITLE
[chore][extension/filestorage] Fix flaky test on windows

### DIFF
--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -247,6 +247,8 @@ func TestComponentNameWithUnsafeCharacters(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, client)
+
+	client.Close(context.Background())
 }
 
 func TestGetClientErrorsOnDeletedDirectory(t *testing.T) {


### PR DESCRIPTION
This test failed on windows ([here](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/6400499092/job/17374210350#step:6:659)), apparently because the storage file is still open when the test framework attempts to clean up the directory.