### PR TITLE
[extension/encoding] Rename for consistency with storage extensions

### DIFF
--- a/.chloggen/rename_encoding_extensions.yaml
+++ b/.chloggen/rename_encoding_extensions.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: encoding extensions
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename encoding extensions for consistency with storage extensions
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24451]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - `jaegerencoding` -> `jaeger_encoding`
+  - `otlpencoding` -> `otlp_encoding`
+  - `textencoding` -> `text_encoding`
+  - `zipkinencoding` -> `zipkin_encoding`
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/encoding/jaegerencodingextension/internal/metadata/generated_status.go
+++ b/extension/encoding/jaegerencodingextension/internal/metadata/generated_status.go
@@ -7,6 +7,6 @@ import (
 )
 
 const (
-	Type               = "jaegerencoding"
+	Type               = "jaeger_encoding"
 	ExtensionStability = component.StabilityLevelDevelopment
 )

--- a/extension/encoding/jaegerencodingextension/metadata.yaml
+++ b/extension/encoding/jaegerencodingextension/metadata.yaml
@@ -1,4 +1,4 @@
-type: jaegerencoding
+type: jaeger_encoding
 
 status:
   class: extension

--- a/extension/encoding/otlpencodingextension/internal/metadata/generated_status.go
+++ b/extension/encoding/otlpencodingextension/internal/metadata/generated_status.go
@@ -7,6 +7,6 @@ import (
 )
 
 const (
-	Type               = "otlpencoding"
+	Type               = "otlp_encoding"
 	ExtensionStability = component.StabilityLevelDevelopment
 )

--- a/extension/encoding/otlpencodingextension/metadata.yaml
+++ b/extension/encoding/otlpencodingextension/metadata.yaml
@@ -1,4 +1,4 @@
-type: otlpencoding
+type: otlp_encoding
 
 status:
   class: extension

--- a/extension/encoding/textencodingextension/internal/metadata/generated_status.go
+++ b/extension/encoding/textencodingextension/internal/metadata/generated_status.go
@@ -7,6 +7,6 @@ import (
 )
 
 const (
-	Type               = "textencoding"
+	Type               = "text_encoding"
 	ExtensionStability = component.StabilityLevelDevelopment
 )

--- a/extension/encoding/textencodingextension/metadata.yaml
+++ b/extension/encoding/textencodingextension/metadata.yaml
@@ -1,4 +1,4 @@
-type: textencoding
+type: text_encoding
 
 status:
   class: extension

--- a/extension/encoding/zipkinencodingextension/internal/metadata/generated_status.go
+++ b/extension/encoding/zipkinencodingextension/internal/metadata/generated_status.go
@@ -7,6 +7,6 @@ import (
 )
 
 const (
-	Type               = "zipkinencoding"
+	Type               = "zipkin_encoding"
 	ExtensionStability = component.StabilityLevelDevelopment
 )

--- a/extension/encoding/zipkinencodingextension/metadata.yaml
+++ b/extension/encoding/zipkinencodingextension/metadata.yaml
@@ -1,4 +1,4 @@
-type: zipkinencoding
+type: zipkin_encoding
 
 status:
   class: extension


### PR DESCRIPTION
Rename encoding extensions for consistency with storage extensions: `db_storage` and `file_storage`.