### PR TITLE
[chore][cmd/oteltestbedcol] Skip linting generated code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ run:
     - third_party
     - local
     - cmd/otelcontribcol
+    - cmd/oteltestbedcol
 
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Same idea as #27865, remove generated code from being linted. The linter is taking longer and longer to run as more components and dependencies are added. This change is to remove unnecessary modules from being linted, which will help reduce runtime and resources required.

**Link to tracking Issue:** <Issue number if applicable>
Related #27850