### PR TITLE
[chore][pkg/stanza] Fix tests which leave files open

### DIFF
--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -67,16 +67,20 @@ func (m *Manager) Start(persister operator.Persister) error {
 	return nil
 }
 
-// Stop will stop the file monitoring process
-func (m *Manager) Stop() error {
-	m.cancel()
-	m.wg.Wait()
+func (m *Manager) closeFiles() {
 	for _, r := range m.previousPollFiles {
 		r.Close()
 	}
 	for _, r := range m.knownFiles {
 		r.Close()
 	}
+}
+
+// Stop will stop the file monitoring process
+func (m *Manager) Stop() error {
+	m.cancel()
+	m.wg.Wait()
+	m.closeFiles()
 	m.cancel = nil
 	return nil
 }

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -91,6 +91,9 @@ func buildTestManager(t *testing.T, cfg *Config, opts ...testManagerOption) (*Ma
 	}
 	input, err := cfg.Build(testutil.Logger(t), testEmitFunc(tmc.emitChan))
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		input.closeFiles()
+	})
 	return input, tmc.emitChan
 }
 


### PR DESCRIPTION
`fileconsumer.Manager.poll` leaves files open so that the next poll cycle can use them. In tests, the direct use of this function should be accompanied by explicit action to clean up the files.