### PR TITLE
[pkg/ottl] Use errors.Join instead of multierr

### DIFF
--- a/pkg/ottl/go.mod
+++ b/pkg/ottl/go.mod
@@ -13,7 +13,6 @@ require (
 	go.opentelemetry.io/collector/component v0.89.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0018
 	go.opentelemetry.io/otel/trace v1.20.0
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20230711023510-fffb14384f22
 )
@@ -37,6 +36,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0018 // indirect
 	go.opentelemetry.io/otel v1.20.0 // indirect
 	go.opentelemetry.io/otel/metric v1.20.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/text v0.14.0 // indirect


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/25121