### PR TITLE
Add async/concurrency to udp receiver

### DIFF
--- a/pkg/stanza/docs/operators/udp_input.md
+++ b/pkg/stanza/docs/operators/udp_input.md
@@ -17,6 +17,11 @@ The `udp_input` operator listens for logs from UDP packets.
 | `preserve_leading_whitespaces`          | false            | Whether to preserve leading whitespaces.                                                                                                                                                                                                                         |
 | `preserve_trailing_whitespaces`             | false            | Whether to preserve trailing whitespaces.                                                                                                                                                                                                                            |
 | `encoding`                              | `utf-8`              | The encoding of the file being read. See the list of supported encodings below for available options. |
+| `async_concurrent_mode`                              | false              | Determines whether UDP receiver processes messages synchronsouly or asynchronsouly and concurrently. |
+| `fixed_async_reader_routine_count`                              | 1              | Concurrency level - Determines how many go routines read from UDP port and write to channel (relevant only if async_concurrent_mode==true). |
+| `fixed_async_processor_routine_count`                              | 1              | Concurrency level - Determines how many go routines read from channel, process (split, add attributes, etc.) and write downstream (relevant only if async_concurrent_mode==true). |
+| `max_async_queue_length`                              | 1000              | Determines max length of channel being used by reader async routines. When channel reaches max number, reader routine will wait until channel has room (relevant only if async_concurrent_mode==true). |
+| `max_graceful_shutdown_time_in_ms`                              | 1000              | During shutdown, determines how long the processor go routine will continue reading from channel and pushing downstream (reader routine will stop reading from UDP port immediately on when shutdown is requested; relevant only if async_concurrent_mode==true). |
 
 #### `multiline` configuration
 

--- a/pkg/stanza/operator/input/udp/config_test.go
+++ b/pkg/stanza/operator/input/udp/config_test.go
@@ -36,3 +36,35 @@ func TestUnmarshal(t *testing.T) {
 		},
 	}.Run(t)
 }
+
+unc TestAsyncUnmarshal(t *testing.T) {
+	operatortest.ConfigUnmarshalTests{
+		DefaultConfig: NewConfig(),
+		TestsFile:     filepath.Join(".", "testdata", "config.yaml"),
+		Tests: []operatortest.ConfigUnmarshalTest{
+			{
+				Name:      "default",
+				ExpectErr: false,
+				Expect:    NewConfig(),
+			},
+			{
+				Name:      "all",
+				ExpectErr: false,
+				Expect: func() *Config {
+					cfg := NewConfig()
+					cfg.ListenAddress = "10.0.0.1:9000"
+					cfg.AddAttributes = true
+					cfg.Encoding = "utf-8"
+					cfg.SplitConfig.LineStartPattern = "ABC"
+					cfg.SplitConfig.LineEndPattern = ""
+					cfg.AsyncConcurrentMode = true
+					cfg.FixedAsyncReaderRoutineCount = 2
+					cfg.FixedAsyncProcessorRoutineCount = 2
+					cfg.MaxAsyncQueueLength = 1000
+					cfg.MaxGracefulShutdownTimeInMS = 1000
+					return cfg
+				}(),
+			},
+		},
+	}.Run(t)
+}

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
@@ -48,6 +49,11 @@ func NewConfigWithID(operatorID string) *Config {
 			SplitConfig: split.Config{
 				LineEndPattern: ".^", // Use never matching regex to not split data by default
 			},
+			AsyncConcurrentMode:             false,
+			FixedAsyncReaderRoutineCount:    1,
+			FixedAsyncProcessorRoutineCount: 1,
+			MaxAsyncQueueLength:             1000,
+			MaxGracefulShutdownTimeInMS:     1000,
 		},
 	}
 }
