### PR TITLE
[pkg/stanza] Move flush state into reader package

### DIFF
--- a/.chloggen/pkg-stanza-metadata-flush.yaml
+++ b/.chloggen/pkg-stanza-metadata-flush.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate 'flush.WithPeriod'. Use 'flush.WithFunc' instead.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27843]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -127,6 +127,20 @@ func BenchmarkFileInput(b *testing.B) {
 				return cfg
 			},
 		},
+		{
+			name: "NoFlush",
+			paths: []string{
+				"file0.log",
+			},
+			config: func() *Config {
+				cfg := NewConfig()
+				cfg.Include = []string{
+					"file*.log",
+				}
+				cfg.FlushPeriod = 0
+				return cfg
+			},
+		},
 	}
 
 	for _, bench := range cases {

--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/header"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/scanner"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/flush"
 )
 
 type Config struct {
@@ -29,6 +31,7 @@ type Config struct {
 	IncludeFileNameResolved bool
 	IncludeFilePathResolved bool
 	DeleteAtEOF             bool
+	FlushTimeout            time.Duration
 }
 
 type Metadata struct {
@@ -36,6 +39,7 @@ type Metadata struct {
 	Offset          int64
 	FileAttributes  map[string]any
 	HeaderFinalized bool
+	FlushState      *flush.State
 }
 
 // Reader manages a single file

--- a/pkg/stanza/fileconsumer/internal/splitter/factory.go
+++ b/pkg/stanza/fileconsumer/internal/splitter/factory.go
@@ -5,43 +5,19 @@ package splitter // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"bufio"
-	"time"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/flush"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
-type Factory interface {
-	SplitFunc() bufio.SplitFunc
-}
-
-type factory struct {
-	splitFunc   bufio.SplitFunc
-	trimFunc    trim.Func
-	flushPeriod time.Duration
-	maxLength   int
-}
-
-var _ Factory = (*factory)(nil)
-
-func NewFactory(splitFunc bufio.SplitFunc, trimFunc trim.Func, flushPeriod time.Duration, maxLength int) Factory {
-	return &factory{
-		splitFunc:   splitFunc,
-		trimFunc:    trimFunc,
-		flushPeriod: flushPeriod,
-		maxLength:   maxLength,
-	}
-}
-
-// SplitFunc builds a bufio.SplitFunc based on the configuration
-func (f *factory) SplitFunc() bufio.SplitFunc {
-	// First apply the base splitFunc.
-	// If no token is found, we may still flush one based on timing.
-	// If a token is emitted for any reason, we must then apply trim rules.
-	// We must trim to max length _before_ trimming whitespace because otherwise we
-	// cannot properly keep track of the number of bytes to advance.
-	// For instance, if we have advance: 5, token: []byte(" foo "):
-	//   Trimming whitespace first would result in advance: 5, token: []byte("foo")
-	//   Then if we trim to max length of 2, we don't know whether or not to reduce advance.
-	return trim.WithFunc(trim.ToLength(flush.WithPeriod(f.splitFunc, f.flushPeriod), f.maxLength), f.trimFunc)
+// Func builds a bufio.SplitFunc based on the configuration
+// First apply the base splitFunc.
+// If a token is emitted for any reason, we must then apply trim rules.
+// We must trim to max length _before_ trimming whitespace because otherwise we
+// cannot properly keep track of the number of bytes to advance.
+// For instance, if we have advance: 5, token: []byte(" foo "):
+//
+//	Trimming whitespace first would result in advance: 5, token: []byte("foo")
+//	Then if we trim to max length of 2, we don't know whether or not to reduce advance.
+func Func(splitFunc bufio.SplitFunc, maxLength int, trimFunc trim.Func) bufio.SplitFunc {
+	return trim.WithFunc(trim.ToLength(splitFunc, maxLength), trimFunc)
 }

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/header"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/reader"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/splitter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
@@ -237,10 +236,12 @@ func testReaderFactory(t *testing.T, sCfg split.Config, maxLogSize int, flushPer
 			FingerprintSize: fingerprint.DefaultSize,
 			MaxLogSize:      maxLogSize,
 			Emit:            testEmitFunc(emitChan),
+			FlushTimeout:    flushPeriod,
 		},
-		FromBeginning:   true,
-		SplitterFactory: splitter.NewFactory(splitFunc, trim.Whitespace, flushPeriod, maxLogSize),
-		Encoding:        enc,
+		FromBeginning: true,
+		Encoding:      enc,
+		SplitFunc:     splitFunc,
+		TrimFunc:      trim.Whitespace,
 	}, emitChan
 }
 

--- a/pkg/stanza/flush/flush_test.go
+++ b/pkg/stanza/flush/flush_test.go
@@ -41,7 +41,9 @@ func TestNewlineSplitFunc(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		splitFunc := WithPeriod(tc.baseFunc, tc.flushPeriod)
-		t.Run(tc.name, splittest.New(splitFunc, tc.input, tc.steps...))
+		t.Run(tc.name+"/WithPeriod", splittest.New(WithPeriod(tc.baseFunc, tc.flushPeriod), tc.input, tc.steps...))
+
+		previousState := &State{LastDataChange: time.Now()}
+		t.Run(tc.name+"/Func", splittest.New(previousState.Func(tc.baseFunc, tc.flushPeriod), tc.input, tc.steps...))
 	}
 }


### PR DESCRIPTION
Subset of #27823

This PR moves flush state to `reader.Metadata`. This works well because `reader.Metadata` is already intended for tracking file state. Flush state was previously tracked independently and loosely associated with a reader.