### PR TITLE
[chore] [exporter/awscloudwatchlogs] Remove duplicate consumer check

### DIFF
--- a/exporter/awscloudwatchlogsexporter/config.go
+++ b/exporter/awscloudwatchlogsexporter/config.go
@@ -68,13 +68,6 @@ func (config *Config) Validate() error {
 		return err
 	}
 
-	// TODO: once QueueSettings.Validate validate the number of consumers remove the next
-	// verification
-
-	if config.QueueSettings.NumConsumers < 1 {
-		return errors.New("'sending_queue.num_consumers' must be 1 or greater")
-	}
-
 	if retErr := cwlogs.ValidateRetentionValue(config.LogRetention); retErr != nil {
 		return retErr
 	}

--- a/exporter/awscloudwatchlogsexporter/config_test.go
+++ b/exporter/awscloudwatchlogsexporter/config_test.go
@@ -76,7 +76,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			id:           component.NewIDWithName(metadata.Type, "invalid_num_consumers"),
-			errorMessage: "'sending_queue.num_consumers' must be 1 or greater",
+			errorMessage: "number of queue consumers must be positive",
 		},
 		{
 			id:           component.NewIDWithName(metadata.Type, "invalid_required_field_stream"),


### PR DESCRIPTION
**Description:** v0.87.0 `exporterhelper.queue_settings.validate()` verifies the consumer setting for us. We no longer need to duplicate that validation. 

**Link to tracking Issue:** <Issue number if applicable> #27624 