### PR TITLE
[chore][exporter/fileexporter] use errors.Join instead of go.uber.org/multierr

### DIFF
--- a/exporter/fileexporter/buffered_writer.go
+++ b/exporter/fileexporter/buffered_writer.go
@@ -5,9 +5,8 @@ package fileexporter // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"bufio"
+	"errors"
 	"io"
-
-	"go.uber.org/multierr"
 )
 
 // bufferedWriteCloser is intended to use more memory
@@ -33,7 +32,7 @@ func (bwc *bufferedWriteCloser) Write(p []byte) (n int, err error) {
 }
 
 func (bwc *bufferedWriteCloser) Close() error {
-	return multierr.Combine(
+	return errors.Join(
 		bwc.buffered.Flush(),
 		bwc.wrapped.Close(),
 	)

--- a/exporter/fileexporter/buffered_writer_test.go
+++ b/exporter/fileexporter/buffered_writer_test.go
@@ -5,6 +5,7 @@ package fileexporter
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/multierr"
 )
 
 const (
@@ -83,7 +83,7 @@ func BenchmarkWriter(b *testing.B) {
 				for i := 0; i < b.N; i++ {
 					_, err = w.Write(payload)
 				}
-				errBenchmark = multierr.Combine(err, w.Close())
+				errBenchmark = errors.Join(err, w.Close())
 			})
 		}
 	}

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -12,7 +12,6 @@ require (
 	go.opentelemetry.io/collector/consumer v0.87.1-0.20231017160804-ec0725874313
 	go.opentelemetry.io/collector/exporter v0.87.1-0.20231017160804-ec0725874313
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0016.0.20231017160804-ec0725874313
-	go.uber.org/multierr v1.11.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -39,6 +39,7 @@ require (
 	go.opentelemetry.io/otel v1.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
fileexporter: use errors.Join instead of go.uber.org/multierr

**Link to tracking Issue:** <Issue number if applicable>
#25121 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>