### PR TITLE
[receiver/windowseventlog]: Parse UserData tag 

### DIFF
--- a/pkg/stanza/operator/input/windows/xml.go
+++ b/pkg/stanza/operator/input/windows/xml.go
@@ -209,12 +209,12 @@ type AnyXML struct {
 	children   []AnyXML
 }
 
-func (u *AnyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	u.tag = start.Name.Local
+func (a *AnyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	a.tag = start.Name.Local
 
-	u.attributes = make(map[string]string, len(start.Attr))
+	a.attributes = make(map[string]string, len(start.Attr))
 	for _, attr := range start.Attr {
-		u.attributes[attr.Name.Local] = attr.Value
+		a.attributes[attr.Name.Local] = attr.Value
 	}
 
 	for {
@@ -232,14 +232,14 @@ func (u *AnyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			if err != nil {
 				return fmt.Errorf("decode start element: %w", err)
 			}
-			u.children = append(u.children, child)
+			a.children = append(a.children, child)
 		case xml.EndElement:
 			// End element means we've reached the end of parsing
 			return nil
 		case xml.CharData:
 			// Strip leading/trailing spaces to ignore newlines and
 			// indentation in formatted XML
-			u.chardata += string(bytes.TrimSpace([]byte(t)))
+			a.chardata += string(bytes.TrimSpace([]byte(t)))
 		case xml.Comment: // ignore comments
 		case xml.ProcInst: // ignore processing instructions
 		case xml.Directive: // ignore directives
@@ -249,22 +249,22 @@ func (u *AnyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	}
 }
 
-func (u AnyXML) asMap() map[string]any {
+func (a AnyXML) asMap() map[string]any {
 	m := make(map[string]any, 4)
 
-	m["tag"] = u.tag
+	m["tag"] = a.tag
 
-	if len(u.attributes) > 0 {
-		m["attributes"] = u.attributes
+	if len(a.attributes) > 0 {
+		m["attributes"] = a.attributes
 	}
 
-	if len(u.chardata) > 0 {
-		m["chardata"] = u.chardata
+	if len(a.chardata) > 0 {
+		m["chardata"] = a.chardata
 	}
 
-	if len(u.children) > 0 {
-		childMaps := make([]map[string]any, 0, len(u.children))
-		for _, child := range u.children {
+	if len(a.children) > 0 {
+		childMaps := make([]map[string]any, 0, len(a.children))
+		for _, child := range a.children {
 			childMaps = append(childMaps, child.asMap())
 		}
 		m["children"] = childMaps

--- a/pkg/stanza/operator/input/windows/xml.go
+++ b/pkg/stanza/operator/input/windows/xml.go
@@ -263,11 +263,11 @@ func (u AnyXML) asMap() map[string]any {
 	}
 
 	if len(u.children) > 0 {
-		childMaps := make([]map[string]any, len(u.children))
+		childMaps := make([]map[string]any, 0, len(u.children))
 		for _, child := range u.children {
 			childMaps = append(childMaps, child.asMap())
 		}
-		m["children"] = append(childMaps, childMaps...)
+		m["children"] = childMaps
 	}
 
 	return m

--- a/pkg/stanza/operator/input/windows/xml.go
+++ b/pkg/stanza/operator/input/windows/xml.go
@@ -4,6 +4,7 @@
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"time"
@@ -31,6 +32,7 @@ type EventXML struct {
 	Security         *Security        `xml:"System>Security"`
 	Execution        *Execution       `xml:"System>Execution"`
 	EventData        []EventDataEntry `xml:"EventData>Data"`
+	UserData         *AnyXML          `xml:"UserData"`
 }
 
 // parseTimestamp will parse the timestamp of the event.
@@ -135,6 +137,10 @@ func (e *EventXML) parseBody() map[string]interface{} {
 		body["execution"] = e.Execution.asMap()
 	}
 
+	if e.UserData != nil {
+		body["user_data"] = e.UserData.asMap()
+	}
+
 	return body
 }
 
@@ -194,6 +200,77 @@ type Provider struct {
 type EventDataEntry struct {
 	Name  string `xml:"Name,attr"`
 	Value string `xml:",chardata"`
+}
+
+type AnyXML struct {
+	tag        string
+	attributes map[string]string
+	chardata   string
+	children   []AnyXML
+}
+
+func (u *AnyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	u.tag = start.Name.Local
+
+	u.attributes = make(map[string]string, len(start.Attr))
+	for _, attr := range start.Attr {
+		u.attributes[attr.Name.Local] = attr.Value
+	}
+
+	for {
+		// We'll iterate over every token,
+		// adding children elements and character data as we continue.
+		anyToken, err := d.Token()
+		if err != nil {
+			return fmt.Errorf("token: %w", err)
+		}
+
+		switch t := anyToken.(type) {
+		case xml.StartElement:
+			child := AnyXML{}
+			err := d.DecodeElement(&child, &t)
+			if err != nil {
+				return fmt.Errorf("decode start element: %w", err)
+			}
+			u.children = append(u.children, child)
+		case xml.EndElement:
+			// End element means we've reached the end of parsing
+			return nil
+		case xml.CharData:
+			// Strip leading/trailing spaces to ignore newlines and
+			// indentation in formatted XML
+			u.chardata += string(bytes.TrimSpace([]byte(t)))
+		case xml.Comment: // ignore comments
+		case xml.ProcInst: // ignore processing instructions
+		case xml.Directive: // ignore directives
+		default:
+			return fmt.Errorf("unexpected token type %t", t)
+		}
+	}
+}
+
+func (u AnyXML) asMap() map[string]any {
+	m := make(map[string]any, 4)
+
+	m["tag"] = u.tag
+
+	if len(u.attributes) > 0 {
+		m["attributes"] = u.attributes
+	}
+
+	if len(u.chardata) > 0 {
+		m["chardata"] = u.chardata
+	}
+
+	if len(u.children) > 0 {
+		childMaps := make([]map[string]any, len(u.children))
+		for _, child := range u.children {
+			childMaps = append(childMaps, child.asMap())
+		}
+		m["children"] = append(childMaps, childMaps...)
+	}
+
+	return m
 }
 
 // Security contains info pertaining to the user triggering the event.

--- a/pkg/stanza/operator/input/windows/xml_test.go
+++ b/pkg/stanza/operator/input/windows/xml_test.go
@@ -480,6 +480,50 @@ func TestUnmarshalWithUserData(t *testing.T) {
 			ProcessID: 1472,
 			ThreadID:  7784,
 		},
+		UserData: &AnyXML{
+			tag:        "UserData",
+			attributes: map[string]string{},
+			children: []AnyXML{
+				{
+					tag: "LogFileCleared",
+					attributes: map[string]string{
+						"xmlns": "http://manifests.microsoft.com/win/2004/08/windows/eventlog",
+					},
+					children: []AnyXML{
+						{
+							tag:        "SubjectUserSid",
+							attributes: map[string]string{},
+							chardata:   "S-1-5-21-1148437859-4135665037-1195073887-1000",
+						},
+						{
+							tag:        "SubjectUserName",
+							attributes: map[string]string{},
+							chardata:   "test_user",
+						},
+						{
+							tag:        "SubjectDomainName",
+							attributes: map[string]string{},
+							chardata:   "TEST",
+						},
+						{
+							tag:        "SubjectLogonId",
+							attributes: map[string]string{},
+							chardata:   "0xa8bb72",
+						},
+						{
+							tag:        "ClientProcessId",
+							attributes: map[string]string{},
+							chardata:   "4536",
+						},
+						{
+							tag:        "ClientProcessStartKey",
+							attributes: map[string]string{},
+							chardata:   "17732923532772643",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	require.Equal(t, xml, event)

--- a/pkg/stanza/operator/input/windows/xml_test.go
+++ b/pkg/stanza/operator/input/windows/xml_test.go
@@ -272,6 +272,140 @@ func TestParseBodyFullExecution(t *testing.T) {
 	require.Equal(t, expected, xml.parseBody())
 }
 
+func TestParseBodyUserData(t *testing.T) {
+	xml := EventXML{
+		EventID: EventID{
+			ID:         1,
+			Qualifiers: 2,
+		},
+		Provider: Provider{
+			Name:            "provider",
+			GUID:            "guid",
+			EventSourceName: "event source",
+		},
+		TimeCreated: TimeCreated{
+			SystemTime: "2020-07-30T01:01:01.123456789Z",
+		},
+		Computer:         "computer",
+		Channel:          "application",
+		RecordID:         1,
+		Level:            "Information",
+		Message:          "message",
+		Task:             "task",
+		Opcode:           "opcode",
+		Keywords:         []string{"keyword"},
+		RenderedLevel:    "rendered_level",
+		RenderedTask:     "rendered_task",
+		RenderedOpcode:   "rendered_opcode",
+		RenderedKeywords: []string{"RenderedKeywords"},
+		UserData: &AnyXML{
+			tag:        "UserData",
+			attributes: map[string]string{},
+			children: []AnyXML{
+				{
+					tag: "LogFileCleared",
+					attributes: map[string]string{
+						"xmlns": "http://manifests.microsoft.com/win/2004/08/windows/eventlog",
+					},
+					children: []AnyXML{
+						{
+							tag:        "SubjectUserSid",
+							attributes: map[string]string{},
+							chardata:   "S-1-5-21-1148437859-4135665037-1195073887-1000",
+						},
+						{
+							tag:        "SubjectUserName",
+							attributes: map[string]string{},
+							chardata:   "test_user",
+						},
+						{
+							tag:        "SubjectDomainName",
+							attributes: map[string]string{},
+							chardata:   "TEST",
+						},
+						{
+							tag:        "SubjectLogonId",
+							attributes: map[string]string{},
+							chardata:   "0xa8bb72",
+						},
+						{
+							tag:        "ClientProcessId",
+							attributes: map[string]string{},
+							chardata:   "4536",
+						},
+						{
+							tag:        "ClientProcessStartKey",
+							attributes: map[string]string{},
+							chardata:   "17732923532772643",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expected := map[string]interface{}{
+		"event_id": map[string]interface{}{
+			"id":         uint32(1),
+			"qualifiers": uint16(2),
+		},
+		"provider": map[string]interface{}{
+			"name":         "provider",
+			"guid":         "guid",
+			"event_source": "event source",
+		},
+		"system_time": "2020-07-30T01:01:01.123456789Z",
+		"computer":    "computer",
+		"channel":     "application",
+		"record_id":   uint64(1),
+		"level":       "rendered_level",
+		"message":     "message",
+		"task":        "rendered_task",
+		"opcode":      "rendered_opcode",
+		"keywords":    []string{"RenderedKeywords"},
+		"event_data":  map[string]interface{}{},
+		"user_data": map[string]any{
+			"tag": "UserData",
+			"children": []map[string]any{
+				{
+					"tag": "LogFileCleared",
+					"attributes": map[string]string{
+						"xmlns": "http://manifests.microsoft.com/win/2004/08/windows/eventlog",
+					},
+					"children": []map[string]any{
+						{
+							"tag":      "SubjectUserSid",
+							"chardata": "S-1-5-21-1148437859-4135665037-1195073887-1000",
+						},
+						{
+							"tag":      "SubjectUserName",
+							"chardata": "test_user",
+						},
+						{
+							"tag":      "SubjectDomainName",
+							"chardata": "TEST",
+						},
+						{
+							"tag":      "SubjectLogonId",
+							"chardata": "0xa8bb72",
+						},
+						{
+							"tag":      "ClientProcessId",
+							"chardata": "4536",
+						},
+						{
+							"tag":      "ClientProcessStartKey",
+							"chardata": "17732923532772643",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.Equal(t, expected, xml.parseBody())
+}
+
 func TestParseNoRendered(t *testing.T) {
 	xml := EventXML{
 		EventID: EventID{


### PR DESCRIPTION
**Description:**
Parses the [UserData](https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-userdatatype-complextype) tag into a recursive structure like this:
```
{
  tag: string
  attributes: map[string]string
  charData: string
  children: []AnyXML 
}: AnyXML
```

**Link to tracking Issue:** #27810

**Testing:**
Unit testing.
Manually tested with clearing audit logs (generates an event with UserData filled in)