### PR TITLE
[chore] bump go versions in workflows to 1.20.11 and 1.21.4

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -44,7 +44,7 @@ jobs:
         run: Install-WindowsFeature -name Web-Server -IncludeManagementTools
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-mod-cache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache
@@ -141,7 +141,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache
@@ -224,7 +224,7 @@ jobs:
   unittest-matrix:
     strategy:
       matrix:
-        go-version: ["~1.21.3", "~1.20.10"] # 1.20 is interpreted as 1.2 without quotes
+        go-version: ["~1.21.4", "~1.20.11"] # 1.20 is interpreted as 1.2 without quotes
         group:
           - receiver-0
           - receiver-1
@@ -316,7 +316,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache
@@ -337,7 +337,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache
@@ -363,7 +363,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache
@@ -432,7 +432,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache
@@ -566,7 +566,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Mkdir bin and dist
         run: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/create-dependabot-pr.yml
+++ b/.github/workflows/create-dependabot-pr.yml
@@ -12,7 +12,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install zsh
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Run dependabot-pr.sh
         run: ./.github/workflows/scripts/dependabot-pr.sh

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,7 +26,7 @@ jobs:
           path: opentelemetry-collector-contrib
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Prepare release for contrib
         working-directory: opentelemetry-collector-contrib

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -26,7 +26,7 @@ jobs:
           path: opentelemetry-collector-contrib
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
       - uses: actions/setup-go@v4
         with:
-          go-version: ~1.20.10
+          go-version: ~1.20.11
           cache: false
       - name: Cache Go
         id: go-cache


### PR DESCRIPTION
**Description:** 
This fixes security vulnerabilities found via govulncheck in the standard library when running against the previous patch versions of golang. While these vulnerabilities don't actually present themselves in the binary, the workflows when running govuln check fail and thus taking in the latest patches fix the issue.

**Link to tracking Issue:**
n/a

**Testing:**
Testing gets caught in workflow run. Noticed the issue originally when running workflows on this pr: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28885

**Documentation:** 
n/a