### PR TITLE
[aws/cwlogs] Reduce noisy logger in CloudWatch logs pusher

### DIFF
--- a/.chloggen/awscwl_noisypusher.yaml
+++ b/.chloggen/awscwl_noisypusher.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awscloudwatchlogsexporter/awsemfexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Reduce noisy logs emitted by CloudWatch Logs Pusher.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: The Collector logger will now write successful CloudWatch API writes at the Debug level instead of Info level.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/awscwl_noisypusher.yaml
+++ b/.chloggen/awscwl_noisypusher.yaml
@@ -10,7 +10,7 @@ component: awscloudwatchlogsexporter/awsemfexporter
 note: Reduce noisy logs emitted by CloudWatch Logs Pusher.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [27774]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/internal/aws/cwlogs/pusher.go
+++ b/internal/aws/cwlogs/pusher.go
@@ -267,7 +267,7 @@ func (p *logPusher) pushEventBatch(req interface{}) error {
 		return err
 	}
 
-	p.logger.Info("logpusher: publish log events successfully.",
+	p.logger.Debug("logpusher: publish log events successfully.",
 		zap.Int("NumOfLogEvents", len(putLogEventsInput.LogEvents)),
 		zap.Float64("LogEventsSize", float64(logEventBatch.byteTotal)/float64(1024)),
 		zap.Int64("Time", time.Since(startTime).Nanoseconds()/int64(time.Millisecond)))


### PR DESCRIPTION
**Description:** Log at the debug level instead of info level. Existing behavior would cause excessive log lines on each successful push. 