### PR TITLE
fix `delete_matching_keys` examples on docs

### DIFF
--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -75,9 +75,9 @@ All keys that match the pattern will be deleted from the map.
 Examples:
 
 
-- `delete_key(attributes, "http.request.header.authorization")`
+- `delete_matching_keys(attributes, "(?i).*password.*")`
 
-- `delete_key(resource.attributes, "http.request.header.authorization")`
+- `delete_matching_keys(resource.attributes, "(?i).*password.*")`
 
 ### keep_keys
 


### PR DESCRIPTION
**Description:** Fix the examples for the `delete_matching_keys` ottl function
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** N/A

**Testing:** N/A

**Documentation:** minor for fox the `delete_matching_keys` since they were referring to the `delete_key` function