### PR TITLE
[receiver/hostmetricsreceiver] Add support for cpu frequency metric

### DIFF
--- a/.chloggen/cpuinfo_frequency_metric.yaml
+++ b/.chloggen/cpuinfo_frequency_metric.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added support for host's cpuinfo frequnecies.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27445]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: In Linux the current frequency is populated using the values from /proc/cpuinfo. An os specific implementation will be needed for Windows and others.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/hostmetricsreceiver/go.mod
+++ b/receiver/hostmetricsreceiver/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.88.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.88.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.88.0
+	github.com/prometheus/procfs v0.11.1
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/stretchr/testify v1.8.4
 	github.com/yusufpapurcu/wmi v1.2.3
@@ -77,7 +78,6 @@ require (
 	github.com/prometheus/client_golang v1.17.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
-	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/prometheus/statsd_exporter v0.22.7 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
@@ -27,3 +27,8 @@ func (s *scraper) recordCPUUtilization(now pcommon.Timestamp, cpuUtilization uca
 	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Idle, cpuUtilization.CPU, metadata.AttributeStateIdle)
 	s.mb.RecordSystemCPUUtilizationDataPoint(now, cpuUtilization.Irq, cpuUtilization.CPU, metadata.AttributeStateInterrupt)
 }
+
+func (s *scraper) getCPUInfo() ([]cpuInfo, error) {
+	var cpuInfos []cpuInfo
+	return cpuInfos, nil
+}

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/documentation.md
@@ -39,6 +39,20 @@ metrics:
     enabled: true
 ```
 
+### system.cpu.frequency
+
+Current frequency of the CPU core in Hz.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| Hz | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| cpu | Logical CPU number starting at 0. | Any Str |
+
 ### system.cpu.logical.count
 
 Number of available logical CPUs.

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config.go
@@ -25,6 +25,7 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for hostmetricsreceiver/cpu metrics.
 type MetricsConfig struct {
+	SystemCPUFrequency     MetricConfig `mapstructure:"system.cpu.frequency"`
 	SystemCPULogicalCount  MetricConfig `mapstructure:"system.cpu.logical.count"`
 	SystemCPUPhysicalCount MetricConfig `mapstructure:"system.cpu.physical.count"`
 	SystemCPUTime          MetricConfig `mapstructure:"system.cpu.time"`
@@ -33,6 +34,9 @@ type MetricsConfig struct {
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
+		SystemCPUFrequency: MetricConfig{
+			Enabled: false,
+		},
 		SystemCPULogicalCount: MetricConfig{
 			Enabled: false,
 		},

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_config_test.go
@@ -26,6 +26,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					SystemCPUFrequency:     MetricConfig{Enabled: true},
 					SystemCPULogicalCount:  MetricConfig{Enabled: true},
 					SystemCPUPhysicalCount: MetricConfig{Enabled: true},
 					SystemCPUTime:          MetricConfig{Enabled: true},
@@ -37,6 +38,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
+					SystemCPUFrequency:     MetricConfig{Enabled: false},
 					SystemCPULogicalCount:  MetricConfig{Enabled: false},
 					SystemCPUPhysicalCount: MetricConfig{Enabled: false},
 					SystemCPUTime:          MetricConfig{Enabled: false},

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics_test.go
@@ -56,6 +56,9 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount := 0
 
 			allMetricsCount++
+			mb.RecordSystemCPUFrequencyDataPoint(ts, 1, "cpu-val")
+
+			allMetricsCount++
 			mb.RecordSystemCPULogicalCountDataPoint(ts, 1)
 
 			allMetricsCount++
@@ -90,6 +93,21 @@ func TestMetricsBuilder(t *testing.T) {
 			validatedMetrics := make(map[string]bool)
 			for i := 0; i < ms.Len(); i++ {
 				switch ms.At(i).Name() {
+				case "system.cpu.frequency":
+					assert.False(t, validatedMetrics["system.cpu.frequency"], "Found a duplicate in the metrics slice: system.cpu.frequency")
+					validatedMetrics["system.cpu.frequency"] = true
+					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+					assert.Equal(t, "Current frequency of the CPU core in Hz.", ms.At(i).Description())
+					assert.Equal(t, "Hz", ms.At(i).Unit())
+					dp := ms.At(i).Gauge().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeDouble, dp.ValueType())
+					assert.Equal(t, float64(1), dp.DoubleValue())
+					attrVal, ok := dp.Attributes().Get("cpu")
+					assert.True(t, ok)
+					assert.EqualValues(t, "cpu-val", attrVal.Str())
 				case "system.cpu.logical.count":
 					assert.False(t, validatedMetrics["system.cpu.logical.count"], "Found a duplicate in the metrics slice: system.cpu.logical.count")
 					validatedMetrics["system.cpu.logical.count"] = true

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/testdata/config.yaml
@@ -1,6 +1,8 @@
 default:
 all_set:
   metrics:
+    system.cpu.frequency:
+      enabled: true
     system.cpu.logical.count:
       enabled: true
     system.cpu.physical.count:
@@ -11,6 +13,8 @@ all_set:
       enabled: true
 none_set:
   metrics:
+    system.cpu.frequency:
+      enabled: false
     system.cpu.logical.count:
       enabled: false
     system.cpu.physical.count:

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -50,3 +50,11 @@ metrics:
       value_type: int
       monotonic: false
       aggregation_temporality: cumulative
+
+  system.cpu.frequency:
+    enabled: false
+    description: Current frequency of the CPU core in Hz.
+    unit: "Hz"
+    gauge:
+      value_type: double
+    attributes: [cpu]


### PR DESCRIPTION
**Description:** : Added support for host's cpu frequency as part
                   of the hostmetricsreceiver.

**Link to tracking Issue:** open-telemetry#26532

**Testing:**

1. Using the following configuration:
```yml
receivers:
  hostmetrics:
    collection_interval: 5s
    scrapers:
      cpu:
        metrics:
          system.cpu.frequency:
            enabled: true

