### PR TITLE
[receiver/mongodbatlas] Logging enhancement for logs retrieval

### DIFF
--- a/.chloggen/logging-improvement-mongodbatlas.yaml
+++ b/.chloggen/logging-improvement-mongodbatlas.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbatlasreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enhanced collector logs to include more information about the MongoDB Atlas API calls being made during logs retrieval.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [28851]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/mongodbatlasreceiver/logs.go
+++ b/receiver/mongodbatlasreceiver/logs.go
@@ -168,12 +168,14 @@ func (s *logsReceiver) collectClusterLogs(clusters []mongodbatlas.Cluster, proje
 		for _, hostname := range hostnames {
 			// Defaults to true if not specified
 			if projectCfg.EnableHostLogs == nil || *projectCfg.EnableHostLogs {
+				s.log.Debug("Collecting logs for host", zap.String("hostname", hostname), zap.String("cluster", cluster.Name))
 				s.collectLogs(pc, hostname, "mongodb.gz", clusterInfo)
 				s.collectLogs(pc, hostname, "mongos.gz", clusterInfo)
 			}
 
 			// Defaults to false if not specified
 			if projectCfg.EnableAuditLogs {
+				s.log.Debug("Collecting audit logs for host", zap.String("hostname", hostname), zap.String("cluster", cluster.Name))
 				s.collectAuditLogs(pc, hostname, "mongodb-audit-log.gz", clusterInfo)
 				s.collectAuditLogs(pc, hostname, "mongos-audit-log.gz", clusterInfo)
 			}
@@ -235,12 +237,12 @@ func (s *logsReceiver) getHostAuditLogs(groupID, hostname, logName string) ([]mo
 func (s *logsReceiver) collectLogs(pc ProjectContext, hostname, logName string, clusterInfo ClusterInfo) {
 	logs, err := s.getHostLogs(pc.Project.ID, hostname, logName, clusterInfo.MongoDBMajorVersion)
 	if err != nil && !errors.Is(err, io.EOF) {
-		s.log.Warn("Failed to retrieve host logs", zap.Error(err), zap.String("log", logName))
+		s.log.Warn("Failed to retrieve host logs", zap.Error(err), zap.String("hostname", hostname), zap.String("log", logName), zap.Time("startTime", s.start), zap.Time("endTime", s.end))
 		return
 	}
 
 	if len(logs) == 0 {
-		s.log.Warn("Attempted to retrieve host logs but received 0 logs", zap.Error(err), zap.String("log", logName))
+		s.log.Warn("Attempted to retrieve host logs but received 0 logs", zap.Error(err), zap.String("log", logName), zap.String("hostname", hostname), zap.Time("startTime", s.start), zap.Time("endTime", s.end))
 		return
 	}
 
@@ -264,12 +266,12 @@ func (s *logsReceiver) collectAuditLogs(pc ProjectContext, hostname, logName str
 	)
 
 	if err != nil && !errors.Is(err, io.EOF) {
-		s.log.Warn("Failed to retrieve audit logs", zap.Error(err), zap.String("log", logName))
+		s.log.Warn("Failed to retrieve audit logs", zap.Error(err), zap.String("hostname", hostname), zap.String("log", logName), zap.Time("startTime", s.start), zap.Time("endTime", s.end))
 		return
 	}
 
 	if len(logs) == 0 {
-		s.log.Warn("Attempted to retrieve audit logs but received 0 logs", zap.Error(err), zap.String("log", logName))
+		s.log.Warn("Attempted to retrieve audit logs but received 0 logs", zap.Error(err), zap.String("hostname", hostname), zap.String("log", logName), zap.Time("startTime", s.start), zap.Time("endTime", s.end))
 		return
 	}
 


### PR DESCRIPTION
**Description:** Enhances current logs by adding more context to the warning message and adds a debug log that will help orient users if they cannot reach that block of code. 

**Link to tracking Issue:** Resolves #28851

**Testing:**
```log
2023-11-09T10:11:17.716-0500	warn	mongodbatlasreceiver@v0.88.0/logs.go:245	Attempted to retrieve host logs but received 0 logs	{"kind": "receiver", "name": "mongodbatlas", "data_type": "logs", "error": "EOF", "log": "mongos.gz", "hostname": "cluster1-shard-00-00.t5hdg.mongodb.net", "startTime": "2023-11-09T10:06:16.618-0500", "endTime": "2023-11-09T10:11:16.618-0500"}
2023-11-09T10:11:17.946-0500	info	LogsExporter	{"kind": "exporter", "data_type": "logs", "name": "logging", "resource logs": 1, "log records": 28}
2023-11-09T10:11:18.131-0500	warn	mongodbatlasreceiver@v0.88.0/logs.go:274	Attempted to retrieve audit logs but received 0 logs	{"kind": "receiver", "name": "mongodbatlas", "data_type": "logs", "error": "EOF", "hostname": "cluster1-shard-00-00.t5hdg.mongodb.net", "log": "mongos-audit-log.gz", "startTime": "2023-11-09T10:06:16.618-0500", "endTime": "2023-11-09T10:11:16.618-0500"}
```


**Documentation:** <Describe the documentation added.>