### PR TITLE
[pdatatest] allow partial matching of resource and metric attributes via regular expression

### DIFF
--- a/.chloggen/add-match-metric-attribute-value.yaml
+++ b/.chloggen/add-match-metric-attribute-value.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pdatatest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow to compare metrics resource attributes or metric attribute values by matching on a portion of the dimension value with a regular expression.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27690]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Use `MatchResourceAttributeValue("node_id", "cloud-node")` to match two metrics with a resource attribute value that starts with "cloud-node".
+  Use `MatchMetricAttributeValue("hostname", "container-tomcat-", "gauge.one", "sum.one")` to match metrics with the `hostname` attribute starting with `container-tomcat-`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/pdatatest/internal/util.go
+++ b/pkg/pdatatest/internal/util.go
@@ -6,6 +6,7 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.uber.org/multierr"
@@ -21,6 +22,17 @@ func ChangeResourceAttributeValue(res pcommon.Resource, attr string, changeFn fu
 	if _, ok := res.Attributes().Get(attr); ok {
 		if v, ok := res.Attributes().Get(attr); ok {
 			res.Attributes().PutStr(attr, changeFn(v.Str()))
+		}
+	}
+}
+
+func MatchResourceAttributeValue(res pcommon.Resource, attr string, re *regexp.Regexp) {
+	if _, ok := res.Attributes().Get(attr); ok {
+		if v, ok := res.Attributes().Get(attr); ok {
+			results := re.FindStringSubmatch(v.Str())
+			if len(results) > 0 {
+				res.Attributes().PutStr(attr, results[0])
+			}
 		}
 	}
 }

