### PR TITLE
[chore][docs] fix typo in stanza timestamp docs

### DIFF
--- a/pkg/stanza/docs/types/timestamp.md
+++ b/pkg/stanza/docs/types/timestamp.md
@@ -17,7 +17,7 @@ If a timestamp block is specified, the parser operator will perform the timestam
 
 ```yaml
 - type: regex_parser
-  regexp: '^Time=(?P<timestamp_field>\d{4}-\d{2}-\d{2}), Host=(?P<host>[^,]+)'
+  regex: '^Time=(?P<timestamp_field>\d{4}-\d{2}-\d{2}), Host=(?P<host>[^,]+)'
   timestamp:
     parse_from: attributes.timestamp_field
     layout_type: strptime


### PR DESCRIPTION
The [regex_parser](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.86.0/pkg/stanza/docs/operators/regex_parser.md#configuration-fields)'s property name is `regex`, not `regexp`.