### PR TITLE
[chore] sqlserverreceiver/Add run as admin to docs

### DIFF
--- a/receiver/sqlserverreceiver/README.md
+++ b/receiver/sqlserverreceiver/README.md
@@ -17,6 +17,8 @@
 The `sqlserver` receiver grabs metrics about a Microsoft SQL Server instance using the Windows Performance Counters.
 Because of this, it is a Windows only receiver.
 
+Make sure to run the collector as administrator in order to collect all performance counters for metrics. 
+
 ## Configuration
 
 The following settings are optional:


### PR DESCRIPTION
**Description:** 
Added a line explaining to run collector as admin, since not all perf counters are collected unless you do. 
(Or I'm missing something, which should be documented)

**Testing:** No unit tests, but observed this with a simple collector install on windows. 

**Documentation:** See above. 