### PR TITLE
[chore] set GOMAXPROCS for collector subprocess

### DIFF
--- a/testbed/testbed/child_process_collector.go
+++ b/testbed/testbed/child_process_collector.go
@@ -204,6 +204,9 @@ func (cp *childProcessCollector) Start(params StartParams) error {
 	}
 	// #nosec
 	cp.cmd = exec.Command(exePath, args...)
+	cp.cmd.Env = append(os.Environ(),
+		"GOMAXPROCS=2",
+	)
 
 	// Capture standard output and standard error.
 	cp.cmd.Stdout = logFile


### PR DESCRIPTION
This will result in more consistent benchmarks across different environments.

Fixes #27429