### PR TITLE
[chore] Reuse the JSON writer to reduce memory allocations

### DIFF
--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -205,7 +205,9 @@ func (c *client) fillLogsBuffer(logs plog.Logs, buf buffer, is iterState) (iterS
 				var err error
 				var l int
 				if c.config.ExportRaw {
-					_, err = buf.Write([]byte(logRecord.Body().AsString() + "\n"))
+					b := []byte(logRecord.Body().AsString() + "\n")
+					l = len(b)
+					_, err = buf.Write(b)
 				} else {
 					// Parsing log record to Splunk event.
 					event := mapLogRecordToSplunkEvent(rl.Resource(), logRecord, c.config)

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -244,6 +244,8 @@ func (c *client) fillLogsBuffer(logs plog.Logs, buf buffer, is iterState) (iterS
 							" content length %d bytes", l, c.config.MaxContentLengthLogs)))
 					return iterState{i, j, k + 1, false}, permanentErrors
 				}
+				// flush exited before resetting the buffer of the stream.
+				jsonStream.Reset(buf)
 				permanentErrors = append(permanentErrors,
 					consumererror.NewPermanent(fmt.Errorf("error writing the event: %w", err)))
 			}
@@ -299,6 +301,8 @@ func (c *client) fillMetricsBuffer(metrics pmetric.Metrics, buf buffer, is iterS
 							" content length %d bytes", jsonStream.Buffered(), c.config.MaxContentLengthMetrics)))
 					return iterState{i, j, k + 1, false}, permanentErrors
 				}
+				// flush exited before resetting the buffer of the stream.
+				jsonStream.Reset(buf)
 				permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf(
 					"error writing the event: %w", err)))
 			}
@@ -345,6 +349,8 @@ func (c *client) fillMetricsBufferMultiMetrics(events []*splunk.Event, buf buffe
 				done:   i+1 != len(events),
 			}, permanentErrors
 		} else if err != nil {
+			// flush exited before resetting the buffer of the stream.
+			jsonStream.Reset(buf)
 			permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf(
 				"error writing the event: %w", err)))
 		}
@@ -398,6 +404,8 @@ func (c *client) fillTracesBuffer(traces ptrace.Traces, buf buffer, is iterState
 							" content length %d bytes", l, c.config.MaxContentLengthTraces)))
 					return iterState{i, j, k + 1, false}, permanentErrors
 				}
+				// flush exited before resetting the buffer of the stream.
+				jsonStream.Reset(buf)
 				permanentErrors = append(permanentErrors, consumererror.NewPermanent(fmt.Errorf(
 					"error writing the event: %w", err)))
 			}


### PR DESCRIPTION
**Description:**
Reuse the JSON writer to reduce memory allocations.

