### PR TITLE
Make pjanotti owner of windowseventlogreceiver

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,7 +133,7 @@ pkg/ottl/                                                               @open-te
 pkg/pdatatest/                                                          @open-telemetry/collector-contrib-approvers @djaglowski @fatsheep9146
 pkg/pdatautil/                                                          @open-telemetry/collector-contrib-approvers @dmitryax
 pkg/resourcetotelemetry/                                                @open-telemetry/collector-contrib-approvers @mx-psi
-pkg/stanza/                                                             @open-telemetry/collector-contrib-approvers @djaglowski @pjanotti
+pkg/stanza/                                                             @open-telemetry/collector-contrib-approvers @djaglowski
 pkg/translator/jaeger/                                                  @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @frzifus
 pkg/translator/loki/                                                    @open-telemetry/collector-contrib-approvers @gouthamve @jpkrohling @mar4uk
 pkg/translator/opencensus/                                              @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,7 +133,7 @@ pkg/ottl/                                                               @open-te
 pkg/pdatatest/                                                          @open-telemetry/collector-contrib-approvers @djaglowski @fatsheep9146
 pkg/pdatautil/                                                          @open-telemetry/collector-contrib-approvers @dmitryax
 pkg/resourcetotelemetry/                                                @open-telemetry/collector-contrib-approvers @mx-psi
-pkg/stanza/                                                             @open-telemetry/collector-contrib-approvers @djaglowski
+pkg/stanza/                                                             @open-telemetry/collector-contrib-approvers @djaglowski @pjanotti
 pkg/translator/jaeger/                                                  @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @frzifus
 pkg/translator/loki/                                                    @open-telemetry/collector-contrib-approvers @gouthamve @jpkrohling @mar4uk
 pkg/translator/opencensus/                                              @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
@@ -257,7 +257,7 @@ receiver/udplogreceiver/                                                @open-te
 receiver/vcenterreceiver/                                               @open-telemetry/collector-contrib-approvers @djaglowski @schmikei
 receiver/wavefrontreceiver/                                             @open-telemetry/collector-contrib-approvers @samiura
 receiver/webhookeventreceiver/                                          @open-telemetry/collector-contrib-approvers @atoulme @shalper2
-receiver/windowseventlogreceiver/                                       @open-telemetry/collector-contrib-approvers @djaglowski @armstrmi
+receiver/windowseventlogreceiver/                                       @open-telemetry/collector-contrib-approvers @djaglowski @armstrmi @pjanotti
 receiver/windowsperfcountersreceiver/                                   @open-telemetry/collector-contrib-approvers @dashpole
 receiver/zipkinreceiver/                                                @open-telemetry/collector-contrib-approvers @MovieStoreGuy @astencel-sumo @crobert-1
 receiver/zookeeperreceiver/                                             @open-telemetry/collector-contrib-approvers @djaglowski


### PR DESCRIPTION
**Description:**
Adding myself as owner of `windowseventlogreceiver` per invite https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27658#issuecomment-1760528763

cc @djaglowski 