### PR TITLE
[pkg/pdatatest] Ignore span timestamps

### DIFF
--- a/.chloggen/pdatatest-ignore-span-timestamps.yaml
+++ b/.chloggen/pdatatest-ignore-span-timestamps.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/pdatatest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "support ignore timestamps in span comparisons for pdatatest"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27688]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/pdatatest/README.md
+++ b/pkg/pdatatest/README.md
@@ -24,7 +24,7 @@ func TestMetricsScraper(t *testing.T) {
 	require.NoError(err)
 
 	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreStartTimestamp(), 
-		pmetrictest.IgnoreTimestamp()))))
+		pmetrictest.IgnoreTimestamp()))
 }
 ```
 
@@ -59,6 +59,7 @@ func TestTraceProcessor(t *testing.T) {
 	expectedTraces, err := readTraces(filepath.Join("testdata", "traces", "expected.json"))
 	require.NoError(t, err)
 	
-	require.NoError(t, ptracetest.CompareTraces(expectedTraces, actualTraces))
+	require.NoError(t, ptracetest.CompareTraces(expectedTraces, actualTraces, ptracetest.IgnoreStartTimestamp(), 
+		ptracetest.IgnoreEndTimestamp()))
 }
 ```

--- a/pkg/pdatatest/ptracetest/testdata/ignore-end-timestamp/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-end-timestamp/actual.yaml
@@ -1,0 +1,22 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: node1
+    scopeSpans:
+      - scope:
+          name: collector
+          version: v0.1.0
+        spans:
+          - attributes:
+              - key: key1
+                value:
+                  stringValue: value1
+            name: span1
+            parentSpanId: ""
+            spanId: fd0da883bb27cd6b
+            endTimeUnixNano: "11651379494838206464"
+            status: {}
+            traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
+

--- a/pkg/pdatatest/ptracetest/testdata/ignore-end-timestamp/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-end-timestamp/expected.yaml
@@ -1,0 +1,20 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: node1
+    scopeSpans:
+      - scope:
+          name: collector
+          version: v0.1.0
+        spans:
+          - attributes:
+              - key: key1
+                value:
+                  stringValue: value1
+            name: span1
+            parentSpanId: ""
+            spanId: fd0da883bb27cd6b
+            status: {}
+            traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/ignore-start-timestamp/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-start-timestamp/actual.yaml
@@ -1,0 +1,22 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: node1
+    scopeSpans:
+      - scope:
+          name: collector
+          version: v0.1.0
+        spans:
+          - attributes:
+              - key: key1
+                value:
+                  stringValue: value1
+            name: span1
+            parentSpanId: ""
+            spanId: fd0da883bb27cd6b
+            startTimeUnixNano: "11651379494838206464"
+            status: {}
+            traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
+

--- a/pkg/pdatatest/ptracetest/testdata/ignore-start-timestamp/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-start-timestamp/expected.yaml
@@ -1,0 +1,20 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: node1
+    scopeSpans:
+      - scope:
+          name: collector
+          version: v0.1.0
+        spans:
+          - attributes:
+              - key: key1
+                value:
+                  stringValue: value1
+            name: span1
+            parentSpanId: ""
+            spanId: fd0da883bb27cd6b
+            status: {}
+            traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/traces_test.go
+++ b/pkg/pdatatest/ptracetest/traces_test.go
@@ -49,6 +49,26 @@ func TestCompareTraces(t *testing.T) {
 			withOptions: nil,
 		},
 		{
+			name: "ignore-start-timestamp",
+			compareOptions: []CompareTracesOption{
+				IgnoreStartTimestamp(),
+			},
+			withoutOptions: multierr.Combine(
+				errors.New("resource \"map[host.name:node1]\": scope \"collector\": span \"span1\": start timestamp doesn't match expected: 11651379494838206464, actual: 0"),
+			),
+			withOptions: nil,
+		},
+		{
+			name: "ignore-end-timestamp",
+			compareOptions: []CompareTracesOption{
+				IgnoreEndTimestamp(),
+			},
+			withoutOptions: multierr.Combine(
+				errors.New("resource \"map[host.name:node1]\": scope \"collector\": span \"span1\": end timestamp doesn't match expected: 11651379494838206464, actual: 0"),
+			),
+			withOptions: nil,
+		},
+		{
 			name: "resourcespans-amount-unequal",
 			withoutOptions: multierr.Combine(
 				errors.New("number of resources doesn't match expected: 1, actual: 2"),


### PR DESCRIPTION
**Description:** 
Support ignore timestamps in span comparisons for pdatatest.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27688

**Testing:**
make chlog-validate
go test for pkg/pdatatest

**Documentation:**
Add usage for `ptracetest.IgnoreStartTimestamp()` and `ptracetest.IgnoreEndTimestamp()`