### PR TITLE
[chore] [dockerstatsreceiver] update dockerstats receiver deprecation schedule

### DIFF
--- a/receiver/dockerstatsreceiver/README.md
+++ b/receiver/dockerstatsreceiver/README.md
@@ -89,8 +89,8 @@ the following process will be followed to phase out the old metrics:
 
 - Between `v0.79.0` and `v0.86.0`, the new metric is introduced and the old metric is marked as deprecated.
   Only the old metric are emitted by default.
-- In `v0.87.0`, the old metric is disabled and the new one enabled by default.
-- In `v0.88.0` and up, the old metric is removed.
+- In `v0.88.0`, the old metric is disabled and the new one enabled by default.
+- In `v0.89.0` and up, the old metric is removed.
 
 To change the enabled state for the specific metrics, use the standard configuration options that are available for all metrics.
 

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
@@ -3560,7 +3560,7 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSettings, options ...metricBuilderOption) *MetricsBuilder {
 	if mbc.Metrics.ContainerCPUPercent.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] `container.cpu.percent` should not be configured: The metric is deprecated and will be removed in v0.88.0. Please use `container.cpu.utilization` instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver#transition-to-cpu-utilization-metric-name-aligned-with-opentelemetry-specification for more details.")
+		settings.Logger.Warn("[WARNING] `container.cpu.percent` should not be configured: The metric is deprecated and will be removed in v0.89.0. Please use `container.cpu.utilization` instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver#transition-to-cpu-utilization-metric-name-aligned-with-opentelemetry-specification for more details.")
 	}
 	mb := &MetricsBuilder{
 		config:                                  mbc,

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics_test.go
@@ -50,7 +50,7 @@ func TestMetricsBuilder(t *testing.T) {
 
 			expectedWarnings := 0
 			if test.configSet == testSetAll || test.configSet == testSetNone {
-				assert.Equal(t, "[WARNING] `container.cpu.percent` should not be configured: The metric is deprecated and will be removed in v0.88.0. Please use `container.cpu.utilization` instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver#transition-to-cpu-utilization-metric-name-aligned-with-opentelemetry-specification for more details.", observedLogs.All()[expectedWarnings].Message)
+				assert.Equal(t, "[WARNING] `container.cpu.percent` should not be configured: The metric is deprecated and will be removed in v0.89.0. Please use `container.cpu.utilization` instead. See https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver#transition-to-cpu-utilization-metric-name-aligned-with-opentelemetry-specification for more details.", observedLogs.All()[expectedWarnings].Message)
 				expectedWarnings++
 			}
 

--- a/receiver/dockerstatsreceiver/metadata.yaml
+++ b/receiver/dockerstatsreceiver/metadata.yaml
@@ -143,7 +143,7 @@ metrics:
     unit: "1"
     warnings:
       if_configured: >-
-        The metric is deprecated and will be removed in v0.88.0. Please use `container.cpu.utilization` instead. See
+        The metric is deprecated and will be removed in v0.89.0. Please use `container.cpu.utilization` instead. See
         https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver#transition-to-cpu-utilization-metric-name-aligned-with-opentelemetry-specification
         for more details.
     gauge:


### PR DESCRIPTION
**Description:** this PR updates dockerstats receiver deprecation schedule, as requested [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27795#issuecomment-1769531853)

**Link to tracking Issue:** #21807

**Testing:** <Describe what testing was performed and which tests were added.>
```
❯ make test
go test -race -timeout 300s -parallel 4 --tags="" ./...
ok      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver  2.065s
ok      github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver/internal/metadata        1.768s
```

**Documentation:** updated deprecation notes. 