### PR TITLE
enable Trace and Span ID in the telemetrygen output

### DIFF
--- a/cmd/telemetrygen/internal/traces/worker.go
+++ b/cmd/telemetrygen/internal/traces/worker.go
@@ -80,6 +80,9 @@ func (w worker) simulateTraces(telemetryAttributes []attribute.KeyValue) {
 		}
 
 		opt := trace.WithTimestamp(time.Now().Add(fakeSpanDuration))
+		w.logger.Info("Trace", zap.String("traceId", sp.SpanContext().TraceID().String()))
+		w.logger.Info("Parent Span", zap.String("spanId", sp.SpanContext().SpanID().String()))
+		w.logger.Info("Child Span", zap.String("spanId", child.SpanContext().SpanID().String()))
 		child.SetStatus(w.statusCode, "")
 		child.End(opt)
 		sp.SetStatus(w.statusCode, "")


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
telemetrygen is an excellent tool for generating test traces; however it is challenging to verify whether the test trace has been successfully sent to the system without trace ID. Providing the trace ID would make it easier for us to locate the test trace in the end system.
This PR will log the trace ID and span ID in the output."
**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
<img width="1238" alt="image" src="https://github.com/open-telemetry/opentelemetry-collector-contrib/assets/84754386/c667dde9-d7b3-4c36-90d6-e02cd06e9bda">

**Documentation:** <Describe the documentation added.>