### PR TITLE
[chore] update dockerstats to pass checkapi

### DIFF
--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -3,7 +3,6 @@ extension/encoding
 extension/observer
 processor/servicegraphprocessor
 receiver/collectdreceiver
-receiver/dockerstatsreceiver
 receiver/journaldreceiver
 receiver/kafkareceiver
 receiver/windowseventlogreceiver

--- a/receiver/dockerstatsreceiver/factory.go
+++ b/receiver/dockerstatsreceiver/factory.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/featuregate"
-	rcvr "go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver/internal/metadata"
@@ -24,11 +24,11 @@ var _ = featuregate.GlobalRegistry().MustRegister(
 	featuregate.WithRegisterToVersion("0.74.0"),
 )
 
-func NewFactory() rcvr.Factory {
-	return rcvr.NewFactory(
+func NewFactory() receiver.Factory {
+	return receiver.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
-		rcvr.WithMetrics(createMetricsReceiver, metadata.MetricsStability))
+		receiver.WithMetrics(createMetricsReceiver, metadata.MetricsStability))
 }
 
 func createDefaultConfig() component.Config {
@@ -45,10 +45,10 @@ func createDefaultConfig() component.Config {
 
 func createMetricsReceiver(
 	_ context.Context,
-	params rcvr.CreateSettings,
+	params receiver.CreateSettings,
 	config component.Config,
 	consumer consumer.Metrics,
-) (rcvr.Metrics, error) {
+) (receiver.Metrics, error) {
 	dockerConfig := config.(*Config)
 	dsr := newReceiver(params, dockerConfig)
 

--- a/receiver/dockerstatsreceiver/receiver.go
+++ b/receiver/dockerstatsreceiver/receiver.go
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	rcvr "go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
 	"go.uber.org/multierr"
 
@@ -35,22 +35,22 @@ type resultV2 struct {
 	err       error
 }
 
-type receiver struct {
+type dockerStatsReceiver struct {
 	config   *Config
-	settings rcvr.CreateSettings
+	settings receiver.CreateSettings
 	client   *docker.Client
 	mb       *metadata.MetricsBuilder
 }
 
-func newReceiver(set rcvr.CreateSettings, config *Config) *receiver {
-	return &receiver{
+func newReceiver(set receiver.CreateSettings, config *Config) *dockerStatsReceiver {
+	return &dockerStatsReceiver{
 		config:   config,
 		settings: set,
 		mb:       metadata.NewMetricsBuilder(config.MetricsBuilderConfig, set),
 	}
 }
 
-func (r *receiver) start(ctx context.Context, _ component.Host) error {
+func (r *dockerStatsReceiver) start(ctx context.Context, _ component.Host) error {
 	dConfig, err := docker.NewConfig(r.config.Endpoint, r.config.Timeout, r.config.ExcludedImages, r.config.DockerAPIVersion)
 	if err != nil {
 		return err
@@ -69,7 +69,7 @@ func (r *receiver) start(ctx context.Context, _ component.Host) error {
 	return nil
 }
 
-func (r *receiver) scrapeV2(ctx context.Context) (pmetric.Metrics, error) {
+func (r *dockerStatsReceiver) scrapeV2(ctx context.Context) (pmetric.Metrics, error) {
 	containers := r.client.Containers()
 	results := make(chan resultV2, len(containers))
 
@@ -111,7 +111,7 @@ func (r *receiver) scrapeV2(ctx context.Context) (pmetric.Metrics, error) {
 	return r.mb.Emit(), errs
 }
 
-func (r *receiver) recordContainerStats(now pcommon.Timestamp, containerStats *dtypes.StatsJSON, container *docker.Container) error {
+func (r *dockerStatsReceiver) recordContainerStats(now pcommon.Timestamp, containerStats *dtypes.StatsJSON, container *docker.Container) error {
 	var errs error
 	r.recordCPUMetrics(now, &containerStats.CPUStats, &containerStats.PreCPUStats)
 	r.recordMemoryMetrics(now, &containerStats.MemoryStats)
@@ -148,7 +148,7 @@ func (r *receiver) recordContainerStats(now pcommon.Timestamp, containerStats *d
 	return errs
 }
 
-func (r *receiver) recordMemoryMetrics(now pcommon.Timestamp, memoryStats *dtypes.MemoryStats) {
+func (r *dockerStatsReceiver) recordMemoryMetrics(now pcommon.Timestamp, memoryStats *dtypes.MemoryStats) {
 	totalUsage := calculateMemUsageNoCache(memoryStats)
 	r.mb.RecordContainerMemoryUsageTotalDataPoint(now, int64(totalUsage))
 
@@ -204,7 +204,7 @@ func (r *receiver) recordMemoryMetrics(now pcommon.Timestamp, memoryStats *dtype
 
 type blkioRecorder func(now pcommon.Timestamp, val int64, devMaj string, devMin string, operation string)
 
-func (r *receiver) recordBlkioMetrics(now pcommon.Timestamp, blkioStats *dtypes.BlkioStats) {
+func (r *dockerStatsReceiver) recordBlkioMetrics(now pcommon.Timestamp, blkioStats *dtypes.BlkioStats) {
 	recordSingleBlkioStat(now, blkioStats.IoMergedRecursive, r.mb.RecordContainerBlockioIoMergedRecursiveDataPoint)
 	recordSingleBlkioStat(now, blkioStats.IoQueuedRecursive, r.mb.RecordContainerBlockioIoQueuedRecursiveDataPoint)
 	recordSingleBlkioStat(now, blkioStats.IoServiceBytesRecursive, r.mb.RecordContainerBlockioIoServiceBytesRecursiveDataPoint)
@@ -226,7 +226,7 @@ func recordSingleBlkioStat(now pcommon.Timestamp, statEntries []dtypes.BlkioStat
 	}
 }
 
-func (r *receiver) recordNetworkMetrics(now pcommon.Timestamp, networks *map[string]dtypes.NetworkStats) {
+func (r *dockerStatsReceiver) recordNetworkMetrics(now pcommon.Timestamp, networks *map[string]dtypes.NetworkStats) {
 	if networks == nil || *networks == nil {
 		return
 	}
@@ -243,7 +243,7 @@ func (r *receiver) recordNetworkMetrics(now pcommon.Timestamp, networks *map[str
 	}
 }
 
-func (r *receiver) recordCPUMetrics(now pcommon.Timestamp, cpuStats *dtypes.CPUStats, prevStats *dtypes.CPUStats) {
+func (r *dockerStatsReceiver) recordCPUMetrics(now pcommon.Timestamp, cpuStats *dtypes.CPUStats, prevStats *dtypes.CPUStats) {
 	r.mb.RecordContainerCPUUsageSystemDataPoint(now, int64(cpuStats.SystemUsage))
 	r.mb.RecordContainerCPUUsageTotalDataPoint(now, int64(cpuStats.CPUUsage.TotalUsage))
 	r.mb.RecordContainerCPUUsageKernelmodeDataPoint(now, int64(cpuStats.CPUUsage.UsageInKernelmode))
@@ -258,7 +258,7 @@ func (r *receiver) recordCPUMetrics(now pcommon.Timestamp, cpuStats *dtypes.CPUS
 	}
 }
 
-func (r *receiver) recordPidsMetrics(now pcommon.Timestamp, pidsStats *dtypes.PidsStats) {
+func (r *dockerStatsReceiver) recordPidsMetrics(now pcommon.Timestamp, pidsStats *dtypes.PidsStats) {
 	// pidsStats are available when kernel version is >= 4.3 and pids_cgroup is supported, it is empty otherwise.
 	if pidsStats.Current != 0 {
 		r.mb.RecordContainerPidsCountDataPoint(now, int64(pidsStats.Current))
@@ -268,7 +268,7 @@ func (r *receiver) recordPidsMetrics(now pcommon.Timestamp, pidsStats *dtypes.Pi
 	}
 }
 
-func (r *receiver) recordBaseMetrics(now pcommon.Timestamp, base *types.ContainerJSONBase) error {
+func (r *dockerStatsReceiver) recordBaseMetrics(now pcommon.Timestamp, base *types.ContainerJSONBase) error {
 	t, err := time.Parse(time.RFC3339, base.State.StartedAt)
 	if err != nil {
 		// value not available or invalid


### PR DESCRIPTION
**Description:**
Update the import to match the signature expected by checkapi. Rename the struct used by the receiver to avoid conflict.
This allows to remove dockerstatsreceiver from the allowlist of checkapi.