### PR TITLE
[pkg/ottl] Add systemd to image

### DIFF
--- a/cmd/otelcontribcol/Dockerfile
+++ b/cmd/otelcontribcol/Dockerfile
@@ -1,14 +1,12 @@
-FROM alpine:latest as prep
-RUN apk --update add ca-certificates
+FROM debian:bookworm-slim
 
-RUN mkdir -p /tmp
-
-FROM scratch
+RUN apt-get update && \
+  apt-get install -qy ca-certificates systemd && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ARG USER_UID=10001
 USER ${USER_UID}
 
-COPY --from=prep /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY otelcontribcol /
 EXPOSE 4317 55680 55679
 ENTRYPOINT ["/otelcontribcol"]


### PR DESCRIPTION
**Description:** Add journalctl to image, by using Debian bookworm as base image, and installing systemd


**Link to tracking Issue:** <Issue number if applicable>

No tracking issue. But https://github.com/open-telemetry/opentelemetry-collector-releases/issues/357#issuecomment-1726424285 describes the usecase

**Testing:**

**Documentation:**