### PR TITLE
[pkg/pdatatest] Ignore span ID for ptracetest

### DIFF
--- a/.chloggen/ptracetest-ignore-spanid.yaml
+++ b/.chloggen/ptracetest-ignore-spanid.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/pdatatest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "support ignore span ID in span comparisons for ptracetest"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27685]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/pdatatest/ptracetest/options.go
+++ b/pkg/pdatatest/ptracetest/options.go
@@ -129,6 +129,28 @@ func sortSpanSlices(ts ptrace.Traces) {
 	}
 }
 
+// IgnoreSpanID is a CompareTracesOption that clears SpanID fields on all spans.
+func IgnoreSpanID() CompareTracesOption {
+	return compareTracesOptionFunc(func(expected, actual ptrace.Traces) {
+		spanID := pcommon.NewSpanIDEmpty()
+		maskSpanID(expected, spanID)
+		maskSpanID(actual, spanID)
+	})
+}
+
+func maskSpanID(traces ptrace.Traces, spanID pcommon.SpanID) {
+	for i := 0; i < traces.ResourceSpans().Len(); i++ {
+		rs := traces.ResourceSpans().At(i)
+		for j := 0; j < rs.ScopeSpans().Len(); j++ {
+			ss := rs.ScopeSpans().At(j)
+			for k := 0; k < ss.Spans().Len(); k++ {
+				span := ss.Spans().At(k)
+				span.SetSpanID(spanID)
+			}
+		}
+	}
+}
+
 // IgnoreStartTimestamp is a CompareTracesOption that clears StartTimestamp fields on all spans.
 func IgnoreStartTimestamp() CompareTracesOption {
 	return compareTracesOptionFunc(func(expected, actual ptrace.Traces) {

--- a/pkg/pdatatest/ptracetest/testdata/ignore-spanid/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-spanid/actual.yaml
@@ -1,0 +1,21 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: node1
+    scopeSpans:
+      - scope:
+          name: collector
+          version: v0.1.0
+        spans:
+          - attributes:
+              - key: key1
+                value:
+                  stringValue: value1
+            name: span1
+            parentSpanId: ""
+            spanId: fd0da883bb27cd6b
+            status: {}
+            traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
+

--- a/pkg/pdatatest/ptracetest/testdata/ignore-spanid/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-spanid/expected.yaml
@@ -1,0 +1,19 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: node1
+    scopeSpans:
+      - scope:
+          name: collector
+          version: v0.1.0
+        spans:
+          - attributes:
+              - key: key1
+                value:
+                  stringValue: value1
+            name: span1
+            parentSpanId: ""
+            status: {}
+            traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/traces_test.go
+++ b/pkg/pdatatest/ptracetest/traces_test.go
@@ -49,6 +49,16 @@ func TestCompareTraces(t *testing.T) {
 			withOptions: nil,
 		},
 		{
+			name: "ignore-spanid",
+			compareOptions: []CompareTracesOption{
+				IgnoreSpanID(),
+			},
+			withoutOptions: multierr.Combine(
+				errors.New("resource \"map[host.name:node1]\": scope \"collector\": span \"span1\": span ID doesn't match expected: fd0da883bb27cd6b, actual: "),
+			),
+			withOptions: nil,
+		},
+		{
 			name: "ignore-start-timestamp",
 			compareOptions: []CompareTracesOption{
 				IgnoreStartTimestamp(),


### PR DESCRIPTION
**Description:** 
Support ignore span ID in span comparisons for ptracetest.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27685

**Testing:** 
make chlog-validate 
go test for pdatatest

**Documentation:** 