### PR TITLE
[chore] [pkg/resourcetotelemetry] reduce memory usage

### DIFF
--- a/.chloggen/optimize-resource-to-telemetry.yaml
+++ b/.chloggen/optimize-resource-to-telemetry.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: pkg/resourcetotelemetry
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Not clone data in pkg/resourcetotelemetry by default
+note: Do not clone data in pkg/resourcetotelemetry by default
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [29327]
@@ -15,7 +15,8 @@ issues: [29327]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+   - The resulting consumer will be marked as `MutatesData` instead
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/optimize-resource-to-telemetry.yaml
+++ b/.chloggen/optimize-resource-to-telemetry.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/resourcetotelemetry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Not clone data in pkg/resourcetotelemetry by default
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29327]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/resourcetotelemetry/resource_to_telemetry.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry.go
@@ -33,8 +33,8 @@ func (wme *wrapperMetricsExporter) ConsumeMetrics(ctx context.Context, md pmetri
 }
 
 func (wme *wrapperMetricsExporter) Capabilities() consumer.Capabilities {
-	// Always return false since this wrapper clones the data.
-	return consumer.Capabilities{MutatesData: false}
+	// Always return true since this wrapper modifies data inplace.
+	return consumer.Capabilities{MutatesData: true}
 }
 
 // WrapMetricsExporter wraps a given exporter.Metrics and based on the given settings
@@ -47,9 +47,7 @@ func WrapMetricsExporter(set Settings, exporter exporter.Metrics) exporter.Metri
 }
 
 func convertToMetricsAttributes(md pmetric.Metrics) pmetric.Metrics {
-	cloneMd := pmetric.NewMetrics()
-	md.CopyTo(cloneMd)
-	rms := cloneMd.ResourceMetrics()
+	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		resource := rms.At(i).Resource()
 
@@ -62,7 +60,7 @@ func convertToMetricsAttributes(md pmetric.Metrics) pmetric.Metrics {
 			}
 		}
 	}
-	return cloneMd
+	return md
 }
 
 // addAttributesToMetric adds additional labels to the given metric

--- a/pkg/resourcetotelemetry/resource_to_telemetry_test.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry_test.go
@@ -20,15 +20,11 @@ func TestConvertResourceToAttributes(t *testing.T) {
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().Len())
 
-	cloneMd := convertToMetricsAttributes(md)
+	md = convertToMetricsAttributes(md)
 
 	// After converting resource to labels
-	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
-	assert.Equal(t, 2, cloneMd.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().Len())
-
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
-	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().Len())
-
+	assert.Equal(t, 2, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().Len())
 }
 
 func TestConvertResourceToAttributesAllDataTypesEmptyDataPoint(t *testing.T) {
@@ -45,26 +41,17 @@ func TestConvertResourceToAttributesAllDataTypesEmptyDataPoint(t *testing.T) {
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(6).ExponentialHistogram().DataPoints().At(0).Attributes().Len())
 
-	cloneMd := convertToMetricsAttributes(md)
+	md = convertToMetricsAttributes(md)
 
 	// After converting resource to labels
-	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).Resource().Attributes().Len())
-	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(1).Gauge().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(2).Sum().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(3).Sum().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(4).Histogram().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 1, cloneMd.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(6).ExponentialHistogram().DataPoints().At(0).Attributes().Len())
-
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).Resource().Attributes().Len())
-	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(1).Gauge().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(2).Sum().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(3).Sum().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(4).Histogram().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
-	assert.Equal(t, 0, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(6).ExponentialHistogram().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Gauge().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(1).Gauge().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(2).Sum().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(3).Sum().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(4).Histogram().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
+	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(6).ExponentialHistogram().DataPoints().At(0).Attributes().Len())
 
 }
 


### PR DESCRIPTION
Description:

1. Reduce memory usage by modify data in place, just let the pipeline builder to determine whether or not to clone data.


Link to tracking Issue:

N/A

Testing:

N/A

Documentation:

N/A