### PR TITLE
[pkg/ottl] Add ConditionSequence struct

### DIFF
--- a/.chloggen/ottl-condition-sequence.yaml
+++ b/.chloggen/ottl-condition-sequence.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `ConditionSequence` for evaluating lists of conditions
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29339]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/connector/countconnector/config_test.go
+++ b/connector/countconnector/config_test.go
@@ -413,7 +413,7 @@ func TestConfigErrors(t *testing.T) {
 					},
 				},
 			},
-			expect: fmt.Sprintf("spans condition: metric %q: unable to parse OTTL statement", defaultMetricNameSpans),
+			expect: fmt.Sprintf("spans condition: metric %q: unable to parse OTTL condition", defaultMetricNameSpans),
 		},
 		{
 			name: "invalid_condition_spanevent",
@@ -425,7 +425,7 @@ func TestConfigErrors(t *testing.T) {
 					},
 				},
 			},
-			expect: fmt.Sprintf("spanevents condition: metric %q: unable to parse OTTL statement", defaultMetricNameSpanEvents),
+			expect: fmt.Sprintf("spanevents condition: metric %q: unable to parse OTTL condition", defaultMetricNameSpanEvents),
 		},
 		{
 			name: "invalid_condition_metric",
@@ -437,7 +437,7 @@ func TestConfigErrors(t *testing.T) {
 					},
 				},
 			},
-			expect: fmt.Sprintf("metrics condition: metric %q: unable to parse OTTL statement", defaultMetricNameMetrics),
+			expect: fmt.Sprintf("metrics condition: metric %q: unable to parse OTTL condition", defaultMetricNameMetrics),
 		},
 		{
 			name: "invalid_condition_datapoint",
@@ -449,7 +449,7 @@ func TestConfigErrors(t *testing.T) {
 					},
 				},
 			},
-			expect: fmt.Sprintf("datapoints condition: metric %q: unable to parse OTTL statement", defaultMetricNameDataPoints),
+			expect: fmt.Sprintf("datapoints condition: metric %q: unable to parse OTTL condition", defaultMetricNameDataPoints),
 		},
 		{
 			name: "invalid_condition_log",
@@ -461,7 +461,7 @@ func TestConfigErrors(t *testing.T) {
 					},
 				},
 			},
-			expect: fmt.Sprintf("logs condition: metric %q: unable to parse OTTL statement", defaultMetricNameLogs),
+			expect: fmt.Sprintf("logs condition: metric %q: unable to parse OTTL condition", defaultMetricNameLogs),
 		},
 	}
 

--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -28,7 +28,7 @@ func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[o
 	if err != nil {
 		return nil, err
 	}
-	c := ottlspan.NewConditionSequence(statements, errorMode, set)
+	c := ottlspan.NewConditionSequence(statements, set, ottlspan.WithConditionSequenceErrorMode(errorMode))
 	return &c, nil
 }
 
@@ -44,7 +44,7 @@ func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Fact
 	if err != nil {
 		return nil, err
 	}
-	c := ottlspanevent.NewConditionSequence(statements, errorMode, set)
+	c := ottlspanevent.NewConditionSequence(statements, set, ottlspanevent.WithConditionSequenceErrorMode(errorMode))
 	return &c, nil
 }
 
@@ -60,7 +60,7 @@ func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory
 	if err != nil {
 		return nil, err
 	}
-	c := ottlmetric.NewConditionSequence(statements, errorMode, set)
+	c := ottlmetric.NewConditionSequence(statements, set, ottlmetric.WithConditionSequenceErrorMode(errorMode))
 	return &c, nil
 }
 
@@ -76,7 +76,7 @@ func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Fact
 	if err != nil {
 		return nil, err
 	}
-	c := ottldatapoint.NewConditionSequence(statements, errorMode, set)
+	c := ottldatapoint.NewConditionSequence(statements, set, ottldatapoint.WithConditionSequenceErrorMode(errorMode))
 	return &c, nil
 }
 
@@ -92,7 +92,7 @@ func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ot
 	if err != nil {
 		return nil, err
 	}
-	c := ottllog.NewConditionSequence(statements, errorMode, set)
+	c := ottllog.NewConditionSequence(statements, set, ottllog.WithConditionSequenceErrorMode(errorMode))
 	return &c, nil
 }
 
