### PR TITLE
[k8sclusterreceiver] deprecate opencensus.resourcetype attribute

### DIFF
--- a/.chloggen/k8sclusterreceiver-deprecate-opencensus.yaml
+++ b/.chloggen/k8sclusterreceiver-deprecate-opencensus.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'deprecation'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sclusterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Deprecate opencensus.resourcetype resource attribute"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26487]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: opencensus.resourcetype resource attribute is deprecated and disabled by default.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/k8sclusterreceiver/documentation.md
+++ b/receiver/k8sclusterreceiver/documentation.md
@@ -438,6 +438,6 @@ Current status reason of the pod (1 - Evicted, 2 - NodeAffinity, 3 - NodeLost, 4
 | k8s.resourcequota.uid | The k8s resourcequota uid. | Any Str | true |
 | k8s.statefulset.name | The k8s statefulset name. | Any Str | true |
 | k8s.statefulset.uid | The k8s statefulset uid. | Any Str | true |
-| opencensus.resourcetype | The OpenCensus resource type. | Any Str | true |
+| opencensus.resourcetype | The OpenCensus resource type. | Any Str | false |
 | openshift.clusterquota.name | The k8s ClusterResourceQuota name. | Any Str | true |
 | openshift.clusterquota.uid | The k8s ClusterResourceQuota uid. | Any Str | true |

--- a/receiver/k8sclusterreceiver/internal/clusterresourcequota/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/clusterresourcequota/testdata/expected.yaml
@@ -7,9 +7,6 @@ resourceMetrics:
         - key: openshift.clusterquota.uid
           value:
             stringValue: test-clusterquota-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/cronjob/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/cronjob/testdata/expected.yaml
@@ -10,9 +10,6 @@ resourceMetrics:
         - key: k8s.cronjob.uid
           value:
             stringValue: test-cronjob-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/demonset/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/demonset/testdata/expected.yaml
@@ -10,9 +10,6 @@ resourceMetrics:
         - key: k8s.daemonset.uid
           value:
             stringValue: test-daemonset-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/deployment/deployments_test.go
+++ b/receiver/k8sclusterreceiver/internal/deployment/deployments_test.go
@@ -37,10 +37,9 @@ func TestDeploymentMetrics(t *testing.T) {
 	rm := m.ResourceMetrics().At(0)
 	assert.Equal(t,
 		map[string]interface{}{
-			"k8s.deployment.uid":      "test-deployment-1-uid",
-			"k8s.deployment.name":     "test-deployment-1",
-			"k8s.namespace.name":      "test-namespace",
-			"opencensus.resourcetype": "k8s",
+			"k8s.deployment.uid":  "test-deployment-1-uid",
+			"k8s.deployment.name": "test-deployment-1",
+			"k8s.namespace.name":  "test-namespace",
 		},
 		rm.Resource().Attributes().AsRaw(),
 	)

--- a/receiver/k8sclusterreceiver/internal/deployment/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/deployment/testdata/expected.yaml
@@ -10,9 +10,6 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: test-namespace
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/jobs/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/jobs/testdata/expected.yaml
@@ -10,9 +10,6 @@ resourceMetrics:
         - key: k8s.job.uid
           value:
             stringValue: test-job-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/jobs/testdata/expected_empty.yaml
+++ b/receiver/k8sclusterreceiver/internal/jobs/testdata/expected_empty.yaml
@@ -10,9 +10,6 @@ resourceMetrics:
         - key: k8s.job.uid
           value:
             stringValue: test-job-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_config.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_config.go
@@ -353,7 +353,7 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 			Enabled: true,
 		},
 		OpencensusResourcetype: ResourceAttributeConfig{
-			Enabled: true,
+			Enabled: false,
 		},
 		OpenshiftClusterquotaName: ResourceAttributeConfig{
 			Enabled: true,

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
@@ -2197,6 +2197,9 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 }
 
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSettings, options ...metricBuilderOption) *MetricsBuilder {
+	if mbc.ResourceAttributes.OpencensusResourcetype.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] `opencensus.resourcetype` should not be configured: This resource_attribute is deprecated and will be removed soon.")
+	}
 	mb := &MetricsBuilder{
 		config:                                  mbc,
 		startTime:                               pcommon.NewTimestampFromTime(time.Now()),

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_metrics_test.go
@@ -49,6 +49,10 @@ func TestMetricsBuilder(t *testing.T) {
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, test.name), settings, WithStartTime(start))
 
 			expectedWarnings := 0
