### PR TITLE
[chore][exporter/datadog] Add a section about how to switch to Zorkian

### DIFF
--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -50,6 +50,12 @@ The exact values for `send_batch_size` and `send_batch_max_size` depends on your
 - Log intake: https://docs.datadoghq.com/api/latest/logs/
 - Metrics V2 intake: https://docs.datadoghq.com/api/latest/metrics/#submit-metrics
 
+### Fall back to the Zorkian metric client with feature gate
+
+Since [v0.69.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.69.0), the Datadog exporter has switched to use the native metric client `datadog-api-client-go` for metric export instead of Zorkian client by default. While `datadog-api-client-go` fixed several issues that are present in Zorkian client, there is a performance regression with it compared to Zorkian client espeicially under high metric volume. If you observe memory or throughput issues in the Datadog exporter with `datadog-api-client-go`, you can configure the Datadog exporter to fall back to the Zorkian client by disabling the feature gate `exporter.datadogexporter.metricexportnativeclient`, e.g.
+```
+otelcol --config=config.yaml --feature-gates=-exporter.datadogexporter.metricexportnativeclient
+```
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha

--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -56,6 +56,7 @@ Since [v0.69.0](https://github.com/open-telemetry/opentelemetry-collector-contri
 ```
 otelcol --config=config.yaml --feature-gates=-exporter.datadogexporter.metricexportnativeclient
 ```
+Note that we are currently migrating the Datadog metrics exporter to use the metrics serializer instead. The feature flag `exporter.datadogexporter.metricexportnativeclient` will be deprecated and evetually removed in the future, following the [feature lifecycle](https://github.com/open-telemetry/opentelemetry-collector/tree/main/featuregate#feature-lifecycle).
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha

--- a/exporter/datadogexporter/README.md
+++ b/exporter/datadogexporter/README.md
@@ -56,7 +56,7 @@ Since [v0.69.0](https://github.com/open-telemetry/opentelemetry-collector-contri
 ```
 otelcol --config=config.yaml --feature-gates=-exporter.datadogexporter.metricexportnativeclient
 ```
-Note that we are currently migrating the Datadog metrics exporter to use the metrics serializer instead. The feature flag `exporter.datadogexporter.metricexportnativeclient` will be deprecated and evetually removed in the future, following the [feature lifecycle](https://github.com/open-telemetry/opentelemetry-collector/tree/main/featuregate#feature-lifecycle).
+Note that we are currently migrating the Datadog metrics exporter to use the metrics serializer instead. The feature flag `exporter.datadogexporter.metricexportnativeclient` will be deprecated and eventually removed in the future, following the [feature lifecycle](https://github.com/open-telemetry/opentelemetry-collector/tree/main/featuregate#feature-lifecycle).
 
 [beta]:https://github.com/open-telemetry/opentelemetry-collector#beta
 [alpha]:https://github.com/open-telemetry/opentelemetry-collector#alpha


### PR DESCRIPTION
**Description:** 
Update README about disabling the feature gate of native metric client and falling back to Zorkian client.