### PR TITLE
[receiver/windowseventlog] Add Execution and Security information to parsed event log

### DIFF
--- a/.chloggen/feat_windows-evlog_security-and-execution.yaml
+++ b/.chloggen/feat_windows-evlog_security-and-execution.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: windowseventlogreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add parsing for Security and Execution sections of the event log
+note: Add parsing for Security and Execution event fields.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [27810]

--- a/.chloggen/feat_windows-evlog_security-and-execution.yaml
+++ b/.chloggen/feat_windows-evlog_security-and-execution.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: windowseventlogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add parsing for Security and Execution sections of the event log
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27810]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: ["user"]

--- a/pkg/stanza/operator/input/windows/testdata/xmlSampleUserData.xml
+++ b/pkg/stanza/operator/input/windows/testdata/xmlSampleUserData.xml
@@ -1,0 +1,28 @@
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <System>
+    <Provider Name="Microsoft-Windows-Eventlog" Guid="{fc65ddd8-d6ef-4962-83d5-6e5cfe9ce148}" />
+    <EventID>1102</EventID>
+    <Version>1</Version>
+    <Level>4</Level>
+    <Task>104</Task>
+    <Opcode>0</Opcode>
+    <Keywords>0x4020000000000000</Keywords>
+    <TimeCreated SystemTime="2023-10-12T10:38:24.543506200Z" />
+    <EventRecordID>2590526</EventRecordID>
+    <Correlation />
+    <Execution ProcessID="1472" ThreadID="7784" />
+    <Channel>Security</Channel>
+    <Computer>test.example.com</Computer>
+    <Security />
+  </System>
+  <UserData>
+    <LogFileCleared xmlns="http://manifests.microsoft.com/win/2004/08/windows/eventlog">
+      <SubjectUserSid>S-1-5-21-1148437859-4135665037-1195073887-1000</SubjectUserSid>
+      <SubjectUserName>test_user</SubjectUserName>
+      <SubjectDomainName>TEST</SubjectDomainName>
+      <SubjectLogonId>0xa8bb72</SubjectLogonId>
+      <ClientProcessId>4536</ClientProcessId>
+      <ClientProcessStartKey>17732923532772643</ClientProcessStartKey>
+    </LogFileCleared>
+  </UserData>
+</Event>

--- a/pkg/stanza/operator/input/windows/testdata/xmlSampleUserData.xml
+++ b/pkg/stanza/operator/input/windows/testdata/xmlSampleUserData.xml
@@ -13,7 +13,7 @@
     <Execution ProcessID="1472" ThreadID="7784" />
     <Channel>Security</Channel>
     <Computer>test.example.com</Computer>
-    <Security UserID="test_user" />
+    <Security UserID="S-1-5-18" />
   </System>
   <UserData>
     <LogFileCleared xmlns="http://manifests.microsoft.com/win/2004/08/windows/eventlog">

--- a/pkg/stanza/operator/input/windows/testdata/xmlSampleUserData.xml
+++ b/pkg/stanza/operator/input/windows/testdata/xmlSampleUserData.xml
@@ -13,7 +13,7 @@
     <Execution ProcessID="1472" ThreadID="7784" />
     <Channel>Security</Channel>
     <Computer>test.example.com</Computer>
-    <Security />
+    <Security UserID="test_user" />
   </System>
   <UserData>
     <LogFileCleared xmlns="http://manifests.microsoft.com/win/2004/08/windows/eventlog">

--- a/pkg/stanza/operator/input/windows/xml.go
+++ b/pkg/stanza/operator/input/windows/xml.go
@@ -4,6 +4,7 @@
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"time"
@@ -32,7 +33,7 @@ type EventXML struct {
 	Security         *Security        `xml:"System>Security"`
 	Execution        *Execution       `xml:"System>Execution"`
 	EventData        []EventDataEntry `xml:"EventData>Data"`
-	UserData         *UserData        `xml:"UserData"`
+	UserData         *AnyXML          `xml:"UserData"`
 }
 
 // parseTimestamp will parse the timestamp of the event.
