### PR TITLE
[chore][pkg/stanza][exporter/signalfx] One more interface{} -> any and skip flaky tests

### DIFF
--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -1318,6 +1318,7 @@ func TestDefaultSystemCPUTimeExcludedAndTranslated(t *testing.T) {
 }
 
 func TestTLSAPIConnection(t *testing.T) {
+	t.Skip("Flaky test see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29099")
 	cfg := createDefaultConfig().(*Config)
 	converter, err := translation.NewMetricsConverter(
 		zap.NewNop(),

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -1207,6 +1207,7 @@ func TestTLSExporterInit(t *testing.T) {
 }
 
 func TestTLSIngestConnection(t *testing.T) {
+	t.Skip("Flaky test see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29099")
 	metricsPayload := pmetric.NewMetrics()
 	rm := metricsPayload.ResourceMetrics().AppendEmpty()
 	ilm := rm.ScopeMetrics().AppendEmpty()

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -139,7 +139,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 	if c.AsyncConfig != nil {
 		udpInput.messageQueue = make(chan messageAndAddress, c.AsyncConfig.MaxQueueLength)
 		udpInput.readBufferPool = sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				buffer := make([]byte, MaxUDPSize)
 				return &buffer
 			},


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28898/files#r1389614720. Looks like a merge conflict.