### PR TITLE
[chore] [translator/prometheusremotewrite] ensure unknown reset hint

### DIFF
--- a/pkg/translator/prometheusremotewrite/histograms.go
+++ b/pkg/translator/prometheusremotewrite/histograms.go
@@ -74,7 +74,17 @@ func exponentialToNativeHistogram(p pmetric.ExponentialHistogramDataPoint) (prom
 	nSpans, nDeltas := convertBucketsLayout(p.Negative(), scaleDown)
 
 	h := prompb.Histogram{
-		Schema: scale,
+		// The counter reset detection must be compatible with Prometheus to
+		// safely set ResetHint to NO. This is not ensured currently.
+		// Sending a sample that triggers counter reset but with ResetHint==NO
+		// would lead to Prometheus panic as it does not double check the hint.
+		// Thus we're explicitly saying UNKNOWN here, which is always safe.
+		// TODO: using created time stamp should be accurate, but we
+		// need to know here if it was used for the detection.
+		// Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28663#issuecomment-1810577303
+		// Counter reset detection in Prometheus: https://github.com/prometheus/prometheus/blob/f997c72f294c0f18ca13fa06d51889af04135195/tsdb/chunkenc/histogram.go#L232
+		ResetHint: prompb.Histogram_UNKNOWN,
+		Schema:    scale,
 
 		ZeroCount: &prompb.Histogram_ZeroCountInt{ZeroCountInt: p.ZeroCount()},
 		// TODO use zero_threshold, if set, see


### PR DESCRIPTION
**Description:** 

Ensure that native histogram reset hint is UNKNOWN and document reasoning. 

See discussion in the related PR: #28663

**Link to tracking Issue:**

N/A

**Testing:** 

N/A

**Documentation:**

N/A