### PR TITLE
[chore][pkg/stanza] Unexport reader's file name field

### DIFF
--- a/pkg/stanza/fileconsumer/internal/reader/factory.go
+++ b/pkg/stanza/fileconsumer/internal/reader/factory.go
@@ -59,7 +59,7 @@ func (f *Factory) build(file *os.File, m *Metadata, lineSplitFunc bufio.SplitFun
 		Config:        f.Config,
 		Metadata:      m,
 		file:          file,
-		FileName:      file.Name(),
+		fileName:      file.Name(),
 		logger:        f.SugaredLogger.With("path", file.Name()),
 		decoder:       decode.New(f.Encoding),
 		lineSplitFunc: lineSplitFunc,
@@ -84,12 +84,12 @@ func (f *Factory) build(file *os.File, m *Metadata, lineSplitFunc bufio.SplitFun
 	}
 
 	// Resolve file name and path attributes
-	resolved := r.FileName
+	resolved := r.fileName
 
 	// Dirty solution, waiting for this permanent fix https://github.com/golang/go/issues/39786
 	// EvalSymlinks on windows is partially working depending on the way you use Symlinks and Junctions
 	if runtime.GOOS != "windows" {
-		resolved, err = filepath.EvalSymlinks(r.FileName)
+		resolved, err = filepath.EvalSymlinks(r.fileName)
 		if err != nil {
 			f.Errorf("resolve symlinks: %w", err)
 		}
@@ -100,12 +100,12 @@ func (f *Factory) build(file *os.File, m *Metadata, lineSplitFunc bufio.SplitFun
 	}
 
 	if f.Config.IncludeFileName {
-		r.FileAttributes[attrs.LogFileName] = filepath.Base(r.FileName)
+		r.FileAttributes[attrs.LogFileName] = filepath.Base(r.fileName)
 	} else if r.FileAttributes[attrs.LogFileName] != nil {
 		delete(r.FileAttributes, attrs.LogFileName)
 	}
 	if f.Config.IncludeFilePath {
-		r.FileAttributes[attrs.LogFilePath] = r.FileName
+		r.FileAttributes[attrs.LogFilePath] = r.fileName
 	} else if r.FileAttributes[attrs.LogFilePath] != nil {
 		delete(r.FileAttributes, attrs.LogFilePath)
 	}

--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -41,7 +41,7 @@ type Metadata struct {
 type Reader struct {
 	*Config
 	*Metadata
-	FileName      string
+	fileName      string
 	logger        *zap.SugaredLogger
 	file          *os.File
 	lineSplitFunc bufio.SplitFunc
@@ -138,8 +138,8 @@ func (r *Reader) Delete() {
 		return
 	}
 	r.Close()
-	if err := os.Remove(r.FileName); err != nil {
-		r.logger.Errorf("could not delete %s", r.FileName)
+	if err := os.Remove(r.fileName); err != nil {
+		r.logger.Errorf("could not delete %s", r.fileName)
 	}
 }
 
@@ -188,6 +188,10 @@ func min0(a, b int) int {
 	return b
 }
 
+func (r *Reader) NameEquals(other *Reader) bool {
+	return r.fileName == other.fileName
+}
+
 // ValidateOrClose returns true if the reader still has a valid file handle, false otherwise.
 // If false is returned, the file handle should be considered closed.
 //
@@ -201,14 +205,14 @@ func (r *Reader) ValidateOrClose() bool {
 	}
 	refreshedFingerprint, err := fingerprint.New(r.file, r.FingerprintSize)
 	if err != nil {
-		r.logger.Debugw("Closing unreadable file", zap.Error(err), zap.String(attrs.LogFileName, r.FileName))
+		r.logger.Debugw("Closing unreadable file", zap.Error(err), zap.String(attrs.LogFileName, r.fileName))
 		r.Close()
 		return false
 	}
 	if refreshedFingerprint.StartsWith(r.Fingerprint) {
 		return true
 	}
-	r.logger.Debugw("Closing truncated file", zap.String(attrs.LogFileName, r.FileName))
+	r.logger.Debugw("Closing truncated file", zap.String(attrs.LogFileName, r.fileName))
 	r.Close()
 	return false
 }

--- a/pkg/stanza/fileconsumer/roller_other.go
+++ b/pkg/stanza/fileconsumer/roller_other.go
@@ -31,7 +31,7 @@ OUTER:
 				continue OUTER
 			}
 
-			if oldReader.FileName != newReader.FileName {
+			if !newReader.NameEquals(oldReader) {
 				continue
 			}
 


### PR DESCRIPTION
Incremental step towards decoupling the Reader struct.

This also clarifies and corrects the behavior of the `ValidateOrClose` function.