### PR TITLE
[processor/k8sattributes] Fix node/ns labels/annotations extraction

### DIFF
--- a/.chloggen/k8s-attrs-fix-ns-node-labels-annotation-setting.yaml
+++ b/.chloggen/k8s-attrs-fix-ns-node-labels-annotation-setting.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/k8sattributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Set attributes from namespace/node labels or annotations even if node/namespaces attribute are not set.
+
+# One or more tracking issues related to the change
+issues: [28837]


### PR DESCRIPTION
Set attributes from namespace/node labels or annotations even if `k8s.namespace.name` and `k8s.node.name` are not extracted.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/28837
