### PR TITLE
[chore][receiver/journald] remove duplicate function NewFactory and pass checkapi

### DIFF
--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -2,5 +2,4 @@ connector/servicegraphconnector
 extension/encoding
 extension/observer
 processor/servicegraphprocessor
-receiver/journaldreceiver
 receiver/kafkareceiver

--- a/receiver/journaldreceiver/factory.go
+++ b/receiver/journaldreceiver/factory.go
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package journaldreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
+
+import (
+	"go.opentelemetry.io/collector/receiver"
+)
+
+// NewFactory creates a factory for journald receiver
+func NewFactory() receiver.Factory {
+	return newFactoryAdapter()
+}

--- a/receiver/journaldreceiver/factory_test.go
+++ b/receiver/journaldreceiver/factory_test.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package journaldreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver/internal/metadata"
+)
+
+func TestNewFactory(t *testing.T) {
+	t.Run("NewFactoryCorrectType", func(t *testing.T) {
+		factory := NewFactory()
+		require.EqualValues(t, metadata.Type, factory.Type())
+	})
+}

--- a/receiver/journaldreceiver/journald.go
+++ b/receiver/journaldreceiver/journald.go
@@ -17,8 +17,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver/internal/metadata"
 )
 
-// NewFactory creates a factory for journald receiver
-func NewFactory() receiver.Factory {
+// newFactoryAdapter creates a factory for journald receiver
+func newFactoryAdapter() receiver.Factory {
 	return adapter.NewFactory(ReceiverType{}, metadata.LogsStability)
 }
 

--- a/receiver/journaldreceiver/journald_nonlinux.go
+++ b/receiver/journaldreceiver/journald_nonlinux.go
@@ -19,8 +19,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver/internal/metadata"
 )
 
-// NewFactory creates a dummy factory.
-func NewFactory() receiver.Factory {
+// newFactoryAdapter creates a dummy factory.
+func newFactoryAdapter() receiver.Factory {
 	return receiver.NewFactory(
 		metadata.Type,
 		createDefaultConfig,

--- a/receiver/journaldreceiver/journald_test.go
+++ b/receiver/journaldreceiver/journald_test.go
@@ -28,7 +28,7 @@ import (
 func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
-	factory := NewFactory()
+	factory := newFactoryAdapter()
 	cfg := factory.CreateDefaultConfig()
 
 	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
@@ -40,7 +40,7 @@ func TestLoadConfig(t *testing.T) {
 
 func TestInputConfigFailure(t *testing.T) {
 	sink := new(consumertest.LogsSink)
-	factory := NewFactory()
+	factory := newFactoryAdapter()
 	badCfg := &JournaldConfig{
 		BaseConfig: adapter.BaseConfig{
 			Operators: []operator.Config{},


### PR DESCRIPTION
**Description:**
Remove duplicate function NewFactory and pass checkapi since we should only keep one NewFactory.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26304

**Testing:**
go run cmd/checkapi/main.go .
go test for journaldreceiver

**Documentation:**