### PR TITLE
Remove duplicated 'compression' documentation from googlecloudexporter readme

### DIFF
--- a/exporter/googlecloudexporter/README.md
+++ b/exporter/googlecloudexporter/README.md
@@ -192,7 +192,6 @@ The following configuration options are supported:
     - `regex`: Match resource keys by regex.
   - `cumulative_normalization` (default = true): If true, normalizes cumulative metrics without start times or with explicit reset points by subtracting subsequent points from the initial point. It is enabled by default. Since it caches starting points, it may result inincreased memory usage.
   - `sum_of_squared_deviation` (default = false): If true, enables calculation of an estimated sum of squared deviation.  It is an estimate, and is not exact.
-  - `compression` (optional): Enable gzip compression for gRPC requests (valid vlaues: `gzip`).
   - `experimental_wal` (default = []): If provided, enables use of a write ahead
     log for time series requests.
     - `directory` (default = `./`): Path to local directory for WAL file.


### PR DESCRIPTION
**Description:**
The `compression` metric option appears more than once in the readme for the googlecloudexporter exporter, so I've deleted one of the copies. The first copy has more detail, so I preserved that one.

**Link to tracking Issue:** 
None.

**Testing:**
Manually reviewed readme on GitHub.

**Documentation:**
This PR is a documentation tidy-up.