### PR TITLE
[chore][processor/servicegraph][connector/servicegraph] Assign an exported function to a variable and pass checkapi

### DIFF
--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -1,3 +1,1 @@
-connector/servicegraphconnector
 extension/observer
-processor/servicegraphprocessor

--- a/connector/servicegraphconnector/factory.go
+++ b/connector/servicegraphconnector/factory.go
@@ -6,8 +6,13 @@
 package servicegraphconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector"
 
 import (
+	"go.opentelemetry.io/collector/connector"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/servicegraphprocessor"
 )
 
-var NewFactory = servicegraphprocessor.NewConnectorFactoryFunc(metadata.Type, metadata.TracesToMetricsStability)
+// NewFactory returns a ConnectorFactory.
+func NewFactory() connector.Factory {
+	return servicegraphprocessor.NewConnectorFactoryFunc(metadata.Type, metadata.TracesToMetricsStability)
+}

--- a/processor/servicegraphprocessor/config_test.go
+++ b/processor/servicegraphprocessor/config_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/otelcol/otelcoltest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/servicegraphprocessor/internal/metadata"
@@ -23,7 +22,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	factories.Processors[metadata.Type] = NewFactory()
-	factories.Connectors[metadata.Type] = newConnectorFactory()
+	factories.Connectors[metadata.Type] = NewConnectorFactoryFunc("servicegraph", component.StabilityLevelAlpha)
 
 	// Test
 	cfg, err := otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "service-graph-config.yaml"), factories)
@@ -66,8 +65,4 @@ func TestLoadConfig(t *testing.T) {
 		cfg.Connectors[component.NewID(metadata.Type)],
 	)
 
-}
-
-func newConnectorFactory() connector.Factory {
-	return NewConnectorFactoryFunc("servicegraph", component.StabilityLevelAlpha)()
 }

--- a/processor/servicegraphprocessor/factory.go
+++ b/processor/servicegraphprocessor/factory.go
@@ -62,16 +62,14 @@ func NewFactory() processor.Factory {
 }
 
 // NewConnectorFactoryFunc creates a function that returns a factory for the servicegraph connector.
-func NewConnectorFactoryFunc(cfgType component.Type, tracesToMetricsStability component.StabilityLevel) func() connector.Factory {
-	return func() connector.Factory {
-		// TODO: Handle this err
-		_ = view.Register(serviceGraphProcessorViews()...)
-		return connector.NewFactory(
-			cfgType,
-			createDefaultConfig,
-			connector.WithTracesToMetrics(createTracesToMetricsConnector, tracesToMetricsStability),
-		)
-	}
+var NewConnectorFactoryFunc = func(cfgType component.Type, tracesToMetricsStability component.StabilityLevel) connector.Factory {
+	// TODO: Handle this err
+	_ = view.Register(serviceGraphProcessorViews()...)
+	return connector.NewFactory(
+		cfgType,
+		createDefaultConfig,
+		connector.WithTracesToMetrics(createTracesToMetricsConnector, tracesToMetricsStability),
+	)
 }
 
 func createDefaultConfig() component.Config {

--- a/processor/servicegraphprocessor/factory_test.go
+++ b/processor/servicegraphprocessor/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/connector/connectortest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/processor/processortest"
@@ -79,7 +80,7 @@ func TestNewConnector(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Prepare
-			factory := newConnectorFactory()
+			factory := NewConnectorFactoryFunc("servicegraph", component.StabilityLevelAlpha)
 
 			creationParams := connectortest.NewNopCreateSettings()
 			cfg := factory.CreateDefaultConfig().(*Config)

--- a/processor/servicegraphprocessor/processor_test.go
+++ b/processor/servicegraphprocessor/processor_test.go
@@ -77,7 +77,7 @@ func TestProcessorStart(t *testing.T) {
 
 func TestConnectorStart(t *testing.T) {
 	// Create servicegraph processor
-	factory := newConnectorFactory()
+	factory := NewConnectorFactoryFunc("servicegraph", component.StabilityLevelAlpha)
 	cfg := factory.CreateDefaultConfig().(*Config)
 
 	procCreationParams := connectortest.NewNopCreateSettings()
@@ -109,7 +109,7 @@ func TestProcessorShutdown(t *testing.T) {
 
 func TestConnectorShutdown(t *testing.T) {
 	// Prepare
-	factory := newConnectorFactory()
+	factory := NewConnectorFactoryFunc("servicegraph", component.StabilityLevelAlpha)
 	cfg := factory.CreateDefaultConfig().(*Config)
 
 	// Test


### PR DESCRIPTION
**Description:**
Assign an exported function to a variable and pass checkapi.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26304

**Testing:**
go run cmd/checkapi/main.go .
go test for servicegraphconnector
go test for servicegraphprocessor

**Documentation:**