### PR TITLE
[connector/datadog] Set MutatesData to true

### DIFF
--- a/.chloggen/datadog-connector-mutates-data.yaml
+++ b/.chloggen/datadog-connector-mutates-data.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Mark datadogconnector as `MutatesData` to prevent data race"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29111]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/datadogconnector/connector.go
+++ b/connector/datadogconnector/connector.go
@@ -82,9 +82,9 @@ func (c *connectorImp) Shutdown(context.Context) error {
 }
 
 // Capabilities implements the consumer interface.
-// tells use whether the component(connector) will mutate the data passed into it. if set to true the processor does modify the data
+// tells use whether the component(connector) will mutate the data passed into it. if set to true the connector does modify the data
 func (c *connectorImp) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: false}
+	return consumer.Capabilities{MutatesData: true} // ConsumeTraces puts a new attribute _dd.stats_computed
 }
 
 func (c *connectorImp) ConsumeTraces(ctx context.Context, traces ptrace.Traces) error {


### PR DESCRIPTION
**Description:** 
Mark datadogconnector as `MutatesData` to prevent data race

**Link to tracking Issue:**
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29111