Before:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_10_10_1024-10                              	   10000	    103345 ns/op	   84927 B/op	    1284 allocs/op
Benchmark_pushLogData_10_10_8K-10                                	   13250	     92038 ns/op	   74039 B/op	    1119 allocs/op
Benchmark_pushLogData_10_10_2M-10                                	   13197	    102655 ns/op	   73368 B/op	    1108 allocs/op
Benchmark_pushLogData_10_200_2M-10                               	     583	   2541275 ns/op	 1463425 B/op	   22010 allocs/op
Benchmark_pushLogData_100_200_2M-10                              	      50	  22397368 ns/op	14689552 B/op	  220023 allocs/op
Benchmark_pushLogData_100_200_5M-10                              	      60	  18596351 ns/op	14772413 B/op	  220012 allocs/op
Benchmark_pushLogData_compressed_10_10_1024-10                   	    1538	    822484 ns/op	 3094845 B/op	    1193 allocs/op
Benchmark_pushLogData_compressed_10_10_8K-10                     	    6994	    170453 ns/op	   74456 B/op	    1108 allocs/op
Benchmark_pushLogData_compressed_10_10_2M-10                     	    7093	    168615 ns/op	   75014 B/op	    1108 allocs/op
Benchmark_pushLogData_compressed_10_200_2M-10                    	     318	   4039126 ns/op	 1463162 B/op	   22010 allocs/op
Benchmark_pushLogData_compressed_100_200_2M-10                   	      30	  38298960 ns/op	14598973 B/op	  220013 allocs/op
Benchmark_pushLogData_compressed_100_200_5M-10                   	      31	  37906039 ns/op	14632622 B/op	  220014 allocs/op
Benchmark_pushMetricData_10_10_1024-10                           	    8258	    143186 ns/op	   87274 B/op	    1809 allocs/op
Benchmark_pushMetricData_10_10_8K-10                             	    8313	    143058 ns/op	   94391 B/op	    1809 allocs/op
Benchmark_pushMetricData_10_10_2M-10                             	    3847	    297034 ns/op	 2184510 B/op	    1811 allocs/op
Benchmark_pushMetricData_10_200_2M-10                            	     386	   3110010 ns/op	 3819866 B/op	   36012 allocs/op
Benchmark_pushMetricData_100_200_2M-10                           	      39	  27988575 ns/op	21426443 B/op	  360033 allocs/op
Benchmark_pushMetricData_100_200_5M-10                           	      38	  28556510 ns/op	27720714 B/op	  360033 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024-10                	    3856	    316465 ns/op	   87768 B/op	    1809 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K-10                  	    3834	    310117 ns/op	   95164 B/op	    1809 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M-10                  	    2533	    473056 ns/op	 2184790 B/op	    1811 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M-10                 	     177	   6769034 ns/op	 3816397 B/op	   36012 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M-10                	      16	  66072646 ns/op	19304013 B/op	  360015 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M-10                	      16	  65443443 ns/op	22449759 B/op	  360015 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric-10               	    3428	    346697 ns/op	  249373 B/op	    3933 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric-10                 	    3471	    356307 ns/op	  249435 B/op	    3933 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric-10                 	    3379	    351554 ns/op	  249395 B/op	    3933 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric-10                	     158	   7598616 ns/op	 4999391 B/op	   78080 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric-10               	      15	  69891719 ns/op	49880953 B/op	  780370 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric-10               	      15	  70634606 ns/op	49880658 B/op	  780368 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-10    	    2259	    523601 ns/op	  249858 B/op	    3934 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-10      	    2305	    531849 ns/op	  250211 B/op	    3934 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-10      	    2254	    531783 ns/op	  251329 B/op	    3934 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-10     	     100	  10937742 ns/op	 5003291 B/op	   78079 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-10    	      10	 106384971 ns/op	49735016 B/op	  780363 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-10    	      10	 104325350 ns/op	49735675 B/op	  780366 allocs/op
BenchmarkConsumeLogsRejected-10                                  	    1252	    955186 ns/op	  731172 B/op	   11010 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter	51.168s
```

After:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_10_10_1024-10                              	   10000	    111112 ns/op	   84927 B/op	    1284 allocs/op
Benchmark_pushLogData_10_10_8K-10                                	   12582	    107567 ns/op	   74043 B/op	    1119 allocs/op
Benchmark_pushLogData_10_10_2M-10                                	   13700	     88075 ns/op	   73415 B/op	    1108 allocs/op
Benchmark_pushLogData_10_200_2M-10                               	     615	   1937167 ns/op	 1464525 B/op	   22011 allocs/op
Benchmark_pushLogData_100_200_2M-10                              	      69	  17182284 ns/op	14655076 B/op	  220024 allocs/op
Benchmark_pushLogData_100_200_5M-10                              	      68	  17121173 ns/op	14747820 B/op	  220012 allocs/op
Benchmark_pushLogData_compressed_10_10_1024-10                   	    1636	    720671 ns/op	 3091384 B/op	    1193 allocs/op
Benchmark_pushLogData_compressed_10_10_8K-10                     	    7143	    164802 ns/op	   73743 B/op	    1108 allocs/op
Benchmark_pushLogData_compressed_10_10_2M-10                     	    6962	    169979 ns/op	   74930 B/op	    1108 allocs/op
Benchmark_pushLogData_compressed_10_200_2M-10                    	     318	   3751716 ns/op	 1463196 B/op	   22010 allocs/op
Benchmark_pushLogData_compressed_100_200_2M-10                   	      31	  36127392 ns/op	14597840 B/op	  220013 allocs/op
Benchmark_pushLogData_compressed_100_200_5M-10                   	      30	  35860571 ns/op	14598989 B/op	  220013 allocs/op
Benchmark_pushMetricData_10_10_1024-10                           	    8790	    139671 ns/op	   87286 B/op	    1809 allocs/op
Benchmark_pushMetricData_10_10_8K-10                             	    8169	    139654 ns/op	   94466 B/op	    1809 allocs/op
Benchmark_pushMetricData_10_10_2M-10                             	    3931	    284921 ns/op	 2184493 B/op	    1811 allocs/op
Benchmark_pushMetricData_10_200_2M-10                            	     385	   3131991 ns/op	 3817129 B/op	   36012 allocs/op
Benchmark_pushMetricData_100_200_2M-10                           	      39	  28169780 ns/op	21533982 B/op	  360034 allocs/op
Benchmark_pushMetricData_100_200_5M-10                           	      39	  28191500 ns/op	27718050 B/op	  360034 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024-10                	    3963	    306657 ns/op	   88580 B/op	    1809 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K-10                  	    3735	    302249 ns/op	   94747 B/op	    1809 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M-10                  	    2466	    475208 ns/op	 2184798 B/op	    1811 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M-10                 	     178	   6623120 ns/op	 3821338 B/op	   36012 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M-10                	      16	  64403557 ns/op	19304047 B/op	  360015 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M-10                	      16	  64579711 ns/op	22449794 B/op	  360016 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric-10               	    3646	    343760 ns/op	  249384 B/op	    3933 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric-10                 	    3447	    348482 ns/op	  249448 B/op	    3933 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric-10                 	    3492	    345359 ns/op	  249432 B/op	    3933 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric-10                	     162	   7430610 ns/op	 4992726 B/op	   78081 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric-10               	      15	  67610550 ns/op	49882049 B/op	  780379 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric-10               	      15	  70016447 ns/op	49880412 B/op	  780367 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-10    	    2228	    547145 ns/op	  250222 B/op	    3934 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-10      	    2173	    579938 ns/op	  251366 B/op	    3934 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-10      	    2210	    522095 ns/op	  249878 B/op	    3934 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-10     	     100	  10844267 ns/op	 5003147 B/op	   78079 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-10    	      10	 102839467 ns/op	49736016 B/op	  780374 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-10    	      10	 103594588 ns/op	49735281 B/op	  780368 allocs/op
BenchmarkConsumeLogsRejected-10                                  	    1220	    962220 ns/op	  732174 B/op	   11010 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter	50.874s
```

