### PR TITLE
[chore] remove mentions of docs.signalfx.com from docs

### DIFF
--- a/exporter/sapmexporter/README.md
+++ b/exporter/sapmexporter/README.md
@@ -28,9 +28,9 @@ and some useful related utilities can be found [here](https://github.com/signalf
 
 The following configuration options are required:
 
-- `access_token` (no default): AccessToken is the authentication token provided by SignalFx or
-another backend that supports the SAPM proto. The SignalFx access token can be obtained from the
-web app. For details on how to do so please refer the documentation [here](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#access-tokens).
+- `access_token` (no default): AccessToken is the authentication token provided by Splunk Observability Cloud or
+another backend that supports the SAPM proto. The access token can be obtained from the
+web app. For details on how to do so please refer the documentation [here](https://docs.splunk.com/observability/en/admin/authentication/authentication-tokens/manage-usage.html).
 - `endpoint` (no default): This is the destination to where traces will be sent to in SAPM
 format. It must be a full URL and include the scheme, port and path e.g,
 <!-- markdown-link-check-disable-line -->https://ingest.us0.signalfx.com/v2/trace. This can be pointed to the SignalFx 

--- a/exporter/signalfxexporter/README.md
+++ b/exporter/signalfxexporter/README.md
@@ -27,13 +27,13 @@ supported.
 The following configuration options are required:
 
 - `access_token` (no default): The access token is the authentication token
-  provided by SignalFx. The SignalFx access token can be obtained from the
-  web app. For details on how to do so please refer the documentation [here](https://docs.signalfx.com/en/latest/admin-guide/tokens.html#access-tokens).
+  provided by Splunk Observability Cloud. The access token can be obtained from the
+  web app. For details on how to do so please refer the documentation [here](https://docs.splunk.com/observability/en/admin/authentication/authentication-tokens/manage-usage.html).
 - Either `realm` or both `api_url` and `ingest_url`. Both `api_url` and
   `ingest_url` take precedence over `realm`.
   - `realm` (no default): SignalFx realm where the data will be received.
-  - `api_url` (no default): Destination to which SignalFx [properties and
-    tags](https://docs.signalfx.com/en/latest/metrics-metadata/metrics-metadata.html#metrics-metadata)
+  - `api_url` (no default): Destination to which [properties and
+    tags](https://docs.splunk.com/observability/en/metrics-and-metadata/metrics-finder-metadata-catalog.html)
     are sent. If `realm` is set, this option is derived and will be
     `https://api.{realm}.signalfx.com`. If a value is explicitly set, the
     value of `realm` will not be used in determining `api_url`. The explicit

--- a/exporter/signalfxexporter/internal/translation/default_metrics.go
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.go
@@ -14,7 +14,6 @@ exclude_metrics:
 # Metrics in SignalFx Agent Format.
 - metric_names:
   # CPU metrics.
-  # Derived from https://docs.signalfx.com/en/latest/integrations/agent/monitors/cpu.html.
   - cpu.interrupt
   - cpu.nice
   - cpu.softirq
@@ -25,7 +24,6 @@ exclude_metrics:
   - cpu.wait
 
   # Disk-IO metrics.
-  # Derived from https://docs.signalfx.com/en/latest/integrations/agent/monitors/disk-io.html.
   - disk_ops.pending
 
   # Virtual memory metrics


### PR DESCRIPTION
The website docs.signalfx.com has been decommissioned and no longer resolves. Changing all doc links to the new doc website or removing them.