### PR TITLE
[chore][pkg/stanza]: when found duplicate, continue from outer loop

### DIFF
--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -197,6 +197,7 @@ func (m *Manager) makeFingerprint(path string) (*fingerprint.Fingerprint, *os.Fi
 // been read this polling interval
 func (m *Manager) makeReaders(paths []string) []*reader.Reader {
 	readers := make([]*reader.Reader, 0, len(paths))
+OUTER:
 	for _, path := range paths {
 		fp, file := m.makeFingerprint(path)
 		if fp == nil {
@@ -210,7 +211,7 @@ func (m *Manager) makeReaders(paths []string) []*reader.Reader {
 				if err := file.Close(); err != nil {
 					m.Debugw("problem closing file", zap.Error(err))
 				}
-				continue
+				continue OUTER
 			}
 		}
 

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -1662,6 +1662,7 @@ func TestStalePartialFingerprintDiscarded(t *testing.T) {
 	waitForToken(t, emitCalls, []byte(content))
 	expectNoTokens(t, emitCalls)
 	operator.wg.Wait()
+	require.Len(t, operator.previousPollFiles, 1)
 
 	// keep append data to file1 and file2
 	newContent := "bbbbbbbbbbbb"


### PR DESCRIPTION
**Description:** 
Fix a bug when duplicate readers are added to the active list even after the underlying file is closed.  To fix this, continue from the outer loop. 
This doesn't result in any duplicates, but this will keep producing the following annoying error every time.
```2023-11-05T02:34:03.530+0530       ERROR       Failed to seek  {"component": "fileconsumer", "path": "/var/folders/fs/njj5c3xx7vdcsr28n19vykw00000gn/T/TestStalePartialFingerprintDiscarded2443925830/001/1616317274.log2", "error": "seek /var/folders/fs/njj5c3xx7vdcsr28n19vykw00000gn/T/TestStalePartialFingerprintDiscarded2443925830/001/1616317274.log2: file already closed"}```

**Testing:** Update the test to check the previouPollFiles
