### PR TITLE
[chore][receiver/hostmetrics] Skip process user error (un)muted test on non-Linux

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -935,6 +935,7 @@ func TestScrapeMetrics_MuteErrorFlags(t *testing.T) {
 
 	type testCase struct {
 		name                 string
+		skipTestCase         bool
 		muteProcessNameError bool
 		muteProcessExeError  bool
 		muteProcessIOError   bool
@@ -1000,6 +1001,7 @@ func TestScrapeMetrics_MuteErrorFlags(t *testing.T) {
 		},
 		{
 			name:                 "Process User Error Muted",
+			skipTestCase:         runtime.GOOS != "linux",
 			muteProcessUserError: true,
 			skipProcessNameError: true,
 			muteProcessExeError:  true,
@@ -1008,6 +1010,7 @@ func TestScrapeMetrics_MuteErrorFlags(t *testing.T) {
 		},
 		{
 			name:                 "Process User Error Unmuted",
+			skipTestCase:         runtime.GOOS != "linux",
 			muteProcessUserError: false,
 			skipProcessNameError: true,
 			muteProcessExeError:  true,
@@ -1019,6 +1022,9 @@ func TestScrapeMetrics_MuteErrorFlags(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			if test.skipTestCase {
+				t.Skipf("skipping test %v on %v", test.name, runtime.GOOS)
+			}
 			config := &Config{MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig()}
 			if !test.omitConfigField {
 				config.MuteProcessNameError = test.muteProcessNameError


### PR DESCRIPTION
**Description:**
Fix #28828 - this is just disabling the test on non-Linux. The broken test was introduced via #28661.

cc @sumo-drosiek 

**Link to tracking Issue:** #28828

**Testing:**
Local run of affected tests (Windows only).

**Documentation:**
N/A