### PR TITLE
[chore][extension/observer] Assign exported function `observer.NewEndpointsWatcher` to a variable and pass checkapi

### DIFF
--- a/cmd/checkapi/allowlist.txt
+++ b/cmd/checkapi/allowlist.txt
@@ -1,3 +1,2 @@
 connector/servicegraphconnector
-extension/observer
 processor/servicegraphprocessor

--- a/extension/observer/endpointswatcher.go
+++ b/extension/observer/endpointswatcher.go
@@ -31,7 +31,7 @@ type EndpointsWatcher struct {
 	logger            *zap.Logger
 }
 
-func NewEndpointsWatcher(endpointsLister EndpointsLister, refreshInterval time.Duration, logger *zap.Logger) *EndpointsWatcher {
+var NewEndpointsWatcher = func(endpointsLister EndpointsLister, refreshInterval time.Duration, logger *zap.Logger) *EndpointsWatcher {
 	return &EndpointsWatcher{
 		EndpointsLister:   endpointsLister,
 		RefreshInterval:   refreshInterval,


### PR DESCRIPTION
**Description:**
Assign exported function `observer.NewEndpointsWatcher` to a variable and pass checkapi.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26304

**Testing:**
go run cmd/checkapi/main.go .
go test for observer
go test for dockerobserver
go test for ecsobserver
go test for ecstaskobserver
go test for hostobserver
go test for k8sobserver


**Documentation:**