### PR TITLE
[receiver/kubeletstatsreceiver] address lint issues: Implicit Memory Aliasing

### DIFF
--- a/receiver/kubeletstatsreceiver/internal/kubelet/metadata.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metadata.go
@@ -91,8 +91,8 @@ func NewMetadata(labels []MetadataLabel, podsMetadata *v1.PodList,
 			allContainersCPURequestsDefined := true
 			allContainersMemoryLimitsDefined := true
 			allContainersMemoryRequestsDefined := true
-			for _, container := range pod.Spec.Containers {
-				// nolint G601
+			for i := range pod.Spec.Containers {
+				container := pod.Spec.Containers[i]
 				containerResource := getContainerResources(&container.Resources)
 
 				if allContainersCPULimitsDefined && containerResource.cpuLimit == 0 {


### PR DESCRIPTION
**Description:** This PR fixes an implicit memory aliasing lint issue in the kubeletstatsreceiver

* fixed code
* removed linting exception

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/28584

**Testing:** ran unit tests

**Documentation:** N/A