@@ -60,12 +66,17 @@ type Config struct {
 
 // BaseConfig is the details configuration of a udp input operator.
 type BaseConfig struct {
-	ListenAddress   string       `mapstructure:"listen_address,omitempty"`
-	OneLogPerPacket bool         `mapstructure:"one_log_per_packet,omitempty"`
-	AddAttributes   bool         `mapstructure:"add_attributes,omitempty"`
-	Encoding        string       `mapstructure:"encoding,omitempty"`
-	SplitConfig     split.Config `mapstructure:"multiline,omitempty"`
-	TrimConfig      trim.Config  `mapstructure:",squash"`
+	ListenAddress                   string       `mapstructure:"listen_address,omitempty"`
+	OneLogPerPacket                 bool         `mapstructure:"one_log_per_packet,omitempty"`
+	AddAttributes                   bool         `mapstructure:"add_attributes,omitempty"`
+	Encoding                        string       `mapstructure:"encoding,omitempty"`
+	SplitConfig                     split.Config `mapstructure:"multiline,omitempty"`
+	TrimConfig                      trim.Config  `mapstructure:",squash"`
+	AsyncConcurrentMode             bool         `mapstructure:"async_concurrent_mode,omitempty"`
+	FixedAsyncReaderRoutineCount    int          `mapstructure:"fixed_async_reader_routine_count,omitempty"`
+	FixedAsyncProcessorRoutineCount int          `mapstructure:"fixed_async_processor_routine_count,omitempty"`
+	MaxAsyncQueueLength             int          `mapstructure:"max_async_queue_length,omitempty"`
+	MaxGracefulShutdownTimeInMS     int          `mapstructure:"max_graceful_shutdown_time_in_ms,omitempty"`
 }
 
 // Build will build a udp input operator.
@@ -102,14 +113,20 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 	}
 
 	udpInput := &Input{
-		InputOperator:   inputOperator,
-		address:         address,
-		buffer:          make([]byte, MaxUDPSize),
-		addAttributes:   c.AddAttributes,
-		encoding:        enc,
-		splitFunc:       splitFunc,
-		resolver:        resolver,
-		OneLogPerPacket: c.OneLogPerPacket,
+		InputOperator:                   inputOperator,
+		address:                         address,
+		buffer:                          make([]byte, MaxUDPSize),
+		addAttributes:                   c.AddAttributes,
+		encoding:                        enc,
+		splitFunc:                       splitFunc,
+		resolver:                        resolver,
+		OneLogPerPacket:                 c.OneLogPerPacket,
+		AsyncConcurrentMode:             c.AsyncConcurrentMode,
+		FixedAsyncReaderRoutineCount:    c.FixedAsyncReaderRoutineCount,
+		FixedAsyncProcessorRoutineCount: c.FixedAsyncProcessorRoutineCount,
+		MaxGracefulShutdownTimeInMS:     c.MaxGracefulShutdownTimeInMS,
+		messageQueue:                    make(chan MessageAndAddr, c.MaxAsyncQueueLength),
+		shutdownChan:                    make(chan struct{}),
 	}
 	return udpInput, nil
 }
