### PR TITLE
[chore][pkg/translator/azure] Add missing code owner @cparkins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -137,7 +137,7 @@ pkg/pdatatest/                                                          @open-te
 pkg/pdatautil/                                                          @open-telemetry/collector-contrib-approvers @dmitryax
 pkg/resourcetotelemetry/                                                @open-telemetry/collector-contrib-approvers @mx-psi
 pkg/stanza/                                                             @open-telemetry/collector-contrib-approvers @djaglowski
-pkg/translator/azure/                                                   @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @atoulme
+pkg/translator/azure/                                                   @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @atoulme @cparkins
 pkg/translator/jaeger/                                                  @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @frzifus
 pkg/translator/loki/                                                    @open-telemetry/collector-contrib-approvers @gouthamve @jpkrohling @mar4uk
 pkg/translator/opencensus/                                              @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This fixes inconsistency introduced with the creation of this package. In #25096 @cparkins was added as a code owner in the [metadata.yaml](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/translator/azure/metadata.yaml) but not the top level `CODEOWNERS` file.