### PR TITLE
[chore][exporter/datadogexporter] use errors.Join instead of go.uber.org/multierr

### DIFF
--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/hostmetadata/valid"
@@ -517,13 +516,15 @@ func (e renameError) Error() string {
 	)
 }
 
-func handleRemovedSettings(configMap *confmap.Conf) (err error) {
+func handleRemovedSettings(configMap *confmap.Conf) error {
+	var errs []error
 	for _, removedErr := range removedSettings {
 		if configMap.IsSet(removedErr.oldName) {
-			err = multierr.Append(err, removedErr)
+			errs = append(errs, removedErr)
 		}
 	}
-	return
+
+	return errors.Join(errs...)
 }
 
 var _ confmap.Unmarshaler = (*Config)(nil)

--- a/exporter/datadogexporter/config_warnings.go
+++ b/exporter/datadogexporter/config_warnings.go
@@ -4,10 +4,10 @@
 package datadogexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
 
 import (
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/collector/confmap"
-	"go.uber.org/multierr"
 )
 
 var _ error = (*deprecatedError)(nil)
@@ -60,9 +60,10 @@ func (e deprecatedError) UpdateCfg(cfg *Config) {
 // handleRenamedSettings for a given configuration map.
 // Error out if any pair of old-new options are set at the same time.
 func handleRenamedSettings(configMap *confmap.Conf, cfg *Config) (warnings []error, err error) {
+	var errs []error
 	for _, renaming := range renamedSettings {
 		isOldNameUsed, errCheck := renaming.Check(configMap)
-		err = multierr.Append(err, errCheck)
+		errs = append(errs, errCheck)
 
 		if errCheck == nil && isOldNameUsed {
 			warnings = append(warnings, renaming)
@@ -70,5 +71,7 @@ func handleRenamedSettings(configMap *confmap.Conf, cfg *Config) (warnings []err
 			renaming.UpdateCfg(cfg)
 		}
 	}
+	err = errors.Join(errs...)
+
 	return
 }

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -42,7 +42,6 @@ require (
 	go.opentelemetry.io/collector/receiver v0.87.1-0.20231017160804-ec0725874313
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.87.1-0.20231017160804-ec0725874313
 	go.opentelemetry.io/collector/semconv v0.87.1-0.20231017160804-ec0725874313
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.26.0
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v2 v2.4.0
@@ -206,6 +205,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.19.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230711023510-fffb14384f22 // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.17.0 // indirect


### PR DESCRIPTION
**Description:** 
use errors.Join instead of go.uber.org/multierr

**Link to tracking Issue:** <Issue number if applicable>
#25121 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>