### PR TITLE
[processor/redactionprocessor] fix mask when multiple patterns exist

### DIFF
--- a/.chloggen/redact-multi.yaml
+++ b/.chloggen/redact-multi.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: redactionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix mask when multiple patterns exist"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27646]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/redactionprocessor/processor.go
+++ b/processor/redactionprocessor/processor.go
@@ -113,13 +113,18 @@ func (s *redaction) processAttrs(_ context.Context, attributes pcommon.Map) {
 
 		// Mask any blocked values for the other attributes
 		strVal := value.Str()
+		var matched bool
 		for _, compiledRE := range s.blockRegexList {
 			match := compiledRE.MatchString(strVal)
 			if match {
-				toBlock = append(toBlock, k)
+				if !matched {
+					matched = true
+					toBlock = append(toBlock, k)
+				}
 
 				maskedValue := compiledRE.ReplaceAllString(strVal, "****")
 				value.SetStr(maskedValue)
+				strVal = maskedValue
 			}
 		}
 		return true

--- a/processor/redactionprocessor/processor_test.go
+++ b/processor/redactionprocessor/processor_test.go
@@ -290,7 +290,7 @@ func TestMultipleBlockValues(t *testing.T) {
 		"mystery": pcommon.NewValueStr("mystery 52000"),
 	}
 	masked := map[string]pcommon.Value{
-		"name": pcommon.NewValueStr("placeholder 4111111111111111"),
+		"name": pcommon.NewValueStr("placeholder 4111111111111111 52000"),
 	}
 	redacted := map[string]pcommon.Value{
 		"credit_card": pcommon.NewValueStr("4111111111111111"),
@@ -324,7 +324,7 @@ func TestMultipleBlockValues(t *testing.T) {
 	assert.Equal(t, int64(len(blockedKeys)), maskedValueCount.Int())
 	nameValue, _ := attr.Get("name")
 	mysteryValue, _ := attr.Get("mystery")
-	assert.Equal(t, "placeholder ****", nameValue.Str())
+	assert.Equal(t, "placeholder **** ****", nameValue.Str())
 	assert.Equal(t, "mystery ****", mysteryValue.Str())
 }
 


### PR DESCRIPTION
**Description:**
Fix mask when multiple patterns exist

With following input:

```
attr: <secret1> <secret2>
```

and config:

```
redaction:
  blocked_values:
    - '<secret1>'
    - '<secret2>'
```

Output before fix:

```
attr: <secret1> ****
```

Output after fix:

```
attr: **** ****
```

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>