### PR TITLE
[extension/opampextension] reports effective config

### DIFF
--- a/.chloggen/feat-27293-reports-effective-config.yaml
+++ b/.chloggen/feat-27293-reports-effective-config.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Implement `extension.NotifyConfig` to be notified of the Collector's effective config and report it to the OpAMP server.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27293]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/feat-27293-reports-effective-config.yaml
+++ b/.chloggen/feat-27293-reports-effective-config.yaml
@@ -4,7 +4,7 @@
 change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: opampextension
+component: extension/opampextension
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Implement `extension.NotifyConfig` to be notified of the Collector's effective config and report it to the OpAMP server.

--- a/cmd/opampsupervisor/specification/README.md
+++ b/cmd/opampsupervisor/specification/README.md
@@ -84,33 +84,33 @@ server:
 # If enabled the Supervisor will also report RemoteConfig status
 # to the Server.
 capabilities:
-  AcceptsRemoteConfig: # false if unspecified
+  accepts_remote_config: # false if unspecified
 
   # The Supervisor will report EffectiveConfig to the Server.
-  ReportsEffectiveConfig: # true if unspecified
+  reports_effective_config: # true if unspecified
   
   # The Supervisor can accept Collector executable package updates.
   # If enabled the Supervisor will also report package status to the
   # Server.
-  AcceptsPackages: # false if unspecified
+  accepts_packages: # false if unspecified
   
   # The Collector will report own metrics to the destination specified by
   # the Server.
-  ReportsOwnMetrics: # true if unspecified
+  reports_own_metrics: # true if unspecified
   
   # The Collector will report own logs to the destination specified by
   # the Server.
-  ReportsOwnLogs: # true if unspecified
+  reports_own_logs: # true if unspecified
   
   # The Collector will accept connections settings for exporters
   # from the Server.
-  AcceptsOtherConnectionSettings: # false if unspecified
+  accepts_other_connection_settings: # false if unspecified
   
   # The Supervisor will accept restart requests.
-  AcceptsRestartCommand: # true if unspecified
+  accepts_restart_command: # true if unspecified
   
   # The Collector will report Health.
-  ReportsHealth: # true if unspecified
+  reports_health: # true if unspecified
 
 storage:
   # A writable directory where the Supervisor can store data

--- a/extension/opampextension/README.md
+++ b/extension/opampextension/README.md
@@ -27,6 +27,7 @@ The following settings are optional:
 - `instance_uid`: A ULID formatted as a 26 character string in canonical
   representation. Auto-generated on start if missing. Setting this ensures the
   instance UID remains constant across process restarts.
+- `ReportsEffectiveConfig`: Whether to enable the OpAMP ReportsEffectiveConfig capability. Default is `true`.
 
 ### Example
 

--- a/extension/opampextension/README.md
+++ b/extension/opampextension/README.md
@@ -27,7 +27,8 @@ The following settings are optional:
 - `instance_uid`: A ULID formatted as a 26 character string in canonical
   representation. Auto-generated on start if missing. Setting this ensures the
   instance UID remains constant across process restarts.
-- `reports_effective_config`: Whether to enable the OpAMP ReportsEffectiveConfig capability. Default is `true`.
+- `capabilities`: Keys with boolean true/false values that enable a particular OpAMP capability.
+  - `reports_effective_config`: Whether to enable the OpAMP ReportsEffectiveConfig capability. Default is `true`.
 
 ### Example
 

--- a/extension/opampextension/README.md
+++ b/extension/opampextension/README.md
@@ -27,7 +27,7 @@ The following settings are optional:
 - `instance_uid`: A ULID formatted as a 26 character string in canonical
   representation. Auto-generated on start if missing. Setting this ensures the
   instance UID remains constant across process restarts.
-- `ReportsEffectiveConfig`: Whether to enable the OpAMP ReportsEffectiveConfig capability. Default is `true`.
+- `reports_effective_config`: Whether to enable the OpAMP ReportsEffectiveConfig capability. Default is `true`.
 
 ### Example
 