@@ -118,9 +135,13 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 type Input struct {
 	buffer []byte
 	helper.InputOperator
-	address         *net.UDPAddr
-	addAttributes   bool
-	OneLogPerPacket bool
+	address                         *net.UDPAddr
+	addAttributes                   bool
+	OneLogPerPacket                 bool
+	AsyncConcurrentMode             bool
+	FixedAsyncReaderRoutineCount    int
+	FixedAsyncProcessorRoutineCount int
+	MaxGracefulShutdownTimeInMS     int
 
 	connection net.PacketConn
 	cancel     context.CancelFunc
@@ -129,12 +150,22 @@ type Input struct {
 	encoding  encoding.Encoding
 	splitFunc bufio.SplitFunc
 	resolver  *helper.IPResolver
+
+	messageQueue chan MessageAndAddr
+	shutdownChan chan struct{}
+}
+
+type MessageAndAddr struct {
+	Message    []byte
+	RemoteAddr net.Addr
 }
 
 // Start will start listening for messages on a socket.
 func (u *Input) Start(_ operator.Persister) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	u.cancel = cancel
+
+	u.wg = sync.WaitGroup{}
 
 	conn, err := net.ListenUDP("udp", u.address)
 	if err != nil {
@@ -148,14 +179,71 @@ func (u *Input) Start(_ operator.Persister) error {
 
 // goHandleMessages will handle messages from a udp connection.
 func (u *Input) goHandleMessages(ctx context.Context) {
-	u.wg.Add(1)
+	if u.AsyncConcurrentMode {
+		// Start the specified number of goroutines
+		for i := 0; i < u.FixedAsyncReaderRoutineCount; i++ {
+			u.wg.Add(1)
+			go u.readMessagesAsync(ctx)
+		}
 
-	go func() {
-		defer u.wg.Done()
+		for i := 0; i < u.FixedAsyncProcessorRoutineCount; i++ {
+			u.wg.Add(1)
+			go u.processMessagesAsync(ctx)
+		}
+	} else {
+		go u.readAndProcessMessages(ctx)
+	}
+}
 
-		dec := decode.New(u.encoding)
-		buf := make([]byte, 0, MaxUDPSize)
-		for {
+func (u *Input) readAndProcessMessages(ctx context.Context) {
+	defer u.wg.Done()
+
+	dec := decode.New(u.encoding)
+	buf := make([]byte, 0, MaxUDPSize)
+
+	for {
+		message, remoteAddr, err := u.readMessage()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				u.Errorw("Failed reading messages", zap.Error(err))
+			}
+			break
+		}
+
+		u.processMessage(ctx, message, remoteAddr, dec, buf)
+	}
+}
+
+func (u *Input) processMessage(ctx context.Context, message []byte, remoteAddr net.Addr, dec *decode.Decoder, buf []byte) {
+	if u.OneLogPerPacket {
+		log := truncateMaxLog(message)
+		u.handleMessage(ctx, remoteAddr, dec, log)
+		return
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(message))
+	scanner.Buffer(buf, MaxUDPSize)
+	scanner.Split(u.splitFunc)
+
+	for scanner.Scan() {
+		u.handleMessage(ctx, remoteAddr, dec, scanner.Bytes())
+	}
+	if err := scanner.Err(); err != nil {
+		u.Errorw("Scanner error", zap.Error(err))
+	}
+}
+
+func (u *Input) readMessagesAsync(ctx context.Context) {
+	defer u.wg.Done()
+
+	for {
+		select {
+		case <-u.shutdownChan:
+			return // Exit gracefully if shutdown is initiated. No need to read more messages from UDP.
+		default:
 			message, remoteAddr, err := u.readMessage()
 			if err != nil {
 				select {
@@ -167,25 +255,34 @@ func (u *Input) goHandleMessages(ctx context.Context) {
 				break
 			}
 
-			if u.OneLogPerPacket {
-				log := truncateMaxLog(message)
-				u.handleMessage(ctx, remoteAddr, dec, log)
-				continue
+			messageAndAddr := MessageAndAddr{
+				Message:    message,
+				RemoteAddr: remoteAddr,
 			}
 
-			scanner := bufio.NewScanner(bytes.NewReader(message))
-			scanner.Buffer(buf, MaxUDPSize)
-
-			scanner.Split(u.splitFunc)
-
-			for scanner.Scan() {
-				u.handleMessage(ctx, remoteAddr, dec, scanner.Bytes())
-			}
-			if err := scanner.Err(); err != nil {
-				u.Errorw("Scanner error", zap.Error(err))
-			}
+			// Send the message to the message queue for processing
+			u.messageQueue <- messageAndAddr
 		}
-	}()
+	}
+}
+
+func (u *Input) processMessagesAsync(ctx context.Context) {
+	defer u.wg.Done()
+
+	dec := decode.New(u.encoding)
+	buf := make([]byte, 0, MaxUDPSize)
+
+	for {
+		// Read a message from the message queue.
+		messageAndAddr, ok := <-u.messageQueue
+		if !ok {
+			// Channel closed, exit the goroutine. Note that the channel will only be closed (by the Stop method during shutdown) once messageQueue is empty.
+			// Until then, processMessagesAsync will keep reading & processing messages from the queue to reduce data-loss.
+			return
+		}
+
+		u.processMessage(ctx, messageAndAddr.Message, messageAndAddr.RemoteAddr, dec, buf)
+	}
 }
 
 func truncateMaxLog(data []byte) (token []byte) {
@@ -249,10 +346,34 @@ func (u *Input) readMessage() ([]byte, net.Addr, error) {
 
 // Stop will stop listening for udp messages.
 func (u *Input) Stop() error {
+	// Signal shutdown. This would cause the readAsync routine to stop reading from UDP port.
+	close(u.shutdownChan)
+
+	if u.AsyncConcurrentMode {
+		startTime := time.Now()
+
+		// Wait for the processAsync method to finish reading & processing all messages from messageQueue. In other words, wait for the channel to be empty, but don't read from it.
+		for len(u.messageQueue) > 0 {
+			if time.Since(startTime) > time.Duration(u.MaxGracefulShutdownTimeInMS)*time.Millisecond {
+				u.Errorf("Stop timed out waiting for messageQueue to become empty. Shutting down despite messageQueue still having messages to process.")
+				break
+			}
+
+			select {
+			case <-time.After(10 * time.Millisecond):
+				// Sleep for 10 milliseconds before checking whehther messageQueue is empty again
+			default:
+			}
+		}
+
+		close(u.messageQueue)
+	}
+
 	if u.cancel == nil {
 		return nil
 	}
 	u.cancel()
+
 	if u.connection != nil {
 		if err := u.connection.Close(); err != nil {
 			u.Errorf("failed to close UDP connection: %s", err)
@@ -262,5 +383,6 @@ func (u *Input) Stop() error {
 	if u.resolver != nil {
 		u.resolver.Stop()
 	}
+
 	return nil
 }

--- a/pkg/stanza/operator/input/udp/udp_test.go
+++ b/pkg/stanza/operator/input/udp/udp_test.go
@@ -240,3 +240,54 @@ func BenchmarkUDPInput(b *testing.B) {
 
 	defer close(done)
 }
+
+func udpInputAsyncTest(input []byte, expected []string) func(t *testing.T) {
+	return func(t *testing.T) {
+		cfg := NewConfigWithID("test_input")
+		cfg.ListenAddress = ":0"
+		cfg.AsyncConcurrentMode = true
+
+		op, err := cfg.Build(testutil.Logger(t))
+		require.NoError(t, err)
+
+		mockOutput := testutil.Operator{}
+		udpInput, ok := op.(*Input)
+		require.True(t, ok)
+
+		udpInput.InputOperator.OutputOperators = []operator.Operator{&mockOutput}
+
+		entryChan := make(chan *entry.Entry, 1)
+		mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			entryChan <- args.Get(1).(*entry.Entry)
+		}).Return(nil)
+
+		err = udpInput.Start(testutil.NewMockPersister("test"))
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, udpInput.Stop(), "expected to stop udp input operator without error")
+		}()
+
+		conn, err := net.Dial("udp", udpInput.connection.LocalAddr().String())
+		require.NoError(t, err)
+		defer conn.Close()
+
+		_, err = conn.Write(input)
+		require.NoError(t, err)
+
+		for _, expectedBody := range expected {
+			select {
+			case entry := <-entryChan:
+				require.Equal(t, expectedBody, entry.Body)
+			case <-time.After(time.Second):
+				require.FailNow(t, "Timed out waiting for message to be written")
+			}
+		}
+
+		select {
+		case entry := <-entryChan:
+			require.FailNow(t, "Unexpected entry: %s", entry)
+		case <-time.After(100 * time.Millisecond):
+			return
+		}
+	}
+}

--- a/receiver/udplogreceiver/README.md
+++ b/receiver/udplogreceiver/README.md
@@ -28,6 +28,11 @@ Receives logs over UDP.
 | `multiline`               |                      | A `multiline` configuration block. See below for details                                                           |
 | `encoding`                | `utf-8`              | The encoding of the file being read. See the list of supported encodings below for available options               |
 | `operators`               | []                   | An array of [operators](../../pkg/stanza/docs/operators/README.md#what-operators-are-available). See below for more details |
+| `async_concurrent_mode`               | false                   | Determines whether UDP receiver processes messages synchronsouly or asynchronsouly and concurrently. |
+| `fixed_async_reader_routine_count`               | 1                   | Concurrency level - Determines how many go routines read from UDP port and write to channel (relevant only if async_concurrent_mode==true). |
+| `fixed_async_processor_routine_count`               | 1                   | Concurrency level - Determines how many go routines read from channel, process (split, add attributes, etc.) and write downstream (relevant only if async_concurrent_mode==true). |
+| `max_async_queue_length`               | 1000                   | Determines max length of channel being used by reader async routines. When channel reaches max number, reader routine will wait until channel has room (relevant only if async_concurrent_mode==true). |
+| `max_graceful_shutdown_time_in_ms`               | 1000                   | During shutdown, determines how long the processor go routine will continue reading from channel and pushing downstream (reader routine will stop reading from UDP port immediately on when shutdown is requested; relevant only if async_concurrent_mode==true). |
 
 ### Operators
 

--- a/receiver/udplogreceiver/udp_test.go
+++ b/receiver/udplogreceiver/udp_test.go
@@ -28,6 +28,12 @@ func TestUdp(t *testing.T) {
 	testUDP(t, testdataConfigYaml())
 }
 
+func TestAsyncUdp(t *testing.T) {
+	cfg := testdataConfigYaml()
+	cfg.AsyncConcurrentMode = true
+	testUDP(t, cfg)
+}
+
 func testUDP(t *testing.T, cfg *UDPLogConfig) {
 	numLogs := 5
 


### PR DESCRIPTION
**Description:** Adding a feature - Adding asynchronous & concurrency mode to the UDP receiver/stanza input operator - goal is to reduce UDP packet loss in high-scale scenarios.
Added 5 new flags to the config: AsyncConcurrentMode, FixedAsyncReaderRoutineCount, FixedAsyncProcessorRoutineCount, MaxAsyncQueueLength, MaxGracefulShutdownTimeInMS.

Goal:
Since the underlying computer's network buffer is limited and there's no handshake in UDP (that would cause the sender to reduce rate, as in TCP), even short term latency on the otel-collector's side (for example, the endpoint receiving logs from the otel-exporter has increased latency) causes UDP packet drop in high scale scenarios (and as a result, data loss).
This feature allows the consumer to load data into the memory (instead of the limited network buffer), so short term latency or issues downstream, will not quickly result in data loss.
Also, since receiver can be configured to perform split & add attributes operations on each packet, it improves performance since it separates the threads that read from UDP from the threads that process (before sending the packets downstream). It allows to raise concurrency level of either thread reader routines & the processor routines, depending on scenario.

**Link to tracking Issue:** 27613

**Testing:** Local stress tests ran and indicated data-loss issue was solved (during high scale scenarios), when MaxAsyncQueueLength was set sufficiently high (+AsyncConcurrentMode==true).
In repo, added single test to udp_test, config_test (in stanza udp operator), and udp_test (in udplogreceiver).

**Documentation:** Updated md file for both udplogreceiver & stanza udp_input operator with the new flags.