### PR TITLE
[pkg/stanza] Use storage.Client natively

### DIFF
--- a/pkg/stanza/adapter/benchmark_test.go
+++ b/pkg/stanza/adapter/benchmark_test.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.uber.org/zap"
 
@@ -183,7 +184,7 @@ type Input struct {
 }
 
 // Start will start generating log entries.
-func (b *Input) Start(_ operator.Persister) error {
+func (b *Input) Start(_ storage.Client) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	b.cancel = cancel
 

--- a/pkg/stanza/adapter/emitter.go
+++ b/pkg/stanza/adapter/emitter.go
@@ -8,10 +8,10 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
@@ -84,7 +84,7 @@ func NewLogEmitter(logger *zap.SugaredLogger, opts ...emitterOption) *LogEmitter
 }
 
 // Start starts the goroutine(s) required for this operator
-func (e *LogEmitter) Start(_ operator.Persister) error {
+func (e *LogEmitter) Start(_ storage.Client) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	e.cancel = cancel
 

--- a/pkg/stanza/adapter/mocks_test.go
+++ b/pkg/stanza/adapter/mocks_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -47,7 +48,7 @@ func (c *UnstartableConfig) Build(logger *zap.SugaredLogger) (operator.Operator,
 }
 
 // Start will return an error
-func (o *UnstartableOperator) Start(_ operator.Persister) error {
+func (o *UnstartableOperator) Start(_ storage.Client) error {
 	return errors.New("something very unusual happened")
 }
 

--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -173,7 +173,7 @@ func BenchmarkFileInput(b *testing.B) {
 			}
 
 			b.ResetTimer()
-			err = op.Start(testutil.NewUnscopedMockPersister())
+			err = op.Start(testutil.NewUnscopedMockStorage())
 			defer func() {
 				require.NoError(b, op.Stop())
 			}()

--- a/pkg/stanza/fileconsumer/internal/checkpoint/checkpoint.go
+++ b/pkg/stanza/fileconsumer/internal/checkpoint/checkpoint.go
@@ -10,14 +10,15 @@ import (
 	"errors"
 	"fmt"
 
+	"go.opentelemetry.io/collector/extension/experimental/storage"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/reader"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
 const knownFilesKey = "knownFiles"
 
 // Save syncs the most recent set of files to the database
-func Save(ctx context.Context, persister operator.Persister, rmds []*reader.Metadata) error {
+func Save(ctx context.Context, client storage.Client, rmds []*reader.Metadata) error {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 
@@ -34,7 +35,7 @@ func Save(ctx context.Context, persister operator.Persister, rmds []*reader.Meta
 		}
 	}
 
-	if err := persister.Set(ctx, knownFilesKey, buf.Bytes()); err != nil {
+	if err := client.Set(ctx, knownFilesKey, buf.Bytes()); err != nil {
 		errs = append(errs, fmt.Errorf("persist known files: %w", err))
 	}
 
@@ -42,8 +43,8 @@ func Save(ctx context.Context, persister operator.Persister, rmds []*reader.Meta
 }
 
 // Load loads the most recent set of files to the database
-func Load(ctx context.Context, persister operator.Persister) ([]*reader.Metadata, error) {
-	encoded, err := persister.Get(ctx, knownFilesKey)
+func Load(ctx context.Context, client storage.Client) ([]*reader.Metadata, error) {
+	encoded, err := client.Get(ctx, knownFilesKey)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/helper/operator.go
+++ b/pkg/stanza/operator/helper/operator.go
@@ -4,10 +4,10 @@
 package helper // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 
 import (
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
 // NewBasicConfig creates a new basic config
@@ -96,7 +96,7 @@ func (p *BasicOperator) Logger() *zap.SugaredLogger {
 }
 
 // Start will start the operator.
-func (p *BasicOperator) Start(_ operator.Persister) error {
+func (p *BasicOperator) Start(_ storage.Client) error {
 	return nil
 }
 

--- a/pkg/stanza/operator/helper/operator_test.go
+++ b/pkg/stanza/operator/helper/operator_test.go
@@ -101,7 +101,7 @@ func TestBasicOperatorStart(t *testing.T) {
 		OperatorID:   "test-id",
 		OperatorType: "test-type",
 	}
-	err := operator.Start(testutil.NewUnscopedMockPersister())
+	err := operator.Start(testutil.NewUnscopedMockStorage())
 	require.NoError(t, err)
 }
 

--- a/pkg/stanza/operator/input/file/file.go
+++ b/pkg/stanza/operator/input/file/file.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/extension/experimental/storage"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
@@ -25,8 +26,8 @@ type Input struct {
 }
 
 // Start will start the file monitoring process
-func (f *Input) Start(persister operator.Persister) error {
-	return f.fileConsumer.Start(persister)
+func (f *Input) Start(client storage.Client) error {
+	return f.fileConsumer.Start(client)
 }
 
 // Stop will stop the file monitoring process

--- a/pkg/stanza/operator/input/file/file_test.go
+++ b/pkg/stanza/operator/input/file/file_test.go
@@ -53,7 +53,7 @@ func TestAddFileResolvedFields(t *testing.T) {
 	resolved, err := filepath.Abs(realPath)
 	require.NoError(t, err)
 
-	require.NoError(t, operator.Start(testutil.NewUnscopedMockPersister()))
+	require.NoError(t, operator.Start(testutil.NewUnscopedMockStorage()))
 	defer func() {
 		require.NoError(t, operator.Stop())
 	}()
@@ -75,7 +75,7 @@ func TestReadExistingLogs(t *testing.T) {
 	temp := openTemp(t, tempDir)
 	writeString(t, temp, "testlog1\ntestlog2\n")
 
-	require.NoError(t, operator.Start(testutil.NewUnscopedMockPersister()))
+	require.NoError(t, operator.Start(testutil.NewUnscopedMockStorage()))
 	defer func() {
 		require.NoError(t, operator.Stop())
 	}()
@@ -140,7 +140,7 @@ func TestReadUsingNopEncoding(t *testing.T) {
 			bytesWritten, err := temp.Write(tc.input)
 			require.Greater(t, bytesWritten, 0)
 			require.NoError(t, err)
-			require.NoError(t, operator.Start(testutil.NewUnscopedMockPersister()))
+			require.NoError(t, operator.Start(testutil.NewUnscopedMockStorage()))
 			defer func() {
 				require.NoError(t, operator.Stop())
 			}()
@@ -156,7 +156,7 @@ func TestReadNewLogs(t *testing.T) {
 	t.Parallel()
 	operator, logReceived, tempDir := newTestFileOperator(t, nil)
 
-	require.NoError(t, operator.Start(testutil.NewUnscopedMockPersister()))
+	require.NoError(t, operator.Start(testutil.NewUnscopedMockStorage()))
 	defer func() {
 		require.NoError(t, operator.Stop())
 	}()
@@ -181,7 +181,7 @@ func TestReadExistingAndNewLogs(t *testing.T) {
 	temp := openTemp(t, tempDir)
 	writeString(t, temp, "testlog1\n")
 
-	require.NoError(t, operator.Start(testutil.NewUnscopedMockPersister()))
+	require.NoError(t, operator.Start(testutil.NewUnscopedMockStorage()))
 	defer func() {
 		require.NoError(t, operator.Stop())
 	}()
@@ -208,7 +208,7 @@ func TestStartAtEnd(t *testing.T) {
 	temp := openTemp(t, tempDir)
 	writeString(t, temp, "testlog1\n")
 
-	require.NoError(t, operator.Start(testutil.NewUnscopedMockPersister()))
+	require.NoError(t, operator.Start(testutil.NewUnscopedMockStorage()))
 	defer func() {
 		require.NoError(t, operator.Stop())
 	}()
@@ -230,7 +230,7 @@ func TestSkipEmpty(t *testing.T) {
 	temp := openTemp(t, tempDir)
 	writeString(t, temp, "testlog1\n\ntestlog2\n")
 
-	require.NoError(t, operator.Start(testutil.NewUnscopedMockPersister()))
+	require.NoError(t, operator.Start(testutil.NewUnscopedMockStorage()))
 	defer func() {
 		require.NoError(t, operator.Stop())
 	}()

--- a/pkg/stanza/operator/input/generate/generate.go
+++ b/pkg/stanza/operator/input/generate/generate.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -63,7 +64,7 @@ type Input struct {
 }
 
 // Start will start generating log entries.
-func (g *Input) Start(_ operator.Persister) error {
+func (g *Input) Start(_ storage.Client) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	g.cancel = cancel
 

--- a/pkg/stanza/operator/input/generate/generate_test.go
+++ b/pkg/stanza/operator/input/generate/generate_test.go
@@ -28,7 +28,7 @@ func TestInputGenerate(t *testing.T) {
 	err = op.SetOutputs([]operator.Operator{fake})
 	require.NoError(t, err)
 
-	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
+	require.NoError(t, op.Start(testutil.NewUnscopedMockStorage()))
 	defer func() {
 		require.NoError(t, op.Stop())
 	}()

--- a/pkg/stanza/operator/input/journald/journald_test.go
+++ b/pkg/stanza/operator/input/journald/journald_test.go
@@ -72,7 +72,7 @@ func TestInputJournald(t *testing.T) {
 		return &fakeJournaldCmd{}
 	}
 
-	err = op.Start(testutil.NewUnscopedMockPersister())
+	err = op.Start(testutil.NewUnscopedMockStorage())
 	assert.EqualError(t, err, "journalctl command exited")
 	defer func() {
 		require.NoError(t, op.Stop())
@@ -246,7 +246,7 @@ func TestInputJournaldError(t *testing.T) {
 		}
 	}
 
-	err = op.Start(testutil.NewUnscopedMockPersister())
+	err = op.Start(testutil.NewUnscopedMockStorage())
 	assert.EqualError(t, err, "journalctl command failed (<nil>): stderr output\n")
 	defer func() {
 		require.NoError(t, op.Stop())

--- a/pkg/stanza/operator/input/stdin/stdin.go
+++ b/pkg/stanza/operator/input/stdin/stdin.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sync"
 
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -55,7 +56,7 @@ type Input struct {
 }
 
 // Start will start generating log entries.
-func (g *Input) Start(_ operator.Persister) error {
+func (g *Input) Start(_ storage.Client) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	g.cancel = cancel
 

--- a/pkg/stanza/operator/input/stdin/stdin_test.go
+++ b/pkg/stanza/operator/input/stdin/stdin_test.go
@@ -29,7 +29,7 @@ func TestStdin(t *testing.T) {
 	stdin := op.(*Input)
 	stdin.stdin = r
 
-	require.NoError(t, stdin.Start(testutil.NewUnscopedMockPersister()))
+	require.NoError(t, stdin.Start(testutil.NewUnscopedMockStorage()))
 	defer func() {
 		require.NoError(t, stdin.Stop())
 	}()

--- a/pkg/stanza/operator/input/syslog/syslog.go
+++ b/pkg/stanza/operator/input/syslog/syslog.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
 
@@ -123,11 +124,11 @@ type Input struct {
 }
 
 // Start will start listening for log entries over tcp or udp.
-func (t *Input) Start(p operator.Persister) error {
+func (t *Input) Start(client storage.Client) error {
 	if t.tcp != nil {
-		return t.tcp.Start(p)
+		return t.tcp.Start(client)
 	}
-	return t.udp.Start(p)
+	return t.udp.Start(client)
 }
 
 // Stop will stop listening for messages.

--- a/pkg/stanza/operator/input/syslog/syslog_test.go
+++ b/pkg/stanza/operator/input/syslog/syslog_test.go
@@ -96,7 +96,7 @@ func InputTest(t *testing.T, cfg *Config, tc syslog.Case) {
 	p, err := pipeline.NewDirectedPipeline(ops)
 	require.NoError(t, err)
 
-	err = p.Start(testutil.NewUnscopedMockPersister())
+	err = p.Start(testutil.NewUnscopedMockStorage())
 	require.NoError(t, err)
 
 	var conn net.Conn

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/jpillora/backoff"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
 
@@ -175,7 +176,7 @@ type Input struct {
 }
 
 // Start will start listening for log entries over tcp.
-func (t *Input) Start(_ operator.Persister) error {
+func (t *Input) Start(_ storage.Client) error {
 	if err := t.configureListener(); err != nil {
 		return fmt.Errorf("failed to listen on interface: %w", err)
 	}

--- a/pkg/stanza/operator/input/tcp/tcp_test.go
+++ b/pkg/stanza/operator/input/tcp/tcp_test.go
@@ -90,7 +90,7 @@ func tcpInputTest(input []byte, expected []string) func(t *testing.T) {
 			entryChan <- args.Get(1).(*entry.Entry)
 		}).Return(nil)
 
-		err = tcpInput.Start(testutil.NewUnscopedMockPersister())
+		err = tcpInput.Start(testutil.NewUnscopedMockStorage())
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, tcpInput.Stop(), "expected to stop tcp input operator without error")
@@ -139,7 +139,7 @@ func tcpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 			entryChan <- args.Get(1).(*entry.Entry)
 		}).Return(nil)
 
-		err = tcpInput.Start(testutil.NewUnscopedMockPersister())
+		err = tcpInput.Start(testutil.NewUnscopedMockStorage())
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, tcpInput.Stop(), "expected to stop tcp input operator without error")
@@ -225,7 +225,7 @@ func tlsInputTest(input []byte, expected []string) func(t *testing.T) {
 			entryChan <- args.Get(1).(*entry.Entry)
 		}).Return(nil)
 
-		err = tcpInput.Start(testutil.NewUnscopedMockPersister())
+		err = tcpInput.Start(testutil.NewUnscopedMockStorage())
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, tcpInput.Stop(), "expected to stop tcp input operator without error")
@@ -397,7 +397,7 @@ func TestFailToBind(t *testing.T) {
 		mockOutput.On("Process", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			entryChan <- args.Get(1).(*entry.Entry)
 		}).Return(nil)
-		err = tcpInput.Start(testutil.NewUnscopedMockPersister())
+		err = tcpInput.Start(testutil.NewUnscopedMockStorage())
 		return tcpInput, err
 	}
 
@@ -422,7 +422,7 @@ func BenchmarkTCPInput(b *testing.B) {
 	tcpInput := op.(*Input)
 	tcpInput.InputOperator.OutputOperators = []operator.Operator{fakeOutput}
 
-	err = tcpInput.Start(testutil.NewUnscopedMockPersister())
+	err = tcpInput.Start(testutil.NewUnscopedMockStorage())
 	require.NoError(b, err)
 
 	done := make(chan struct{})

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"sync"
 
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
 
@@ -169,7 +170,7 @@ type messageAndAddress struct {
 }
 
 // Start will start listening for messages on a socket.
-func (u *Input) Start(_ operator.Persister) error {
+func (u *Input) Start(_ storage.Client) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	u.cancel = cancel
 

--- a/pkg/stanza/operator/input/udp/udp_test.go
+++ b/pkg/stanza/operator/input/udp/udp_test.go
@@ -34,7 +34,7 @@ func udpInputTest(input []byte, expected []string, cfg *Config) func(t *testing.
 			entryChan <- args.Get(1).(*entry.Entry)
 		}).Return(nil)
 
-		err = udpInput.Start(testutil.NewUnscopedMockPersister())
+		err = udpInput.Start(testutil.NewUnscopedMockStorage())
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, udpInput.Stop(), "expected to stop udp input operator without error")
@@ -85,7 +85,7 @@ func udpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 			entryChan <- args.Get(1).(*entry.Entry)
 		}).Return(nil)
 
-		err = udpInput.Start(testutil.NewUnscopedMockPersister())
+		err = udpInput.Start(testutil.NewUnscopedMockStorage())
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, udpInput.Stop(), "expected to stop udp input operator without error")
@@ -193,7 +193,7 @@ func TestFailToBind(t *testing.T) {
 			entryChan <- args.Get(1).(*entry.Entry)
 		}).Return(nil)
 
-		err = udpInput.Start(testutil.NewUnscopedMockPersister())
+		err = udpInput.Start(testutil.NewUnscopedMockStorage())
 		return udpInput, err
 	}
 
@@ -218,7 +218,7 @@ func BenchmarkUDPInput(b *testing.B) {
 	udpInput := op.(*Input)
 	udpInput.InputOperator.OutputOperators = []operator.Operator{fakeOutput}
 
-	err = udpInput.Start(testutil.NewUnscopedMockPersister())
+	err = udpInput.Start(testutil.NewUnscopedMockStorage())
 	require.NoError(b, err)
 
 	done := make(chan struct{})

--- a/pkg/stanza/operator/operator.go
+++ b/pkg/stanza/operator/operator.go
@@ -6,6 +6,7 @@ package operator // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -19,7 +20,7 @@ type Operator interface {
 	Type() string
 
 	// Start will start the operator.
-	Start(Persister) error
+	Start(storage.Client) error
 	// Stop will stop the operator.
 	Stop() error
 

--- a/pkg/stanza/operator/output/file/file.go
+++ b/pkg/stanza/operator/output/file/file.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"sync"
 
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -75,7 +76,7 @@ type Output struct {
 }
 
 // Start will open the output file.
-func (fo *Output) Start(_ operator.Persister) error {
+func (fo *Output) Start(_ storage.Client) error {
 	var err error
 	fo.file, err = os.OpenFile(fo.path, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {

--- a/pkg/stanza/operator/persister.go
+++ b/pkg/stanza/operator/persister.go
@@ -10,24 +10,30 @@ import (
 	"go.opentelemetry.io/collector/extension/experimental/storage"
 )
 
-type ScopedPersister struct {
+type ScopedStorage struct {
 	client storage.Client
 	scope  string
 }
 
-func NewScopedPersister(s string, client storage.Client) storage.Client {
-	return &ScopedPersister{
+func NewScopedStorage(s string, client storage.Client) storage.Client {
+	return &ScopedStorage{
 		client: client,
 		scope:  s,
 	}
 }
 
-func (p ScopedPersister) Get(ctx context.Context, key string) ([]byte, error) {
+func (p ScopedStorage) Get(ctx context.Context, key string) ([]byte, error) {
 	return p.client.Get(ctx, fmt.Sprintf("%s.%s", p.scope, key))
 }
-func (p ScopedPersister) Set(ctx context.Context, key string, value []byte) error {
+func (p ScopedStorage) Set(ctx context.Context, key string, value []byte) error {
 	return p.client.Set(ctx, fmt.Sprintf("%s.%s", p.scope, key), value)
 }
-func (p ScopedPersister) Delete(ctx context.Context, key string) error {
+func (p ScopedStorage) Delete(ctx context.Context, key string) error {
 	return p.client.Delete(ctx, fmt.Sprintf("%s.%s", p.scope, key))
+}
+func (p ScopedStorage) Batch(ctx context.Context, ops ...storage.Operation) error {
+	return p.client.Batch(ctx, ops...)
+}
+func (p ScopedStorage) Close(ctx context.Context) error {
+	return p.client.Close(ctx)
 }

--- a/pkg/stanza/operator/persister.go
+++ b/pkg/stanza/operator/persister.go
@@ -6,33 +6,28 @@ package operator // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 	"fmt"
+
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 )
 
-// Persister is an interface used to persist data
-type Persister interface {
-	Get(context.Context, string) ([]byte, error)
-	Set(context.Context, string, []byte) error
-	Delete(context.Context, string) error
+type ScopedPersister struct {
+	client storage.Client
+	scope  string
 }
 
-type scopedPersister struct {
-	Persister
-	scope string
-}
-
-func NewScopedPersister(s string, p Persister) Persister {
-	return &scopedPersister{
-		Persister: p,
-		scope:     s,
+func NewScopedPersister(s string, client storage.Client) storage.Client {
+	return &ScopedPersister{
+		client: client,
+		scope:  s,
 	}
 }
 
-func (p scopedPersister) Get(ctx context.Context, key string) ([]byte, error) {
-	return p.Persister.Get(ctx, fmt.Sprintf("%s.%s", p.scope, key))
+func (p ScopedPersister) Get(ctx context.Context, key string) ([]byte, error) {
+	return p.client.Get(ctx, fmt.Sprintf("%s.%s", p.scope, key))
 }
-func (p scopedPersister) Set(ctx context.Context, key string, value []byte) error {
-	return p.Persister.Set(ctx, fmt.Sprintf("%s.%s", p.scope, key), value)
+func (p ScopedPersister) Set(ctx context.Context, key string, value []byte) error {
+	return p.client.Set(ctx, fmt.Sprintf("%s.%s", p.scope, key), value)
 }
-func (p scopedPersister) Delete(ctx context.Context, key string) error {
-	return p.Persister.Delete(ctx, fmt.Sprintf("%s.%s", p.scope, key))
+func (p ScopedPersister) Delete(ctx context.Context, key string) error {
+	return p.client.Delete(ctx, fmt.Sprintf("%s.%s", p.scope, key))
 }

--- a/pkg/stanza/operator/transformer/recombine/recombine.go
+++ b/pkg/stanza/operator/transformer/recombine/recombine.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/antonmedv/expr"
 	"github.com/antonmedv/expr/vm"
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -161,7 +162,7 @@ type sourceBatch struct {
 	firstEntryObservedTime time.Time
 }
 
-func (r *Transformer) Start(_ operator.Persister) error {
+func (r *Transformer) Start(_ storage.Client) error {
 	go r.flushLoop()
 
 	return nil

--- a/pkg/stanza/operator/transformer/recombine/recombine_test.go
+++ b/pkg/stanza/operator/transformer/recombine/recombine_test.go
@@ -477,7 +477,7 @@ func TestTransformer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			op, err := tc.config.Build(testutil.Logger(t))
 			require.NoError(t, err)
-			require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
+			require.NoError(t, op.Start(testutil.NewUnscopedMockStorage()))
 			recombine := op.(*Transformer)
 
 			fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/pipeline/directed_test.go
+++ b/pkg/stanza/pipeline/directed_test.go
@@ -76,8 +76,8 @@ func TestPipeline(t *testing.T) {
 		pipeline, err := NewDirectedPipeline([]operator.Operator{})
 		require.NoError(t, err)
 
-		require.NoError(t, pipeline.Start(testutil.NewMockPersister("test1")))
-		require.Error(t, pipeline.Start(testutil.NewMockPersister("test2")))
+		require.NoError(t, pipeline.Start(testutil.NewMockStorage("test1")))
+		require.Error(t, pipeline.Start(testutil.NewMockStorage("test2")))
 
 		require.NoError(t, pipeline.Stop())
 	})
@@ -86,7 +86,7 @@ func TestPipeline(t *testing.T) {
 		pipeline, err := NewDirectedPipeline([]operator.Operator{})
 		require.NoError(t, err)
 
-		require.NoError(t, pipeline.Start(testutil.NewMockPersister("test3")))
+		require.NoError(t, pipeline.Start(testutil.NewMockStorage("test3")))
 
 		require.NoError(t, pipeline.Stop())
 		require.Error(t, pipeline.Stop())
@@ -183,7 +183,7 @@ func TestPipelineStartOrder(t *testing.T) {
 	mockOperator1 := testutil.NewMockOperator("operator1")
 	mockOperator2 := testutil.NewMockOperator("operator2")
 	mockOperator3 := testutil.NewMockOperator("operator3")
-	mockPersister := testutil.NewUnscopedMockPersister()
+	mockPersister := testutil.NewUnscopedMockStorage()
 
 	mockOperator1.On("Outputs").Return([]operator.Operator{mockOperator2})
 	mockOperator2.On("Outputs").Return([]operator.Operator{mockOperator3})
@@ -197,9 +197,9 @@ func TestPipelineStartOrder(t *testing.T) {
 	mockOperator2.On("Logger", mock.Anything).Return(zap.NewNop().Sugar())
 	mockOperator3.On("Logger", mock.Anything).Return(zap.NewNop().Sugar())
 
-	mockOperator1.On("Start", testutil.NewMockPersister(mockOperator1.ID())).Return(fmt.Errorf("operator 1 failed to start"))
-	mockOperator2.On("Start", testutil.NewMockPersister(mockOperator2.ID())).Run(func(mock.Arguments) { mock2Started = true }).Return(nil)
-	mockOperator3.On("Start", testutil.NewMockPersister(mockOperator3.ID())).Run(func(mock.Arguments) { mock3Started = true }).Return(nil)
+	mockOperator1.On("Start", testutil.NewMockStorage(mockOperator1.ID())).Return(fmt.Errorf("operator 1 failed to start"))
+	mockOperator2.On("Start", testutil.NewMockStorage(mockOperator2.ID())).Run(func(mock.Arguments) { mock2Started = true }).Return(nil)
+	mockOperator3.On("Start", testutil.NewMockStorage(mockOperator3.ID())).Run(func(mock.Arguments) { mock3Started = true }).Return(nil)
 
 	pipeline, err := NewDirectedPipeline([]operator.Operator{mockOperator1, mockOperator2, mockOperator3})
 	require.NoError(t, err)
@@ -217,7 +217,7 @@ func TestPipelineStopOrder(t *testing.T) {
 	mockOperator1 := testutil.NewMockOperator("operator1")
 	mockOperator2 := testutil.NewMockOperator("operator2")
 	mockOperator3 := testutil.NewMockOperator("operator3")
-	mockPersister := testutil.NewUnscopedMockPersister()
+	mockPersister := testutil.NewUnscopedMockStorage()
 
 	mockOperator1.On("Outputs").Return([]operator.Operator{mockOperator2})
 	mockOperator2.On("Outputs").Return([]operator.Operator{mockOperator3})
@@ -231,9 +231,9 @@ func TestPipelineStopOrder(t *testing.T) {
 	mockOperator2.On("Logger", mock.Anything).Return(zap.NewNop().Sugar())
 	mockOperator3.On("Logger", mock.Anything).Return(zap.NewNop().Sugar())
 
-	mockOperator1.On("Start", testutil.NewMockPersister(mockOperator1.ID())).Return(nil)
-	mockOperator2.On("Start", testutil.NewMockPersister(mockOperator2.ID())).Return(nil)
-	mockOperator3.On("Start", testutil.NewMockPersister(mockOperator3.ID())).Return(nil)
+	mockOperator1.On("Start", testutil.NewMockStorage(mockOperator1.ID())).Return(nil)
+	mockOperator2.On("Start", testutil.NewMockStorage(mockOperator2.ID())).Return(nil)
+	mockOperator3.On("Start", testutil.NewMockStorage(mockOperator3.ID())).Return(nil)
 
 	mockOperator1.On("Stop").Run(func(mock.Arguments) { stopOrder = append(stopOrder, 1) }).Return(nil)
 	mockOperator2.On("Stop").Run(func(mock.Arguments) { stopOrder = append(stopOrder, 2) }).Return(nil)

--- a/pkg/stanza/pipeline/pipeline.go
+++ b/pkg/stanza/pipeline/pipeline.go
@@ -4,12 +4,14 @@
 package pipeline // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/pipeline"
 
 import (
+	"go.opentelemetry.io/collector/extension/experimental/storage"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
 // Pipeline is a collection of connected operators that exchange entries
 type Pipeline interface {
-	Start(persister operator.Persister) error
+	Start(storage.Client) error
 	Stop() error
 	Operators() []operator.Operator
 	Render() ([]byte, error)

--- a/pkg/stanza/testutil/mocks.go
+++ b/pkg/stanza/testutil/mocks.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 
@@ -64,7 +65,7 @@ func (f *FakeOutput) SetOutputs(_ []operator.Operator) error { return nil }
 func (f *FakeOutput) SetOutputIDs(_ []string) {}
 
 // Start immediately returns nil for a fake output
-func (f *FakeOutput) Start(_ operator.Persister) error { return nil }
+func (f *FakeOutput) Start(_ storage.Client) error { return nil }
 
 // Stop immediately returns nil for a fake output
 func (f *FakeOutput) Stop() error { return nil }

--- a/pkg/stanza/testutil/operator.go
+++ b/pkg/stanza/testutil/operator.go
@@ -7,6 +7,7 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 	zap "go.uber.org/zap"
+	"go.opentelemetry.io/collector/extension/experimental/storage"
 
 	entry "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	operator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -141,11 +142,11 @@ func (_m *Operator) SetOutputs(_a0 []operator.Operator) error {
 }
 
 // Start provides a mock function with given fields: _a0
-func (_m *Operator) Start(_a0 operator.Persister) error {
+func (_m *Operator) Start(_a0 storage.Client) error {
 	ret := _m.Called(_a0)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(operator.Persister) error); ok {
+	if rf, ok := ret.Get(0).(func(storage.Client) error); ok {
 		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)


### PR DESCRIPTION
WIP - Opening now to validate changes against CI.

TODO:
- Wait for `extension/storage` package to be available (See https://github.com/open-telemetry/opentelemetry-collector/pull/8767)
- This includes many breaking changes in the API. Use deprecations wherever possible. 