### PR TITLE
[receiver/sshcheck] Change keyfile -> key_file in e.g. config and docs

### DIFF
--- a/.chloggen/sshcheckreceiver-fix-key_file-config-27035.yaml
+++ b/.chloggen/sshcheckreceiver-fix-key_file-config-27035.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sshcheckreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use key_file instead of keyfile for the key in config. Aligns project practice, code, and docs.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27035]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/sshcheckreceiver/README.md
+++ b/receiver/sshcheckreceiver/README.md
@@ -24,9 +24,9 @@ If `ignore_host_key` is not set then host key validation requires the agent eith
 The following settings are required:
 - `endpoint`
 - `username`
-- `password` or `keyfile`
+- `password` or `key_file`
 
-Either `password` or `keyfile` must be set. But if both are set then password is treated as the `passphrase` and the key is assumed to be encrypted.
+Either `password` or `key_file` must be set. But if both are set then password is treated as the `passphrase` and the key is assumed to be encrypted.
 
 The following settings are optional:
 

--- a/receiver/sshcheckreceiver/config.go
+++ b/receiver/sshcheckreceiver/config.go
@@ -20,7 +20,7 @@ var (
 	errMissingEndpoint           = errors.New(`"endpoint" not specified in config`)
 	errInvalidEndpoint           = errors.New(`"endpoint" is invalid`)
 	errMissingUsername           = errors.New(`"username" not specified in config`)
-	errMissingPasswordAndKeyFile = errors.New(`either "password" or "keyfile" is required`)
+	errMissingPasswordAndKeyFile = errors.New(`either "password" or "key_file" is required`)
 
 	errConfigNotSSHCheck  = errors.New("config was not a SSH check receiver config")
 	errWindowsUnsupported = errors.New(metadata.Type + " is unsupported on Windows.")

--- a/receiver/sshcheckreceiver/config_test.go
+++ b/receiver/sshcheckreceiver/config_test.go
@@ -110,7 +110,6 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-
 func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
@@ -124,7 +123,7 @@ func TestLoadConfig(t *testing.T) {
 
 	expected := factory.CreateDefaultConfig().(*Config)
 	expected.Endpoint = "notdefault:1313"
-	expected.Username = "noteault_username"
+	expected.Username = "notdefault_username"
 	expected.Password = "notdefault_password"
 	expected.KeyFile = "notdefault/path/keyfile"
 	expected.CollectionInterval = 10 * time.Second

--- a/receiver/sshcheckreceiver/testdata/config.yaml
+++ b/receiver/sshcheckreceiver/testdata/config.yaml
@@ -1,10 +1,10 @@
 receivers:
   sshcheck:
     endpoint: notdefault:1313
-    username: notdefault_password
+    username: notdefault_username
     password: notdefault_password
-    keyfile: notdefault/path/keyfile
-    collection_interval: 13m
+    key_file: notdefault/path/keyfile
+    collection_interval: 10s
     known_hosts: path/to/collector_known_hosts
     ignore_host_key: false
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`keyfile` was the key used in config and documented in sshcheck, but `key_file` is the preferred key for these purposes.

**Link to tracking Issue:** #27035 

**Testing:** Update tests to ensure this key is used in default.

**Documentation:** Updated documentation to reflect the change in key.