### PR TITLE
[chore] error wasn't checked in loadtest

### DIFF
--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -300,7 +300,8 @@ func ScenarioTestTraceNoBackend10kSPS(
 
 	tc.Sleep(tc.Duration)
 
-	rss, _, _ := tc.AgentMemoryInfo()
+	rss, _, err := tc.AgentMemoryInfo()
+	require.NoError(t, err)
 	assert.Less(t, configuration.ExpectedMinFinalRAM, rss)
 }
 


### PR DESCRIPTION
An error appears to be the load tests to fail, but it's not being checked which makes it hard to debug. Helps with #27429