Benchstat:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
                                                     │  before.txt   │               after.txt               │
                                                     │    sec/op     │    sec/op      vs base                │
_pushLogData_10_10_1024-10                              103.3µ ± ∞ ¹    111.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                                92.04µ ± ∞ ¹   107.57µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-10                               102.66µ ± ∞ ¹    88.08µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-10                               2.541m ± ∞ ¹    1.937m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-10                              22.40m ± ∞ ¹    17.18m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-10                              18.60m ± ∞ ¹    17.12m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-10                   822.5µ ± ∞ ¹    720.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-10                     170.5µ ± ∞ ¹    164.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-10                     168.6µ ± ∞ ¹    170.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-10                    4.039m ± ∞ ¹    3.752m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-10                   38.30m ± ∞ ¹    36.13m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-10                   37.91m ± ∞ ¹    35.86m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-10                           143.2µ ± ∞ ¹    139.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-10                             143.1µ ± ∞ ¹    139.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-10                             297.0µ ± ∞ ¹    284.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-10                            3.110m ± ∞ ¹    3.132m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-10                           27.99m ± ∞ ¹    28.17m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-10                           28.56m ± ∞ ¹    28.19m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-10                316.5µ ± ∞ ¹    306.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-10                  310.1µ ± ∞ ¹    302.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-10                  473.1µ ± ∞ ¹    475.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-10                 6.769m ± ∞ ¹    6.623m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-10                66.07m ± ∞ ¹    64.40m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-10                65.44m ± ∞ ¹    64.58m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-10               346.7µ ± ∞ ¹    343.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-10                 356.3µ ± ∞ ¹    348.5µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-10                 351.6µ ± ∞ ¹    345.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-10                7.599m ± ∞ ¹    7.431m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-10               69.89m ± ∞ ¹    67.61m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-10               70.63m ± ∞ ¹    70.02m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-10    523.6µ ± ∞ ¹    547.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-10      531.8µ ± ∞ ¹    579.9µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-10      531.8µ ± ∞ ¹    522.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-10     10.94m ± ∞ ¹    10.84m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-10    106.4m ± ∞ ¹    102.8m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-10    104.3m ± ∞ ¹    103.6m ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeLogsRejected-10                                  955.2µ ± ∞ ¹    962.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                 2.377m          2.306m        -3.02%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │  before.txt   │               after.txt               │
                                                     │     B/op      │     B/op       vs base                │
