### PR TITLE
[connector/exceptions] Add trace id and span id to generated logs

### DIFF
--- a/.chloggen/exceptions-connector-add-span-trace-id.yaml
+++ b/.chloggen/exceptions-connector-add-span-trace-id.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exceptionsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add trace id and span id to generated logs from exceptions when using exceptionsconnector.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24407]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/exceptionsconnector/connector_logs.go
+++ b/connector/exceptionsconnector/connector_logs.go
@@ -98,6 +98,8 @@ func (c *logsConnector) attrToLogRecord(sl plog.ScopeLogs, serviceName string, s
 	logRecord.SetTimestamp(event.Timestamp())
 	logRecord.SetSeverityNumber(plog.SeverityNumberError)
 	logRecord.SetSeverityText("ERROR")
+	logRecord.SetSpanID(span.SpanID())
+	logRecord.SetTraceID(span.TraceID())
 	eventAttrs := event.Attributes()
 	spanAttrs := span.Attributes()
 

--- a/connector/exceptionsconnector/testdata/logs.yml
+++ b/connector/exceptionsconnector/testdata/logs.yml
@@ -24,8 +24,8 @@ resourceLogs:
             body: {}
             severityNumber: 17
             severityText: ERROR
-            spanId: ""
-            traceId: ""
+            spanId: 2a00000000000000
+            traceId: 2a000000000000000000000000000000
           - attributes:
               - key: span.kind
                 value:
@@ -48,8 +48,8 @@ resourceLogs:
             body: {}
             severityNumber: 17
             severityText: ERROR
-            spanId: ""
-            traceId: ""
+            spanId: 2a00000000000000
+            traceId: 2a000000000000000000000000000000
         scope: {}
   - resource: {}
     scopeLogs:
@@ -76,6 +76,6 @@ resourceLogs:
             body: {}
             severityNumber: 17
             severityText: ERROR
-            spanId: ""
-            traceId: ""
+            spanId: 2a00000000000000
+            traceId: 2a000000000000000000000000000000
         scope: {}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The current implementation generates logs from recorded exceptions in spans, but is not possible to see which traces and spans generated those logs. This PR adds that information to the logs

**Link to tracking Issue:** Fixes #24407 