### PR TITLE
[chore] [receiver/sqlquery] Skip TestOracleDBIntegrationMetrics

### DIFF
--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -443,6 +443,7 @@ func TestPostgresqlIntegrationMetrics(t *testing.T) {
 // This test ensures the collector can connect to an Oracle DB, and properly get metrics. It's not intended to
 // test the receiver itself.
 func TestOracleDBIntegrationMetrics(t *testing.T) {
+	t.Skip("Skipping the test until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27577 is fixed")
 	if runtime.GOARCH == "arm64" {
 		t.Skip("Incompatible with arm64")
 	}


### PR DESCRIPTION
To unblock the CI until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27577 is fixed
