### PR TITLE
Update doc.go of filelogreceiver

### DIFF
--- a/receiver/filelogreceiver/doc.go
+++ b/receiver/filelogreceiver/doc.go
@@ -3,6 +3,6 @@
 
 //go:generate mdatagen metadata.yaml
 
-// Package stanzareceiver implements a receiver that can be used by the
+// Package filelogreceiver implements a receiver that can be used by the
 // Opentelemetry collector to receive logs using the stanza log agent
 package filelogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"

--- a/receiver/filelogreceiver/doc.go
+++ b/receiver/filelogreceiver/doc.go
@@ -4,5 +4,5 @@
 //go:generate mdatagen metadata.yaml
 
 // Package filelogreceiver implements a receiver that can be used by the
-// Opentelemetry collector to receive logs using the stanza log agent
+// OpenTelemetry collector to receive logs using the stanza log agent
 package filelogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver"


### PR DESCRIPTION
nit fix of the GoDoc to be updated with the current package name

**Description:**

Fixed a nit document bug that mentions old package name and may confuse the user. 

**Link to tracking Issue:**

No issue number as this is a nit fix.

**Testing:**

Because this is a nit document change only, no need for test.

**Documentation:**

No documentation addition. Just a small change.