### PR TITLE
[Spanmetrics] Add events_total metric to get the measurement for list of configured event attributes for a span

### DIFF
--- a/.chloggen/events-metric-to-span-metrics.yaml
+++ b/.chloggen/events-metric-to-span-metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: spanmetricsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add Events metric to span metrics connector that adds list of event attributes as dimensions
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27451]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -102,6 +102,9 @@ The following settings can be optionally configured:
 - `metrics_flush_interval` (default: `15s`): Defines the flush interval of the generated metrics.
 - `exemplars`:  Use to configure how to attach exemplars to histograms
   - `enabled` (default: `false`): enabling will add spans as Exemplars.
+- `events`: Use to configure if events metric should be enabled. events_total metric can be configured when you want to get the metrics for different attributes configured as Events for a span.
+  - `enabled`: (default: `false`): enabling will add events metric
+  - `dimensions`: the list of event attributes for a span that needs to be added as dimensions to events metric 
 
 ## Examples
 
@@ -132,7 +135,12 @@ connectors:
     exclude_dimensions: ['status.code']
     dimensions_cache_size: 1000
     aggregation_temporality: "AGGREGATION_TEMPORALITY_CUMULATIVE"    
-    metrics_flush_interval: 15s 
+    metrics_flush_interval: 15s
+    events:
+      enabled: true
+      dimensions:
+        - name: exception.type
+        - name: exception.message
 
 service:
   pipelines:

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -102,9 +102,9 @@ The following settings can be optionally configured:
 - `metrics_flush_interval` (default: `15s`): Defines the flush interval of the generated metrics.
 - `exemplars`:  Use to configure how to attach exemplars to histograms
   - `enabled` (default: `false`): enabling will add spans as Exemplars.