@@ -138,7 +139,7 @@ func (e *EventXML) parseBody() map[string]interface{} {
 	}
 
 	if e.UserData != nil {
-		body["user_data"] = e.UserData.RawXML
+		body["user_data"] = e.UserData.asMap()
 	}
 
 	return body
@@ -202,8 +203,75 @@ type EventDataEntry struct {
 	Value string `xml:",chardata"`
 }
 
-type UserData struct {
-	RawXML string `xml:",innerxml"`
+type AnyXML struct {
+	tag        string
+	attributes map[string]string
+	chardata   string
+	children   []AnyXML
+}
+
+func (u *AnyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	u.tag = start.Name.Local
+
+	u.attributes = make(map[string]string, len(start.Attr))
+	for _, attr := range start.Attr {
+		u.attributes[attr.Name.Local] = attr.Value
+	}
+
+	for {
+		// We'll iterate over every token,
+		// adding children elements and character data as we continue.
+		anyToken, err := d.Token()
+		if err != nil {
+			return fmt.Errorf("token: %w", err)
+		}
+
+		switch t := anyToken.(type) {
+		case xml.StartElement:
+			child := AnyXML{}
+			err := d.DecodeElement(&child, &t)
+			if err != nil {
+				return fmt.Errorf("decode start element: %w", err)
+			}
+			u.children = append(u.children, child)
+		case xml.EndElement:
+			// End element means we've reached the end of parsing
+			return nil
+		case xml.CharData:
+			// Strip leading/trailing spaces to ignore newlines and
+			// indentation in formatted XML
+			u.chardata += string(bytes.TrimSpace([]byte(t)))
+		case xml.Comment: // ignore comments
+		case xml.ProcInst: // ignore processing instructions
+		case xml.Directive: // ignore directives
+		default:
+			return fmt.Errorf("unexpected token type %t", t)
+		}
+	}
+}
+
+func (u AnyXML) asMap() map[string]any {
+	m := make(map[string]any, 4)
+
+	m["tag"] = u.tag
+
+	if len(u.attributes) > 0 {
+		m["attributes"] = u.attributes
+	}
+
+	if len(u.chardata) > 0 {
+		m["chardata"] = u.chardata
+	}
+
+	if len(u.children) > 0 {
+		childMaps := make([]map[string]any, len(u.children))
+		for _, child := range u.children {
+			childMaps = append(childMaps, child.asMap())
+		}
+		m["children"] = append(childMaps, childMaps...)
+	}
+
+	return m
 }
 
 // Security contains info pertaining to the user triggering the event.

--- a/pkg/stanza/operator/input/windows/xml.go
+++ b/pkg/stanza/operator/input/windows/xml.go
@@ -221,23 +221,23 @@ func (e Execution) asMap() map[string]any {
 	}
 
 	if e.ProcessorID != nil {
-		result["processor_id"] = e.ProcessorID
+		result["processor_id"] = *e.ProcessorID
 	}
 
 	if e.SessionID != nil {
-		result["session_id"] = e.SessionID
+		result["session_id"] = *e.SessionID
 	}
 
 	if e.KernelTime != nil {
-		result["kernel_time"] = e.KernelTime
+		result["kernel_time"] = *e.KernelTime
 	}
 
 	if e.UserTime != nil {
-		result["user_time"] = e.UserTime
+		result["user_time"] = *e.UserTime
 	}
 
 	if e.ProcessorTime != nil {
-		result["processor_time"] = e.ProcessorTime
+		result["processor_time"] = *e.ProcessorTime
 	}
 
 	return result

--- a/pkg/stanza/operator/input/windows/xml_test.go
+++ b/pkg/stanza/operator/input/windows/xml_test.go
@@ -260,6 +260,7 @@ func TestUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	xml := EventXML{
+		Namespace: "http://schemas.microsoft.com/win/2004/08/events/event",
 		EventID: EventID{
 			ID:         16384,
 			Qualifiers: 16384,
@@ -283,7 +284,58 @@ func TestUnmarshal(t *testing.T) {
 			{Name: "Time", Value: "2022-04-28T19:48:52Z"},
 			{Name: "Source", Value: "RulesEngine"},
 		},
-		Keywords: []string{"0x80000000000000"},
+		Keywords:  []string{"0x80000000000000"},
+		Security:  &Security{},
+		Execution: &Execution{},
+	}
+
+	require.Equal(t, xml, event)
+}
+
+func TestUnmarshalWithUserData(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "xmlSampleUserData.xml"))
+	require.NoError(t, err)
+
+	event, err := unmarshalEventXML(data)
+	require.NoError(t, err)
+
+	xml := EventXML{
+		Namespace: "http://schemas.microsoft.com/win/2004/08/events/event",
+		EventID: EventID{
+			ID: 1102,
+		},
+		Provider: Provider{
+			Name: "Microsoft-Windows-Eventlog",
+			GUID: "{fc65ddd8-d6ef-4962-83d5-6e5cfe9ce148}",
+		},
+		TimeCreated: TimeCreated{
+			SystemTime: "2023-10-12T10:38:24.543506200Z",
+		},
+		Computer: "test.example.com",
+		Channel:  "Security",
+		RecordID: 2590526,
+		Level:    "4",
+		Message:  "",
+		Task:     "104",
+		Opcode:   "0",
+		Keywords: []string{"0x4020000000000000"},
+		Security: &Security{},
+		Execution: &Execution{
+			ProcessID: 1472,
+			ThreadID:  7784,
+		},
+		UserData: &UserData{
+			RawXML: `
+    <LogFileCleared xmlns="http://manifests.microsoft.com/win/2004/08/windows/eventlog">
+      <SubjectUserSid>S-1-5-21-1148437859-4135665037-1195073887-1000</SubjectUserSid>
+      <SubjectUserName>test_user</SubjectUserName>
+      <SubjectDomainName>TEST</SubjectDomainName>
+      <SubjectLogonId>0xa8bb72</SubjectLogonId>
+      <ClientProcessId>4536</ClientProcessId>
+      <ClientProcessStartKey>17732923532772643</ClientProcessStartKey>
+    </LogFileCleared>
+  `,
+		},
 	}
 
 	require.Equal(t, xml, event)