@@ -108,6 +108,6 @@ func NewBoolExprForResource(conditions []string, functions map[string]ottl.Facto
 	if err != nil {
 		return nil, err
 	}
-	c := ottlresource.NewConditionSequence(statements, errorMode, set)
+	c := ottlresource.NewConditionSequence(statements, set, ottlresource.WithConditionSequenceErrorMode(errorMode))
 	return &c, nil
 }

--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -20,10 +20,6 @@ import (
 // The passed in functions should use the ottlspan.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[ottlspan.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlspan.TransformContext], error) {
-	match := newMatchFactory[ottlspan.TransformContext]()
-	if _, ok := functions[match.Name()]; !ok {
-		functions[match.Name()] = match
-	}
 	parser, err := ottlspan.NewParser(functions, set)
 	if err != nil {
 		return nil, err
@@ -40,10 +36,6 @@ func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[o
 // The passed in functions should use the ottlspanevent.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Factory[ottlspanevent.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlspanevent.TransformContext], error) {
-	match := newMatchFactory[ottlspanevent.TransformContext]()
-	if _, ok := functions[match.Name()]; !ok {
-		functions[match.Name()] = match
-	}
 	parser, err := ottlspanevent.NewParser(functions, set)
 	if err != nil {
 		return nil, err
@@ -60,10 +52,6 @@ func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Fact
 // The passed in functions should use the ottlmetric.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory[ottlmetric.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlmetric.TransformContext], error) {
-	match := newMatchFactory[ottlmetric.TransformContext]()
-	if _, ok := functions[match.Name()]; !ok {
-		functions[match.Name()] = match
-	}
 	parser, err := ottlmetric.NewParser(functions, set)
 	if err != nil {
 		return nil, err
@@ -80,10 +68,6 @@ func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory
 // The passed in functions should use the ottldatapoint.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Factory[ottldatapoint.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottldatapoint.TransformContext], error) {
-	match := newMatchFactory[ottldatapoint.TransformContext]()
-	if _, ok := functions[match.Name()]; !ok {
-		functions[match.Name()] = match
-	}
 	parser, err := ottldatapoint.NewParser(functions, set)
 	if err != nil {
 		return nil, err
@@ -100,10 +84,6 @@ func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Fact
 // The passed in functions should use the ottllog.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ottllog.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottllog.TransformContext], error) {
-	match := newMatchFactory[ottllog.TransformContext]()
-	if _, ok := functions[match.Name()]; !ok {
-		functions[match.Name()] = match
-	}
 	parser, err := ottllog.NewParser(functions, set)
 	if err != nil {
 		return nil, err
@@ -120,10 +100,6 @@ func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ot
 // The passed in functions should use the ottlresource.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForResource(conditions []string, functions map[string]ottl.Factory[ottlresource.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (expr.BoolExpr[ottlresource.TransformContext], error) {
-	match := newMatchFactory[ottlresource.TransformContext]()
-	if _, ok := functions[match.Name()]; !ok {
-		functions[match.Name()] = match
-	}
 	parser, err := ottlresource.NewParser(functions, set)
 	if err != nil {
 		return nil, err

--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -24,17 +24,16 @@ func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[o
 	if _, ok := functions[match.Name()]; !ok {
 		functions[match.Name()] = match
 	}
-	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlspan.NewParser(functions, set)
 	if err != nil {
 		return nil, err
 	}
-	statements, err := parser.ParseStatements(statmentsStr)
+	statements, err := parser.ParseConditions(conditions)
 	if err != nil {
 		return nil, err
 	}
-	s := ottlspan.NewStatements(statements, set, ottlspan.WithErrorMode(errorMode))
-	return &s, nil
+	c := ottlspan.NewConditionSequence(statements, errorMode, set)
+	return &c, nil
 }
 
 // NewBoolExprForSpanEvent creates a BoolExpr[ottlspanevent.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
@@ -45,17 +44,16 @@ func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Fact
 	if _, ok := functions[match.Name()]; !ok {
 		functions[match.Name()] = match
 	}
-	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlspanevent.NewParser(functions, set)
 	if err != nil {
 		return nil, err
 	}
-	statements, err := parser.ParseStatements(statmentsStr)
+	statements, err := parser.ParseConditions(conditions)
 	if err != nil {
 		return nil, err
 	}
-	s := ottlspanevent.NewStatements(statements, set, ottlspanevent.WithErrorMode(errorMode))
-	return &s, nil
+	c := ottlspanevent.NewConditionSequence(statements, errorMode, set)
+	return &c, nil
 }
 
 // NewBoolExprForMetric creates a BoolExpr[ottlmetric.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
@@ -66,17 +64,16 @@ func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory
 	if _, ok := functions[match.Name()]; !ok {
 		functions[match.Name()] = match
 	}
-	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlmetric.NewParser(functions, set)
 	if err != nil {
 		return nil, err
 	}
-	statements, err := parser.ParseStatements(statmentsStr)
+	statements, err := parser.ParseConditions(conditions)
 	if err != nil {
 		return nil, err
 	}
-	s := ottlmetric.NewStatements(statements, set, ottlmetric.WithErrorMode(errorMode))
-	return &s, nil
+	c := ottlmetric.NewConditionSequence(statements, errorMode, set)
+	return &c, nil
 }
 
 // NewBoolExprForDataPoint creates a BoolExpr[ottldatapoint.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
@@ -87,17 +84,16 @@ func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Fact
 	if _, ok := functions[match.Name()]; !ok {
 		functions[match.Name()] = match
 	}
-	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottldatapoint.NewParser(functions, set)
 	if err != nil {
 		return nil, err
 	}
-	statements, err := parser.ParseStatements(statmentsStr)
+	statements, err := parser.ParseConditions(conditions)
 	if err != nil {
 		return nil, err
 	}
-	s := ottldatapoint.NewStatements(statements, set, ottldatapoint.WithErrorMode(errorMode))
-	return &s, nil
+	c := ottldatapoint.NewConditionSequence(statements, errorMode, set)
+	return &c, nil
 }
 
 // NewBoolExprForLog creates a BoolExpr[ottllog.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
@@ -108,17 +104,16 @@ func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ot
 	if _, ok := functions[match.Name()]; !ok {
 		functions[match.Name()] = match
 	}
-	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottllog.NewParser(functions, set)
 	if err != nil {
 		return nil, err
 	}
-	statements, err := parser.ParseStatements(statmentsStr)
+	statements, err := parser.ParseConditions(conditions)
 	if err != nil {
 		return nil, err
 	}
-	s := ottllog.NewStatements(statements, set, ottllog.WithErrorMode(errorMode))
-	return &s, nil
+	c := ottllog.NewConditionSequence(statements, errorMode, set)
+	return &c, nil
 }
 
 // NewBoolExprForResource creates a BoolExpr[ottlresource.TransformContext] that will return true if any of the given OTTL conditions evaluate to true.
@@ -129,23 +124,14 @@ func NewBoolExprForResource(conditions []string, functions map[string]ottl.Facto
 	if _, ok := functions[match.Name()]; !ok {
 		functions[match.Name()] = match
 	}
-	statmentsStr := conditionsToStatements(conditions)
 	parser, err := ottlresource.NewParser(functions, set)
 	if err != nil {
 		return nil, err
 	}
-	statements, err := parser.ParseStatements(statmentsStr)
+	statements, err := parser.ParseConditions(conditions)
 	if err != nil {
 		return nil, err
 	}
-	s := ottlresource.NewStatements(statements, set, ottlresource.WithErrorMode(errorMode))
-	return &s, nil
-}
-
-func conditionsToStatements(conditions []string) []string {
-	statements := make([]string, len(conditions))
-	for i, condition := range conditions {
-		statements[i] = "match() where " + condition
-	}
-	return statements
+	c := ottlresource.NewConditionSequence(statements, errorMode, set)
+	return &c, nil
 }

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -20,15 +20,15 @@ import (
 )
 
 func StandardSpanFuncs() map[string]ottl.Factory[ottlspan.TransformContext] {
-	return standardFuncs[ottlspan.TransformContext]()
+	return ottlfuncs.StandardConverters[ottlspan.TransformContext]()
 }
 
 func StandardSpanEventFuncs() map[string]ottl.Factory[ottlspanevent.TransformContext] {
-	return standardFuncs[ottlspanevent.TransformContext]()
+	return ottlfuncs.StandardConverters[ottlspanevent.TransformContext]()
 }
 
 func StandardMetricFuncs() map[string]ottl.Factory[ottlmetric.TransformContext] {
-	m := standardFuncs[ottlmetric.TransformContext]()
+	m := ottlfuncs.StandardConverters[ottlmetric.TransformContext]()
 	hasAttributeOnDatapointFactory := newHasAttributeOnDatapointFactory()
 	hasAttributeKeyOnDatapointFactory := newHasAttributeKeyOnDatapointFactory()
 	m[hasAttributeOnDatapointFactory.Name()] = hasAttributeOnDatapointFactory
@@ -37,36 +37,15 @@ func StandardMetricFuncs() map[string]ottl.Factory[ottlmetric.TransformContext] 
 }
 
 func StandardDataPointFuncs() map[string]ottl.Factory[ottldatapoint.TransformContext] {
-	return standardFuncs[ottldatapoint.TransformContext]()
+	return ottlfuncs.StandardConverters[ottldatapoint.TransformContext]()
 }
 
 func StandardLogFuncs() map[string]ottl.Factory[ottllog.TransformContext] {
-	return standardFuncs[ottllog.TransformContext]()
+	return ottlfuncs.StandardConverters[ottllog.TransformContext]()
 }
 
 func StandardResourceFuncs() map[string]ottl.Factory[ottlresource.TransformContext] {
-	return standardFuncs[ottlresource.TransformContext]()
-}
-
-func standardFuncs[K any]() map[string]ottl.Factory[K] {
-	m := ottlfuncs.StandardConverters[K]()
-	f := newMatchFactory[K]()
-	m[f.Name()] = f
-	return m
-}
-
-func newMatchFactory[K any]() ottl.Factory[K] {
-	return ottl.NewFactory("match", nil, createMatchFunction[K])
-}
-
-func createMatchFunction[K any](_ ottl.FunctionContext, _ ottl.Arguments) (ottl.ExprFunc[K], error) {
-	return matchFn[K]()
-}
-
-func matchFn[K any]() (ottl.ExprFunc[K], error) {
-	return func(context.Context, K) (any, error) {
-		return true, nil
-	}, nil
+	return ottlfuncs.StandardConverters[ottlresource.TransformContext]()
 }
 
 type hasAttributeOnDatapointArguments struct {

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -98,8 +98,20 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
-	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+
+func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
+	return func(c *ottl.ConditionSequence[TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	}
+}
+
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+	c := ottl.NewConditionSequence(conditions, telemetrySettings)
+	for _, op := range options {
+		op(&c)
+	}
+	return c
 }
 
 var symbolTable = map[ottl.EnumSymbol]ottl.Enum{

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -98,6 +98,10 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
+	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+}
+
 var symbolTable = map[ottl.EnumSymbol]ottl.Enum{
 	"FLAG_NONE":              0,
 	"FLAG_NO_RECORDED_VALUE": 1,

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -88,6 +88,10 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
+	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+}
+
 var symbolTable = map[ottl.EnumSymbol]ottl.Enum{
 	"SEVERITY_NUMBER_UNSPECIFIED": ottl.Enum(plog.SeverityNumberUnspecified),
 	"SEVERITY_NUMBER_TRACE":       ottl.Enum(plog.SeverityNumberTrace),

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -88,8 +88,20 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
-	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+
+func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
+	return func(c *ottl.ConditionSequence[TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	}
+}
+
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+	c := ottl.NewConditionSequence(conditions, telemetrySettings)
+	for _, op := range options {
+		op(&c)
+	}
+	return c
 }
 
 var symbolTable = map[ottl.EnumSymbol]ottl.Enum{

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -92,6 +92,10 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
+	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+}
+
 var symbolTable = internal.MetricSymbolTable
 
 func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -92,8 +92,20 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
-	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+
+func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
+	return func(c *ottl.ConditionSequence[TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	}
+}
+
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+	c := ottl.NewConditionSequence(conditions, telemetrySettings)
+	for _, op := range options {
+		op(&c)
+	}
+	return c
 }
 
 var symbolTable = internal.MetricSymbolTable

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -71,6 +71,10 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
+	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+}
+
 func parseEnum(_ *ottl.EnumSymbol) (*ottl.Enum, error) {
 	return nil, fmt.Errorf("resource context does not provide Enum support")
 }

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -71,8 +71,20 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
-	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+
+func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
+	return func(c *ottl.ConditionSequence[TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	}
+}
+
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+	c := ottl.NewConditionSequence(conditions, telemetrySettings)
+	for _, op := range options {
+		op(&c)
+	}
+	return c
 }
 
 func parseEnum(_ *ottl.EnumSymbol) (*ottl.Enum, error) {

--- a/pkg/ottl/contexts/ottlscope/scope.go
+++ b/pkg/ottl/contexts/ottlscope/scope.go
@@ -78,8 +78,20 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
-	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+
+func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
+	return func(c *ottl.ConditionSequence[TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	}
+}
+
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+	c := ottl.NewConditionSequence(conditions, telemetrySettings)
+	for _, op := range options {
+		op(&c)
+	}
+	return c
 }
 
 func parseEnum(_ *ottl.EnumSymbol) (*ottl.Enum, error) {

--- a/pkg/ottl/contexts/ottlscope/scope.go
+++ b/pkg/ottl/contexts/ottlscope/scope.go
@@ -78,6 +78,10 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
+	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+}
+
 func parseEnum(_ *ottl.EnumSymbol) (*ottl.Enum, error) {
 	return nil, fmt.Errorf("instrumentation scope context does not provide Enum support")
 }

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -85,8 +85,20 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
-	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+
+func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
+	return func(c *ottl.ConditionSequence[TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	}
+}
+
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+	c := ottl.NewConditionSequence(conditions, telemetrySettings)
+	for _, op := range options {
+		op(&c)
+	}
+	return c
 }
 
 func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -85,6 +85,10 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
