### PR TITLE
[chore][receiver/windowseventlog] Add @pjanotti as codeowner in metadata.yaml

### DIFF
--- a/receiver/windowseventlogreceiver/README.md
+++ b/receiver/windowseventlogreceiver/README.md
@@ -6,7 +6,7 @@
 | Stability     | [alpha]: logs   |
 | Distributions | [observiq], [splunk], [sumo] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fwindowseventlog%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fwindowseventlog) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fwindowseventlog%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fwindowseventlog) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@djaglowski](https://www.github.com/djaglowski), [@armstrmi](https://www.github.com/armstrmi) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@djaglowski](https://www.github.com/djaglowski), [@armstrmi](https://www.github.com/armstrmi), [@pjanotti](https://www.github.com/pjanotti) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [observiq]: https://github.com/observIQ/observiq-otel-collector

--- a/receiver/windowseventlogreceiver/metadata.yaml
+++ b/receiver/windowseventlogreceiver/metadata.yaml
@@ -6,4 +6,4 @@ status:
     alpha: [logs]
   distributions: [splunk, observiq, sumo]
   codeowners:
-    active: [djaglowski, armstrmi]
+    active: [djaglowski, armstrmi, pjanotti]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
As a result of #27667, we're [getting errors](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27874#discussion_r1367145001) in the `.github/CODEOWNERS` file. This is because the `receiver/windowseventlogreceiver/metadata.yaml` file wasn't updated to include @pjanotti as code owner, resulting in these two sources being out of sync.