### PR TITLE
Fixes issue 27567 - tail_sampling processor metrics wrong

### DIFF
--- a/.chloggen/27567-tailsampler-fix-metrics.yaml
+++ b/.chloggen/27567-tailsampler-fix-metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Publish tail_sampler count_traces_sampled metric differently per individual policy
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27567]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Fixes tail_sampler count_traces_sampled metric to report sampled true/false count per policy. Previously all policies received the same count based on the sampling "final decision"
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
**Description:** 
Fixes [27567](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27567)
<Describe what has changed.>
In the `tail_sampling` processor, record `statCountTracesSampled ` metric sampling decision for each policy seperately, depending on the actual decision for that policy, instead of using the `finalDecision` for all policies equally.
**Link to tracking Issue:** 
[27567](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27567)

**Testing:** 
Send traces which match some of the defined tail_sampling policies, check the collector metrics are correct.

**Documentation:** 
None. 
Please advise if I should so anything... :)