### PR TITLE
[processor/k8sattributes] fix(docs): typo for kubernetes label

### DIFF
--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -143,7 +143,7 @@ k8sattributes/2:
       - k8s.pod.start_time
    labels:
      - tag_name: app.label.component
-       key: app.kubenetes.io/component
+       key: app.kubernetes.io/component
        from: pod
   pod_association:
     - sources:


### PR DESCRIPTION
**Description:** typo for kubernetes label in k8sattributesprocessor

**Link to tracking Issue:** n/a

**Testing:** n/a docs

**Documentation:** n/a