### PR TITLE
[exporter/signalfx] expose build version in user agent string

### DIFF
--- a/.chloggen/signalfxexporter-user-agent.yaml
+++ b/.chloggen/signalfxexporter-user-agent.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add the build version to the user agent of the SignalFx exporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [16841]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -52,6 +52,7 @@ func (sme *signalfMetadataExporter) ConsumeMetadata(metadata []*metadata.Metadat
 
 type signalfxExporter struct {
 	config             *Config
+	version            string
 	logger             *zap.Logger
 	telemetrySettings  component.TelemetrySettings
 	pushMetricsData    func(ctx context.Context, md pmetric.Metrics) (droppedTimeSeries int, err error)
@@ -90,6 +91,7 @@ func newSignalFxExporter(
 
 	return &signalfxExporter{
 		config:            config,
+		version:           createSettings.BuildInfo.Version,
 		logger:            createSettings.Logger,
 		telemetrySettings: createSettings.TelemetrySettings,
 		converter:         converter,
@@ -102,7 +104,7 @@ func (se *signalfxExporter) start(ctx context.Context, host component.Host) (err
 		return err
 	}
 
-	headers := buildHeaders(se.config)
+	headers := buildHeaders(se.config, se.version)
 	client, err := se.createClient(host)
 	if err != nil {
 		return err
@@ -176,6 +178,7 @@ func newEventExporter(config *Config, createSettings exporter.CreateSettings) (*
 
 	return &signalfxExporter{
 		config:            config,
+		version:           createSettings.BuildInfo.Version,
 		logger:            createSettings.Logger,
 		telemetrySettings: createSettings.TelemetrySettings,
 	}, nil
@@ -188,7 +191,7 @@ func (se *signalfxExporter) startLogs(_ context.Context, host component.Host) er
 		return err
 	}
 
-	headers := buildHeaders(se.config)
+	headers := buildHeaders(se.config, se.version)
 	client, err := se.createClient(host)
 	if err != nil {
 		return err
@@ -252,11 +255,11 @@ func (se *signalfxExporter) pushMetadata(metadata []*metadata.MetadataUpdate) er
 	return se.dimClient.PushMetadata(metadata)
 }
 
-func buildHeaders(config *Config) map[string]string {
+func buildHeaders(config *Config, version string) map[string]string {
 	headers := map[string]string{
 		"Connection":   "keep-alive",
 		"Content-Type": "application/x-protobuf",
-		"User-Agent":   "OpenTelemetry-Collector SignalFx Exporter/v0.0.1",
+		"User-Agent":   fmt.Sprintf("OpenTelemetry-Collector SignalFx Exporter/%s", version),
 	}
 
 	if config.AccessToken != "" {


### PR DESCRIPTION
**Description:**
The current SignalFx exporter maps to a static user agent string "OpenTelemetry-Collector SignalFx Exporter/v0.0.1".

This PR changes the version to match the build info version.

**Link to tracking Issue:**
Fixes #16841