_pushLogData_10_10_1024-10                             82.94Ki ± ∞ ¹   82.94Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                               72.30Ki ± ∞ ¹   72.31Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_10_10_2M-10                               71.65Ki ± ∞ ¹   71.69Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_10_200_2M-10                              1.396Mi ± ∞ ¹   1.397Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_2M-10                             14.01Mi ± ∞ ¹   13.98Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_5M-10                             14.09Mi ± ∞ ¹   14.06Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_10_10_1024-10                  2.951Mi ± ∞ ¹   2.948Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_10_10_8K-10                    72.71Ki ± ∞ ¹   72.01Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_10_10_2M-10                    73.26Ki ± ∞ ¹   73.17Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_10_200_2M-10                   1.395Mi ± ∞ ¹   1.395Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_100_200_2M-10                  13.92Mi ± ∞ ¹   13.92Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_compressed_100_200_5M-10                  13.95Mi ± ∞ ¹   13.92Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_1024-10                          85.23Ki ± ∞ ¹   85.24Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_8K-10                            92.18Ki ± ∞ ¹   92.25Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_2M-10                            2.083Mi ± ∞ ¹   2.083Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_200_2M-10                           3.643Mi ± ∞ ¹   3.640Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_2M-10                          20.43Mi ± ∞ ¹   20.54Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M-10                          26.44Mi ± ∞ ¹   26.43Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024-10               85.71Ki ± ∞ ¹   86.50Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_8K-10                 92.93Ki ± ∞ ¹   92.53Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_2M-10                 2.084Mi ± ∞ ¹   2.084Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_200_2M-10                3.640Mi ± ∞ ¹   3.644Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_2M-10               18.41Mi ± ∞ ¹   18.41Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_5M-10               21.41Mi ± ∞ ¹   21.41Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_1024_MultiMetric-10              243.5Ki ± ∞ ¹   243.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_8K_MultiMetric-10                243.6Ki ± ∞ ¹   243.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_2M_MultiMetric-10                243.5Ki ± ∞ ¹   243.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_200_2M_MultiMetric-10               4.768Mi ± ∞ ¹   4.761Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_2M_MultiMetric-10              47.57Mi ± ∞ ¹   47.57Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M_MultiMetric-10              47.57Mi ± ∞ ¹   47.57Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024_MultiMetric-10   244.0Ki ± ∞ ¹   244.4Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_8K_MultiMetric-10     244.3Ki ± ∞ ¹   245.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_2M_MultiMetric-10     245.4Ki ± ∞ ¹   244.0Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_200_2M_MultiMetric-10    4.772Mi ± ∞ ¹   4.771Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_2M_MultiMetric-10   47.43Mi ± ∞ ¹   47.43Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_5M_MultiMetric-10   47.43Mi ± ∞ ¹   47.43Mi ± ∞ ¹       ~ (p=1.000 n=1) ³
ConsumeLogsRejected-10                                 714.0Ki ± ∞ ¹   715.0Ki ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                                1.514Mi         1.514Mi        -0.01%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05

                                                     │  before.txt  │              after.txt               │
                                                     │  allocs/op   │  allocs/op    vs base                │
_pushLogData_10_10_1024-10                             1.284k ± ∞ ¹   1.284k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                               1.119k ± ∞ ¹   1.119k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-10                               1.108k ± ∞ ¹   1.108k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-10                              22.01k ± ∞ ¹   22.01k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_2M-10                             220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_5M-10                             220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-10                  1.193k ± ∞ ¹   1.193k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-10                    1.108k ± ∞ ¹   1.108k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-10                    1.108k ± ∞ ¹   1.108k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-10                   22.01k ± ∞ ¹   22.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-10                  220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-10                  220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_1024-10                          1.809k ± ∞ ¹   1.809k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-10                            1.809k ± ∞ ¹   1.809k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-10                            1.811k ± ∞ ¹   1.811k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-10                           36.01k ± ∞ ¹   36.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-10                          360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M-10                          360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024-10               1.809k ± ∞ ¹   1.809k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-10                 1.809k ± ∞ ¹   1.809k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-10                 1.811k ± ∞ ¹   1.811k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-10                36.01k ± ∞ ¹   36.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-10               360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-10               360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_10_10_1024_MultiMetric-10              3.933k ± ∞ ¹   3.933k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-10                3.933k ± ∞ ¹   3.933k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-10                3.933k ± ∞ ¹   3.933k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-10               78.08k ± ∞ ¹   78.08k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_2M_MultiMetric-10              780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M_MultiMetric-10              780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024_MultiMetric-10   3.934k ± ∞ ¹   3.934k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-10     3.934k ± ∞ ¹   3.934k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-10     3.934k ± ∞ ¹   3.934k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-10    78.08k ± ∞ ¹   78.08k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-10   780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_5M_MultiMetric-10   780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
ConsumeLogsRejected-10                                 11.01k ± ∞ ¹   11.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                18.95k         18.95k        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
```