### PR TITLE
[chore][receiver/windowseventlog] remove duplicate function NewFactory and pass checkapi

### DIFF
--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -5,4 +5,3 @@ processor/servicegraphprocessor
 receiver/dockerstatsreceiver
 receiver/journaldreceiver
 receiver/kafkareceiver
-receiver/windowseventlogreceiver

--- a/receiver/windowseventlogreceiver/factory.go
+++ b/receiver/windowseventlogreceiver/factory.go
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package windowseventlogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
+
+import (
+	"go.opentelemetry.io/collector/receiver"
+)
+
+// NewFactory creates a factory for windowseventlog receiver
+func NewFactory() receiver.Factory {
+	return newFactoryAdapter()
+}

--- a/receiver/windowseventlogreceiver/factory_test.go
+++ b/receiver/windowseventlogreceiver/factory_test.go
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package windowseventlogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver/internal/metadata"
+)
+
+func TestNewFactory(t *testing.T) {
+	t.Run("NewFactoryCorrectType", func(t *testing.T) {
+		factory := NewFactory()
+		require.EqualValues(t, metadata.Type, factory.Type())
+	})
+}

--- a/receiver/windowseventlogreceiver/receiver_others.go
+++ b/receiver/windowseventlogreceiver/receiver_others.go
@@ -19,8 +19,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver/internal/metadata"
 )
 
-// NewFactory creates a factory for windowseventlog receiver
-func NewFactory() receiver.Factory {
+// newFactoryAdapter creates a dummy factory for windowseventlog receiver
+func newFactoryAdapter() receiver.Factory {
 	return receiver.NewFactory(
 		metadata.Type,
 		createDefaultConfig,

--- a/receiver/windowseventlogreceiver/receiver_others_test.go
+++ b/receiver/windowseventlogreceiver/receiver_others_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestDefaultConfigFailure(t *testing.T) {
-	factory := NewFactory()
+	factory := newFactoryAdapter()
 	cfg := factory.CreateDefaultConfig()
 	require.NotNil(t, cfg, "failed to create default config")
 	require.NoError(t, componenttest.CheckConfigStruct(cfg))

--- a/receiver/windowseventlogreceiver/receiver_windows.go
+++ b/receiver/windowseventlogreceiver/receiver_windows.go
@@ -17,8 +17,8 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver/internal/metadata"
 )
 
-// NewFactory creates a factory for windowseventlog receiver
-func NewFactory() receiver.Factory {
+// newFactoryAdapter creates a factory for windowseventlog receiver
+func newFactoryAdapter() receiver.Factory {
 	return adapter.NewFactory(ReceiverType{}, metadata.LogsStability)
 }
 

--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestDefaultConfig(t *testing.T) {
-	factory := NewFactory()
+	factory := newFactoryAdapter()
 	cfg := factory.CreateDefaultConfig()
 	require.NotNil(t, cfg, "failed to create default config")
 	require.NoError(t, componenttest.CheckConfigStruct(cfg))
@@ -39,7 +39,7 @@ func TestDefaultConfig(t *testing.T) {
 func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
-	factory := NewFactory()
+	factory := newFactoryAdapter()
 	cfg := factory.CreateDefaultConfig()
 
 	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "").String())
@@ -60,7 +60,7 @@ func TestCreateWithInvalidInputConfig(t *testing.T) {
 		}(),
 	}
 
-	_, err := NewFactory().CreateLogsReceiver(
+	_, err := newFactoryAdapter().CreateLogsReceiver(
 		context.Background(),
 		receivertest.NewNopCreateSettings(),
 		cfg,
@@ -73,7 +73,7 @@ func TestReadWindowsEventLogger(t *testing.T) {
 	logMessage := "Test log"
 
 	ctx := context.Background()
-	factory := NewFactory()
+	factory := newFactoryAdapter()
 	createSettings := receivertest.NewNopCreateSettings()
 	cfg := createTestConfig()
 	sink := new(consumertest.LogsSink)
@@ -133,7 +133,7 @@ func TestReadWindowsEventLoggerRaw(t *testing.T) {
 	logMessage := "Test log"
 
 	ctx := context.Background()
-	factory := NewFactory()
+	factory := newFactoryAdapter()
 	createSettings := receivertest.NewNopCreateSettings()
 	cfg := createTestConfig()
 	cfg.InputConfig.Raw = true
@@ -186,7 +186,7 @@ func TestReadWindowsEventLoggerWithExcludeProvider(t *testing.T) {
 	src := "otel"
 
 	ctx := context.Background()
-	factory := NewFactory()
+	factory := newFactoryAdapter()
 	createSettings := receivertest.NewNopCreateSettings()
 	cfg := createTestConfig()
 	cfg.InputConfig.ExcludeProviders = []string{src}
@@ -225,7 +225,7 @@ func TestReadWindowsEventLoggerRawWithExcludeProvider(t *testing.T) {
 	src := "otel"
 
 	ctx := context.Background()
-	factory := NewFactory()
+	factory := newFactoryAdapter()
 	createSettings := receivertest.NewNopCreateSettings()
 	cfg := createTestConfig()
 	cfg.InputConfig.Raw = true


### PR DESCRIPTION
**Description:**
Remove duplicate function NewFactory and pass checkapi.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26304

**Testing:**
go run cmd/checkapi/main.go .
go test for windowseventlogreceiver

**Documentation:**