+			if test.configSet == testSetAll || test.configSet == testSetNone {
+				assert.Equal(t, "[WARNING] `opencensus.resourcetype` should not be configured: This resource_attribute is deprecated and will be removed soon.", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
 
 			assert.Equal(t, expectedWarnings, observedLogs.Len())
 

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_resource_test.go
@@ -52,7 +52,7 @@ func TestResourceBuilder(t *testing.T) {
 
 			switch test {
 			case "default":
-				assert.Equal(t, 31, res.Attributes().Len())
+				assert.Equal(t, 30, res.Attributes().Len())
 			case "all_set":
 				assert.Equal(t, 33, res.Attributes().Len())
 			case "none_set":
@@ -213,7 +213,7 @@ func TestResourceBuilder(t *testing.T) {
 				assert.EqualValues(t, "k8s.statefulset.uid-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("opencensus.resourcetype")
-			assert.True(t, ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "opencensus.resourcetype-val", val.Str())
 			}

--- a/receiver/k8sclusterreceiver/internal/namespace/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/namespace/testdata/expected.yaml
@@ -7,9 +7,6 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: test-namespace-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/node/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/node/testdata/expected.yaml
@@ -7,9 +7,6 @@ resourceMetrics:
         - key: k8s.node.uid
           value:
             stringValue: test-node-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/node/testdata/expected_optional.yaml
+++ b/receiver/k8sclusterreceiver/internal/node/testdata/expected_optional.yaml
@@ -13,9 +13,6 @@ resourceMetrics:
         - key: k8s.kubeproxy.version
           value:
             stringValue: v1.25.3
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected.yaml
@@ -13,9 +13,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -54,9 +51,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_evicted.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_evicted.yaml
@@ -13,9 +13,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
@@ -60,9 +57,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: test-pod-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/replicaset/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/replicaset/testdata/expected.yaml
@@ -10,9 +10,6 @@ resourceMetrics:
         - key: k8s.replicaset.uid
           value:
             stringValue: test-replicaset-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/replicationcontroller/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/replicationcontroller/testdata/expected.yaml
@@ -10,9 +10,6 @@ resourceMetrics:
         - key: k8s.replicationcontroller.uid
           value:
             stringValue: test-replicationcontroller-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/resourcequota/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/resourcequota/testdata/expected.yaml
@@ -10,9 +10,6 @@ resourceMetrics:
         - key: k8s.resourcequota.uid
           value:
             stringValue: test-resourcequota-1-uid
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:

--- a/receiver/k8sclusterreceiver/internal/statefulset/statefulsets_test.go
+++ b/receiver/k8sclusterreceiver/internal/statefulset/statefulsets_test.go
@@ -33,10 +33,9 @@ func TestStatefulsetMetrics(t *testing.T) {
 	rm := m.ResourceMetrics().At(0)
 	assert.Equal(t,
 		map[string]interface{}{
-			"k8s.statefulset.uid":     "test-statefulset-1-uid",
-			"k8s.statefulset.name":    "test-statefulset-1",
-			"k8s.namespace.name":      "test-namespace",
-			"opencensus.resourcetype": "k8s",
+			"k8s.statefulset.uid":  "test-statefulset-1-uid",
+			"k8s.statefulset.name": "test-statefulset-1",
+			"k8s.namespace.name":   "test-namespace",
 		}, rm.Resource().Attributes().AsRaw(),
 	)
 

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -175,7 +175,9 @@ resource_attributes:
   opencensus.resourcetype:
     description: The OpenCensus resource type.
     type: string
-    enabled: true
+    enabled: false
+    warnings:
+      if_configured: This resource_attribute is deprecated and will be removed soon.
 
 attributes:
   k8s.namespace.name:

--- a/receiver/k8sclusterreceiver/testdata/e2e/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/expected.yaml
@@ -7,9 +7,6 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: 3604b135-20f2-404b-9c1a-175ef649793e
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -31,9 +28,6 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: 414da07d-33d0-4043-ae7c-d6b264d134e5
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -55,9 +49,6 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: 7516afba-1597-49e3-8569-9732b7b94865
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -79,9 +70,6 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: 8dd32894-d0ff-4cff-bd75-b818c20fc72b
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -103,9 +91,6 @@ resourceMetrics:
         - key: k8s.namespace.uid
           value:
             stringValue: caa467a2-d3e8-4e66-8b76-a155464bac79
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -127,9 +112,6 @@ resourceMetrics:
         - key: k8s.node.uid
           value:
             stringValue: afd51338-8dbe-4234-aed3-0d1a9b3ee38e
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -154,9 +136,6 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: kube-system
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -202,9 +181,6 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: kube-system
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -250,9 +226,6 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: kube-system
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -284,9 +257,6 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: local-path-storage
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -318,9 +288,6 @@ resourceMetrics:
         - key: k8s.namespace.name
           value:
             stringValue: default
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -352,9 +319,6 @@ resourceMetrics:
         - key: k8s.replicaset.uid
           value:
             stringValue: fafc728a-82c7-49d6-a816-6bff81a191b4
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -386,9 +350,6 @@ resourceMetrics:
         - key: k8s.replicaset.uid
           value:
             stringValue: 8477bceb-33de-4072-9bb1-fbc762defdda
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -420,9 +381,6 @@ resourceMetrics:
         - key: k8s.replicaset.uid
           value:
             stringValue: 59e21dbf-09e1-4053-851d-90aad70bfb01
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -457,9 +415,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 5e4d1b29-35e5-4ff6-9779-b02921adcace
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -487,9 +442,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: ebd4da01-4a19-4ed8-bb2b-a75fa9c66160
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -517,9 +469,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 2c672907-5d69-4f91-85e0-f1792164cadc
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -547,9 +496,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 16463557-8966-458d-b356-54f16895a1dd
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -577,9 +523,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 9405ca8b-7b7d-4271-80d1-41901f84c9e8
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -607,9 +550,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 4ce29152-4749-43a7-89b4-b8265bf35b09
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -637,9 +577,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 5ebe0d65-e661-4e6b-a053-a3a22adec893
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -667,9 +604,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 38e3c8d5-0c3e-465f-8a79-4117dbcd7607
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -697,9 +631,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: d966df8b-e9d3-41d5-9b25-6c1a5ec9d3dc
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -727,9 +658,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 22a22d93-0ec2-4c90-91b1-29a0b3ea9173
-        - key: opencensus.resourcetype
-          value:
-            stringValue: k8s
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -769,9 +697,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 16463557-8966-458d-b356-54f16895a1dd
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -832,9 +757,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 9405ca8b-7b7d-4271-80d1-41901f84c9e8
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -909,9 +831,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 4ce29152-4749-43a7-89b4-b8265bf35b09
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -965,9 +884,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: d966df8b-e9d3-41d5-9b25-6c1a5ec9d3dc
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -1021,9 +937,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 5ebe0d65-e661-4e6b-a053-a3a22adec893
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -1077,9 +990,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 38e3c8d5-0c3e-465f-8a79-4117dbcd7607
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -1126,9 +1036,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: ebd4da01-4a19-4ed8-bb2b-a75fa9c66160
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -1196,9 +1103,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 5e4d1b29-35e5-4ff6-9779-b02921adcace
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -1273,9 +1177,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 22a22d93-0ec2-4c90-91b1-29a0b3ea9173
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:
@@ -1322,9 +1223,6 @@ resourceMetrics:
         - key: k8s.pod.uid
           value:
             stringValue: 2c672907-5d69-4f91-85e0-f1792164cadc
-        - key: opencensus.resourcetype
-          value:
-            stringValue: container
     schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
     scopeMetrics:
       - metrics:


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Deprecate opencensus.resourcetype resource attribute.

This PR disables this resource attribute and adds a warning message.

**Link to tracking Issue:** <Issue number if applicable>

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26487


**Testing:** <Describe what testing was performed and which tests were added.>
- Updated unit tests.

Manually tested, built and image and manually enabled and disabled this resource attribute.

This is the warning we publish:

> {"level":"warn","ts":1696935210.905353,"caller":"metadata/generated_metrics.go:2201","msg":"[WARNING] `opencensus.resourcetype` should not be configured: This resource_attribute is deprecated and will be removed soon.","kind":"receiver","name":"k8s_cluster","data_type":"metrics"}

**Documentation:** <Describe the documentation added.>

- Generated