### PR TITLE
[chore][exporter/elasticsearchexporter] use errors.Join instead of go.uber.org/multierr

### DIFF
--- a/exporter/elasticsearchexporter/go.mod
+++ b/exporter/elasticsearchexporter/go.mod
@@ -16,7 +16,6 @@ require (
 	go.opentelemetry.io/collector/exporter v0.87.1-0.20231017160804-ec0725874313
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0016.0.20231017160804-ec0725874313
 	go.opentelemetry.io/collector/semconv v0.87.1-0.20231017160804-ec0725874313
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.26.0
 )
 
@@ -44,6 +43,7 @@ require (
 	go.opentelemetry.io/otel v1.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.19.0 // indirect
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/exporter/elasticsearchexporter/logs_exporter.go
+++ b/exporter/elasticsearchexporter/logs_exporter.go
@@ -7,11 +7,11 @@ package elasticsearchexporter // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 
@@ -96,7 +96,7 @@ func (e *elasticsearchLogsExporter) pushLogsData(ctx context.Context, ld plog.Lo
 		}
 	}
 
-	return multierr.Combine(errs...)
+	return errors.Join(errs...)
 }
 
 func (e *elasticsearchLogsExporter) pushLogRecord(ctx context.Context, resource pcommon.Resource, record plog.LogRecord) error {

--- a/exporter/elasticsearchexporter/trace_exporter.go
+++ b/exporter/elasticsearchexporter/trace_exporter.go
@@ -7,11 +7,11 @@ package elasticsearchexporter // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 
@@ -88,7 +88,7 @@ func (e *elasticsearchTracesExporter) pushTraceData(
 		}
 	}
 
-	return multierr.Combine(errs...)
+	return errors.Join(errs...)
 }
 
 func (e *elasticsearchTracesExporter) pushTraceRecord(ctx context.Context, resource pcommon.Resource, span ptrace.Span) error {


### PR DESCRIPTION
**Description:** 
use errors.Join instead of go.uber.org/multierr

**Link to tracking Issue:** <Issue number if applicable>
#25121 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>