### PR TITLE
[chore] fix issuegenerator path

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: GitHub Issue Generator
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
-        run: issuegenerator $TEST_RESULTS
+        run: ./.tools/issuegenerator $TEST_RESULTS
 
   update-benchmarks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
workflows have been failing and then trying to use `issuegenerator` to create issues, but the path for the tool was incorrect. see https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/6895702499/job/18761957296 as an example