### PR TITLE
[chore][pkg/stanza] Simplify delete_after_read handling of deleted files

### DIFF
--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -150,22 +150,6 @@ func (m *Manager) consume(ctx context.Context, paths []string) {
 	}
 	wg.Wait()
 
-	// Save off any files that were not fully read
-	if m.deleteAfterRead {
-		unfinished := make([]*reader.Reader, 0, len(readers))
-		for _, r := range readers {
-			if !r.EOF {
-				unfinished = append(unfinished, r)
-			}
-		}
-		readers = unfinished
-
-		// If all files were read and deleted then no need to do bookkeeping on readers
-		if len(readers) == 0 {
-			return
-		}
-	}
-
 	// Any new files that appear should be consumed entirely
 	m.readerFactory.FromBeginning = true
 


### PR DESCRIPTION
This removes some special handling for the `delete_after_read` setting. Previously, this code would ensure that if we shut down while reading, we forget about the files which we've deleted. This is unnecessary complexity since there's no harm in remembering files which we've deleted.