### PR TITLE
[chore][pkg/stanza] Log matching paths

### DIFF
--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -110,6 +110,7 @@ func (m *Manager) poll(ctx context.Context) {
 	if err != nil {
 		m.Debugf("finding files: %v", err)
 	}
+	m.Debugf("matched files", zap.Strings("paths", matches))
 
 	for len(matches) > m.maxBatchFiles {
 		m.consume(ctx, matches[:m.maxBatchFiles])


### PR DESCRIPTION
This PR adds a debug log to give visibility into the exact outcome of file matching configuration. 

It also removes some fragile logging expectations from batching tests. I believe the meaningful part of the tests remain intact.