### PR TITLE
[pkg/stanza] Fix issue where batching caused incorrect starting point

### DIFF
--- a/.chloggen/pkg-stanza-fileconsumer-reader-from-end-batches.yaml
+++ b/.chloggen/pkg-stanza-fileconsumer-reader-from-end-batches.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix issue where batching of files could result in ignoring start_at setting.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27773]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -118,6 +118,9 @@ func (m *Manager) poll(ctx context.Context) {
 		matches = matches[m.maxBatchFiles:]
 	}
 	m.consume(ctx, matches)
+
+	// Any new files that appear should be consumed entirely
+	m.readerFactory.FromBeginning = true
 }
 
 func (m *Manager) consume(ctx context.Context, paths []string) {
@@ -144,9 +147,6 @@ func (m *Manager) consume(ctx context.Context, paths []string) {
 		}(r)
 	}
 	wg.Wait()
-
-	// Any new files that appear should be consumed entirely
-	m.readerFactory.FromBeginning = true
 
 	m.roller.roll(ctx, readers)
 	m.saveCurrent(readers)


### PR DESCRIPTION
The `start_at` setting applies only to the first poll interval. Once this interval is complete, we should always read new files from the beginning. This fixes a bug which prematurely switched to reading from the beginning, when files are numerous enough to require batching.