### PR TITLE
[chore] limit number of published benchmark datapoints

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -133,6 +133,7 @@ jobs:
           tool: 'customSmallerIsBetter'
           output-file-path: output.json
           gh-pages-branch: benchmarks
+          max-items-in-chart: 100
           github-token: ${{ secrets.GITHUB_TOKEN }}
           benchmark-data-dir-path: "docs/benchmarks/loadtests"
           auto-push: true


### PR DESCRIPTION
currently the charts are hard to read and the data file is 32mb in size. 100 data points per chart seem enough.
