### PR TITLE
[exporter/honeycombmarker] Fix default url and dataset_slug

### DIFF
--- a/.chloggen/honeycombmarker-fix-url-bug.yaml
+++ b/.chloggen/honeycombmarker-fix-url-bug.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: honeycombmarkerexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix default api_url and dataset_slug
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29309]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/honeycombmarkerexporter/README.md
+++ b/exporter/honeycombmarkerexporter/README.md
@@ -1,31 +1,30 @@
 @@ -0,0 +1,18 @@
 # Honeycomb Marker Exporter
 
-This exporter allows creating markers, via the Honeycomb Markers API, based on the look of incoming telemetry. 
+This exporter allows creating [markers](https://docs.honeycomb.io/working-with-your-data/markers/), via the [Honeycomb Markers API](https://docs.honeycomb.io/api/tag/Markers#operation/createMarker), based on the look of incoming telemetry. 
 
 The following configuration options are supported:
 
 * `api_key` (Required): This is the API key for your Honeycomb account.
-* `api_url` (Required): This sets the hostname to send marker data to.
+* `api_url` (Optional): This sets the hostname to send marker data to. If not set, will default to `https://api.honeycomb.io/`
 * `markers` (Required): This is a list of configurations to create an event marker. 
-  * `type` (Required): Specifies the marker type. 
-  * `message_key`: This attribute will be used as the message. It describes the event marker. If necessary the value will be converted to a string.
-  * `url_key`: This attribute will be used as the url. It can be accessed through the event marker in Honeycomb. If necessary the value will be converted to a string.
-  * `rules` (Required): This is a list of OTTL rules that determine when to create an event marker. 
-    * `log_conditions` (Required): A list of ottllog conditions that determine a match
-  Example:
+  * `type` (Required): Specifies the marker type.
+  * `dataset_slug` (Optional): The dataset in which to create the marker. If not set, will default to `__all__`.
+  * `message_key` (Optional): This attribute will be used as the message. It describes the event marker. If necessary the value will be converted to a string.
+  * `url_key` (Optional): This attribute will be used as the url. It can be accessed through the event marker in Honeycomb. If necessary the value will be converted to a string.
+  * `rules` (Required): This is a list of [OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl) rules that determine when to create an event marker. 
+    * `log_conditions` (Required): A list of [OTTL log](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog) conditions that determine a match. The marker will be created if **ANY** condition matches.
 
+Example:
 ```yaml
 exporters:
   honeycombmarker:
-    api_key: "environment-api-key"
-    api_url: "https://api.honeycomb.io"
+    api_key: {{env:HONEYCOMB_API_KEY}}
     markers:
-      - type: "marker-type"
-        message_key: "marker-message"
-        url_key: "marker-url"
-        dataset_slug: "__all__"
+      # Creates a new marker anytime the exporter sees a k8s event with a reason of Backoff
+      - type: k8s-backoff-events
         rules:
           - log_conditions:
-              - body == "test"
+              - IsMap(body) and IsMap(body["object"] and body["object"]["reason"] == "Backoff"
 ```
+

--- a/exporter/honeycombmarkerexporter/README.md
+++ b/exporter/honeycombmarkerexporter/README.md
@@ -9,11 +9,11 @@ The following configuration options are supported:
 * `api_url` (Optional): This sets the hostname to send marker data to. If not set, will default to `https://api.honeycomb.io/`
 * `markers` (Required): This is a list of configurations to create an event marker. 
   * `type` (Required): Specifies the marker type.
-  * `dataset_slug` (Optional): The dataset in which to create the marker. If not set, will default to `__all__`.
-  * `message_key` (Optional): This attribute will be used as the message. It describes the event marker. If necessary the value will be converted to a string.
-  * `url_key` (Optional): This attribute will be used as the url. It can be accessed through the event marker in Honeycomb. If necessary the value will be converted to a string.
   * `rules` (Required): This is a list of [OTTL](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl) rules that determine when to create an event marker. 
     * `log_conditions` (Required): A list of [OTTL log](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog) conditions that determine a match. The marker will be created if **ANY** condition matches.
+  * `dataset_slug` (Optional): The dataset in which to create the marker. If not set, will default to `__all__`.
+  * `message_key` (Optional): The key of the attribute whose value will be used as the marker's message. If necessary the value will be converted to a string.
+  * `url_key` (Optional): The key of the attribute whose value will be used as the marker's url. If necessary the value will be converted to a string.
 
 Example:
 ```yaml

--- a/exporter/honeycombmarkerexporter/config.go
+++ b/exporter/honeycombmarkerexporter/config.go
@@ -73,10 +73,6 @@ func (cfg *Config) Validate() error {
 				return fmt.Errorf("marker must have a type %v", m)
 			}
 
-			if m.DatasetSlug == "" {
-				return fmt.Errorf("marker must have a dataset slug %v", m)
-			}
-
 			if len(m.Rules.LogConditions) == 0 {
 				return fmt.Errorf("marker must have rules %v", m)
 			}

--- a/exporter/honeycombmarkerexporter/config_test.go
+++ b/exporter/honeycombmarkerexporter/config_test.go
@@ -29,6 +29,23 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, ""),
 			expected: &Config{
+				APIKey: "test-apikey",
+				APIURL: "https://api.honeycomb.io",
+				Markers: []Marker{
+					{
+						Type: "fooType",
+						Rules: Rules{
+							LogConditions: []string{
+								`body == "test"`,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "all_fields"),
+			expected: &Config{
 				QueueSettings: exporterhelper.NewDefaultQueueSettings(),
 				RetrySettings: exporterhelper.NewDefaultRetrySettings(),
 				APIKey:        "test-apikey",
@@ -43,7 +60,7 @@ func TestLoadConfig(t *testing.T) {
 								`body == "test"`,
 							},
 						},
-						DatasetSlug: "__all__",
+						DatasetSlug: "testing",
 					},
 				},
 			},
@@ -59,9 +76,6 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "no_markers_supplied"),
-		},
-		{
-			id: component.NewIDWithName(metadata.Type, "no_dataset_slug"),
 		},
 	}
 

--- a/exporter/honeycombmarkerexporter/factory.go
+++ b/exporter/honeycombmarkerexporter/factory.go
@@ -23,9 +23,7 @@ func NewFactory() exporter.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		APIKey:  "",
-		APIURL:  "api.honeycomb.io:443",
-		Markers: []Marker{},
+		APIURL: "https://api.honeycomb.io",
 	}
 }
 

--- a/exporter/honeycombmarkerexporter/logs_exporter.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -17,6 +18,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
+)
+
+const (
+	defaultDatasetSlug = "__all__"
 )
 
 type honeycombLogsExporter struct {
@@ -95,7 +100,12 @@ func (e *honeycombLogsExporter) sendMarker(ctx context.Context, marker Marker, l
 		return err
 	}
 
-	url := fmt.Sprintf("%s/1/markers/%s", e.config.APIURL, marker.DatasetSlug)
+	datasetSlug := marker.DatasetSlug
+	if datasetSlug == "" {
+		datasetSlug = defaultDatasetSlug
+	}
+
+	url := fmt.Sprintf("%s/1/markers/%s", strings.TrimRight(e.config.APIURL, "/"), marker.DatasetSlug)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(request))
 	if err != nil {
 		return err

--- a/exporter/honeycombmarkerexporter/logs_exporter.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter.go
@@ -105,7 +105,7 @@ func (e *honeycombLogsExporter) sendMarker(ctx context.Context, marker Marker, l
 		datasetSlug = defaultDatasetSlug
 	}
 
-	url := fmt.Sprintf("%s/1/markers/%s", strings.TrimRight(e.config.APIURL, "/"), marker.DatasetSlug)
+	url := fmt.Sprintf("%s/1/markers/%s", strings.TrimRight(e.config.APIURL, "/"), datasetSlug)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(request))
 	if err != nil {
 		return err

--- a/exporter/honeycombmarkerexporter/logs_exporter_test.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter_test.go
@@ -22,6 +22,7 @@ func TestExportMarkers(t *testing.T) {
 		name         string
 		config       Config
 		attributeMap map[string]string
+		expectedURL  string
 	}{
 		{
 			name: "all fields",
@@ -46,6 +47,7 @@ func TestExportMarkers(t *testing.T) {
 				"url":     "https://api.testhost.io",
 				"type":    "test-type",
 			},
+			expectedURL: "/1/markers/test-dataset",
 		},
 		{
 			name: "no message key",
@@ -68,6 +70,7 @@ func TestExportMarkers(t *testing.T) {
 				"url":  "https://api.testhost.io",
 				"type": "test-type",
 			},
+			expectedURL: "/1/markers/test-dataset",
 		},
 		{
 			name: "no url",
@@ -90,6 +93,27 @@ func TestExportMarkers(t *testing.T) {
 				"message": "this is a test message",
 				"type":    "test-type",
 			},
+			expectedURL: "/1/markers/test-dataset",
+		},
+		{
+			name: "no dataset_slug",
+			config: Config{
+				APIKey: "test-apikey",
+				Markers: []Marker{
+					{
+						Type: "test-type",
+						Rules: Rules{
+							LogConditions: []string{
+								`body == "test"`,
+							},
+						},
+					},
+				},
+			},
+			attributeMap: map[string]string{
+				"type": "test-type",
+			},
+			expectedURL: "/1/markers/__all__",
 		},
 	}
 
@@ -106,7 +130,7 @@ func TestExportMarkers(t *testing.T) {
 				for attr := range tt.attributeMap {
 					assert.Equal(t, decodedBody[attr], tt.attributeMap[attr])
 				}
-				assert.Contains(t, req.URL.Path, tt.config.Markers[0].DatasetSlug)
+				assert.Contains(t, req.URL.Path, tt.expectedURL)
 
 				apiKey := req.Header.Get("X-Honeycomb-Team")
 				assert.Equal(t, apiKey, string(tt.config.APIKey))

--- a/exporter/honeycombmarkerexporter/testdata/config.yaml
+++ b/exporter/honeycombmarkerexporter/testdata/config.yaml
@@ -1,5 +1,12 @@
 honeycombmarker:
   api_key: "test-apikey"
+  markers:
+    - type: "fooType"
+      rules:
+        log_conditions:
+          - body == "test"
+honeycombmarker/all_fields:
+  api_key: "test-apikey"
   api_url: "https://api.testhost.io"
   sending_queue:
     enabled: true
@@ -16,7 +23,7 @@ honeycombmarker:
     - type: "fooType"
       message_key: "test message"
       url_key: "https://api.testhost.io"
-      dataset_slug: "__all__"
+      dataset_slug: "testing"
       rules:
         log_conditions:
           - body == "test"


### PR DESCRIPTION
**Description:** 
Fixes an issue with an incorrect default url.  Also fixes issue where dataset slug was required.

**Link to tracking Issue:** <Issue number if applicable>
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/27666

**Testing:** <Describe what testing was performed and which tests were added.>
Added new tests and tested manually.

**Documentation:** <Describe the documentation added.>
 Updated up README