### PR TITLE
feat(awsS3Exporter): add support for `s3_force_path_style` and `disable_ssl` parameters

### DIFF
--- a/.chloggen/support-extrat-parameters-to-be-compatible-with-minio.yaml
+++ b/.chloggen/support-extrat-parameters-to-be-compatible-with-minio.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awss3exporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "add support for `s3_force_path_style` and `disable_ssl` parameters"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [ 29331 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+    In order to support alternative object-storage, these parameters are useful and help to leverage those systems not
+    compatible with domain style path, or just hosted without ssl (like just deployed in a k8s namespace).
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [ user ]

--- a/exporter/awss3exporter/README.md
+++ b/exporter/awss3exporter/README.md
@@ -19,18 +19,20 @@ This exporter targets to support proto/json format.
 
 ## Exporter Configuration
 
-The following exporter configuration parameters are supported. 
+The following exporter configuration parameters are supported.
 
-| Name           | Description                                                                                          | Default     |
-|:---------------|:-----------------------------------------------------------------------------------------------------|-------------|
-| `region`       | AWS region.                                                                                          | "us-east-1" |
-| `s3_bucket`    | S3 bucket                                                                                            |             |
-| `s3_prefix`    | prefix for the S3 key (root directory inside bucket).                                                |             |
-| `s3_partition` | time granularity of S3 key: hour or minute                                                           | "minute"    |
-| `role_arn`     | the Role ARN to be assumed                                                                           |             |
-| `file_prefix`  | file prefix defined by user                                                                          |             |
-| `marshaler`    | marshaler used to produce output data                                                                | `otlp_json` |
-| `endpoint`     | overrides the endpoint used by the exporter instead of constructing it from `region` and `s3_bucket` |             |
+| Name                  | Description                                                                                                                                  | Default     |
+|:----------------------|:---------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| `region`              | AWS region.                                                                                                                                  | "us-east-1" |
+| `s3_bucket`           | S3 bucket                                                                                                                                    |             |
+| `s3_prefix`           | prefix for the S3 key (root directory inside bucket).                                                                                        |             |
+| `s3_partition`        | time granularity of S3 key: hour or minute                                                                                                   | "minute"    |
+| `role_arn`            | the Role ARN to be assumed                                                                                                                   |             |
+| `file_prefix`         | file prefix defined by user                                                                                                                  |             |
+| `marshaler`           | marshaler used to produce output data                                                                                                        | `otlp_json` |
+| `endpoint`            | overrides the endpoint used by the exporter instead of constructing it from `region` and `s3_bucket`                                         |             |
+| `s3_force_path_style` | [set this to `true` to force the request to use path-style addressing](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html)   | false       |
+| `disable_ssl`         | set this to `true` to disable SSL when sending requests                                                                                      | false       |
 
 ### Marshaler
 

--- a/exporter/awss3exporter/config.go
+++ b/exporter/awss3exporter/config.go
@@ -12,13 +12,15 @@ import (
 // S3UploaderConfig contains aws s3 uploader related config to controls things
 // like bucket, prefix, batching, connections, retries, etc.
 type S3UploaderConfig struct {
-	Region      string `mapstructure:"region"`
-	S3Bucket    string `mapstructure:"s3_bucket"`
-	S3Prefix    string `mapstructure:"s3_prefix"`
-	S3Partition string `mapstructure:"s3_partition"`
-	FilePrefix  string `mapstructure:"file_prefix"`
-	Endpoint    string `mapstructure:"endpoint"`
-	RoleArn     string `mapstructure:"role_arn"`
+	Region           string `mapstructure:"region"`
+	S3Bucket         string `mapstructure:"s3_bucket"`
+	S3Prefix         string `mapstructure:"s3_prefix"`
+	S3Partition      string `mapstructure:"s3_partition"`
+	FilePrefix       string `mapstructure:"file_prefix"`
+	Endpoint         string `mapstructure:"endpoint"`
+	RoleArn          string `mapstructure:"role_arn"`
+	S3ForcePathStyle bool   `mapstructure:"s3_force_path_style"`
+	DisableSSL       bool   `mapstructure:"disable_ssl"`
 }
 
 type MarshalerType string

--- a/exporter/awss3exporter/config_test.go
+++ b/exporter/awss3exporter/config_test.go
@@ -67,6 +67,36 @@ func TestConfig(t *testing.T) {
 	)
 }
 
+func TestConfigForS3CompatibleSystems(t *testing.T) {
+	factories, err := otelcoltest.NopFactories()
+	assert.Nil(t, err)
+
+	factory := NewFactory()
+	factories.Exporters[factory.Type()] = factory
+	cfg, err := otelcoltest.LoadConfigAndValidate(
+		filepath.Join("testdata", "config-s3-compatible-systems.yaml"), factories)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	e := cfg.Exporters[component.NewID("awss3")].(*Config)
+
+	assert.Equal(t, e,
+		&Config{
+			S3Uploader: S3UploaderConfig{
+				Region:           "us-east-1",
+				S3Bucket:         "foo",
+				S3Prefix:         "bar",
+				S3Partition:      "minute",
+				Endpoint:         "alternative-s3-system.example.com",
+				S3ForcePathStyle: true,
+				DisableSSL:       true,
+			},
+			MarshalerName: "otlp_json",
+		},
+	)
+}
+
 func TestConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/exporter/awss3exporter/s3_writer.go
+++ b/exporter/awss3exporter/s3_writer.go
@@ -49,7 +49,9 @@ func getS3Key(time time.Time, keyPrefix string, partition string, filePrefix str
 
 func getSessionConfig(config *Config) *aws.Config {
 	sessionConfig := &aws.Config{
-		Region: aws.String(config.S3Uploader.Region),
+		Region:           aws.String(config.S3Uploader.Region),
+		S3ForcePathStyle: &config.S3Uploader.S3ForcePathStyle,
+		DisableSSL:       &config.S3Uploader.DisableSSL,
 	}
 
 	endpoint := config.S3Uploader.Endpoint

--- a/exporter/awss3exporter/testdata/config-s3-compatible-systems.yaml
+++ b/exporter/awss3exporter/testdata/config-s3-compatible-systems.yaml
@@ -1,0 +1,22 @@
+receivers:
+    nop:
+
+exporters:
+    awss3:
+        s3uploader:
+            s3_bucket: 'foo'
+            s3_prefix: 'bar'
+            s3_partition: 'minute'
+            endpoint: "alternative-s3-system.example.com"
+            s3_force_path_style: true
+            disable_ssl: true
+
+processors:
+    nop:
+
+service:
+    pipelines:
+        traces:
+            receivers: [nop]
+            processors: [nop]
+            exporters: [awss3]


### PR DESCRIPTION
**Description:** 

In order to support alternative object-storage, these parameters (`s3_force_path_style` and `disable_ssl`) are useful and help to leverage those object storage systems, not compatible with domain style path, or just hosted without ssl (like a minio pod deployed in a k8s namespace).

**Testing:**: 

I've tested it in this project: https://gitlab.com/davinkevin.fr/experimentations/opentelemetry/spring-boot-otel-to-minio

It was deployed in a k3d cluster and used to store metrics generated gathered by the prometheus receiver. 

**Documentation:**, minimal, just description of the two new parameters, usually well known by administrators or operators in charge to connect systems to their S3-Compatible storages. 