processors:
  resourcedetection/system:
    detectors: ["system"]
    system:
      hostname_sources: ["lookup", "cname", "dns", "os"]
      resource_attributes:
        host.name:
          enabled: true
        host.id:
          enabled: true
        host.cpu.cache.l2.size:
          enabled: true
        host.cpu.family:
          enabled: true
        host.cpu.model.id:
          enabled: true
        host.cpu.model.name:
          enabled: true
        host.cpu.stepping:
          enabled: true
        host.cpu.vendor.id:
          enabled: true

service:
  pipelines:
    metrics:
      receivers: [hostmetrics]
      exporters: [file]
      processors: [resourcedetection/system]

exporters:
  file:
    path: ./output.json
```

2. Start the collector with ./bin/otelcontribcol_linux_amd64 --config examples/host_config.yaml
3. The output reports the added metric successfully:

```json
{
   "resourceMetrics":[
      {
         "scopeMetrics":[
            {
               "scope":{
                  "name":"otelcol/hostmetricsreceiver/cpu",
                  "version":"0.85.0-dev"
               },
               "metrics":[
                  {
                     "name":"system.cpu.frequency",
                     "description":"Current frequency of the CPU core in MHz.",
                     "unit":"MHz",
                     "gauge":{
                        "dataPoints":[
                           {
                              "attributes":[
                                 {
                                    "key":"cpu",
                                    "value":{
                                       "stringValue":"cpu0"
                                    }
                                 }
                              ],
                              "startTimeUnixNano":"1696487580000000000",
                              "timeUnixNano":"1696512423758783158",
                              "asDouble":3000
                           },
                           {
                              "attributes":[
                                 {
                                    "key":"cpu",
                                    "value":{
                                       "stringValue":"cpu1"
                                    }
                                 }
                              ],
                              "startTimeUnixNano":"1696487580000000000",
                              "timeUnixNano":"1696512423758783158",
                              "asDouble":3000
                           },
...
```

**Documentation:** <Describe the documentation added.>
Updated https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27445/files#diff-e5d245f325735381e769c33274f8bfa0f99f09bcb1963f651c22cc4faa340428R42