--- a/extension/opampextension/config.go
+++ b/extension/opampextension/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/open-telemetry/opamp-go/protobufs"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 )
@@ -27,6 +28,17 @@ type Config struct {
 type Capabilities struct {
 	// ReportsEffectiveConfig enables the OpAMP ReportsEffectiveConfig Capability. (default: true)
 	ReportsEffectiveConfig bool `mapstructure:"reports_effective_config"`
+}
+
+func (caps Capabilities) toAgentCapabilities() protobufs.AgentCapabilities {
+	// All Agents MUST report status.
+	agentCapabilities := protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus
+
+	if caps.ReportsEffectiveConfig {
+		agentCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig
+	}
+
+	return agentCapabilities
 }
 
 // OpAMPServer contains the OpAMP transport configuration.

--- a/extension/opampextension/config.go
+++ b/extension/opampextension/config.go
@@ -19,6 +19,9 @@ type Config struct {
 	// InstanceUID is a ULID formatted as a 26 character string in canonical
 	// representation. Auto-generated on start if missing.
 	InstanceUID string `mapstructure:"instance_uid"`
+
+	// Enable the ReportsEffectiveConfig Capability.
+	ReportsEffectiveConfig bool `mapstructure:"reports_effective_config"`
 }
 
 // OpAMPServer contains the OpAMP transport configuration.

--- a/extension/opampextension/config.go
+++ b/extension/opampextension/config.go
@@ -20,7 +20,12 @@ type Config struct {
 	// representation. Auto-generated on start if missing.
 	InstanceUID string `mapstructure:"instance_uid"`
 
-	// ReportsEffectiveConfig enables the OpAMP ReportsEffectiveConfig Capability.
+	// Capabilities contains options to enable a particular OpAMP capability
+	Capabilities Capabilities `mapstructure:"capabilities"`
+}
+
+type Capabilities struct {
+	// ReportsEffectiveConfig enables the OpAMP ReportsEffectiveConfig Capability. (default: true)
 	ReportsEffectiveConfig bool `mapstructure:"reports_effective_config"`
 }
 

--- a/extension/opampextension/config.go
+++ b/extension/opampextension/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	// representation. Auto-generated on start if missing.
 	InstanceUID string `mapstructure:"instance_uid"`
 
-	// Enable the ReportsEffectiveConfig Capability.
+	// ReportsEffectiveConfig enables the OpAMP ReportsEffectiveConfig Capability.
 	ReportsEffectiveConfig bool `mapstructure:"reports_effective_config"`
 }
 

--- a/extension/opampextension/config_test.go
+++ b/extension/opampextension/config_test.go
@@ -34,7 +34,8 @@ func TestUnmarshalConfig(t *testing.T) {
 					Endpoint: "wss://127.0.0.1:4320/v1/opamp",
 				},
 			},
-			InstanceUID: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
+			InstanceUID:            "01BX5ZZKBKACTAV9WEVGEMMVRZ",
+			ReportsEffectiveConfig: true,
 		}, cfg)
 }
 

--- a/extension/opampextension/config_test.go
+++ b/extension/opampextension/config_test.go
@@ -34,8 +34,10 @@ func TestUnmarshalConfig(t *testing.T) {
 					Endpoint: "wss://127.0.0.1:4320/v1/opamp",
 				},
 			},
-			InstanceUID:            "01BX5ZZKBKACTAV9WEVGEMMVRZ",
-			ReportsEffectiveConfig: true,
+			InstanceUID: "01BX5ZZKBKACTAV9WEVGEMMVRZ",
+			Capabilities: Capabilities{
+				ReportsEffectiveConfig: true,
+			},
 		}, cfg)
 }
 

--- a/extension/opampextension/factory.go
+++ b/extension/opampextension/factory.go
@@ -26,7 +26,9 @@ func createDefaultConfig() component.Config {
 		Server: &OpAMPServer{
 			WS: &OpAMPWebsocket{},
 		},
-		ReportsEffectiveConfig: true,
+		Capabilities: Capabilities{
+			ReportsEffectiveConfig: true,
+		},
 	}
 }
 

--- a/extension/opampextension/factory.go
+++ b/extension/opampextension/factory.go
@@ -26,6 +26,7 @@ func createDefaultConfig() component.Config {
 		Server: &OpAMPServer{
 			WS: &OpAMPWebsocket{},
 		},
+		ReportsEffectiveConfig: true,
 	}
 }
 