--- a/pkg/stanza/operator/input/windows/xml_test.go
+++ b/pkg/stanza/operator/input/windows/xml_test.go
@@ -324,17 +324,49 @@ func TestUnmarshalWithUserData(t *testing.T) {
 			ProcessID: 1472,
 			ThreadID:  7784,
 		},
-		UserData: &UserData{
-			RawXML: `
-    <LogFileCleared xmlns="http://manifests.microsoft.com/win/2004/08/windows/eventlog">
-      <SubjectUserSid>S-1-5-21-1148437859-4135665037-1195073887-1000</SubjectUserSid>
-      <SubjectUserName>test_user</SubjectUserName>
-      <SubjectDomainName>TEST</SubjectDomainName>
-      <SubjectLogonId>0xa8bb72</SubjectLogonId>
-      <ClientProcessId>4536</ClientProcessId>
-      <ClientProcessStartKey>17732923532772643</ClientProcessStartKey>
-    </LogFileCleared>
-  `,
+		UserData: &AnyXML{
+			tag:        "UserData",
+			attributes: map[string]string{},
+			children: []AnyXML{
+				{
+					tag: "LogFileCleared",
+					attributes: map[string]string{
+						"xmlns": "http://manifests.microsoft.com/win/2004/08/windows/eventlog",
+					},
+					children: []AnyXML{
+						{
+							tag:        "SubjectUserSid",
+							attributes: map[string]string{},
+							chardata:   "S-1-5-21-1148437859-4135665037-1195073887-1000",
+						},
+						{
+							tag:        "SubjectUserName",
+							attributes: map[string]string{},
+							chardata:   "test_user",
+						},
+						{
+							tag:        "SubjectDomainName",
+							attributes: map[string]string{},
+							chardata:   "TEST",
+						},
+						{
+							tag:        "SubjectLogonId",
+							attributes: map[string]string{},
+							chardata:   "0xa8bb72",
+						},
+						{
+							tag:        "ClientProcessId",
+							attributes: map[string]string{},
+							chardata:   "4536",
+						},
+						{
+							tag:        "ClientProcessStartKey",
+							attributes: map[string]string{},
+							chardata:   "17732923532772643",
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/stanza/operator/input/windows/xml_test.go
+++ b/pkg/stanza/operator/input/windows/xml_test.go
@@ -388,7 +388,7 @@ func TestUnmarshalWithUserData(t *testing.T) {
 		Opcode:   "0",
 		Keywords: []string{"0x4020000000000000"},
 		Security: &Security{
-			UserID: "test_user",
+			UserID: "S-1-5-18",
 		},
 		Execution: &Execution{
 			ProcessID: 1472,

--- a/pkg/stanza/operator/input/windows/xml_test.go
+++ b/pkg/stanza/operator/input/windows/xml_test.go
@@ -186,6 +186,92 @@ func TestParseBodySecurityExecution(t *testing.T) {
 	require.Equal(t, expected, xml.parseBody())
 }
 
+func TestParseBodyFullExecution(t *testing.T) {
+	processorID := uint(3)
+	sessionID := uint(2)
+	kernelTime := uint(3)
+	userTime := uint(100)
+	processorTime := uint(200)
+
+	xml := EventXML{
+		EventID: EventID{
+			ID:         1,
+			Qualifiers: 2,
+		},
+		Provider: Provider{
+			Name:            "provider",
+			GUID:            "guid",
+			EventSourceName: "event source",
+		},
+		TimeCreated: TimeCreated{
+			SystemTime: "2020-07-30T01:01:01.123456789Z",
+		},
+		Computer: "computer",
+		Channel:  "application",
+		RecordID: 1,
+		Level:    "Information",
+		Message:  "message",
+		Task:     "task",
+		Opcode:   "opcode",
+		Keywords: []string{"keyword"},
+		EventData: []EventDataEntry{
+			{Name: "name", Value: "value"}, {Name: "another_name", Value: "another_value"},
+		},
+		Execution: &Execution{
+			ProcessID:     13,
+			ThreadID:      102,
+			ProcessorID:   &processorID,
+			SessionID:     &sessionID,
+			KernelTime:    &kernelTime,
+			UserTime:      &userTime,
+			ProcessorTime: &processorTime,
+		},
+		Security: &Security{
+			UserID: "my-user-id",
+		},
+		RenderedLevel:    "rendered_level",
+		RenderedTask:     "rendered_task",
+		RenderedOpcode:   "rendered_opcode",
+		RenderedKeywords: []string{"RenderedKeywords"},
+	}
+
+	expected := map[string]interface{}{
+		"event_id": map[string]interface{}{
+			"id":         uint32(1),
+			"qualifiers": uint16(2),
+		},
+		"provider": map[string]interface{}{
+			"name":         "provider",
+			"guid":         "guid",
+			"event_source": "event source",
+		},
+		"system_time": "2020-07-30T01:01:01.123456789Z",
+		"computer":    "computer",
+		"channel":     "application",
+		"record_id":   uint64(1),
+		"level":       "rendered_level",
+		"message":     "message",
+		"task":        "rendered_task",
+		"opcode":      "rendered_opcode",
+		"keywords":    []string{"RenderedKeywords"},
+		"execution": map[string]any{
+			"process_id":     uint(13),
+			"thread_id":      uint(102),
+			"processor_id":   processorID,
+			"session_id":     sessionID,
+			"kernel_time":    kernelTime,
+			"user_time":      userTime,
+			"processor_time": processorTime,
+		},
+		"security": map[string]any{
+			"user_id": "my-user-id",
+		},
+		"event_data": map[string]interface{}{"name": "value", "another_name": "another_value"},
+	}
+
+	require.Equal(t, expected, xml.parseBody())
+}
+
 func TestParseNoRendered(t *testing.T) {
 	xml := EventXML{
 		EventID: EventID{


### PR DESCRIPTION
**Description:**
Adds parsing for Execution and Security sections of the event log, as defined in the schema here: https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-systempropertiestype-complextype

**Link to tracking Issue:** #27810

**Testing:**
* Added some unit tests
* Tested on a windows machine to make sure it parsed correctly on a real system 
