### PR TITLE
[receiver/azuremonitor] Add semantic-conventions resource attributes

### DIFF
--- a/.chloggen/azuremonitor-receiver-semconv.yaml
+++ b/.chloggen/azuremonitor-receiver-semconv.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: azuremonitorreceiver

--- a/.chloggen/azuremonitor-receiver-semconv.yaml
+++ b/.chloggen/azuremonitor-receiver-semconv.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add resource attributes per semantic conventions for cloud.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [28871]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/azuremonitorreceiver/internal/metadata/generated_config.go
+++ b/receiver/azuremonitorreceiver/internal/metadata/generated_config.go
@@ -27,15 +27,39 @@ func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
 type ResourceAttributesConfig struct {
 	AzuremonitorSubscriptionID ResourceAttributeConfig `mapstructure:"azuremonitor.subscription_id"`
 	AzuremonitorTenantID       ResourceAttributeConfig `mapstructure:"azuremonitor.tenant_id"`
+	CloudAccountID             ResourceAttributeConfig `mapstructure:"cloud.account.id"`
+	CloudAvailabilityZone      ResourceAttributeConfig `mapstructure:"cloud.availability_zone"`
+	CloudPlatform              ResourceAttributeConfig `mapstructure:"cloud.platform"`
+	CloudProvider              ResourceAttributeConfig `mapstructure:"cloud.provider"`
+	CloudRegion                ResourceAttributeConfig `mapstructure:"cloud.region"`
+	CloudResourceID            ResourceAttributeConfig `mapstructure:"cloud.resource_id"`
 }
 
 func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 	return ResourceAttributesConfig{
 		AzuremonitorSubscriptionID: ResourceAttributeConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		AzuremonitorTenantID: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		CloudAccountID: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		CloudAvailabilityZone: ResourceAttributeConfig{
 			Enabled: false,
+		},
+		CloudPlatform: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		CloudProvider: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		CloudRegion: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		CloudResourceID: ResourceAttributeConfig{
+			Enabled: true,
 		},
 	}
 }

--- a/receiver/azuremonitorreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/azuremonitorreceiver/internal/metadata/generated_config_test.go
@@ -27,6 +27,12 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				AzuremonitorSubscriptionID: ResourceAttributeConfig{Enabled: true},
 				AzuremonitorTenantID:       ResourceAttributeConfig{Enabled: true},
+				CloudAccountID:             ResourceAttributeConfig{Enabled: true},
+				CloudAvailabilityZone:      ResourceAttributeConfig{Enabled: true},
+				CloudPlatform:              ResourceAttributeConfig{Enabled: true},
+				CloudProvider:              ResourceAttributeConfig{Enabled: true},
+				CloudRegion:                ResourceAttributeConfig{Enabled: true},
+				CloudResourceID:            ResourceAttributeConfig{Enabled: true},
 			},
 		},
 		{
@@ -34,6 +40,12 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				AzuremonitorSubscriptionID: ResourceAttributeConfig{Enabled: false},
 				AzuremonitorTenantID:       ResourceAttributeConfig{Enabled: false},
+				CloudAccountID:             ResourceAttributeConfig{Enabled: false},
+				CloudAvailabilityZone:      ResourceAttributeConfig{Enabled: false},
+				CloudPlatform:              ResourceAttributeConfig{Enabled: false},
+				CloudProvider:              ResourceAttributeConfig{Enabled: false},
+				CloudRegion:                ResourceAttributeConfig{Enabled: false},
+				CloudResourceID:            ResourceAttributeConfig{Enabled: false},
 			},
 		},
 	}

--- a/receiver/azuremonitorreceiver/internal/metadata/generated_resource.go
+++ b/receiver/azuremonitorreceiver/internal/metadata/generated_resource.go
@@ -35,6 +35,48 @@ func (rb *ResourceBuilder) SetAzuremonitorTenantID(val string) {
 	}
 }
 
