### PR TITLE
Update README.md

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -53,9 +53,9 @@ The following settings can be optionally configured:
 - `namespace`: prefix attached to each exported metric name.
 - `add_metric_suffixes`: If set to false, type and unit suffixes will not be added to metrics. Default: true.
 - `remote_write_queue`: fine tuning for queueing and sending of the outgoing remote writes.
-  - `enabled`: enable the sending queue
-  - `queue_size`: number of OTLP metrics that can be queued. Ignored if `enabled` is `false`
-  - `num_consumers`: minimum number of workers to use to fan out the outgoing requests.
+  - `enabled`: enable the sending queue (default: `true`)
+  - `queue_size`: number of OTLP metrics that can be queued. Ignored if `enabled` is `false` (default: `10000`)
+  - `num_consumers`: minimum number of workers to use to fan out the outgoing requests. (default: `5`)
 - `resource_to_telemetry_conversion`
   - `enabled` (default = false): If `enabled` is `true`, all the resource attributes will be converted to metric labels by default.
 - `target_info`: customize `target_info` metric


### PR DESCRIPTION
Added default values of the remote_write_queue config

**Description:** 
The Prometheus Remote write exporter is missing the details of default values for the remote write queue config. Added the values after looking into the code for the same. 

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>