--- a/extension/opampextension/go.mod
+++ b/extension/opampextension/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0018.0.20231127181443-575c5f5e2531
 	go.opentelemetry.io/collector/semconv v0.89.1-0.20231127181443-575c5f5e2531
 	go.uber.org/zap v1.26.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -44,5 +45,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d // indirect
 	google.golang.org/grpc v1.59.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -111,9 +111,8 @@ func (o *opampAgent) Shutdown(ctx context.Context) error {
 }
 
 func (o *opampAgent) NotifyConfig(ctx context.Context, conf *confmap.Conf) error {
-	o.updateEffectiveConfig(conf)
-
 	if o.reportsEffectiveConfig {
+		o.updateEffectiveConfig(conf)
 		return o.opampClient.UpdateEffectiveConfig(ctx)
 	}
 	return nil

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -10,8 +10,6 @@ import (
 	"runtime"
 	"sync"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/google/uuid"
 	"github.com/oklog/ulid/v2"
 	"github.com/open-telemetry/opamp-go/client"
@@ -22,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	semconv "go.opentelemetry.io/collector/semconv/v1.18.0"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
 )
 
 type opampAgent struct {

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -166,7 +166,7 @@ func newOpampAgent(cfg *Config, logger *zap.Logger, build component.BuildInfo, r
 		agentType:              agentType,
 		agentVersion:           agentVersion,
 		instanceID:             uid,
-		reportsEffectiveConfig: cfg.ReportsEffectiveConfig,
+		reportsEffectiveConfig: cfg.Capabilities.ReportsEffectiveConfig,
 	}
 
 	return agent, nil

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -112,14 +112,19 @@ func (o *opampAgent) Shutdown(ctx context.Context) error {
 }
 
 func (o *opampAgent) NotifyConfig(ctx context.Context, conf *confmap.Conf) error {
-	o.eclk.Lock()
-	o.effectiveConfig = conf
-	o.eclk.Unlock()
+	o.updateEffectiveConfig(conf)
 
 	if o.reportsEffectiveConfig {
 		return o.opampClient.UpdateEffectiveConfig(ctx)
 	}
 	return nil
+}
+
+func (o *opampAgent) updateEffectiveConfig(conf *confmap.Conf) {
+	o.eclk.Lock()
+	defer o.eclk.Unlock()
+
+	o.effectiveConfig = conf
 }
 
 func newOpampAgent(cfg *Config, logger *zap.Logger, build component.BuildInfo, res pcommon.Resource) (*opampAgent, error) {

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -76,11 +76,7 @@ func (o *opampAgent) Start(_ context.Context, _ component.Host) error {
 			},
 			OnMessageFunc: o.onMessage,
 		},
-		Capabilities: protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus,
-	}
-
-	if o.capabilities.ReportsEffectiveConfig {
-		settings.Capabilities |= protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig
+		Capabilities: o.capabilities.toAgentCapabilities(),
 	}
 
 	if err := o.createAgentDescription(); err != nil {

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -86,7 +86,9 @@ func TestComposeEffectiveConfig(t *testing.T) {
 
 	ecFileName := filepath.Join("testdata", "effective.yaml")
 	cm, err := confmaptest.LoadConf(ecFileName)
+	assert.NoError(t, err)
 	expected, err := os.ReadFile(ecFileName)
+	assert.NoError(t, err)
 
 	o.updateEffectiveConfig(cm)
 	ec = o.composeEffectiveConfig()

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -27,7 +27,7 @@ func TestNewOpampAgent(t *testing.T) {
 	assert.Equal(t, "otelcoltest", o.agentType)
 	assert.Equal(t, "test version", o.agentVersion)
 	assert.NotEmpty(t, o.instanceID.String())
-	assert.True(t, o.reportsEffectiveConfig)
+	assert.True(t, o.capabilities.ReportsEffectiveConfig)
 	assert.Empty(t, o.effectiveConfig)
 	assert.Nil(t, o.agentDescription)
 }

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -5,12 +5,15 @@ package opampextension
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/extension/extensiontest"
 	semconv "go.opentelemetry.io/collector/semconv/v1.18.0"
 )
@@ -24,7 +27,8 @@ func TestNewOpampAgent(t *testing.T) {
 	assert.Equal(t, "otelcoltest", o.agentType)
 	assert.Equal(t, "test version", o.agentVersion)
 	assert.NotEmpty(t, o.instanceID.String())
-	assert.NotEmpty(t, o.effectiveConfig)
+	assert.True(t, o.reportsEffectiveConfig)
+	assert.Empty(t, o.effectiveConfig)
 	assert.Nil(t, o.agentDescription)
 }
 
@@ -75,10 +79,19 @@ func TestComposeEffectiveConfig(t *testing.T) {
 	set := extensiontest.NewNopCreateSettings()
 	o, err := newOpampAgent(cfg.(*Config), set.Logger, set.BuildInfo, set.Resource)
 	assert.NoError(t, err)
-	assert.NotEmpty(t, o.effectiveConfig)
+	assert.Empty(t, o.effectiveConfig)
 
 	ec := o.composeEffectiveConfig()
+	assert.Nil(t, ec)
+
+	ecFileName := filepath.Join("testdata", "effective.yaml")
+	cm, err := confmaptest.LoadConf(ecFileName)
+	expected, err := os.ReadFile(ecFileName)
+
+	o.updateEffectiveConfig(cm)
+	ec = o.composeEffectiveConfig()
 	assert.NotNil(t, ec)
+	assert.YAMLEq(t, string(expected), string(ec.ConfigMap.ConfigMap[""].Body))
 }
 
 func TestShutdown(t *testing.T) {

--- a/extension/opampextension/testdata/effective.yaml
+++ b/extension/opampextension/testdata/effective.yaml
@@ -1,0 +1,14 @@
+exporters:
+  otlp:
+    endpoint: localhost:1111
+receivers:
+  otlp:
+    protocols:
+      grpc: {}
+      http: {}
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [otlp]


### PR DESCRIPTION
**Link to tracking Issue:** resolve #27293

**Testing:**
unittest
manual test with opamp-go example:
* collector version: modified otelcontribcol including opampextension
* collector config: 
```yaml
receivers:
  # otlp:
  #   protocols:
  #     grpc:
  filelog:
    include:
      - /tmp/xxxxx.log

exporters:
  debug:
    #verbosity: debug

extensions:
  opamp:
    server:
      ws:
        endpoint: ws://127.0.0.1:4320/v1/opamp
        tls:
          insecure_skip_verify: true

service:
  pipelines:
    logs:
      receivers: [filelog]
      exporters: [debug]
  telemetry:
    logs:
      level: info
  extensions: [opamp]
```
* server ui: ![Screenshot 2023-11-28 at 22-14-59 OpAMP Server](https://github.com/open-telemetry/opentelemetry-collector-contrib/assets/9400582/38ea49bb-f2f7-4618-859f-2b66257ef89a)

**Documentation:** README.md