### PR TITLE
remove Close calls in mongodb, cleaned up automatically

### DIFF
--- a/receiver/mongodbreceiver/client_test.go
+++ b/receiver/mongodbreceiver/client_test.go
@@ -70,7 +70,6 @@ func (fc *fakeClient) IndexStats(ctx context.Context, dbName, collectionName str
 
 func TestListDatabaseNames(t *testing.T) {
 	mont := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
-	defer mont.Close()
 
 	mont.Run("list database names", func(mt *mtest.T) {
 		// mocking out a listdatabase call
@@ -106,7 +105,6 @@ const (
 
 func TestRunCommands(t *testing.T) {
 	mont := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
-	defer mont.Close()
 
 	loadedDbStats, err := loadDBStats()
 	require.NoError(t, err)
@@ -174,7 +172,6 @@ func TestRunCommands(t *testing.T) {
 
 func TestGetVersion(t *testing.T) {
 	mont := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
-	defer mont.Close()
 
 	buildInfo, err := loadBuildInfo()
 	require.NoError(t, err)
@@ -199,7 +196,6 @@ func TestGetVersion(t *testing.T) {
 
 func TestGetVersionFailures(t *testing.T) {
 	mont := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
-	defer mont.Close()
 
 	malformedBuildInfo := bson.D{
 		primitive.E{Key: "ok", Value: 1},

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -332,7 +332,6 @@ func TestScraperScrape(t *testing.T) {
 
 func TestTopMetricsAggregation(t *testing.T) {
 	mont := mtest.New(t, mtest.NewOptions().ClientType(mtest.Mock))
-	defer mont.Close()
 
 	loadedTop, err := loadTop()
 	require.NoError(t, err)


### PR DESCRIPTION
This was fixed in the mongo integration test https://jira.mongodb.org/browse/GODRIVER-2876