### PR TITLE
[k8sclusterreceiver] deprecate node_condition_types_to_report config

### DIFF
--- a/.chloggen/k8sclusterreceiver-node-condition-deprecate.yaml
+++ b/.chloggen/k8sclusterreceiver-node-condition-deprecate.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "k8sclusterreceiver"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Disable and deprecate node_condition_types_to_report configuration. Use new k8s.node.condition metric instead."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27617]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -50,7 +50,7 @@ In addition, metadata of all entities is collected periodically even if no chang
 This setting controls the interval between periodic collections.
 Setting the duration to 0 will disable periodic collection (however will not impact
 metadata collection on changes).
-- `node_conditions_to_report` (default = `[Ready]`): An array of node
+- `node_conditions_to_report` (default = `[]`): Deprecated configuration. Use `k8s.node.condition` metric instead. An array of node
 conditions this receiver should report. See
 [here](https://kubernetes.io/docs/concepts/architecture/nodes/#condition) for
 list of node conditions. The receiver will emit one metric per entry in the
@@ -87,6 +87,8 @@ The full list of settings exposed for this receiver are documented [here](./conf
 with detailed sample configurations [here](./testdata/config.yaml).
 
 ### node_conditions_to_report
+
+This configuration option is deprecated. Please use `k8s.node.condition` metric instead.
 
 For example, with the config below the receiver will emit two metrics
 `k8s.node.condition_ready` and `k8s.node.condition_memory_pressure`, one

--- a/receiver/k8sclusterreceiver/config_test.go
+++ b/receiver/k8sclusterreceiver/config_test.go
@@ -52,7 +52,7 @@ func TestLoadConfig(t *testing.T) {
 			expected: &Config{
 				Distribution:               distributionOpenShift,
 				CollectionInterval:         30 * time.Second,
-				NodeConditionTypesToReport: []string{"Ready"},
+				NodeConditionTypesToReport: []string{},
 				APIConfig: k8sconfig.APIConfig{
 					AuthType: k8sconfig.AuthTypeServiceAccount,
 				},

--- a/receiver/k8sclusterreceiver/factory.go
+++ b/receiver/k8sclusterreceiver/factory.go
@@ -25,7 +25,7 @@ const (
 	defaultMetadataCollectionInterval = 5 * time.Minute
 )
 
-var defaultNodeConditionsToReport = []string{"Ready"}
+var defaultNodeConditionsToReport = []string{}
 
 func createDefaultConfig() component.Config {
 	return &Config{

--- a/receiver/k8sclusterreceiver/receiver.go
+++ b/receiver/k8sclusterreceiver/receiver.go
@@ -43,6 +43,10 @@ func (kr *kubernetesReceiver) Start(ctx context.Context, host component.Host) er
 		return err
 	}
 
+	if len(kr.config.NodeConditionTypesToReport) > 0 {
+		kr.settings.Logger.Warn("node_condition_types_to_report is deprecated and will be removed in a future release. Please use k8s.node.condition metric instead.")
+	}
+
 	exporters := host.GetExporters() //nolint:staticcheck
 	if err := kr.resourceWatcher.setupMetadataExporters(
 		exporters[component.DataTypeMetrics], kr.config.MetadataExporters); err != nil {

--- a/receiver/k8sclusterreceiver/testdata/e2e/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/expected.yaml
@@ -106,27 +106,6 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
-        - key: k8s.node.name
-          value:
-            stringValue: kind-control-plane
-        - key: k8s.node.uid
-          value:
-            stringValue: afd51338-8dbe-4234-aed3-0d1a9b3ee38e
-    schemaUrl: "https://opentelemetry.io/schemas/1.18.0"
-    scopeMetrics:
-      - metrics:
-          - description: Ready condition status of the node (true=1, false=0, unknown=-1)
-            gauge:
-              dataPoints:
-                - asInt: "1"
-                  timeUnixNano: "1686772769034865545"
-            name: k8s.node.condition_ready
-            unit: ""
-        scope:
-          name: otelcol/k8sclusterreceiver
-          version: latest
-  - resource:
-      attributes:
         - key: k8s.daemonset.name
           value:
             stringValue: kindnet


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Deprecate node_condition_types_to_report config.

Change default `node_condition_types_to_report` to [] and add warning:

Example log when configured:
> {"level":"warn","ts":1698235514.45659,"caller":"k8sclusterreceiver@v0.86.1-0.20231004185026-b5635a7a90d2/receiver.go:47","msg":"node_conditio
n_types_to_report is deprecated and will be removed in a future release. Please use k8s.node.condition metric instead.","kind":"receiver","na
me":"k8s_cluster","data_type":"metrics"}

**Link to tracking Issue:** <Issue number if applicable>

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27617


**Testing:** <Describe what testing was performed and which tests were added.>
- manually tested in kind

**Documentation:** <Describe the documentation added.>