### PR TITLE
[pkg/ottl] Fix issue with named parameter spacing

### DIFF
--- a/.chloggen/ottl-fix-named-param-spacing.yaml
+++ b/.chloggen/ottl-fix-named-param-spacing.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where named parameters needed a space after the equal sign (`=`).
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [28511]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -6,7 +6,6 @@ package ottl // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"encoding/hex"
 	"fmt"
-	"strings"
 
 	"github.com/alecthomas/participle/v2/lexer"
 )
@@ -144,9 +143,8 @@ var compareOpTable = map[string]compareOp{
 
 // Capture is how the parser converts an operator string to a compareOp.
 func (c *compareOp) Capture(values []string) error {
-	op, ok := compareOpTable[strings.Join(values, "")]
+	op, ok := compareOpTable[values[0]]
 	if !ok {
-
 		return fmt.Errorf("'%s' is not a valid operator", values[0])
 	}
 	*c = op
@@ -176,7 +174,7 @@ func (c *compareOp) String() string {
 // comparison represents an optional boolean condition.
 type comparison struct {
 	Left  value     `parser:"@@"`
-	Op    compareOp `parser:"@(OpComparison | Equal Equal)"`
+	Op    compareOp `parser:"@OpComparison"`
 	Right value     `parser:"@@"`
 }
 
@@ -220,7 +218,7 @@ type converter struct {
 }
 
 type argument struct {
-	Name  string `parser:"(@(Lowercase(Uppercase | Lowercase)*) Equal (?! Equal))?"`
+	Name  string `parser:"(@(Lowercase(Uppercase | Lowercase)*) Equal)?"`
 	Value value  `parser:"@@"`
 }
 
@@ -436,14 +434,14 @@ func buildLexer() *lexer.StatefulDefinition {
 		{Name: `Float`, Pattern: `[-+]?\d*\.\d+([eE][-+]?\d+)?`},
 		{Name: `Int`, Pattern: `[-+]?\d+`},
 		{Name: `String`, Pattern: `"(\\"|[^"])*"`},
-		{Name: `Equal`, Pattern: `=`},
 		{Name: `OpNot`, Pattern: `\b(not)\b`},
 		{Name: `OpOr`, Pattern: `\b(or)\b`},
 		{Name: `OpAnd`, Pattern: `\b(and)\b`},
-		{Name: `OpComparison`, Pattern: `!=|>=|<=|>|<`},
+		{Name: `OpComparison`, Pattern: `==|!=|>=|<=|>|<`},
 		{Name: `OpAddSub`, Pattern: `\+|\-`},
 		{Name: `OpMultDiv`, Pattern: `\/|\*`},
 		{Name: `Boolean`, Pattern: `\b(true|false)\b`},
+		{Name: `Equal`, Pattern: `=`},
 		{Name: `LParen`, Pattern: `\(`},
 		{Name: `RParen`, Pattern: `\)`},
 		{Name: `Punct`, Pattern: `[,.\[\]]`},

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -6,6 +6,7 @@ package ottl // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/alecthomas/participle/v2/lexer"
 )
@@ -143,8 +144,9 @@ var compareOpTable = map[string]compareOp{
 
 // Capture is how the parser converts an operator string to a compareOp.
 func (c *compareOp) Capture(values []string) error {
-	op, ok := compareOpTable[values[0]]
+	op, ok := compareOpTable[strings.Join(values, "")]
 	if !ok {
+
 		return fmt.Errorf("'%s' is not a valid operator", values[0])
 	}
 	*c = op
@@ -174,7 +176,7 @@ func (c *compareOp) String() string {
 // comparison represents an optional boolean condition.
 type comparison struct {
 	Left  value     `parser:"@@"`
-	Op    compareOp `parser:"@OpComparison"`
+	Op    compareOp `parser:"@(OpComparison | Equal Equal)"`
 	Right value     `parser:"@@"`
 }
 
@@ -218,7 +220,7 @@ type converter struct {
 }
 
 type argument struct {
-	Name  string `parser:"(@(Lowercase(Uppercase | Lowercase)*) Equal)?"`
+	Name  string `parser:"(@(Lowercase(Uppercase | Lowercase)*) Equal (?! Equal))?"`
 	Value value  `parser:"@@"`
 }
 
@@ -434,11 +436,11 @@ func buildLexer() *lexer.StatefulDefinition {
 		{Name: `Float`, Pattern: `[-+]?\d*\.\d+([eE][-+]?\d+)?`},
 		{Name: `Int`, Pattern: `[-+]?\d+`},
 		{Name: `String`, Pattern: `"(\\"|[^"])*"`},
-		{Name: `Equal`, Pattern: `=[^=]`},
+		{Name: `Equal`, Pattern: `=`},
 		{Name: `OpNot`, Pattern: `\b(not)\b`},
 		{Name: `OpOr`, Pattern: `\b(or)\b`},
 		{Name: `OpAnd`, Pattern: `\b(and)\b`},
-		{Name: `OpComparison`, Pattern: `==|!=|>=|<=|>|<`},
+		{Name: `OpComparison`, Pattern: `!=|>=|<=|>|<`},
 		{Name: `OpAddSub`, Pattern: `\+|\-`},
 		{Name: `OpMultDiv`, Pattern: `\/|\*`},
 		{Name: `Boolean`, Pattern: `\b(true|false)\b`},

--- a/pkg/ottl/lexer_test.go
+++ b/pkg/ottl/lexer_test.go
@@ -38,7 +38,8 @@ func Test_lexer(t *testing.T) {
 		}},
 		{"basic_equality", "3==4.9", false, []result{
 			{"Int", "3"},
-			{"OpComparison", "=="},
+			{"Equal", "="},
+			{"Equal", "="},
 			{"Float", "4.9"},
 		}},
 		{"basic_inequality", "3!=4.9", false, []result{

--- a/pkg/ottl/lexer_test.go
+++ b/pkg/ottl/lexer_test.go
@@ -38,8 +38,7 @@ func Test_lexer(t *testing.T) {
 		}},
 		{"basic_equality", "3==4.9", false, []result{
 			{"Int", "3"},
-			{"Equal", "="},
-			{"Equal", "="},
+			{"OpComparison", "=="},
 			{"Float", "4.9"},
 		}},
 		{"basic_inequality", "3!=4.9", false, []result{

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -1059,6 +1059,24 @@ func Test_parse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "editor with named arg",
+			statement: `set(name="foo")`,
+			expected: &parsedStatement{
+				Editor: editor{
+					Function: "set",
+					Arguments: []argument{
+						{
+							Name: "name",
+							Value: value{
+								String: ottltest.Strp("foo"),
+							},
+						},
+					},
+				},
+				WhereClause: nil,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**Description:** 
Fixes an issue with the grammar where named parameters had to have a space after the `=`.

**Link to tracking Issue:**
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27638

**Testing:** 
Added a new unit test