### PR TITLE
[pkg/pdatatest] Ignore span attribute value

### DIFF
--- a/.chloggen/ptracetest-ignore-attribute-value.yaml
+++ b/.chloggen/ptracetest-ignore-attribute-value.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/pdatatest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "support ignore span attribute value in span comparisons for ptracetest"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27689]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/pdatatest/ptracetest/options.go
+++ b/pkg/pdatatest/ptracetest/options.go
@@ -151,6 +151,29 @@ func maskSpanID(traces ptrace.Traces, spanID pcommon.SpanID) {
 	}
 }
 
+// IgnoreSpanAttributeValue is a CompareTracesOption that clears value of the span attribute.
+func IgnoreSpanAttributeValue(attributeName string) CompareTracesOption {
+	return compareTracesOptionFunc(func(expected, actual ptrace.Traces) {
+		maskSpanAttributeValue(expected, attributeName)
+		maskSpanAttributeValue(actual, attributeName)
+	})
+}
+
+func maskSpanAttributeValue(traces ptrace.Traces, attributeName string) {
+	for i := 0; i < traces.ResourceSpans().Len(); i++ {
+		rs := traces.ResourceSpans().At(i)
+		for j := 0; j < rs.ScopeSpans().Len(); j++ {
+			ss := rs.ScopeSpans().At(j)
+			for k := 0; k < ss.Spans().Len(); k++ {
+				span := ss.Spans().At(k)
+				if _, ok := span.Attributes().Get(attributeName); ok {
+					span.Attributes().PutStr(attributeName, "*")
+				}
+			}
+		}
+	}
+}
+
 // IgnoreStartTimestamp is a CompareTracesOption that clears StartTimestamp fields on all spans.
 func IgnoreStartTimestamp() CompareTracesOption {
 	return compareTracesOptionFunc(func(expected, actual ptrace.Traces) {

--- a/pkg/pdatatest/ptracetest/testdata/ignore-attribute-value/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-attribute-value/actual.yaml
@@ -1,0 +1,27 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: node1
+    scopeSpans:
+      - scope:
+          name: collector
+          version: v0.1.0
+        spans:
+          - attributes:
+              - key: testKey1
+                value:
+                  stringValue: teststringvalue1
+            parentSpanId: ""
+            spanId: ""
+            status: {}
+            traceId: ""
+          - attributes:
+              - key: testKey2
+                value:
+                  stringValue: teststringvalue2
+            parentSpanId: ""
+            spanId: ""
+            status: {}
+            traceId: ""

--- a/pkg/pdatatest/ptracetest/testdata/ignore-attribute-value/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-attribute-value/expected.yaml
@@ -1,0 +1,27 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: node1
+    scopeSpans:
+      - scope:
+          name: collector
+          version: v0.1.0
+        spans:
+          - attributes:
+              - key: testKey1
+                value:
+                  stringValue: teststringvalue1
+            parentSpanId: ""
+            spanId: ""
+            status: {}
+            traceId: ""
+          - attributes:
+              - key: testKey2
+                value:
+                  stringValue: unpredictable
+            parentSpanId: ""
+            spanId: ""
+            status: {}
+            traceId: ""

--- a/pkg/pdatatest/ptracetest/traces_test.go
+++ b/pkg/pdatatest/ptracetest/traces_test.go
@@ -59,6 +59,16 @@ func TestCompareTraces(t *testing.T) {
 			withOptions: nil,
 		},
 		{
+			name: "ignore-attribute-value",
+			compareOptions: []CompareTracesOption{
+				IgnoreSpanAttributeValue("testKey2"),
+			},
+			withoutOptions: multierr.Combine(
+				errors.New("resource \"map[host.name:node1]\": scope \"collector\": span \"\": attributes don't match expected: map[testKey2:teststringvalue2], actual: map[testKey2:unpredictable]"),
+			),
+			withOptions: nil,
+		},
+		{
 			name: "ignore-start-timestamp",
 			compareOptions: []CompareTracesOption{
 				IgnoreStartTimestamp(),


### PR DESCRIPTION
**Description:**
Support ignore span attribute value in span comparisons for ptracetest.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27689

**Testing:** 
make chlog-validate
go test for pkg/pdatatest

**Documentation:**