### PR TITLE
[connector/spanmetrics] fix(docs): add example of R.E.D metrics for span data

### DIFF
--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -32,20 +32,20 @@ dimensions, including Errors. Multiple metrics can be aggregated if, for instanc
 a user wishes to view call counts just on `service.name` and `span.name`.
 
 ```
-calls{service.name="shipping",span.name="get_shipping/{shippingId}"}
+calls{service.name="shipping",span.name="get_shipping/{shippingId}",span.kind="SERVER",status.code="Ok"}
 ```
 
 **Error** counts are computed from the Request counts which have an `Error` Status Code metric dimension.
 
 ```
-calls{http.method="GET",http.route="/shipping/{shippingId}",status.code=STATUS_CODE_ERROR}
+calls{service.name="shipping",span.name="get_shipping/{shippingId},span.kind="SERVER",status.code="Error"}
 ```
 
 **Duration** is computed from the difference between the span start and end times and inserted into the
 relevant duration histogram time bucket for each unique set dimensions.
 
 ```
-duration{http.method="GET",http.route="/shipping/{shippingId}"}
+duration{service.name="shipping",span.name="get_shipping/{shippingId}",span.kind="SERVER",status.code="Ok"}
 ```
 
 Each metric will have _at least_ the following dimensions because they are common

--- a/connector/spanmetricsconnector/README.md
+++ b/connector/spanmetricsconnector/README.md
@@ -31,10 +31,22 @@ Aggregates Request, Error and Duration (R.E.D) OpenTelemetry metrics from span d
 dimensions, including Errors. Multiple metrics can be aggregated if, for instance,
 a user wishes to view call counts just on `service.name` and `span.name`.
 
+```
+calls{service.name="shipping",span.name="get_shipping/{shippingId}"}
+```
+
 **Error** counts are computed from the Request counts which have an `Error` Status Code metric dimension.
+
+```
+calls{http.method="GET",http.route="/shipping/{shippingId}",status.code=STATUS_CODE_ERROR}
+```
 
 **Duration** is computed from the difference between the span start and end times and inserted into the
 relevant duration histogram time bucket for each unique set dimensions.
+
+```
+duration{http.method="GET",http.route="/shipping/{shippingId}"}
+```
 
 Each metric will have _at least_ the following dimensions because they are common
 across all spans:


### PR DESCRIPTION
**Description:** This is to clarify the metrics name generated.

**Link to tracking Issue:** [26520](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26520)

**Testing:** n/a docs

**Documentation:** n/a