### PR TITLE
[pkg/stanza] Fix nil pointer dereference

### DIFF
--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -22,6 +22,21 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
+func TestCopyReaderWithoutFlusher(t *testing.T) {
+	f, _ := testReaderFactory(t, split.Config{}, defaultMaxLogSize, 0)
+
+	temp := openTemp(t, t.TempDir())
+	fp, err := f.NewFingerprint(temp)
+	require.NoError(t, err)
+
+	r, err := f.NewReader(temp, fp)
+	require.NoError(t, err)
+
+	// A copy of the reader should not panic
+	_, err = f.Copy(r, temp)
+	assert.NoError(t, err)
+}
+
 func TestPersistFlusher(t *testing.T) {
 	flushPeriod := 100 * time.Millisecond
 	f, emitChan := testReaderFactory(t, split.Config{}, defaultMaxLogSize, flushPeriod)

--- a/pkg/stanza/flush/flush.go
+++ b/pkg/stanza/flush/flush.go
@@ -13,11 +13,21 @@ type State struct {
 	LastDataLength int
 }
 
+func (s *State) Copy() *State {
+	if s == nil {
+		return nil
+	}
+	return &State{
+		LastDataChange: s.LastDataChange,
+		LastDataLength: s.LastDataLength,
+	}
+}
+
 // Func wraps a bufio.SplitFunc with a timer.
 // When the timer expires, an incomplete token may be returned.
 // The timer will reset any time the data parameter changes.
 func (s *State) Func(splitFunc bufio.SplitFunc, period time.Duration) bufio.SplitFunc {
-	if period <= 0 {
+	if s == nil || period <= 0 {
 		return splitFunc
 	}
 


### PR DESCRIPTION
**Description:** 
Copying reader with empty FlushState will cause a nil pointer dereference.
