### PR TITLE
[receiver/carbon] do not expose method

### DIFF
--- a/.chloggen/carbonreceiver-checkapi-26304.yaml
+++ b/.chloggen/carbonreceiver-checkapi-26304.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'breaking'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: carbonreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not export function New and pass checkapi.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [26304]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -2,7 +2,6 @@ connector/servicegraphconnector
 extension/encoding
 extension/observer
 processor/servicegraphprocessor
-receiver/carbonreceiver
 receiver/collectdreceiver
 receiver/dockerstatsreceiver
 receiver/journaldreceiver

--- a/receiver/carbonreceiver/factory.go
+++ b/receiver/carbonreceiver/factory.go
@@ -48,5 +48,5 @@ func createMetricsReceiver(
 ) (receiver.Metrics, error) {
 
 	rCfg := cfg.(*Config)
-	return New(params, *rCfg, consumer)
+	return newMetricsReceiver(params, *rCfg, consumer)
 }

--- a/receiver/carbonreceiver/receiver.go
+++ b/receiver/carbonreceiver/receiver.go
@@ -35,8 +35,8 @@ type carbonReceiver struct {
 
 var _ receiver.Metrics = (*carbonReceiver)(nil)
 
-// New creates the Carbon receiver with the given configuration.
-func New(
+// newMetricsReceiver creates the Carbon receiver with the given configuration.
+func newMetricsReceiver(
 	set receiver.CreateSettings,
 	config Config,
 	nextConsumer consumer.Metrics,

--- a/receiver/carbonreceiver/receiver_test.go
+++ b/receiver/carbonreceiver/receiver_test.go
@@ -97,7 +97,7 @@ func Test_carbonreceiver_New(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(receivertest.NewNopCreateSettings(), tt.args.config, tt.args.nextConsumer)
+			got, err := newMetricsReceiver(receivertest.NewNopCreateSettings(), tt.args.config, tt.args.nextConsumer)
 			assert.Equal(t, tt.wantErr, err)
 			if err == nil {
 				require.NotNil(t, got)
@@ -157,7 +157,7 @@ func Test_carbonreceiver_Start(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(receivertest.NewNopCreateSettings(), tt.args.config, tt.args.nextConsumer)
+			got, err := newMetricsReceiver(receivertest.NewNopCreateSettings(), tt.args.config, tt.args.nextConsumer)
 			require.NoError(t, err)
 			err = got.Start(context.Background(), componenttest.NewNopHost())
 			assert.Equal(t, tt.wantErr, err)
@@ -218,7 +218,7 @@ func Test_carbonreceiver_EndToEnd(t *testing.T) {
 			rt := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
 			cs := receivertest.NewNopCreateSettings()
 			cs.TracerProvider = rt
-			rcv, err := New(cs, *cfg, sink)
+			rcv, err := newMetricsReceiver(cs, *cfg, sink)
 			require.NoError(t, err)
 			r := rcv.(*carbonReceiver)
 


### PR DESCRIPTION
**Description:** 
Do not export function `New` and pass checkapi.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26304

**Testing:** 
go run cmd/checkapi/main.go .
make chlog-validate
go test for carbonreceiver

**Documentation:**