### PR TITLE
syslog tests: cleanup subprocess

### DIFF
--- a/testbed/tests/syslog_integration_test.go
+++ b/testbed/tests/syslog_integration_test.go
@@ -145,6 +145,12 @@ service:
 	})
 	require.NoError(t, err)
 
+	t.Cleanup(func() {
+		stopped, e := collector.Stop()
+		require.NoError(t, e)
+		require.True(t, stopped)
+	})
+
 	// prepare data
 
 	message := ""


### PR DESCRIPTION
**Description:**
Fixes a flake issue where one collector subprocess isn't torn down before the next test run:

```
2023-11-20T19:30:42.822Z	error	otelcol@v0.89.0/collector.go:255	Asynchronous error received, terminating process	{"error": "listen tcp :8888: bind: address already in use"}
```

**Testing:**
Adds asserted case cleanup.

**Documentation:**
none needed