### PR TITLE
[receiver/hostmetrics] Add braydonk to hostmetricsreceiver codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -215,7 +215,7 @@ receiver/gitproviderreceiver/                                           @open-te
 receiver/googlecloudpubsubreceiver/                                     @open-telemetry/collector-contrib-approvers @alexvanboxel
 receiver/googlecloudspannerreceiver/                                    @open-telemetry/collector-contrib-approvers @architjugran @varunraiko @kiranmayib
 receiver/haproxyreceiver/                                               @open-telemetry/collector-contrib-approvers @atoulme @MovieStoreGuy
-receiver/hostmetricsreceiver/                                           @open-telemetry/collector-contrib-approvers @dmitryax
+receiver/hostmetricsreceiver/                                           @open-telemetry/collector-contrib-approvers @dmitryax @braydonk
 receiver/httpcheckreceiver/                                             @open-telemetry/collector-contrib-approvers @codeboten
 receiver/iisreceiver/                                                   @open-telemetry/collector-contrib-approvers @Mrod1598 @djaglowski
 receiver/influxdbreceiver/                                              @open-telemetry/collector-contrib-approvers @jacobmarble

--- a/receiver/hostmetricsreceiver/README.md
+++ b/receiver/hostmetricsreceiver/README.md
@@ -6,7 +6,7 @@
 | Stability     | [beta]: metrics   |
 | Distributions | [core], [contrib], [observiq], [splunk], [sumo] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fhostmetrics%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fhostmetrics) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fhostmetrics%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fhostmetrics) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@dmitryax](https://www.github.com/dmitryax) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@dmitryax](https://www.github.com/dmitryax), [@braydonk](https://www.github.com/braydonk) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol

--- a/receiver/hostmetricsreceiver/metadata.yaml
+++ b/receiver/hostmetricsreceiver/metadata.yaml
@@ -6,4 +6,4 @@ status:
     beta: [metrics]
   distributions: [core, contrib, observiq, splunk, sumo]
   codeowners:
-    active: [dmitryax]
+    active: [dmitryax, braydonk]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR adds braydonk to the list of active hostmetricsreceiver codeowners.

**Link to tracking Issue:** <Issue number if applicable>
Closes #29287 

**Testing:** <Describe what testing was performed and which tests were added.>
None necessary.

**Documentation:** <Describe the documentation added.>
Added to `codeowners` section in `metadata.yaml`, which added me to the README listed as a codeowner as well.