+// SetCloudAccountID sets provided value as "cloud.account.id" attribute.
+func (rb *ResourceBuilder) SetCloudAccountID(val string) {
+	if rb.config.CloudAccountID.Enabled {
+		rb.res.Attributes().PutStr("cloud.account.id", val)
+	}
+}
+
+// SetCloudAvailabilityZone sets provided value as "cloud.availability_zone" attribute.
+func (rb *ResourceBuilder) SetCloudAvailabilityZone(val string) {
+	if rb.config.CloudAvailabilityZone.Enabled {
+		rb.res.Attributes().PutStr("cloud.availability_zone", val)
+	}
+}
+
+// SetCloudPlatform sets provided value as "cloud.platform" attribute.
+func (rb *ResourceBuilder) SetCloudPlatform(val string) {
+	if rb.config.CloudPlatform.Enabled {
+		rb.res.Attributes().PutStr("cloud.platform", val)
+	}
+}
+
+// SetCloudProvider sets provided value as "cloud.provider" attribute.
+func (rb *ResourceBuilder) SetCloudProvider(val string) {
+	if rb.config.CloudProvider.Enabled {
+		rb.res.Attributes().PutStr("cloud.provider", val)
+	}
+}
+
+// SetCloudRegion sets provided value as "cloud.region" attribute.
+func (rb *ResourceBuilder) SetCloudRegion(val string) {
+	if rb.config.CloudRegion.Enabled {
+		rb.res.Attributes().PutStr("cloud.region", val)
+	}
+}
+
+// SetCloudResourceID sets provided value as "cloud.resource_id" attribute.
+func (rb *ResourceBuilder) SetCloudResourceID(val string) {
+	if rb.config.CloudResourceID.Enabled {
+		rb.res.Attributes().PutStr("cloud.resource_id", val)
+	}
+}
+
 // Emit returns the built resource and resets the internal builder state.
 func (rb *ResourceBuilder) Emit() pcommon.Resource {
 	r := rb.res

--- a/receiver/azuremonitorreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/azuremonitorreceiver/internal/metadata/generated_resource_test.go
@@ -15,15 +15,21 @@ func TestResourceBuilder(t *testing.T) {
 			rb := NewResourceBuilder(cfg)
 			rb.SetAzuremonitorSubscriptionID("azuremonitor.subscription_id-val")
 			rb.SetAzuremonitorTenantID("azuremonitor.tenant_id-val")
+			rb.SetCloudAccountID("cloud.account.id-val")
+			rb.SetCloudAvailabilityZone("cloud.availability_zone-val")
+			rb.SetCloudPlatform("cloud.platform-val")
+			rb.SetCloudProvider("cloud.provider-val")
+			rb.SetCloudRegion("cloud.region-val")
+			rb.SetCloudResourceID("cloud.resource_id-val")
 
 			res := rb.Emit()
 			assert.Equal(t, 0, rb.Emit().Attributes().Len()) // Second call should return empty Resource
 
 			switch test {
 			case "default":
-				assert.Equal(t, 0, res.Attributes().Len())
+				assert.Equal(t, 7, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 2, res.Attributes().Len())
+				assert.Equal(t, 8, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -32,14 +38,44 @@ func TestResourceBuilder(t *testing.T) {
 			}
 
 			val, ok := res.Attributes().Get("azuremonitor.subscription_id")
-			assert.Equal(t, test == "all_set", ok)
+			assert.True(t, ok)
 			if ok {
 				assert.EqualValues(t, "azuremonitor.subscription_id-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("azuremonitor.tenant_id")
-			assert.Equal(t, test == "all_set", ok)
+			assert.True(t, ok)
 			if ok {
 				assert.EqualValues(t, "azuremonitor.tenant_id-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("cloud.account.id")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "cloud.account.id-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("cloud.availability_zone")
+			assert.Equal(t, test == "all_set", ok)
+			if ok {
+				assert.EqualValues(t, "cloud.availability_zone-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("cloud.platform")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "cloud.platform-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("cloud.provider")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "cloud.provider-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("cloud.region")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "cloud.region-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("cloud.resource_id")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "cloud.resource_id-val", val.Str())
 			}
 		})
 	}

--- a/receiver/azuremonitorreceiver/internal/metadata/metrics_test.go
+++ b/receiver/azuremonitorreceiver/internal/metadata/metrics_test.go
@@ -59,7 +59,7 @@ func TestMetricsBuilder(t *testing.T) {
 			attributes := map[string]*string{}
 			mb.AddDataPoint("resId1", "metric1", "count", "unit", attributes, ts, val1)
 
-			metrics := mb.Emit(WithAzureMonitorSubscriptionID("attr-val"), WithAzureMonitorTenantID("attr-val"))
+			metrics := mb.Emit(WithAzuremonitorSubscriptionID("attr-val"), WithAzuremonitorTenantID("attr-val"))
 
 			if test.configSet == testSetNone {
 				assert.Equal(t, 0, metrics.ResourceMetrics().Len())
@@ -72,15 +72,15 @@ func TestMetricsBuilder(t *testing.T) {
 			enabledAttrCount := 0
 			attrVal, ok := rm.Resource().Attributes().Get("azuremonitor.subscription_id")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.AzureMonitorSubscriptionID.Enabled, ok)
-			if mb.resourceAttributesSettings.AzureMonitorSubscriptionID.Enabled {
+			assert.Equal(t, mb.config.ResourceAttributes.AzuremonitorSubscriptionID.Enabled, ok)
+			if mb.config.ResourceAttributes.AzuremonitorSubscriptionID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}
 			attrVal, ok = rm.Resource().Attributes().Get("azuremonitor.tenant_id")
 			attrCount++
-			assert.Equal(t, mb.resourceAttributesSettings.AzureMonitorTenantID.Enabled, ok)
-			if mb.resourceAttributesSettings.AzureMonitorTenantID.Enabled {
+			assert.Equal(t, mb.config.ResourceAttributes.AzuremonitorTenantID.Enabled, ok)
+			if mb.config.ResourceAttributes.AzuremonitorTenantID.Enabled {
 				enabledAttrCount++
 				assert.EqualValues(t, "attr-val", attrVal.Str())
 			}

--- a/receiver/azuremonitorreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/azuremonitorreceiver/internal/metadata/testdata/config.yaml
@@ -5,9 +5,33 @@ all_set:
       enabled: true
     azuremonitor.tenant_id:
       enabled: true
+    cloud.account.id:
+      enabled: true
+    cloud.availability_zone:
+      enabled: true
+    cloud.platform:
+      enabled: true
+    cloud.provider:
+      enabled: true
+    cloud.region:
+      enabled: true
+    cloud.resource_id:
+      enabled: true
 none_set:
   resource_attributes:
     azuremonitor.subscription_id:
       enabled: false
     azuremonitor.tenant_id:
+      enabled: false
+    cloud.account.id:
+      enabled: false
+    cloud.availability_zone:
+      enabled: false
+    cloud.platform:
+      enabled: false
+    cloud.provider:
+      enabled: false
+    cloud.region:
+      enabled: false
+    cloud.resource_id:
       enabled: false

--- a/receiver/azuremonitorreceiver/metadata.yaml
+++ b/receiver/azuremonitorreceiver/metadata.yaml
@@ -12,6 +12,34 @@ resource_attributes:
   azuremonitor.tenant_id:
     description: Azure tenant ID
     type: string
+    enabled: true
   azuremonitor.subscription_id:
     description: Azure subscription ID
     type: string
+    enabled: true
+  cloud.account.id:
+    description: The cloud account ID the resource is assigned to.
+    type: string
+    enabled: true
+  cloud.availability_zone:
+    description: Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
+    type: string
+    enabled: false
+  cloud.platform:
+    description: The cloud platform in use.
+    # Semantic Conventions document 6 well known Azure platforms: azure_vm,	azure_container_instances, azure_aks, azure_functions, azure_app_service, azure_openshift,
+    # but we are not limited to them. We can use any string here.
+    type: string
+    enabled: true
+  cloud.provider:
+    description: Name of the cloud provider. Default `azure`.
+    type: string
+    enabled: true
+  cloud.region:
+    description: The geographical region where the resource is running.
+    type: string
+    enabled: true
+  cloud.resource_id:
+    description: Cloud provider-specific native identifier of the monitored cloud resource (e.g. `/subscriptions/<SUBSCIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>`)
+    type: string
+    enabled: true

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -195,9 +195,17 @@ func TestAzureScraperScrape(t *testing.T) {
 		ctx context.Context
 	}
 	cfg := createDefaultConfig().(*Config)
+	cfg.SubscriptionID = "testSubscriptionID_x"
+	cfg.TenantID = "testTenantID_x"
+	cfg.ClientID = "testClientID_x"
+	cfg.ClientSecret = "testClientSecret_x"
 	cfg.MaximumNumberOfMetricsInACall = 2
 
 	cfgTagsEnabled := createDefaultConfig().(*Config)
+	cfgTagsEnabled.SubscriptionID = "testSubscriptionID_TagsEnabled"
+	cfgTagsEnabled.TenantID = "testTenantID_TagsEnabled"
+	cfgTagsEnabled.ClientID = "testClientID_TagsEnabled"
+	cfgTagsEnabled.ClientSecret = "testClientSecret_TagsEnabled"
 	cfgTagsEnabled.AppendTagsAsAttributes = true
 	cfgTagsEnabled.MaximumNumberOfMetricsInACall = 2
 
@@ -229,6 +237,9 @@ func TestAzureScraperScrape(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// validate the config to start
+			require.NoError(t, tt.fields.cfg.Validate())
+
 			settings := receivertest.NewNopCreateSettings()
 
 			armClientMock := &armClientMock{
@@ -264,6 +275,11 @@ func TestAzureScraperScrape(t *testing.T) {
 			}
 
 			expectedFile := filepath.Join("testdata", "expected_metrics", tt.name+".yaml")
+			/* Uncomment stanza below to regenerate the golden files */
+			// if err := golden.WriteMetrics(t, expectedFile, metrics); err != nil {
+			// 	t.Error("failed to write metrics: ", err)
+			// }
+			/* End of stanza */
 			expectedMetrics, err := golden.ReadMetrics(expectedFile)
 			require.NoError(t, err)
 			require.NoError(t, pmetrictest.CompareMetrics(

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -1,12 +1,5 @@
 resourceMetrics:
-  - resource:
-      attributes:
-        - key: azuremonitor.subscription_id
-          value:
-            stringValue: ""
-        - key: azuremonitor.tenant_id
-          value:
-            stringValue: ""
+  - resource: {}
     scopeMetrics:
       - metrics:
           - gauge:
@@ -14,6 +7,18 @@ resourceMetrics:
                 - asDouble: 1
                   attributes:
                     - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId1
                     - key: location
@@ -30,13 +35,95 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric1_maximum
+            name: azure_metric1_count
             unit: unit1
           - gauge:
               dataPoints:
                 - asDouble: 1
                   attributes:
                     - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric2_count
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric2_total
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId1
                     - key: location
@@ -62,327 +149,16 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
                       value:
                         stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric4_minimum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric4_total
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
-                    - key: metadata_dimension2
-                      value:
-                        stringValue: dimension value
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric5_count
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
-                    - key: metadata_dimension2
-                      value:
-                        stringValue: dimension value
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric5_maximum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
-                    - key: metadata_dimension2
-                      value:
-                        stringValue: dimension value
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric5_total
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric2_average
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric3_maximum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric6_maximum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric1_total
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric3_total
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric4_average
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric4_maximum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId3
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric7_count
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
@@ -414,6 +190,18 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
                     - key: location
                       value:
                         stringValue: location1
@@ -431,13 +219,25 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric6_average
+            name: azure_metric6_minimum
             unit: unit1
           - gauge:
               dataPoints:
                 - asDouble: 1
                   attributes:
                     - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId1
                     - key: location
@@ -454,7 +254,7 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric1_count
+            name: azure_metric1_average
             unit: unit1
           - gauge:
               dataPoints:
@@ -463,73 +263,16 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
                       value:
                         stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric1_minimum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric2_count
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric2_total
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId1
                     - key: location
@@ -555,6 +298,56 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric6_total
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
                     - key: location
                       value:
                         stringValue: location1
@@ -569,13 +362,244 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric4_count
+            name: azure_metric1_minimum
             unit: unit1
           - gauge:
               dataPoints:
                 - asDouble: 1
                   attributes:
                     - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric3_total
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric4_average
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
+                      value:
+                        stringValue: dimension value
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric5_count
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric6_count
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric2_maximum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric2_minimum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
@@ -606,80 +630,26 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
                       value:
                         stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric1_average
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric2_maximum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric2_minimum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
                       value:
                         stringValue: location1
                     - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
                       value:
                         stringValue: dimension value
                     - key: name
@@ -693,7 +663,7 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric6_minimum
+            name: azure_metric5_total
             unit: unit1
           - gauge:
               dataPoints:
@@ -701,13 +671,22 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
                     - key: location
                       value:
                         stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
                     - key: name
                       value:
                         stringValue: name1
@@ -719,13 +698,25 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric6_total
+            name: azure_metric1_maximum
             unit: unit1
           - gauge:
               dataPoints:
                 - asDouble: 1
                   attributes:
                     - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId1
                     - key: location
@@ -750,6 +741,91 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
+                        stringValue: /resourceGroups/group1/resourceId3
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId3
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric7_count
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric4_count
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
                       value:
@@ -768,7 +844,296 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric6_count
+            name: azure_metric6_average
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric1_total
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric4_total
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric4_maximum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
+                      value:
+                        stringValue: dimension value
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric5_maximum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric2_average
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric3_maximum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric4_minimum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_x
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric6_maximum
             unit: unit1
         scope:
           name: otelcol/azuremonitorreceiver

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_tags_golden.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_tags_golden.yaml
@@ -1,12 +1,5 @@
 resourceMetrics:
-  - resource:
-      attributes:
-        - key: azuremonitor.subscription_id
-          value:
-            stringValue: ""
-        - key: azuremonitor.tenant_id
-          value:
-            stringValue: ""
+  - resource: {}
     scopeMetrics:
       - metrics:
           - gauge:
@@ -16,15 +9,21 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
                     - key: location
                       value:
                         stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
-                    - key: metadata_dimension2
-                      value:
-                        stringValue: dimension value
                     - key: name
                       value:
                         stringValue: name1
@@ -36,13 +35,63 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric5_minimum
+            name: azure_metric4_minimum
             unit: unit1
           - gauge:
               dataPoints:
                 - asDouble: 1
                   attributes:
                     - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric2_maximum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
@@ -70,262 +119,17 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric1_average
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric1_minimum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric3_average
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric3_count
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric3_maximum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
                         stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
                       value:
                         stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric4_count
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId3
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric7_count
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric2_average
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric2_total
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric6_maximum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
@@ -348,7 +152,7 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric5_total
+            name: azure_metric5_average
             unit: unit1
           - gauge:
               dataPoints:
@@ -356,57 +160,17 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
                       value:
                         stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric1_count
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric3_minimum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
@@ -438,163 +202,16 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
                       value:
                         stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric6_total
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric1_total
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric2_count
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
-                    - key: metadata_dimension2
-                      value:
-                        stringValue: dimension value
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric5_average
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric2_minimum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: tags_tagName1
-                      value:
-                        stringValue: tagValue1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric1_maximum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
@@ -611,13 +228,139 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric4_total
+            name: azure_metric4_average
             unit: unit1
           - gauge:
               dataPoints:
                 - asDouble: 1
                   attributes:
                     - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric1_count
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric2_average
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric3_average
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
@@ -648,6 +391,56 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric2_minimum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
                       value:
@@ -663,13 +456,104 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric4_average
+            name: azure_metric4_maximum
             unit: unit1
           - gauge:
               dataPoints:
                 - asDouble: 1
                   attributes:
                     - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric1_minimum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
+                      value:
+                        stringValue: dimension value
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric5_minimum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
@@ -697,6 +581,53 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric4_count
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
                         stringValue: /resourceGroups/group1/resourceId1
                     - key: location
                       value:
@@ -715,13 +646,174 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric2_maximum
+            name: azure_metric1_maximum
             unit: unit1
           - gauge:
               dataPoints:
                 - asDouble: 1
                   attributes:
                     - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric3_maximum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId3
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId3
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric7_count
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric4_total
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric2_count
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId1
                     - key: location
@@ -750,9 +842,24 @@ resourceMetrics:
                     - key: azuremonitor.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
                     - key: location
                       value:
                         stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
                     - key: name
                       value:
                         stringValue: name1
@@ -764,13 +871,294 @@ resourceMetrics:
                         stringValue: type1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric4_minimum
+            name: azure_metric6_total
             unit: unit1
           - gauge:
               dataPoints:
                 - asDouble: 1
                   attributes:
                     - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric6_maximum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric1_average
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric1_total
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric2_total
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric3_count
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: tags_tagName1
+                      value:
+                        stringValue: tagValue1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric3_minimum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: metadata_dimension2
+                      value:
+                        stringValue: dimension value
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric5_total
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: cloud.account.id
+                      value:
+                        stringValue: testSubscriptionID_TagsEnabled
+                    - key: cloud.provider
+                      value:
+                        stringValue: azure
+                    - key: cloud.region
+                      value:
+                        stringValue: location1
+                    - key: cloud.resource_id
                       value:
                         stringValue: /resourceGroups/group1/resourceId2
                     - key: location
@@ -791,29 +1179,6 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: azure_metric6_count
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId2
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric4_maximum
             unit: unit1
         scope:
           name: otelcol/azuremonitorreceiver


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
To streamline your reviewing, I'm providing a checklist that I believe covers the questions a diligent review must answer. Hopefully you feel kindly helped and not limited.

- [ ] changes in `metadata.yaml` align to [semantic conventions for cloud](https://github.com/open-telemetry/semantic-conventions/blob/main/model/resource/cloud.yaml))
- [ ] changes in `metrics.go` align the code to more conventional receiver patterns that leverage code generated by `mdatagen`
- [ ] expected result is apparent in telemetry generated by new code (see testing section)

Please let me know if you need additional content to help with your review. I'll explain some more to help filter the diffs for you, so you can focus on substance...

First of all, all of the changes to files with the `generated_` prefix are caused either by changes to `mdatagen` since earlier work on this receiver combined only with updates in `metadata` which is really the substance of the PR. CI confirms that generated code in those files aligns with the metadata. I believe the following checklist w

This PR adds semantic convention attributes for cloud resources ([link](https://github.com/open-telemetry/semantic-conventions/blob/main/model/resource/cloud.yaml)).
Minor additional code changes here relate only to relying more on structs generated with `mdatagen` based only on the new `metadata.yaml`, rather than updating older structs which duplicate structs that are generated now. This should only increase confidence in accuracy and reduce maintenance going forward. Avoiding these changes for purpose of keeping a more singular purpose in this PR would have required manual updates to the code that was duplicating functionality.

**Link to tracking Issue:** <Issue number if applicable>
N/A

**Testing:** <Describe what testing was performed and which tests were added.>
Updated scraper tests to include checks for the new attributes.

Additionally I tested this with Azure Monitor. Here are relevant lines from Collector logs, followed by the receiver configuration which was running.

LOGS:
```
newreceiver-otel-collector-1  | Data point attributes:
newreceiver-otel-collector-1  |      -> azuremonitor.resource_id: Str(/subscriptions/15258dc9-b89e-4380-bce5-72728ed2b52f/resourceGroups/ex-compute-vm/providers/Microsoft.Compute/virtualMachines/ex-compute-vm-vm1)
newreceiver-otel-collector-1  |      -> resource_group: Str(ex-compute-vm)
newreceiver-otel-collector-1  |      -> cloud.region: Str(eastus)
newreceiver-otel-collector-1  |      -> cloud.account.id: Str(15258dc9-b89e-4380-bce5-72728ed2b52f)
newreceiver-otel-collector-1  |      -> name: Str(ex-compute-vm-vm1)
newreceiver-otel-collector-1  |      -> type: Str(Microsoft.Compute/virtualMachines)
hines/ex-compute-vm-vm1)
newreceiver-otel-collector-1  |      -> location: Str(eastus)
newreceiver-otel-collector-1  |      -> cloud.region: Str(eastus)
newreceiver-otel-collector-1  |      -> cloud.platform: Str(azure_vm)
newreceiver-otel-collector-1  |      -> resource_group: Str(ex-compute-vm)
newreceiver-otel-collector-1  |      -> type: Str(Microsoft.Compute/virtualMachines)
newreceiver-otel-collector-1  |      -> cloud.resource_id: Str(/subscriptions/15258dc9-b89e-4380-bce5-72728ed2b52f/resourceGroups/ex-compute-vm/providers/Microsoft.Compute/virtualMachines/ex-compute-vm-vm1)
newreceiver-otel-collector-1  |      -> cloud.account.id: Str(15258dc9-b89e-4380-bce5-72728ed2b52f)
newreceiver-otel-collector-1  |      -> cloud.provider: Str(azure)
newreceiver-otel-collector-1  |      -> name: Str(ex-compute-vm-vm1)
```

COLLECTOR CONFIG:
```yaml
  azuremonitor:
    subscription_id: "${AZURE_SUBSCRIPTION_ID}"
    tenant_id: "${AZURE_TENANT_ID}"
    client_id: "${AZURE_CLIENT_ID}"
    client_secret: "${AZURE_CLIENT_SECRET}"
    resource_groups:
      - "ex-compute-vm"
    services:
      - "Microsoft.Compute/virtualMachines"
    collection_interval: 60s
```

**Documentation:** <Describe the documentation added.>
N/A. Only adding resource attributes which doesn't impact parts covered in docs.