### PR TITLE
[chore] Fix typo in README

### DIFF
--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -356,7 +356,7 @@ transform:
         - set(attributes["body"], body)
 ``` 
 
-### Comnbine two attributes
+### Combine two attributes
 Set attribute `test` to the value of attributes `"foo"` and `"bar"` combined. 
 ```yaml
 transform:


### PR DESCRIPTION
**Documentation:** <Describe the documentation added.>
Found a typo while reading the transform processor readme.