### PR TITLE
[receiver/hostmetrics/scrapers/process]: add configuration option to mute `error reading username for process`

### DIFF
--- a/.chloggen/drosiek-mute-process-user-error.yaml
+++ b/.chloggen/drosiek-mute-process-user-error.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/hostmetrics/scrapers/process
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add configuration option to mute `error reading username for process`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [14311, 17187]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -118,6 +118,7 @@ process:
   mute_process_name_error: <true|false>
   mute_process_exe_error: <true|false>
   mute_process_io_error: <true|false>
+  mute_process_user_error: <true|false>
   scrape_process_delay: <time>
 ```
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -35,6 +35,10 @@ type Config struct {
 	// the collector does not have permission to read it's executable path (Linux)
 	MuteProcessExeError bool `mapstructure:"mute_process_exe_error,omitempty"`
 
+	// MuteProcessUserError is a flag that will mute the error encountered when trying to read uid which
+	// doesn't exist on the system, eg. is owned by user existing in container only
+	MuteProcessUserError bool `mapstructure:"mute_process_user_error,omitempty"`
+
 	// ScrapeProcessDelay is used to indicate the minimum amount of time a process must be running
 	// before metrics are scraped for it.  The default value is 0 seconds (0s)
 	ScrapeProcessDelay time.Duration `mapstructure:"scrape_process_delay"`

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -219,7 +219,9 @@ func (s *scraper) getProcessMetadata() ([]*processMetadata, error) {
 
 		username, err := handle.UsernameWithContext(ctx)
 		if err != nil {
-			errs.AddPartial(0, fmt.Errorf("error reading username for process %q (pid %v): %w", executable.name, pid, err))
+			if !s.config.MuteProcessUserError {
+				errs.AddPartial(0, fmt.Errorf("error reading username for process %q (pid %v): %w", executable.name, pid, err))
+			}
 		}
 
 		createTime, err := s.getProcessCreateTime(handle, ctx)


### PR DESCRIPTION
**Description:**

add configuration option `mute_process_user_error`) to mute `error reading username for process`

**Link to tracking Issue:**

* #14311
* #17187

**Testing:**

Unit tests

**Documentation:**

README.md