### PR TITLE
[chore][checkapi] Do not enforce that all packages must have exactly one function

### DIFF
--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -1,5 +1,4 @@
 connector/servicegraphconnector
-extension/encoding
 extension/observer
 processor/servicegraphprocessor
 receiver/collectdreceiver

--- a/cmd/checkapi/main.go
+++ b/cmd/checkapi/main.go
@@ -172,12 +172,13 @@ func walkFolder(folder string, componentType string) error {
 		return nil
 	}
 
+	if len(result.Functions) == 0 {
+		return nil
+	}
 	if len(result.Functions) > 1 {
 		return fmt.Errorf("%s has more than one function: %q", folder, strings.Join(fnNames, ","))
 	}
-	if len(result.Functions) == 0 {
-		return fmt.Errorf("%s has no functions defined", folder)
-	}
+
 	newFactoryFn := result.Functions[0]
 	if newFactoryFn.Name != "NewFactory" {
 		return fmt.Errorf("%s does not define a NewFactory function", folder)


### PR DESCRIPTION
If no functions are exposed, exit with no error.

This change allows to remove `extension/encoding` from the allowlist.