--- a/pkg/pdatatest/pmetrictest/metrics_test.go
+++ b/pkg/pdatatest/pmetrictest/metrics_test.go
@@ -305,9 +305,40 @@ func TestCompareMetrics(t *testing.T) {
 			),
 		},
 		{
+			name: "match-one-attribute-value",
+			compareOptions: []CompareMetricsOption{
+				MatchMetricAttributeValue("hostname", "also", "gauge.one", "sum.one"),
+			},
+			withoutOptions: multierr.Combine(
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.two:value A hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.two:value B hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.two:value A hostname:random]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.two:value B hostname:random]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": missing expected datapoint: map[hostname:also unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "sum.one": unexpected datapoint: map[hostname:also random]`),
+			),
+			withOptions: multierr.Combine(
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.two:value A hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": missing expected datapoint: map[attribute.two:value B hostname:unpredictable]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.two:value A hostname:random]`),
+				errors.New(`resource "map[]": scope "": metric "gauge.one": unexpected datapoint: map[attribute.two:value B hostname:random]`),
+			),
+		},
+		{
 			name: "ignore-one-resource-attribute",
 			compareOptions: []CompareMetricsOption{
 				IgnoreResourceAttributeValue("node_id"),
+			},
+			withoutOptions: multierr.Combine(
+				errors.New("missing expected resource: map[node_id:a-different-random-id]"),
+				errors.New("unexpected resource: map[node_id:a-random-id]"),
+			),
+			withOptions: nil,
+		},
+		{
+			name: "match-one-resource-attribute",
+			compareOptions: []CompareMetricsOption{
+				MatchResourceAttributeValue("node_id", "random"),
 			},
 			withoutOptions: multierr.Combine(
 				errors.New("missing expected resource: map[node_id:a-different-random-id]"),

--- a/pkg/pdatatest/pmetrictest/testdata/match-one-attribute-value/actual.yaml
+++ b/pkg/pdatatest/pmetrictest/testdata/match-one-attribute-value/actual.yaml
@@ -1,0 +1,29 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - attributes:
+                    - key: hostname
+                      value:
+                        stringValue: random
+                    - key: attribute.two
+                      value:
+                        stringValue: value A
+                - attributes:
+                    - key: hostname
+                      value:
+                        stringValue: random
+                    - key: attribute.two
+                      value:
+                        stringValue: value B
+            name: gauge.one
+          - name: sum.one
+            sum:
+              dataPoints:
+                - attributes:
+                    - key: hostname
+                      value:
+                        stringValue: also random
+        scope: {}

--- a/pkg/pdatatest/pmetrictest/testdata/match-one-attribute-value/expected.yaml
+++ b/pkg/pdatatest/pmetrictest/testdata/match-one-attribute-value/expected.yaml
@@ -1,0 +1,29 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - attributes:
+                    - key: hostname
+                      value:
+                        stringValue: unpredictable
+                    - key: attribute.two
+                      value:
+                        stringValue: value A
+                - attributes:
+                    - key: hostname
+                      value:
+                        stringValue: unpredictable
+                    - key: attribute.two
+                      value:
+                        stringValue: value B
+            name: gauge.one
+          - name: sum.one
+            sum:
+              dataPoints:
+                - attributes:
+                    - key: hostname
+                      value:
+                        stringValue: also unpredictable
+        scope: {}

--- a/pkg/pdatatest/pmetrictest/testdata/match-one-resource-attribute/actual.yaml
+++ b/pkg/pdatatest/pmetrictest/testdata/match-one-resource-attribute/actual.yaml
@@ -1,0 +1,104 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: node_id
+          value:
+            stringValue: a-random-id
+    scopeMetrics:
+      - metrics:
+          - description: Number of connections opened and closed to the node
+            name: aerospike.node.connection.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "149"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: client
+                    - key: op
+                      value:
+                        stringValue: close
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "150"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: client
+                    - key: op
+                      value:
+                        stringValue: open
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "0"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: fabric
+                    - key: op
+                      value:
+                        stringValue: close
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "48"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: fabric
+                    - key: op
+                      value:
+                        stringValue: open
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "0"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: heartbeat
+                    - key: op
+                      value:
+                        stringValue: close
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "2"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: heartbeat
+                    - key: op
+                      value:
+                        stringValue: open
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+              isMonotonic: true
+            unit: '{connections}'
+          - description: Number of open connections to the node
+            name: aerospike.node.connection.open
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: client
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "48"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: fabric
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "2"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: heartbeat
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+            unit: '{connections}'
+        scope:
+          name: otelcol/aerospikereceiver

--- a/pkg/pdatatest/pmetrictest/testdata/match-one-resource-attribute/expected.yaml
+++ b/pkg/pdatatest/pmetrictest/testdata/match-one-resource-attribute/expected.yaml
@@ -1,0 +1,104 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: node_id
+          value:
+            stringValue: a-different-random-id
+    scopeMetrics:
+      - metrics:
+          - description: Number of connections opened and closed to the node
+            name: aerospike.node.connection.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "149"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: client
+                    - key: op
+                      value:
+                        stringValue: close
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "150"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: client
+                    - key: op
+                      value:
+                        stringValue: open
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "0"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: fabric
+                    - key: op
+                      value:
+                        stringValue: close
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "48"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: fabric
+                    - key: op
+                      value:
+                        stringValue: open
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "0"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: heartbeat
+                    - key: op
+                      value:
+                        stringValue: close
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "2"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: heartbeat
+                    - key: op
+                      value:
+                        stringValue: open
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+              isMonotonic: true
+            unit: '{connections}'
+          - description: Number of open connections to the node
+            name: aerospike.node.connection.open
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: client
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "48"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: fabric
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+                - asInt: "2"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: heartbeat
+                  startTimeUnixNano: "1652734551332787000"
+                  timeUnixNano: "1652734556334562000"
+            unit: '{connections}'
+        scope:
+          name: otelcol/aerospikereceiver


### PR DESCRIPTION
**Description:**
Allow to compare metrics resource attributes or metric attribute values by matching on a portion of the dimension value with a regular expression.

**Link to tracking Issue:**
Fixes #27690

**Testing:**
Unit tests.