### PR TITLE
[internal/filterottl] Switch to `match` instead of drop

### DIFF
--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -18,11 +18,11 @@ import (
 
 // NewBoolExprForSpan creates a BoolExpr[ottlspan.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlspan.TransformContext.
-// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[ottlspan.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlspan.TransformContext], error) {
-	noop := newNoopFactory[ottlspan.TransformContext]()
-	if _, ok := functions[noop.Name()]; !ok {
-		functions[noop.Name()] = noop
+	match := newMatchFactory[ottlspan.TransformContext]()
+	if _, ok := functions[match.Name()]; !ok {
+		functions[match.Name()] = match
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlspan.NewParser(functions, set)
@@ -39,11 +39,11 @@ func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[o
 
 // NewBoolExprForSpanEvent creates a BoolExpr[ottlspanevent.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlspanevent.TransformContext.
-// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Factory[ottlspanevent.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlspanevent.TransformContext], error) {
-	noop := newNoopFactory[ottlspanevent.TransformContext]()
-	if _, ok := functions[noop.Name()]; !ok {
-		functions[noop.Name()] = noop
+	match := newMatchFactory[ottlspanevent.TransformContext]()
+	if _, ok := functions[match.Name()]; !ok {
+		functions[match.Name()] = match
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlspanevent.NewParser(functions, set)
@@ -60,11 +60,11 @@ func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Fact
 
 // NewBoolExprForMetric creates a BoolExpr[ottlmetric.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlmetric.TransformContext.
-// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory[ottlmetric.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlmetric.TransformContext], error) {
-	noop := newNoopFactory[ottlmetric.TransformContext]()
-	if _, ok := functions[noop.Name()]; !ok {
-		functions[noop.Name()] = noop
+	match := newMatchFactory[ottlmetric.TransformContext]()
+	if _, ok := functions[match.Name()]; !ok {
+		functions[match.Name()] = match
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlmetric.NewParser(functions, set)
@@ -81,11 +81,11 @@ func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory
 
 // NewBoolExprForDataPoint creates a BoolExpr[ottldatapoint.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottldatapoint.TransformContext.
-// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Factory[ottldatapoint.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottldatapoint.TransformContext], error) {
-	noop := newNoopFactory[ottldatapoint.TransformContext]()
-	if _, ok := functions[noop.Name()]; !ok {
-		functions[noop.Name()] = noop
+	match := newMatchFactory[ottldatapoint.TransformContext]()
+	if _, ok := functions[match.Name()]; !ok {
+		functions[match.Name()] = match
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottldatapoint.NewParser(functions, set)
@@ -102,11 +102,11 @@ func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Fact
 
 // NewBoolExprForLog creates a BoolExpr[ottllog.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottllog.TransformContext.
-// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ottllog.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottllog.TransformContext], error) {
-	noop := newNoopFactory[ottllog.TransformContext]()
-	if _, ok := functions[noop.Name()]; !ok {
-		functions[noop.Name()] = noop
+	match := newMatchFactory[ottllog.TransformContext]()
+	if _, ok := functions[match.Name()]; !ok {
+		functions[match.Name()] = match
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottllog.NewParser(functions, set)
@@ -123,11 +123,11 @@ func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ot
 
 // NewBoolExprForResource creates a BoolExpr[ottlresource.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlresource.TransformContext.
-// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForResource(conditions []string, functions map[string]ottl.Factory[ottlresource.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlresource.TransformContext], error) {
-	noop := newNoopFactory[ottlresource.TransformContext]()
-	if _, ok := functions[noop.Name()]; !ok {
-		functions[noop.Name()] = noop
+	match := newMatchFactory[ottlresource.TransformContext]()
+	if _, ok := functions[match.Name()]; !ok {
+		functions[match.Name()] = match
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlresource.NewParser(functions, set)
@@ -145,7 +145,7 @@ func NewBoolExprForResource(conditions []string, functions map[string]ottl.Facto
 func conditionsToStatements(conditions []string) []string {
 	statements := make([]string, len(conditions))
 	for i, condition := range conditions {
-		statements[i] = "noop() where " + condition
+		statements[i] = "match() where " + condition
 	}
 	return statements
 }

--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -18,9 +18,9 @@ import (
 
 // NewBoolExprForSpan creates a BoolExpr[ottlspan.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlspan.TransformContext.
-// If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[ottlspan.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlspan.TransformContext], error) {
-	noop := newDropFactory[ottlspan.TransformContext]()
+	noop := newNoopFactory[ottlspan.TransformContext]()
 	if _, ok := functions[noop.Name()]; !ok {
 		functions[noop.Name()] = noop
 	}
@@ -39,9 +39,9 @@ func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[o
 
 // NewBoolExprForSpanEvent creates a BoolExpr[ottlspanevent.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlspanevent.TransformContext.
-// If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Factory[ottlspanevent.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlspanevent.TransformContext], error) {
-	noop := newDropFactory[ottlspanevent.TransformContext]()
+	noop := newNoopFactory[ottlspanevent.TransformContext]()
 	if _, ok := functions[noop.Name()]; !ok {
 		functions[noop.Name()] = noop
 	}
@@ -60,9 +60,9 @@ func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Fact
 
 // NewBoolExprForMetric creates a BoolExpr[ottlmetric.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlmetric.TransformContext.
-// If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory[ottlmetric.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlmetric.TransformContext], error) {
-	noop := newDropFactory[ottlmetric.TransformContext]()
+	noop := newNoopFactory[ottlmetric.TransformContext]()
 	if _, ok := functions[noop.Name()]; !ok {
 		functions[noop.Name()] = noop
 	}
@@ -81,9 +81,9 @@ func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory
 
 // NewBoolExprForDataPoint creates a BoolExpr[ottldatapoint.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottldatapoint.TransformContext.
-// If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Factory[ottldatapoint.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottldatapoint.TransformContext], error) {
-	noop := newDropFactory[ottldatapoint.TransformContext]()
+	noop := newNoopFactory[ottldatapoint.TransformContext]()
 	if _, ok := functions[noop.Name()]; !ok {
 		functions[noop.Name()] = noop
 	}
@@ -102,9 +102,9 @@ func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Fact
 
 // NewBoolExprForLog creates a BoolExpr[ottllog.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottllog.TransformContext.
-// If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ottllog.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottllog.TransformContext], error) {
-	noop := newDropFactory[ottllog.TransformContext]()
+	noop := newNoopFactory[ottllog.TransformContext]()
 	if _, ok := functions[noop.Name()]; !ok {
 		functions[noop.Name()] = noop
 	}
@@ -123,9 +123,9 @@ func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ot
 
 // NewBoolExprForResource creates a BoolExpr[ottlresource.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
 // The passed in functions should use the ottlresource.TransformContext.
-// If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
+// If a function named `noop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForResource(conditions []string, functions map[string]ottl.Factory[ottlresource.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlresource.TransformContext], error) {
-	noop := newDropFactory[ottlresource.TransformContext]()
+	noop := newNoopFactory[ottlresource.TransformContext]()
 	if _, ok := functions[noop.Name()]; !ok {
 		functions[noop.Name()] = noop
 	}

--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -20,9 +20,9 @@ import (
 // The passed in functions should use the ottlspan.TransformContext.
 // If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[ottlspan.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlspan.TransformContext], error) {
-	drop := newDropFactory[ottlspan.TransformContext]()
-	if _, ok := functions[drop.Name()]; !ok {
-		functions[drop.Name()] = drop
+	noop := newDropFactory[ottlspan.TransformContext]()
+	if _, ok := functions[noop.Name()]; !ok {
+		functions[noop.Name()] = noop
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlspan.NewParser(functions, set)
@@ -41,9 +41,9 @@ func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[o
 // The passed in functions should use the ottlspanevent.TransformContext.
 // If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Factory[ottlspanevent.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlspanevent.TransformContext], error) {
-	drop := newDropFactory[ottlspanevent.TransformContext]()
-	if _, ok := functions[drop.Name()]; !ok {
-		functions[drop.Name()] = drop
+	noop := newDropFactory[ottlspanevent.TransformContext]()
+	if _, ok := functions[noop.Name()]; !ok {
+		functions[noop.Name()] = noop
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlspanevent.NewParser(functions, set)
@@ -62,9 +62,9 @@ func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Fact
 // The passed in functions should use the ottlmetric.TransformContext.
 // If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory[ottlmetric.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlmetric.TransformContext], error) {
-	drop := newDropFactory[ottlmetric.TransformContext]()
-	if _, ok := functions[drop.Name()]; !ok {
-		functions[drop.Name()] = drop
+	noop := newDropFactory[ottlmetric.TransformContext]()
+	if _, ok := functions[noop.Name()]; !ok {
+		functions[noop.Name()] = noop
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlmetric.NewParser(functions, set)
@@ -83,9 +83,9 @@ func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory
 // The passed in functions should use the ottldatapoint.TransformContext.
 // If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Factory[ottldatapoint.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottldatapoint.TransformContext], error) {
-	drop := newDropFactory[ottldatapoint.TransformContext]()
-	if _, ok := functions[drop.Name()]; !ok {
-		functions[drop.Name()] = drop
+	noop := newDropFactory[ottldatapoint.TransformContext]()
+	if _, ok := functions[noop.Name()]; !ok {
+		functions[noop.Name()] = noop
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottldatapoint.NewParser(functions, set)
@@ -104,9 +104,9 @@ func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Fact
 // The passed in functions should use the ottllog.TransformContext.
 // If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ottllog.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottllog.TransformContext], error) {
-	drop := newDropFactory[ottllog.TransformContext]()
-	if _, ok := functions[drop.Name()]; !ok {
-		functions[drop.Name()] = drop
+	noop := newDropFactory[ottllog.TransformContext]()
+	if _, ok := functions[noop.Name()]; !ok {
+		functions[noop.Name()] = noop
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottllog.NewParser(functions, set)
@@ -125,9 +125,9 @@ func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ot
 // The passed in functions should use the ottlresource.TransformContext.
 // If a function named `drop` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForResource(conditions []string, functions map[string]ottl.Factory[ottlresource.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlresource.TransformContext], error) {
-	drop := newDropFactory[ottlresource.TransformContext]()
-	if _, ok := functions[drop.Name()]; !ok {
-		functions[drop.Name()] = drop
+	noop := newDropFactory[ottlresource.TransformContext]()
+	if _, ok := functions[noop.Name()]; !ok {
+		functions[noop.Name()] = noop
 	}
 	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlresource.NewParser(functions, set)
@@ -145,7 +145,7 @@ func NewBoolExprForResource(conditions []string, functions map[string]ottl.Facto
 func conditionsToStatements(conditions []string) []string {
 	statements := make([]string, len(conditions))
 	for i, condition := range conditions {
-		statements[i] = "drop() where " + condition
+		statements[i] = "noop() where " + condition
 	}
 	return statements
 }

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -56,14 +56,14 @@ func standardFuncs[K any]() map[string]ottl.Factory[K] {
 }
 
 func newDropFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("drop", nil, createDropFunction[K])
+	return ottl.NewFactory("noop", nil, createNoopFunction[K])
 }
 
-func createDropFunction[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return dropFn[K]()
+func createNoopFunction[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
+	return noopFn[K]()
 }
 
-func dropFn[K any]() (ottl.ExprFunc[K], error) {
+func noopFn[K any]() (ottl.ExprFunc[K], error) {
 	return func(context.Context, K) (interface{}, error) {
 		return true, nil
 	}, nil

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -50,12 +50,12 @@ func StandardResourceFuncs() map[string]ottl.Factory[ottlresource.TransformConte
 
 func standardFuncs[K any]() map[string]ottl.Factory[K] {
 	m := ottlfuncs.StandardConverters[K]()
-	f := newDropFactory[K]()
+	f := newNoopFactory[K]()
 	m[f.Name()] = f
 	return m
 }
 
-func newDropFactory[K any]() ottl.Factory[K] {
+func newNoopFactory[K any]() ottl.Factory[K] {
 	return ottl.NewFactory("noop", nil, createNoopFunction[K])
 }
 

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -50,20 +50,20 @@ func StandardResourceFuncs() map[string]ottl.Factory[ottlresource.TransformConte
 
 func standardFuncs[K any]() map[string]ottl.Factory[K] {
 	m := ottlfuncs.StandardConverters[K]()
-	f := newNoopFactory[K]()
+	f := newMatchFactory[K]()
 	m[f.Name()] = f
 	return m
 }
 
-func newNoopFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("noop", nil, createNoopFunction[K])
+func newMatchFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("match", nil, createMatchFunction[K])
 }
 
-func createNoopFunction[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return noopFn[K]()
+func createMatchFunction[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
+	return matchFn[K]()
 }
 
-func noopFn[K any]() (ottl.ExprFunc[K], error) {
+func matchFn[K any]() (ottl.ExprFunc[K], error) {
 	return func(context.Context, K) (interface{}, error) {
 		return true, nil
 	}, nil


### PR DESCRIPTION
**Description:** 
We noticed that if you pass in a condition that fails parsing that the error message includes `drop() where ...` and it was jarring to see `drop` as the function when using filterottl to generate a condition that was not related to dropping data. While we wait for the ability to parse conditions in isolation (https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545), this change makes `filterottl` a little friendlier.  

**Testing:** <Describe what testing was performed and which tests were added.>
Updated unit tests