-- `events`: Use to configure if events metric should be enabled. events_total metric can be configured when you want to get the metrics for different attributes configured as Events for a span.
-  - `enabled`: (default: `false`): enabling will add events metric
-  - `dimensions`: the list of event attributes for a span that needs to be added as dimensions to events metric 
+- `events`: Use to configure the events metric.
+  - `enabled`: (default: `false`): enabling will add the events metric.
+  - `dimensions`: (mandatory if `enabled`) the list of the span's event attributes to add as dimensions to the events metric, which will be included _on top of_ the common and configured `dimensions` for span and resource attributes.
 
 ## Examples
 

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -60,7 +60,7 @@ type Config struct {
 	Exemplars ExemplarsConfig `mapstructure:"exemplars"`
 
 	// Events defines the configuration for events section of spans.
-	Events Event `mapstructure:"events"`
+	Events EventsConfig `mapstructure:"events"`
 }
 
 type HistogramConfig struct {

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -151,6 +151,5 @@ func validateEventDimensions(enabled bool, dimensions []Dimension) error {
 	if len(dimensions) == 0 {
 		return fmt.Errorf("no dimensions configured for events")
 	}
-	err := validateDimensions(dimensions)
-	return err
+	return validateDimensions(dimensions)
 }

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -58,6 +58,9 @@ type Config struct {
 
 	// Exemplars defines the configuration for exemplars.
 	Exemplars ExemplarsConfig `mapstructure:"exemplars"`
+
+	// Events defines the configuration for events section of spans.
+	Events Event `mapstructure:"events"`
 }
 
 type HistogramConfig struct {
@@ -78,6 +81,13 @@ type ExponentialHistogramConfig struct {
 type ExplicitHistogramConfig struct {
 	// Buckets is the list of durations representing explicit histogram buckets.
 	Buckets []time.Duration `mapstructure:"buckets"`
+}
+
+type Event struct {
+	// Enabled is a flag to enable events.
+	Enabled bool `mapstructure:"enabled"`
+	// Dimensions defines the list of dimensions to be added to events metric
+	Dimensions []Dimension `mapstructure:"dimensions"`
 }
 
 var _ component.ConfigValidator = (*Config)(nil)

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -98,9 +98,8 @@ func (c Config) Validate() error {
 	if err != nil {
 		return err
 	}
-	err = validateEventDimensions(c.Events.Enabled, c.Events.Dimensions)
-	if err != nil {
-		return err
+	if err = validateEventDimensions(c.Events.Enabled, c.Events.Dimensions); err != nil {
+		return fmt.Errorf("failed validating event dimensions: %w", err)
 	}
 
 	if c.DimensionsCacheSize <= 0 {

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -98,6 +98,10 @@ func (c Config) Validate() error {
 	if err != nil {
 		return err
 	}
+	err = validateEventDimensions(c.Events.Enabled, c.Events.Dimensions)
+	if err != nil {
+		return err
+	}
 
 	if c.DimensionsCacheSize <= 0 {
 		return fmt.Errorf(
@@ -110,10 +114,6 @@ func (c Config) Validate() error {
 		return errors.New("use either `explicit` or `exponential` buckets histogram")
 	}
 
-	err = validateEventDimensions(c.Events.Dimensions)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -144,7 +144,10 @@ func validateDimensions(dimensions []Dimension) error {
 }
 
 // validateEventDimensions checks for empty and duplicates for the dimensions configured.
-func validateEventDimensions(dimensions []Dimension) error {
+func validateEventDimensions(enabled bool, dimensions []Dimension) error {
+	if !enabled {
+		return nil
+	}
 	if len(dimensions) == 0 {
 		return fmt.Errorf("no dimensions configured for events")
 	}

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -86,7 +86,7 @@ type ExplicitHistogramConfig struct {
 type Event struct {
 	// Enabled is a flag to enable events.
 	Enabled bool `mapstructure:"enabled"`
-	// Dimensions defines the list of dimensions to be added to events metric
+	// Dimensions defines the list of dimensions to add to the events metric.
 	Dimensions []Dimension `mapstructure:"dimensions"`
 }
 

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -83,7 +83,7 @@ type ExplicitHistogramConfig struct {
 	Buckets []time.Duration `mapstructure:"buckets"`
 }
 
-type Event struct {
+type EventsConfig struct {
 	// Enabled is a flag to enable events.
 	Enabled bool `mapstructure:"enabled"`
 	// Dimensions defines the list of dimensions to add to the events metric.
@@ -108,6 +108,11 @@ func (c Config) Validate() error {
 
 	if c.Histogram.Explicit != nil && c.Histogram.Exponential != nil {
 		return errors.New("use either `explicit` or `exponential` buckets histogram")
+	}
+
+	err = validateEventDimensions(c.Events.Dimensions)
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -136,4 +141,13 @@ func validateDimensions(dimensions []Dimension) error {
 	}
 
 	return nil
+}
+
+// validateEventDimensions checks for empty and duplicates for the dimensions configured.
+func validateEventDimensions(dimensions []Dimension) error {
+	if len(dimensions) == 0 {
+		return fmt.Errorf("no dimensions configured for events")
+	}
+	err := validateDimensions(dimensions)
+	return err
 }

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -94,11 +94,10 @@ var _ component.ConfigValidator = (*Config)(nil)
 
 // Validate checks if the processor configuration is valid
 func (c Config) Validate() error {
-	err := validateDimensions(c.Dimensions)
-	if err != nil {
-		return err
+	if err := validateDimensions(c.Dimensions); err != nil {
+		return fmt.Errorf("failed validating dimensions: %w", err)
 	}
-	if err = validateEventDimensions(c.Events.Enabled, c.Events.Dimensions); err != nil {
+	if err := validateEventDimensions(c.Events.Enabled, c.Events.Dimensions); err != nil {
 		return fmt.Errorf("failed validating event dimensions: %w", err)
 	}
 

--- a/connector/spanmetricsconnector/config_test.go
+++ b/connector/spanmetricsconnector/config_test.go
@@ -171,3 +171,47 @@ func TestValidateDimensions(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateEventDimensions(t *testing.T) {
+	for _, tc := range []struct {
+		enabled     bool
+		name        string
+		dimensions  []Dimension
+		expectedErr string
+	}{
+		{
+			enabled:    false,
+			name:       "disabled - no additional dimensions",
+			dimensions: []Dimension{},
+		},
+		{
+			enabled:     true,
+			name:        "enabled - no additional dimensions",
+			dimensions:  []Dimension{},
+			expectedErr: "no dimensions configured for events",
+		},
+		{
+			enabled:    true,
+			name:       "enabled - no duplicate dimensions",
+			dimensions: []Dimension{{Name: "exception_type"}},
+		},
+		{
+			enabled: true,
+			name:    "enabled - duplicate dimensions",
+			dimensions: []Dimension{
+				{Name: "exception_type"},
+				{Name: "exception_type"},
+			},
+			expectedErr: "duplicate dimension name exception_type",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateEventDimensions(tc.enabled, tc.dimensions)
+			if tc.expectedErr != "" {
+				assert.EqualError(t, err, tc.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -71,7 +71,7 @@ type connectorImp struct {
 	// Event dimensions to add to the events metric.
 	eDimensions []dimension
 
-	events Event
+	events EventsConfig
 }
 
 type resourceMetrics struct {
@@ -256,7 +256,7 @@ func (p *connectorImp) buildMetrics() pmetric.Metrics {
 		}
 
 		events := rawMetrics.events
-		if p.events.Enabled && len(p.events.Dimensions) > 0 {
+		if p.events.Enabled {
 			metric = sm.Metrics().AppendEmpty()
 			metric.SetName(buildMetricName(p.config.Namespace, metricNameEvents))
 			events.BuildMetrics(metric, p.startTimestamp, p.config.GetAggregationTemporality())
@@ -340,7 +340,7 @@ func (p *connectorImp) aggregateMetrics(traces ptrace.Traces) {
 				s.Add(1)
 
 				// aggregate events metrics
-				if p.events.Enabled && len(p.events.Dimensions) > 0 {
+				if p.events.Enabled {
 					for l := 0; l < span.Events().Len(); l++ {
 						event := span.Events().At(l)
 						eDimensions := p.dimensions

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -256,7 +256,7 @@ func (p *connectorImp) buildMetrics() pmetric.Metrics {
 		}
 
 		events := rawMetrics.events
-		if p.events.Enabled {
+		if p.events.Enabled && len(p.events.Dimensions) > 0 {
 			metric = sm.Metrics().AppendEmpty()
 			metric.SetName(buildMetricName(p.config.Namespace, metricNameEvents))
 			events.BuildMetrics(metric, p.startTimestamp, p.config.GetAggregationTemporality())
@@ -340,7 +340,7 @@ func (p *connectorImp) aggregateMetrics(traces ptrace.Traces) {
 				s.Add(1)
 
 				// aggregate events metrics
-				if p.events.Enabled {
+				if p.events.Enabled && len(p.events.Dimensions) > 0 {
 					for l := 0; l < span.Events().Len(); l++ {
 						event := span.Events().At(l)
 						eDimensions := p.dimensions

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -343,7 +343,8 @@ func (p *connectorImp) aggregateMetrics(traces ptrace.Traces) {
 				if p.events.Enabled {
 					for l := 0; l < span.Events().Len(); l++ {
 						event := span.Events().At(l)
-						eDimensions := append(p.dimensions, p.eDimensions...)
+						eDimensions := p.dimensions
+						eDimensions = append(eDimensions, p.eDimensions...)
 
 						rscAndEventAttrs := pcommon.NewMap()
 						rscAndEventAttrs.EnsureCapacity(resourceAttr.Len() + event.Attributes().Len())

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -68,7 +68,7 @@ type connectorImp struct {
 
 	shutdownOnce sync.Once
 
-	// Addition event dimensions to add to events metric
+	// Event dimensions to add to the events metric.
 	eDimensions []dimension
 
 	events Event

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -586,7 +586,7 @@ func TestConcurrentShutdown(t *testing.T) {
 	ticker := mockClock.NewTicker(time.Nanosecond)
 
 	// Test
-	p := newConnectorImp(t, new(consumertest.MetricsSink), nil, explicitHistogramsConfig, disabledExemplarsConfig, Event{}, cumulative, logger, ticker)
+	p := newConnectorImp(t, new(consumertest.MetricsSink), nil, explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, logger, ticker)
 	err := p.Start(ctx, componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -666,7 +666,7 @@ func TestConsumeMetricsErrors(t *testing.T) {
 	}
 	mockClock := clock.NewMock(time.Now())
 	ticker := mockClock.NewTicker(time.Nanosecond)
-	p := newConnectorImp(t, mcon, nil, explicitHistogramsConfig, disabledExemplarsConfig, Event{}, cumulative, logger, ticker)
+	p := newConnectorImp(t, mcon, nil, explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, logger, ticker)
 
 	ctx := metadata.NewIncomingContext(context.Background(), nil)
 	err := p.Start(ctx, componenttest.NewNopHost())
@@ -828,7 +828,7 @@ func TestConsumeTraces(t *testing.T) {
 			mockClock := clock.NewMock(time.Now())
 			ticker := mockClock.NewTicker(time.Nanosecond)
 
-			p := newConnectorImp(t, mcon, stringp("defaultNullValue"), tc.histogramConfig, tc.exemplarConfig, Event{}, tc.aggregationTemporality, zaptest.NewLogger(t), ticker)
+			p := newConnectorImp(t, mcon, stringp("defaultNullValue"), tc.histogramConfig, tc.exemplarConfig, EventsConfig{}, tc.aggregationTemporality, zaptest.NewLogger(t), ticker)
 
 			ctx := metadata.NewIncomingContext(context.Background(), nil)
 			err := p.Start(ctx, componenttest.NewNopHost())
@@ -854,7 +854,7 @@ func TestConsumeTraces(t *testing.T) {
 func TestMetricKeyCache(t *testing.T) {
 	mcon := consumertest.NewNop()
 
-	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, Event{}, cumulative, zaptest.NewLogger(t), nil)
+	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, zaptest.NewLogger(t), nil)
 	traces := buildSampleTrace()
 
 	// Test
@@ -885,7 +885,7 @@ func BenchmarkConnectorConsumeTraces(b *testing.B) {
 	// Prepare
 	mcon := consumertest.NewNop()
 
-	conn := newConnectorImp(nil, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, Event{}, cumulative, zaptest.NewLogger(b), nil)
+	conn := newConnectorImp(nil, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, zaptest.NewLogger(b), nil)
 
 	traces := buildSampleTrace()
 
@@ -899,7 +899,7 @@ func BenchmarkConnectorConsumeTraces(b *testing.B) {
 func TestExcludeDimensionsConsumeTraces(t *testing.T) {
 	mcon := consumertest.NewNop()
 	excludeDimensions := []string{"span.kind", "span.name", "totallyWrongNameDoesNotAffectAnything"}
-	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, Event{}, cumulative, zaptest.NewLogger(t), nil, excludeDimensions...)
+	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, zaptest.NewLogger(t), nil, excludeDimensions...)
 	traces := buildSampleTrace()
 
 	// Test
@@ -948,7 +948,7 @@ func TestExcludeDimensionsConsumeTraces(t *testing.T) {
 
 }
 
-func newConnectorImp(t *testing.T, mcon consumer.Metrics, defaultNullValue *string, histogramConfig func() HistogramConfig, exemplarsConfig func() ExemplarsConfig, eventsConfig Event, temporality string, logger *zap.Logger, ticker *clock.Ticker, excludedDimensions ...string) *connectorImp {
+func newConnectorImp(t *testing.T, mcon consumer.Metrics, defaultNullValue *string, histogramConfig func() HistogramConfig, exemplarsConfig func() ExemplarsConfig, eventsConfig EventsConfig, temporality string, logger *zap.Logger, ticker *clock.Ticker, excludedDimensions ...string) *connectorImp {
 
 	cfg := &Config{
 		AggregationTemporality: temporality,
@@ -1067,7 +1067,7 @@ func TestConnectorConsumeTracesEvictedCacheKey(t *testing.T) {
 	ticker := mockClock.NewTicker(time.Nanosecond)
 
 	// Note: default dimension key cache size is 2.
-	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, Event{}, cumulative, zaptest.NewLogger(t), ticker)
+	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, zaptest.NewLogger(t), ticker)
 
 	ctx := metadata.NewIncomingContext(context.Background(), nil)
 	err := p.Start(ctx, componenttest.NewNopHost())
@@ -1269,22 +1269,22 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 func TestSpanMetrics_Events(t *testing.T) {
 	tests := []struct {
 		name                   string
-		eventsConfig           Event
+		eventsConfig           EventsConfig
 		shouldEventMetricExist bool
 	}{
 		{
 			name:                   "events disabled",
-			eventsConfig:           Event{Enabled: false, Dimensions: []Dimension{{Name: "exception.type", Default: stringp("NullPointerException")}}},
+			eventsConfig:           EventsConfig{Enabled: false, Dimensions: []Dimension{{Name: "exception.type", Default: stringp("NullPointerException")}}},
 			shouldEventMetricExist: false,
 		},
 		{
 			name:                   "events without dimensions",
-			eventsConfig:           Event{Enabled: true, Dimensions: []Dimension{}},
+			eventsConfig:           EventsConfig{Enabled: true, Dimensions: []Dimension{}},
 			shouldEventMetricExist: false,
 		},
 		{
 			name:                   "events with dimensions",
-			eventsConfig:           Event{Enabled: true, Dimensions: []Dimension{{Name: "exception.type", Default: stringp("NullPointerException")}}},
+			eventsConfig:           EventsConfig{Enabled: true, Dimensions: []Dimension{{Name: "exception.type", Default: stringp("NullPointerException")}}},
 			shouldEventMetricExist: true,
 		},
 	}

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -1268,24 +1268,24 @@ func TestConnector_initHistogramMetrics(t *testing.T) {
 
 func TestSpanMetrics_Events(t *testing.T) {
 	tests := []struct {
-		name                   string
-		eventsConfig           EventsConfig
-		shouldEventMetricExist bool
+		name                    string
+		eventsConfig            EventsConfig
+		shouldEventsMetricExist bool
 	}{
 		{
-			name:                   "events disabled",
-			eventsConfig:           EventsConfig{Enabled: false, Dimensions: []Dimension{{Name: "exception.type", Default: stringp("NullPointerException")}}},
-			shouldEventMetricExist: false,
+			name:                    "events disabled",
+			eventsConfig:            EventsConfig{Enabled: false, Dimensions: []Dimension{{Name: "exception.type", Default: stringp("NullPointerException")}}},
+			shouldEventsMetricExist: false,
 		},
 		{
-			name:                   "events without dimensions",
-			eventsConfig:           EventsConfig{Enabled: true, Dimensions: []Dimension{}},
-			shouldEventMetricExist: false,
+			name:                    "events without dimensions",
+			eventsConfig:            EventsConfig{Enabled: true, Dimensions: []Dimension{}},
+			shouldEventsMetricExist: false,
 		},
 		{
-			name:                   "events with dimensions",
-			eventsConfig:           EventsConfig{Enabled: true, Dimensions: []Dimension{{Name: "exception.type", Default: stringp("NullPointerException")}}},
-			shouldEventMetricExist: true,
+			name:                    "events with dimensions",
+			eventsConfig:            EventsConfig{Enabled: true, Dimensions: []Dimension{{Name: "exception.type", Default: stringp("NullPointerException")}}},
+			shouldEventsMetricExist: true,
 		},
 	}
 	for _, tt := range tests {
@@ -1311,12 +1311,10 @@ func TestSpanMetrics_Events(t *testing.T) {
 				ism := rm.ScopeMetrics()
 				for ilmC := 0; ilmC < ism.Len(); ilmC++ {
 					m := ism.At(ilmC).Metrics()
-
-					if !tt.shouldEventMetricExist {
+					if !tt.shouldEventsMetricExist {
 						assert.Equal(t, 2, m.Len())
 						continue
 					}
-
 					assert.Equal(t, 3, m.Len())
 					for mC := 0; mC < m.Len(); mC++ {
 						metric := m.At(mC)

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -1311,24 +1311,26 @@ func TestSpanMetrics_Events(t *testing.T) {
 				ism := rm.ScopeMetrics()
 				for ilmC := 0; ilmC < ism.Len(); ilmC++ {
 					m := ism.At(ilmC).Metrics()
-					if tt.shouldEventMetricExist {
-						assert.Equal(t, m.Len(), 3)
-						for mC := 0; mC < m.Len(); mC++ {
-							metric := m.At(mC)
-							if metric.Name() == "events" {
-								assert.Equal(t, metric.Type(), pmetric.MetricTypeSum)
-								for idp := 0; idp < metric.Sum().DataPoints().Len(); idp++ {
-									attrs := metric.Sum().DataPoints().At(idp).Attributes()
-									assert.Contains(t, attrs.AsRaw(), exceptionTypeAttrName)
-								}
-							}
+
+					if !tt.shouldEventMetricExist {
+						assert.Equal(t, 2, m.Len())
+						continue
+					}
+
+					assert.Equal(t, 3, m.Len())
+					for mC := 0; mC < m.Len(); mC++ {
+						metric := m.At(mC)
+						if metric.Name() != "events" {
+							continue
 						}
-					} else {
-						assert.Equal(t, m.Len(), 2)
+						assert.Equal(t, pmetric.MetricTypeSum, metric.Type())
+						for idp := 0; idp < metric.Sum().DataPoints().Len(); idp++ {
+							attrs := metric.Sum().DataPoints().At(idp).Attributes()
+							assert.Contains(t, attrs.AsRaw(), exceptionTypeAttrName)
+						}
 					}
 				}
 			}
-
 		})
 	}
 }

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -1270,7 +1270,6 @@ func TestSpanMetrics_Events(t *testing.T) {
 		name                    string
 		eventsConfig            EventsConfig
 		shouldEventsMetricExist bool
-		validateError           string
 	}{
 		{
 			name:                    "events disabled",
@@ -1278,13 +1277,7 @@ func TestSpanMetrics_Events(t *testing.T) {
 			shouldEventsMetricExist: false,
 		},
 		{
-			name:                    "events without dimensions",
-			eventsConfig:            EventsConfig{Enabled: true, Dimensions: []Dimension{}},
-			shouldEventsMetricExist: false,
-			validateError:           "no dimensions configured for events",
-		},
-		{
-			name:                    "events with dimensions",
+			name:                    "events enabled",
 			eventsConfig:            EventsConfig{Enabled: true, Dimensions: []Dimension{{Name: "exception.type", Default: stringp("NullPointerException")}}},
 			shouldEventsMetricExist: true,
 		},

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -586,7 +586,7 @@ func TestConcurrentShutdown(t *testing.T) {
 	ticker := mockClock.NewTicker(time.Nanosecond)
 
 	// Test
-	p := newConnectorImp(t, new(consumertest.MetricsSink), nil, explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, logger, ticker)
+	p := newConnectorImp(t, new(consumertest.MetricsSink), nil, explicitHistogramsConfig, disabledExemplarsConfig, cumulative, logger, ticker)
 	err := p.Start(ctx, componenttest.NewNopHost())
 	require.NoError(t, err)
 
@@ -666,7 +666,7 @@ func TestConsumeMetricsErrors(t *testing.T) {
 	}
 	mockClock := clock.NewMock(time.Now())
 	ticker := mockClock.NewTicker(time.Nanosecond)
-	p := newConnectorImp(t, mcon, nil, explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, logger, ticker)
+	p := newConnectorImp(t, mcon, nil, explicitHistogramsConfig, disabledExemplarsConfig, cumulative, logger, ticker)
 
 	ctx := metadata.NewIncomingContext(context.Background(), nil)
 	err := p.Start(ctx, componenttest.NewNopHost())
@@ -828,7 +828,7 @@ func TestConsumeTraces(t *testing.T) {
 			mockClock := clock.NewMock(time.Now())
 			ticker := mockClock.NewTicker(time.Nanosecond)
 
-			p := newConnectorImp(t, mcon, stringp("defaultNullValue"), tc.histogramConfig, tc.exemplarConfig, EventsConfig{}, tc.aggregationTemporality, zaptest.NewLogger(t), ticker)
+			p := newConnectorImp(t, mcon, stringp("defaultNullValue"), tc.histogramConfig, tc.exemplarConfig, tc.aggregationTemporality, zaptest.NewLogger(t), ticker)
 
 			ctx := metadata.NewIncomingContext(context.Background(), nil)
 			err := p.Start(ctx, componenttest.NewNopHost())
@@ -854,7 +854,7 @@ func TestConsumeTraces(t *testing.T) {
 func TestMetricKeyCache(t *testing.T) {
 	mcon := consumertest.NewNop()
 
-	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, zaptest.NewLogger(t), nil)
+	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, cumulative, zaptest.NewLogger(t), nil)
 	traces := buildSampleTrace()
 
 	// Test
@@ -885,7 +885,7 @@ func BenchmarkConnectorConsumeTraces(b *testing.B) {
 	// Prepare
 	mcon := consumertest.NewNop()
 
-	conn := newConnectorImp(nil, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, zaptest.NewLogger(b), nil)
+	conn := newConnectorImp(nil, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, cumulative, zaptest.NewLogger(b), nil)
 
 	traces := buildSampleTrace()
 
@@ -899,7 +899,7 @@ func BenchmarkConnectorConsumeTraces(b *testing.B) {
 func TestExcludeDimensionsConsumeTraces(t *testing.T) {
 	mcon := consumertest.NewNop()
 	excludeDimensions := []string{"span.kind", "span.name", "totallyWrongNameDoesNotAffectAnything"}
-	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, zaptest.NewLogger(t), nil, excludeDimensions...)
+	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, cumulative, zaptest.NewLogger(t), nil, excludeDimensions...)
 	traces := buildSampleTrace()
 
 	// Test
@@ -948,7 +948,7 @@ func TestExcludeDimensionsConsumeTraces(t *testing.T) {
 
 }
 
-func newConnectorImp(t *testing.T, mcon consumer.Metrics, defaultNullValue *string, histogramConfig func() HistogramConfig, exemplarsConfig func() ExemplarsConfig, eventsConfig EventsConfig, temporality string, logger *zap.Logger, ticker *clock.Ticker, excludedDimensions ...string) *connectorImp {
+func newConnectorImp(t *testing.T, mcon consumer.Metrics, defaultNullValue *string, histogramConfig func() HistogramConfig, exemplarsConfig func() ExemplarsConfig, temporality string, logger *zap.Logger, ticker *clock.Ticker, excludedDimensions ...string) *connectorImp {
 
 	cfg := &Config{
 		AggregationTemporality: temporality,
@@ -972,7 +972,6 @@ func newConnectorImp(t *testing.T, mcon consumer.Metrics, defaultNullValue *stri
 			// Add a resource attribute to test "process" attributes like IP, host, region, cluster, etc.
 			{regionResourceAttrName, nil},
 		},
-		Events: eventsConfig,
 	}
 	c, err := newConnector(logger, cfg, ticker)
 	require.NoError(t, err)
@@ -1067,7 +1066,7 @@ func TestConnectorConsumeTracesEvictedCacheKey(t *testing.T) {
 	ticker := mockClock.NewTicker(time.Nanosecond)
 
 	// Note: default dimension key cache size is 2.
-	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, EventsConfig{}, cumulative, zaptest.NewLogger(t), ticker)
+	p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, cumulative, zaptest.NewLogger(t), ticker)
 
 	ctx := metadata.NewIncomingContext(context.Background(), nil)
 	err := p.Start(ctx, componenttest.NewNopHost())
@@ -1271,6 +1270,7 @@ func TestSpanMetrics_Events(t *testing.T) {
 		name                    string
 		eventsConfig            EventsConfig
 		shouldEventsMetricExist bool
+		validateError           string
 	}{
 		{
 			name:                    "events disabled",
@@ -1281,6 +1281,7 @@ func TestSpanMetrics_Events(t *testing.T) {
 			name:                    "events without dimensions",
 			eventsConfig:            EventsConfig{Enabled: true, Dimensions: []Dimension{}},
 			shouldEventsMetricExist: false,
+			validateError:           "no dimensions configured for events",
 		},
 		{
 			name:                    "events with dimensions",
@@ -1290,22 +1291,14 @@ func TestSpanMetrics_Events(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Prepare
-			mcon := &consumertest.MetricsSink{}
-
-			mockClock := clock.NewMock(time.Now())
-			ticker := mockClock.NewTicker(time.Nanosecond)
-
-			p := newConnectorImp(t, mcon, stringp("defaultNullValue"), explicitHistogramsConfig, disabledExemplarsConfig, tt.eventsConfig, cumulative, zaptest.NewLogger(t), ticker)
-
-			ctx := metadata.NewIncomingContext(context.Background(), nil)
-			err := p.Start(ctx, componenttest.NewNopHost())
-			defer func() { sdErr := p.Shutdown(ctx); require.NoError(t, sdErr) }()
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig().(*Config)
+			cfg.Events = tt.eventsConfig
+			c, err := newConnector(zaptest.NewLogger(t), cfg, nil)
 			require.NoError(t, err)
-
-			err = p.ConsumeTraces(ctx, buildSampleTrace())
+			err = c.ConsumeTraces(context.Background(), buildSampleTrace())
 			require.NoError(t, err)
-			metrics := p.buildMetrics()
+			metrics := c.buildMetrics()
 			for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
 				rm := metrics.ResourceMetrics().At(i)
 				ism := rm.ScopeMetrics()


### PR DESCRIPTION
**Description:**
We have an events section for a span. The details for all the exceptions like exception.type and exception.message are recorded as Events for a span. Right now, we don't have a feature to add event attributes to span metrics.

The idea of this PR is to develop a feature which adds a new metric `events_total` with a default set of dimensions like `service_name, span_name, span_kind, status_code`. We can configure to add additional set of dimensions like `exception.type` and `exception.message` which will be fetched from the Events section for a span

**Link to tracking Issue:** [27451](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27451)