### PR TITLE
[connector/spanmetrics] Fix memory leak

### DIFF
--- a/.chloggen/bripkens-spanmetrics-memory-leak.yaml
+++ b/.chloggen/bripkens-spanmetrics-memory-leak.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: connector/spanmetrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix memory leak when the cumulative temporality is used.
+
+# One or more tracking issues related to the change
+issues: [27654]

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -109,6 +109,8 @@ The following settings can be optionally configured:
   If no `default` is provided, this dimension will be **omitted** from the metric.
 - `exclude_dimensions`: the list of dimensions to be excluded from the default set of dimensions. Use to exclude unneeded data from metrics. 
 - `dimensions_cache_size` (default: `1000`): the size of cache for storing Dimensions to improve collectors memory usage. Must be a positive number. 
+- `resource_metrics_cache_size` (default: `1000`): the size of the cache holding metrics for a service. This is mostly relevant for
+   cumulative temporality to avoid memory leaks and correct metric timestamp resets.
 - `aggregation_temporality` (default: `AGGREGATION_TEMPORALITY_CUMULATIVE`): Defines the aggregation temporality of the generated metrics. 
   One of either `AGGREGATION_TEMPORALITY_CUMULATIVE` or `AGGREGATION_TEMPORALITY_DELTA`.
 - `namespace`: Defines the namespace of the generated metrics. If `namespace` provided, generated metric name will be added `namespace.` prefix.

--- a/connector/spanmetricsconnector/config.go
+++ b/connector/spanmetricsconnector/config.go
@@ -46,6 +46,11 @@ type Config struct {
 	// Optional. See defaultDimensionsCacheSize in connector.go for the default value.
 	DimensionsCacheSize int `mapstructure:"dimensions_cache_size"`
 
+	// ResourceMetricsCacheSize defines the size of the cache holding metrics for a service. This is mostly relevant for
+	// cumulative temporality to avoid memory leaks and correct metric timestamp resets.
+	// Optional. See defaultResourceMetricsCacheSize in connector.go for the default value.
+	ResourceMetricsCacheSize int `mapstructure:"resource_metrics_cache_size"`
+
 	AggregationTemporality string `mapstructure:"aggregation_temporality"`
 
 	Histogram HistogramConfig `mapstructure:"histogram"`

--- a/connector/spanmetricsconnector/config_test.go
+++ b/connector/spanmetricsconnector/config_test.go
@@ -47,8 +47,9 @@ func TestLoadConfig(t *testing.T) {
 					{Name: "http.method", Default: &defaultMethod},
 					{Name: "http.status_code", Default: (*string)(nil)},
 				},
-				DimensionsCacheSize:  1500,
-				MetricsFlushInterval: 30 * time.Second,
+				DimensionsCacheSize:      1500,
+				ResourceMetricsCacheSize: 1600,
+				MetricsFlushInterval:     30 * time.Second,
 				Exemplars: ExemplarsConfig{
 					Enabled: true,
 				},
@@ -66,9 +67,10 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, "exponential_histogram"),
 			expected: &Config{
-				AggregationTemporality: cumulative,
-				DimensionsCacheSize:    1000,
-				MetricsFlushInterval:   15 * time.Second,
+				AggregationTemporality:   cumulative,
+				DimensionsCacheSize:      defaultDimensionsCacheSize,
+				ResourceMetricsCacheSize: defaultResourceMetricsCacheSize,
+				MetricsFlushInterval:     15 * time.Second,
 				Histogram: HistogramConfig{
 					Unit: metrics.Milliseconds,
 					Exponential: &ExponentialHistogramConfig{
@@ -88,11 +90,12 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, "exemplars_enabled"),
 			expected: &Config{
-				AggregationTemporality: "AGGREGATION_TEMPORALITY_CUMULATIVE",
-				DimensionsCacheSize:    defaultDimensionsCacheSize,
-				MetricsFlushInterval:   15 * time.Second,
-				Histogram:              HistogramConfig{Disable: false, Unit: defaultUnit},
-				Exemplars:              ExemplarsConfig{Enabled: true},
+				AggregationTemporality:   "AGGREGATION_TEMPORALITY_CUMULATIVE",
+				DimensionsCacheSize:      defaultDimensionsCacheSize,
+				ResourceMetricsCacheSize: defaultResourceMetricsCacheSize,
+				MetricsFlushInterval:     15 * time.Second,
+				Histogram:                HistogramConfig{Disable: false, Unit: defaultUnit},
+				Exemplars:                ExemplarsConfig{Enabled: true},
 			},
 		},
 	}

--- a/connector/spanmetricsconnector/factory.go
+++ b/connector/spanmetricsconnector/factory.go
@@ -28,10 +28,11 @@ func NewFactory() connector.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		AggregationTemporality: "AGGREGATION_TEMPORALITY_CUMULATIVE",
-		DimensionsCacheSize:    defaultDimensionsCacheSize,
-		MetricsFlushInterval:   15 * time.Second,
-		Histogram:              HistogramConfig{Disable: false, Unit: defaultUnit},
+		AggregationTemporality:   "AGGREGATION_TEMPORALITY_CUMULATIVE",
+		DimensionsCacheSize:      defaultDimensionsCacheSize,
+		ResourceMetricsCacheSize: defaultResourceMetricsCacheSize,
+		MetricsFlushInterval:     15 * time.Second,
+		Histogram:                HistogramConfig{Disable: false, Unit: defaultUnit},
 	}
 }
 

--- a/connector/spanmetricsconnector/internal/cache/cache.go
+++ b/connector/spanmetricsconnector/internal/cache/cache.go
@@ -74,3 +74,17 @@ func (c *Cache[K, V]) Purge() {
 	c.lru.Purge()
 	c.RemoveEvictedItems()
 }
+
+// ForEach iterates over all the items within the cache, as well as the evicted items (if any).
+func (c *Cache[K, V]) ForEach(fn func(k K, v V)) {
+	for _, k := range c.lru.Keys() {
+		v, ok := c.lru.Get(k)
+		if ok {
+			fn(k.(K), v.(V))
+		}
+	}
+
+	for k, v := range c.evictedItems {
+		fn(k, v)
+	}
+}

--- a/connector/spanmetricsconnector/testdata/config.yaml
+++ b/connector/spanmetricsconnector/testdata/config.yaml
@@ -15,6 +15,7 @@ spanmetrics/full:
   exemplars:
     enabled: true
   dimensions_cache_size: 1500
+  resource_metrics_cache_size: 1600
 
   # Additional list of dimensions on top of:
   # - service.name


### PR DESCRIPTION
# Why

The `spanmetrics` connector has a memory leak that occurs when the cumulative temporality is used. The `connectorImp#resourceMetrics` map is only ever cleaned up in delta temporality.

# What

Turn `connectorImp#resourceMetrics` into a LRU cache with a maximum size. To correctly handle metric resets we also introduce a start timestamp per `resourceMetric` instance.

# References

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27654
