### PR TITLE
[exporter/influxdb] fix panic on init

### DIFF
--- a/.chloggen/influxdb-v1compat-no-panic.yaml
+++ b/.chloggen/influxdb-v1compat-no-panic.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: influxdbexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: When InfluxDB v1 compatibility is enabled AND username&password are set, the exporter panics. Not any more!
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [27084]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/influxdbexporter/writer.go
+++ b/exporter/influxdbexporter/writer.go
@@ -88,15 +88,21 @@ func composeWriteURL(config *Config) (string, error) {
 		queryValues.Set("db", config.V1Compatibility.DB)
 
 		if config.V1Compatibility.Username != "" && config.V1Compatibility.Password != "" {
-			var basicAuth []byte
-			base64.StdEncoding.Encode(basicAuth, []byte(config.V1Compatibility.Username+":"+string(config.V1Compatibility.Password)))
-			config.HTTPClientSettings.Headers["Authorization"] = configopaque.String("Basic " + string(basicAuth))
+			basicAuth := base64.StdEncoding.EncodeToString(
+				[]byte(config.V1Compatibility.Username + ":" + string(config.V1Compatibility.Password)))
+			if config.HTTPClientSettings.Headers == nil {
+				config.HTTPClientSettings.Headers = make(map[string]configopaque.String, 1)
+			}
+			config.HTTPClientSettings.Headers["Authorization"] = configopaque.String("Basic " + basicAuth)
 		}
 	} else {
 		queryValues.Set("org", config.Org)
 		queryValues.Set("bucket", config.Bucket)
 
 		if config.Token != "" {
+			if config.HTTPClientSettings.Headers == nil {
+				config.HTTPClientSettings.Headers = make(map[string]configopaque.String, 1)
+			}
 			config.HTTPClientSettings.Headers["Authorization"] = "Token " + config.Token
 		}
 	}

--- a/exporter/influxdbexporter/writer_test.go
+++ b/exporter/influxdbexporter/writer_test.go
@@ -186,3 +186,24 @@ func Test_influxHTTPWriterBatch_EnqueuePoint_emptyTagValue(t *testing.T) {
 		assert.Equal(t, "m,k=v f=1i 1000000002000", strings.TrimSpace(string(recordedRequestBody)))
 	}
 }
+
+func Test_composeWriteURL_doesNotPanic(t *testing.T) {
+	assert.NotPanics(t, func() {
+		cfg := &Config{}
+		_, err := composeWriteURL(cfg)
+		assert.NoError(t, err)
+	})
+
+	assert.NotPanics(t, func() {
+		cfg := &Config{
+			V1Compatibility: V1Compatibility{
+				Enabled:  true,
+				DB:       "my-db",
+				Username: "my-username",
+				Password: "my-password",
+			},
+		}
+		_, err := composeWriteURL(cfg)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
When InfluxDB v1 compatibility is enabled AND username&password are set, the exporter panics. Not any more!

**Link to tracking Issue:** #27084

**Testing:** I've added one regression test.

**Documentation:** n/a