### PR TITLE
hostmetricsreceiver: remove unused function

### DIFF
--- a/receiver/hostmetricsreceiver/factory.go
+++ b/receiver/hostmetricsreceiver/factory.go
@@ -123,16 +123,11 @@ func createHostMetricsScraper(ctx context.Context, set receiver.CreateSettings, 
 
 type environment interface {
 	Lookup(k string) (string, bool)
-	Set(k, v string) error
 }
 
 type osEnv struct{}
 
 var _ environment = (*osEnv)(nil)
-
-func (e *osEnv) Set(k, v string) error {
-	return os.Setenv(k, v)
-}
 
 func (e *osEnv) Lookup(k string) (string, bool) {
 	return os.LookupEnv(k)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
`gopsutil` recently added the capability to pass environment vars through context. This is now done everywhere. This environment variable setting function is no longer used or necessary. This PR removes it.

**Link to tracking Issue:** #23055

**Testing:**
`make otelopscol`
`cd receiver/hostmetricsreceiver`
`go test .`

**Documentation:** 
None necessary.