### PR TITLE
Revert "[chore][pkg/stanza] Ensure all start/stop calls in are balanced (#28294)

### DIFF
--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -79,8 +79,11 @@ See this issue for details: https://github.com/census-instrumentation/opencensus
 	operator, _ := buildTestManager(t, cfg)
 
 	_ = openTemp(t, tempDir)
-	require.NoError(t, operator.Start(testutil.NewUnscopedMockPersister()))
-	require.NoError(t, operator.Stop())
+	err := operator.Start(testutil.NewUnscopedMockPersister())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
 }
 
 // AddFields tests that the `log.file.name` and `log.file.path` fields are included
@@ -488,6 +491,9 @@ func TestReadNewLogs(t *testing.T) {
 
 	// Poll once so we know this isn't a new file
 	operator.poll(context.Background())
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
 
 	// Create a new file
 	temp := openTemp(t, tempDir)
@@ -1577,13 +1583,14 @@ func TestHeaderPersistance(t *testing.T) {
 	writeString(t, temp, "#headerField: headerValue\nlog line\n")
 
 	persister := testutil.NewUnscopedMockPersister()
-
 	require.NoError(t, op1.Start(persister))
+
 	waitForTokenWithAttributes(t, emitCalls1, []byte("log line"), map[string]any{
 		"header_key":      "headerField",
 		"header_value":    "headerValue",
 		attrs.LogFileName: filepath.Base(temp.Name()),
 	})
+
 	require.NoError(t, op1.Stop())
 
 	writeString(t, temp, "log line 2\n")
@@ -1591,11 +1598,13 @@ func TestHeaderPersistance(t *testing.T) {
 	op2, emitCalls2 := buildTestManager(t, cfg)
 
 	require.NoError(t, op2.Start(persister))
+
 	waitForTokenWithAttributes(t, emitCalls2, []byte("log line 2"), map[string]any{
 		"header_key":      "headerField",
 		"header_value":    "headerValue",
 		attrs.LogFileName: filepath.Base(temp.Name()),
 	})
+
 	require.NoError(t, op2.Stop())
 }
 
@@ -1617,10 +1626,12 @@ func TestHeaderPersistanceInHeader(t *testing.T) {
 	writeString(t, temp, "|headerField1: headerValue1\n")
 
 	persister := testutil.NewUnscopedMockPersister()
-
-	// Start and stop the operator, ensuring that at least one poll cycle occurs in between
 	require.NoError(t, op1.Start(persister))
-	time.Sleep(2 * cfg1.PollInterval)
+
+	// The operator will poll at fixed time intervals, but we just want to make sure at least
+	// one poll operation occurs between now and when we stop.
+	op1.poll(context.Background())
+
 	require.NoError(t, op1.Stop())
 
 	writeString(t, temp, "|headerField2: headerValue2\nlog line\n")
@@ -1632,11 +1643,13 @@ func TestHeaderPersistanceInHeader(t *testing.T) {
 	op2, emitCalls := buildTestManager(t, cfg2)
 
 	require.NoError(t, op2.Start(persister))
+
 	waitForTokenWithAttributes(t, emitCalls, []byte("log line"), map[string]any{
 		"header_value_1":  "headerValue1",
 		"header_value_2":  "headerValue2",
 		attrs.LogFileName: filepath.Base(temp.Name()),
 	})
+
 	require.NoError(t, op2.Stop())
 }
 

--- a/pkg/stanza/fileconsumer/rotation_test.go
+++ b/pkg/stanza/fileconsumer/rotation_test.go
@@ -365,6 +365,10 @@ func TestMoveFile(t *testing.T) {
 	temp1.Close()
 
 	operator.poll(context.Background())
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
 	waitForToken(t, emitCalls, []byte("testlog1"))
 
 	// Wait until all goroutines are finished before renaming
@@ -393,6 +397,10 @@ func TestTrackMovedAwayFiles(t *testing.T) {
 	temp1.Close()
 
 	operator.poll(context.Background())
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
 	waitForToken(t, emitCalls, []byte("testlog1"))
 
 	// Wait until all goroutines are finished before renaming
@@ -549,7 +557,12 @@ func TestTruncateThenWrite(t *testing.T) {
 	writeString(t, temp1, "testlog1\ntestlog2\n")
 
 	operator.poll(context.Background())
-	waitForTokens(t, emitCalls, []byte("testlog1"), []byte("testlog2"))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	waitForToken(t, emitCalls, []byte("testlog1"))
+	waitForToken(t, emitCalls, []byte("testlog2"))
 
 	require.NoError(t, temp1.Truncate(0))
 	_, err := temp1.Seek(0, 0)
@@ -581,7 +594,12 @@ func TestCopyTruncateWriteBoth(t *testing.T) {
 	writeString(t, temp1, "testlog1\ntestlog2\n")
 
 	operator.poll(context.Background())
-	waitForTokens(t, emitCalls, []byte("testlog1"), []byte("testlog2"))
+	defer func() {
+		require.NoError(t, operator.Stop())
+	}()
+
+	waitForToken(t, emitCalls, []byte("testlog1"))
+	waitForToken(t, emitCalls, []byte("testlog2"))
 	operator.wg.Wait() // wait for all goroutines to finish
 
 	// Copy the first file to a new file, and add another log


### PR DESCRIPTION
Some of the `Stop` statements were apparently necessary in order to close all files.