### PR TITLE
[receiver/kafkareceiver] Add settings to Kafka Receiver for group management facilities

### DIFF
--- a/.chloggen/kafkareceiversettings.yaml
+++ b/.chloggen/kafkareceiversettings.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add settings session_timeout and heartbeat_interval to Kafka Receiver for group management facilities
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [28630]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -44,7 +44,7 @@ The following settings can be optionally configured:
 - `group_id` (default = otel-collector): The consumer group that receiver will be consuming messages from
 - `client_id` (default = otel-collector): The consumer client ID that receiver will use
 - `initial_offset` (default = latest): The initial offset to use if no offset was previously committed. Must be `latest` or `earliest`.
-- `session_timeout` (default = `10s`): The request timeout for detecting client failures when using Kafka’s group management facility.
+- `session_timeout` (default = `10s`): The request timeout for detecting client failures when using Kafka’s group management facilities.
 - `heartbeat_interval` (default = `3s`): The expected time between heartbeats to the consumer coordinator when using Kafka’s group management facilities.
 - `auth`
   - `plain_text`

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -44,6 +44,8 @@ The following settings can be optionally configured:
 - `group_id` (default = otel-collector): The consumer group that receiver will be consuming messages from
 - `client_id` (default = otel-collector): The consumer client ID that receiver will use
 - `initial_offset` (default = latest): The initial offset to use if no offset was previously committed. Must be `latest` or `earliest`.
