### PR TITLE
[processor/resourcedetectionprocessor] change host.cpu.family resource attribute to string

### DIFF
--- a/.chloggen/fix-cpu-family.yaml
+++ b/.chloggen/fix-cpu-family.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: "resourcedetectionprocessor"
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Change host.cpu.family to string"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29025]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/resourcedetectionprocessor/internal/system/internal/metadata/generated_resource.go
+++ b/processor/resourcedetectionprocessor/internal/system/internal/metadata/generated_resource.go
@@ -36,9 +36,9 @@ func (rb *ResourceBuilder) SetHostCPUCacheL2Size(val int64) {
 }
 
 // SetHostCPUFamily sets provided value as "host.cpu.family" attribute.
-func (rb *ResourceBuilder) SetHostCPUFamily(val int64) {
+func (rb *ResourceBuilder) SetHostCPUFamily(val string) {
 	if rb.config.HostCPUFamily.Enabled {
-		rb.res.Attributes().PutInt("host.cpu.family", val)
+		rb.res.Attributes().PutStr("host.cpu.family", val)
 	}
 }
 

--- a/processor/resourcedetectionprocessor/internal/system/internal/metadata/generated_resource_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/internal/metadata/generated_resource_test.go
@@ -15,7 +15,7 @@ func TestResourceBuilder(t *testing.T) {
 			rb := NewResourceBuilder(cfg)
 			rb.SetHostArch("host.arch-val")
 			rb.SetHostCPUCacheL2Size(22)
-			rb.SetHostCPUFamily(15)
+			rb.SetHostCPUFamily("host.cpu.family-val")
 			rb.SetHostCPUModelID(17)
 			rb.SetHostCPUModelName("host.cpu.model.name-val")
 			rb.SetHostCPUStepping(17)
@@ -53,7 +53,7 @@ func TestResourceBuilder(t *testing.T) {
 			val, ok = res.Attributes().Get("host.cpu.family")
 			assert.Equal(t, test == "all_set", ok)
 			if ok {
-				assert.EqualValues(t, 15, val.Int())
+				assert.EqualValues(t, "host.cpu.family-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("host.cpu.model.id")
 			assert.Equal(t, test == "all_set", ok)

--- a/processor/resourcedetectionprocessor/internal/system/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/system/metadata.yaml
@@ -29,7 +29,7 @@ resource_attributes:
     enabled: false
   host.cpu.family:
     description: The host.cpu.family
-    type: int
+    type: string
     enabled: false
   host.cpu.model.id:
     description: The host.cpu.model.id

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -147,11 +147,7 @@ func reverseLookupHost(d *Detector) (string, error) {
 func setHostCPUInfo(d *Detector, cpuInfo cpu.InfoStat) error {
 	d.logger.Debug("getting host's cpuinfo", zap.String("coreID", cpuInfo.CoreID))
 	d.rb.SetHostCPUVendorID(cpuInfo.VendorID)
-	family, err := strconv.ParseInt(cpuInfo.Family, 10, 64)
-	if err != nil {
-		return fmt.Errorf("failed to convert cpuinfo family to integer: %w", err)
-	}
-	d.rb.SetHostCPUFamily(family)
+	d.rb.SetHostCPUFamily(cpuInfo.Family)
 
 	// For windows, this field is left blank. See https://github.com/shirou/gopsutil/blob/v3.23.9/cpu/cpu_windows.go#L113
 	// Skip setting modelId if the field is blank.


### PR DESCRIPTION
**Description:**

ange host.cpu.family resource attribute to string, because family might string such as POWER, etc. 

See examples in : https://github.com/search?q=repo%3Arandombit%2Fcpuinfo%20Family&type=code

**Link to tracking Issue:** 

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29025

**Testing:** 

**Documentation:** 
- generated