### PR TITLE
Update README.md, fix receiver OTLP instead of bad naming OLTP in the…

### DIFF
--- a/connector/routingconnector/README.md
+++ b/connector/routingconnector/README.md
@@ -64,7 +64,7 @@ connectors:
 service:
   pipelines:
     traces/in:
-      receivers: [oltp]
+      receivers: [otlp]
       exporters: [routing]
     traces/jaeger:
       receivers: [routing]


### PR DESCRIPTION
Fixed a typo in README.md, in the example:

**Before:**
traces/in:
      receivers: [_**oltp**_]
      exporters: [routing]

**After:**
traces/in:
      receivers: [_**otlp**_]
      exporters: [routing]