### PR TITLE
[chore][pkg/stanza] Simplify reader.ValidateOrClose

### DIFF
--- a/pkg/stanza/fileconsumer/roller_other.go
+++ b/pkg/stanza/fileconsumer/roller_other.go
@@ -38,8 +38,8 @@ OUTER:
 			// At this point, we know that the file has been rotated. However, we do not know
 			// if it was moved or truncated. If truncated, then both handles point to the same
 			// file, in which case we should only read from it using the new reader. We can use
-			// the ValidateOrClose method to establish that the file has not been truncated.
-			if !oldReader.ValidateOrClose() {
+			// the Validate method to ensure that the file has not been truncated.
+			if !oldReader.Validate() {
 				continue OUTER
 			}
 		}


### PR DESCRIPTION
This PR changes `ValidateOrClose` to `Validate`. The closing behavior is reasonable in theory but become problematic if closing a reader is associated with popping out its metadata (see #27823). Ultimately, it is not necessary because continuing the loop effectively skips over the reader and it is closed shortly thereafter along with all the other files in the slice.