+- `session_timeout` (default = `10s`): The request timeout for detecting client failures when using Kafka’s group management facility.
+- `heartbeat_interval` (default = `3s`): The expected time between heartbeats to the consumer coordinator when using Kafka’s group management facilities.
 - `auth`
   - `plain_text`
     - `username`: The username to use.

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -43,6 +43,10 @@ type Config struct {
 	Brokers []string `mapstructure:"brokers"`
 	// Kafka protocol version
 	ProtocolVersion string `mapstructure:"protocol_version"`
+	// Session interval for the Kafka consumer
+	SessionTimeout time.Duration `mapstructure:"session_timeout"`
+	// Heartbeat interval for the Kafka consumer
+	HeartbeatInterval time.Duration `mapstructure:"heartbeat_interval"`
 	// The name of the kafka topic to consume from (default "otlp_spans")
 	Topic string `mapstructure:"topic"`
 	// Encoding of the messages (default "otlp_proto")

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -33,12 +33,14 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, ""),
 			expected: &Config{
-				Topic:         "spans",
-				Encoding:      "otlp_proto",
-				Brokers:       []string{"foo:123", "bar:456"},
-				ClientID:      "otel-collector",
-				GroupID:       "otel-collector",
-				InitialOffset: "latest",
+				Topic:             "spans",
+				Encoding:          "otlp_proto",
+				Brokers:           []string{"foo:123", "bar:456"},
+				ClientID:          "otel-collector",
+				GroupID:           "otel-collector",
+				SessionTimeout:    10 * time.Second,
+				HeartbeatInterval: 3 * time.Second,
+				InitialOffset:     "latest",
 				Authentication: kafka.Authentication{
 					TLS: &configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{
@@ -65,12 +67,14 @@ func TestLoadConfig(t *testing.T) {
 
 			id: component.NewIDWithName(metadata.Type, "logs"),
 			expected: &Config{
-				Topic:         "logs",
-				Encoding:      "direct",
-				Brokers:       []string{"coffee:123", "foobar:456"},
-				ClientID:      "otel-collector",
-				GroupID:       "otel-collector",
-				InitialOffset: "earliest",
+				Topic:             "logs",
+				Encoding:          "direct",
+				Brokers:           []string{"coffee:123", "foobar:456"},
+				ClientID:          "otel-collector",
+				GroupID:           "otel-collector",
+				InitialOffset:     "earliest",
+				SessionTimeout:    45 * time.Second,
+				HeartbeatInterval: 15 * time.Second,
 				Authentication: kafka.Authentication{
 					TLS: &configtls.TLSClientSetting{
 						TLSSetting: configtls.TLSSetting{

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -17,12 +17,14 @@ import (
 )
 
 const (
-	defaultTopic         = "otlp_spans"
-	defaultEncoding      = "otlp_proto"
-	defaultBroker        = "localhost:9092"
-	defaultClientID      = "otel-collector"
-	defaultGroupID       = defaultClientID
-	defaultInitialOffset = offsetLatest
+	defaultTopic             = "otlp_spans"
+	defaultEncoding          = "otlp_proto"
+	defaultBroker            = "localhost:9092"
+	defaultClientID          = "otel-collector"
+	defaultGroupID           = defaultClientID
+	defaultInitialOffset     = offsetLatest
+	defaultSessionTimeout    = 10 * time.Second
+	defaultHeartbeatInterval = 3 * time.Second
 
 	// default from sarama.NewConfig()
 	defaultMetadataRetryMax = 3
@@ -90,12 +92,14 @@ func NewFactory(options ...FactoryOption) receiver.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Topic:         defaultTopic,
-		Encoding:      defaultEncoding,
-		Brokers:       []string{defaultBroker},
-		ClientID:      defaultClientID,
-		GroupID:       defaultGroupID,
-		InitialOffset: defaultInitialOffset,
+		Topic:             defaultTopic,
+		Encoding:          defaultEncoding,
+		Brokers:           []string{defaultBroker},
+		ClientID:          defaultClientID,
+		GroupID:           defaultGroupID,
+		InitialOffset:     defaultInitialOffset,
+		SessionTimeout:    defaultSessionTimeout,
+		HeartbeatInterval: defaultHeartbeatInterval,
 		Metadata: kafkaexporter.Metadata{
 			Full: defaultMetadataFull,
 			Retry: kafkaexporter.MetadataRetry{

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -23,7 +23,7 @@ const (
 	defaultClientID          = "otel-collector"
 	defaultGroupID           = defaultClientID
 	defaultInitialOffset     = offsetLatest
-	defaultSessionTimeout    = 45 * time.Second
+	defaultSessionTimeout    = 10 * time.Second
 	defaultHeartbeatInterval = 3 * time.Second
 
 	// default from sarama.NewConfig()

--- a/receiver/kafkareceiver/factory.go
+++ b/receiver/kafkareceiver/factory.go
@@ -23,7 +23,7 @@ const (
 	defaultClientID          = "otel-collector"
 	defaultGroupID           = defaultClientID
 	defaultInitialOffset     = offsetLatest
-	defaultSessionTimeout    = 10 * time.Second
+	defaultSessionTimeout    = 45 * time.Second
 	defaultHeartbeatInterval = 3 * time.Second
 
 	// default from sarama.NewConfig()

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -25,6 +25,8 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, defaultGroupID, cfg.GroupID)
 	assert.Equal(t, defaultClientID, cfg.ClientID)
 	assert.Equal(t, defaultInitialOffset, cfg.InitialOffset)
+	assert.Equal(t, defaultSessionTimeout, cfg.SessionTimeout)
+	assert.Equal(t, defaultHeartbeatInterval, cfg.HeartbeatInterval)
 }
 
 func TestCreateTracesReceiver(t *testing.T) {

--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -93,6 +93,9 @@ func newTracesReceiver(config Config, set receiver.CreateSettings, unmarshalers 
 	c.Metadata.Retry.Backoff = config.Metadata.Retry.Backoff
 	c.Consumer.Offsets.AutoCommit.Enable = config.AutoCommit.Enable
 	c.Consumer.Offsets.AutoCommit.Interval = config.AutoCommit.Interval
+	c.Consumer.Group.Session.Timeout = config.SessionTimeout
+	c.Consumer.Group.Heartbeat.Interval = config.HeartbeatInterval
+
 	if initialOffset, err := toSaramaInitialOffset(config.InitialOffset); err == nil {
 		c.Consumer.Offsets.Initial = initialOffset
 	} else {
@@ -195,6 +198,9 @@ func newMetricsReceiver(config Config, set receiver.CreateSettings, unmarshalers
 	c.Metadata.Retry.Backoff = config.Metadata.Retry.Backoff
 	c.Consumer.Offsets.AutoCommit.Enable = config.AutoCommit.Enable
 	c.Consumer.Offsets.AutoCommit.Interval = config.AutoCommit.Interval
+	c.Consumer.Group.Session.Timeout = config.SessionTimeout
+	c.Consumer.Group.Heartbeat.Interval = config.HeartbeatInterval
+
 	if initialOffset, err := toSaramaInitialOffset(config.InitialOffset); err == nil {
 		c.Consumer.Offsets.Initial = initialOffset
 	} else {
@@ -292,6 +298,9 @@ func newLogsReceiver(config Config, set receiver.CreateSettings, unmarshalers ma
 	c.Metadata.Retry.Backoff = config.Metadata.Retry.Backoff
 	c.Consumer.Offsets.AutoCommit.Enable = config.AutoCommit.Enable
 	c.Consumer.Offsets.AutoCommit.Interval = config.AutoCommit.Interval
+	c.Consumer.Group.Session.Timeout = config.SessionTimeout
+	c.Consumer.Group.Heartbeat.Interval = config.HeartbeatInterval
+
 	if initialOffset, err := toSaramaInitialOffset(config.InitialOffset); err == nil {
 		c.Consumer.Offsets.Initial = initialOffset
 	} else {

--- a/receiver/kafkareceiver/testdata/config.yaml
+++ b/receiver/kafkareceiver/testdata/config.yaml
@@ -16,6 +16,8 @@ kafka:
       backoff: 5s
 kafka/logs:
   topic: logs
+  session_timeout: 45s
+  heartbeat_interval: 15s
   encoding: direct
   brokers:
     - "coffee:123"


### PR DESCRIPTION
**Description:** 

To address #28630 i've wired in the session timeout and heartbeat interval settings. I would have exposed max.poll.interval as well but it appears Sarama doesn't make that setting available. It has a similar setting called `MaxProcessingTime` that we could implement if desired but behavior is different. Something to note is that Kafka recommends a 45s session timeout for consumers but Samara actually defaults to 10s so I've also defaulted to 10s to keep behavior consistent.

**Link to tracking Issue:** #28630

**Testing:**

I started the OTel collector with the following configuration and verified via debugger that the settings were applied to the Sarama client.
```
receivers:
  kafka:
    topic: test
    session_timeout: 15s
    heartbeat_interval: 5s

exporters:
  debug:

service:
  pipelines:
    logs:  # a pipeline of “traces” type
      receivers: [kafka]
      exporters: [debug]

```

I then added a test to `config_test` that tests the default values and tests providing the values via config.

**Documentation:** <Describe the documentation added.>

I modified the readme to reference the new settings.