+	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+}
+
 func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 	if val != nil {
 		if enum, ok := internal.SpanSymbolTable[*val]; ok {

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -93,8 +93,20 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
-func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
-	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+type ConditionSequenceOption func(*ottl.ConditionSequence[TransformContext])
+
+func WithConditionSequenceErrorMode(errorMode ottl.ErrorMode) ConditionSequenceOption {
+	return func(c *ottl.ConditionSequence[TransformContext]) {
+		ottl.WithConditionSequenceErrorMode[TransformContext](errorMode)(c)
+	}
+}
+
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption) ottl.ConditionSequence[TransformContext] {
+	c := ottl.NewConditionSequence(conditions, telemetrySettings)
+	for _, op := range options {
+		op(&c)
+	}
+	return c
 }
 
 func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -93,6 +93,10 @@ func NewStatements(statements []*ottl.Statement[TransformContext], telemetrySett
 	return s
 }
 
+func NewConditionSequence(conditions []*ottl.Condition[TransformContext], errorMode ottl.ErrorMode, telemetrySettings component.TelemetrySettings, options ...ottl.ConditionSequenceOption[TransformContext]) ottl.ConditionSequence[TransformContext] {
+	return ottl.NewConditionSequence(conditions, errorMode, telemetrySettings, options...)
+}
+
 func parseEnum(val *ottl.EnumSymbol) (*ottl.Enum, error) {
 	if val != nil {
 		if enum, ok := internal.SpanSymbolTable[*val]; ok {

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -307,7 +307,7 @@ func (s *Statements[K]) Eval(ctx context.Context, tCtx K) (bool, error) {
 	return false, nil
 }
 
-// ConditionSequence represents a list of Condition that will be executed sequentially for a TransformContext
+// ConditionSequence represents a list of Conditions that will be evaluated sequentially for a TransformContext
 // and will handle errors returned by conditions based on an ErrorMode.
 type ConditionSequence[K any] struct {
 	conditions        []*Condition[K]
@@ -333,7 +333,7 @@ func NewConditionSequence[K any](conditions []*Condition[K], errorMode ErrorMode
 
 // Eval evaluates the result of each Condition in the ConditionSequence.
 // If any Condition evaluates to true, then true is returned.
-// If all Condition evaluate to false, then false is returned.
+// If all Conditions evaluate to false, then false is returned.
 // When the ErrorMode of the ConditionSequence is `propagate`, errors cause the evaluation to be false and an error is returned.
 // When the ErrorMode of the ConditionSequence is `ignore`, errors cause the evaluation to continue to the next condition.
 func (c *ConditionSequence[K]) Eval(ctx context.Context, tCtx K) (bool, error) {

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -359,7 +359,7 @@ func WithLogicOperation[K any](logicOp LogicOperation) ConditionSequenceOption[K
 func NewConditionSequence[K any](conditions []*Condition[K], telemetrySettings component.TelemetrySettings, options ...ConditionSequenceOption[K]) ConditionSequence[K] {
 	c := ConditionSequence[K]{
 		conditions:        conditions,
-		errorMode:         IgnoreError,
+		errorMode:         PropagateError,
 		telemetrySettings: telemetrySettings,
 		logicOp:           Or,
 	}

--- a/pkg/ottl/parser.go
+++ b/pkg/ottl/parser.go
@@ -32,6 +32,24 @@ func (e *ErrorMode) UnmarshalText(text []byte) error {
 	}
 }
 
+type LogicOperation string
+
+const (
+	And LogicOperation = "and"
+	Or  LogicOperation = "or"
+)
+
+func (l *LogicOperation) UnmarshalText(text []byte) error {
+	str := LogicOperation(strings.ToLower(string(text)))
+	switch str {
+	case And, Or:
+		*l = str
+		return nil
+	default:
+		return fmt.Errorf("unknown LogicOperation %v", str)
+	}
+}
+
 // Statement holds a top level Statement for processing telemetry data. A Statement is a combination of a function
 // invocation and the boolean expression to match telemetry for invoking the function.
 type Statement[K any] struct {
@@ -309,13 +327,24 @@ func (s *Statements[K]) Eval(ctx context.Context, tCtx K) (bool, error) {
 
 // ConditionSequence represents a list of Conditions that will be evaluated sequentially for a TransformContext
 // and will handle errors returned by conditions based on an ErrorMode.
+// By default, the conditions are ORed together, but they can be ANDed together using the WithLogicOperation option.
 type ConditionSequence[K any] struct {
 	conditions        []*Condition[K]
 	errorMode         ErrorMode
 	telemetrySettings component.TelemetrySettings
+	logicOp           LogicOperation
 }
 
 type ConditionSequenceOption[K any] func(*ConditionSequence[K])
+
+// WithLogicOperation sets the LogicOperation of a ConditionSequence
+// When setting AND the conditions will be ANDed together.
+// When setting OR the conditions will be ORed together.
+func WithLogicOperation[K any](logicOp LogicOperation) ConditionSequenceOption[K] {
+	return func(c *ConditionSequence[K]) {
+		c.logicOp = logicOp
+	}
+}
 
 // NewConditionSequence creates a new ConditionSequence with the provided Condition slice, ErrorMode, and component.TelemetrySettings.
 // You may also augment the ConditionSequence with a slice of ConditionSequenceOption.
@@ -324,6 +353,7 @@ func NewConditionSequence[K any](conditions []*Condition[K], errorMode ErrorMode
 		conditions:        conditions,
 		errorMode:         errorMode,
 		telemetrySettings: telemetrySettings,
+		logicOp:           Or,
 	}
 	for _, op := range options {
 		op(&s)
@@ -332,11 +362,13 @@ func NewConditionSequence[K any](conditions []*Condition[K], errorMode ErrorMode
 }
 
 // Eval evaluates the result of each Condition in the ConditionSequence.
-// If any Condition evaluates to true, then true is returned.
-// If all Conditions evaluate to false, then false is returned.
+// The boolean logic between conditions is based on the ConditionSequence's Logic Operator.
+// If using the default OR LogicOperation, if any Condition evaluates to true, then true is returned and if all Conditions evaluate to false, then false is returned.
+// If using the AND LogicOperation, if any Condition evaluates to false, then false is returned and if all Conditions evaluate to true, then true is returned.
 // When the ErrorMode of the ConditionSequence is `propagate`, errors cause the evaluation to be false and an error is returned.
 // When the ErrorMode of the ConditionSequence is `ignore`, errors cause the evaluation to continue to the next condition.
 func (c *ConditionSequence[K]) Eval(ctx context.Context, tCtx K) (bool, error) {
+	var atLeastOneMatch bool
 	for _, condition := range c.conditions {
 		match, err := condition.Eval(ctx, tCtx)
 		if err != nil {
@@ -348,8 +380,14 @@ func (c *ConditionSequence[K]) Eval(ctx context.Context, tCtx K) (bool, error) {
 			continue
 		}
 		if match {
-			return true, nil
+			if c.logicOp == Or {
+				return true, nil
+			}
+			atLeastOneMatch = true
+		}
+		if !match && c.logicOp == And {
+			return false, nil
 		}
 	}
-	return false, nil
+	return c.logicOp == And && atLeastOneMatch, nil
 }


### PR DESCRIPTION
**Description:** 

Adds a new `ConditionSequence` struct to help handle processing a list of Conditions. The primary reason to use a `ConditionSequence` is to let the struct handle errors. Since that is its defining purpose, I opted to make `ErrorMode` a required argument in the "constructor" instead of an Option.

I also update `internal/filterottl` to use this struct instead of `Statements`. This is a non-breaking change.

If we like this pattern, I will do a breaking change to replace `Statements` with a similar `StatementSequence` struct in a future PR .

See these structs implemented in components here: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/29294

**Link to tracking Issue:** <Issue number if applicable>

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/13545

**Testing:**

Added new tests

**Documentation:** <Describe the documentation added.>
Added godoc comments