### PR TITLE
[chore] move load tests execution to dedicated hardware

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -4,7 +4,6 @@ on:
     branches: [ main ]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 # Do not cancel this workflow on main. See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16616
 concurrency:
@@ -19,7 +18,7 @@ env:
 jobs:
   setup-environment:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:
       loadtest_matrix: ${{ steps.splitloadtest.outputs.loadtest_matrix }}
@@ -56,7 +55,7 @@ jobs:
         run: ./.github/workflows/scripts/setup_e2e_tests.sh
 
   loadtest:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: [setup-environment]
     strategy:
       fail-fast: false


### PR DESCRIPTION
This will allow the load tests to produce consistent results. Note that I removed the execution on every pull request as part of this change. This is because the load tests running on every build would be too much for the dedicated hardware to handle.

I'm not sure if we're getting much benefit from those tests running on every build at this time, though we could always change this to only run on main/tagged releases on hardware and otherwise on regular github runners.

Waiting on https://github.com/open-telemetry/community/issues/1708 before marking as ready for review