### PR TITLE
[chore] throw error if GITHUB_TOKEN env is not set

### DIFF
--- a/cmd/githubgen/main.go
+++ b/cmd/githubgen/main.go
@@ -376,7 +376,11 @@ LOOP:
 }
 
 func getGithubMembers() (map[string]struct{}, error) {
-	client := github.NewTokenClient(context.Background(), os.Getenv("GITHUB_TOKEN"))
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken == "" {
+		return nil, fmt.Errorf("Set the environment variable `GITHUB_TOKEN` to a PAT token to authenticate")
+	}
+	client := github.NewTokenClient(context.Background(), githubToken)
 	var allUsers []*github.User
 	pageIndex := 0
 	for {


### PR DESCRIPTION
**Description:** 
running `make gengithub` or `make update-codeowners` with an incorrect token or without setting the token throws the  same following error:
```https://api.github.com/orgs/open-telemetry/members?per_page=50: 401 Bad credentials []```

It makes sense to throw an error if the user has forgotten to set the GITHUB_TOKEN variable and it also distinguishes between the two cases (incorrect token and token not set)
