### PR TITLE
[testbed] update jaeger test

### DIFF
--- a/testbed/datareceivers/jaeger.go
+++ b/testbed/datareceivers/jaeger.go
@@ -52,13 +52,15 @@ func (jr *jaegerDataReceiver) Stop() error {
 
 func (jr *jaegerDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
+	// The Jaeger exporter is no longer supported, therefore
+	// we export data using OTLP instead
 	return fmt.Sprintf(`
-  jaeger:
+  otlp/jaeger:
     endpoint: "127.0.0.1:%d"
     tls:
       insecure: true`, jr.Port)
 }
 
 func (jr *jaegerDataReceiver) ProtocolName() string {
-	return "jaeger"
+	return "otlp/jaeger"
 }

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -114,7 +114,7 @@ func NewTestCase(
 	tc.LoadGenerator, err = NewLoadGenerator(dataProvider, sender)
 	require.NoError(t, err, "Cannot create generator")
 
-	tc.MockBackend = NewMockBackend(tc.composeTestResultFileName("backend.log"), receiver)
+	tc.MockBackend = NewMockBackend(tc.ComposeTestResultFileName("backend.log"), receiver)
 	tc.MockBackend.WithDecisionFunc(tc.decision)
 
 	go tc.logStats()
@@ -122,7 +122,7 @@ func NewTestCase(
 	return &tc
 }
 
-func (tc *TestCase) composeTestResultFileName(fileName string) string {
+func (tc *TestCase) ComposeTestResultFileName(fileName string) string {
 	fileName, err := filepath.Abs(path.Join(tc.resultDir, fileName))
 	require.NoError(tc.t, err, "Cannot resolve %s", fileName)
 	return fileName
@@ -131,7 +131,7 @@ func (tc *TestCase) composeTestResultFileName(fileName string) string {
 // StartAgent starts the agent and redirects its standard output and standard error
 // to "agent.log" file located in the test directory.
 func (tc *TestCase) StartAgent(args ...string) {
-	logFileName := tc.composeTestResultFileName("agent.log")
+	logFileName := tc.ComposeTestResultFileName("agent.log")
 
 	startParams := StartParams{
 		Name:         "Agent",

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -179,6 +179,70 @@ func Scenario10kItemsPerSecond(
 	tc.ValidateData()
 }
 
+// Scenario10kItemsPerSecondAlternateBackend runs 10k data items/sec test using specified sender and receiver protocols.
+// The only difference from Scenario10kItemsPerSecond is that this method can be used to specify a different backend. This
+// is useful when testing components for which there is no exporter that emits the same format as the receiver format.
+func Scenario10kItemsPerSecondAlternateBackend(
+	t *testing.T,
+	sender testbed.DataSender,
+	receiver testbed.DataReceiver,
+	backend testbed.DataReceiver,
+	resourceSpec testbed.ResourceSpec,
+	resultsSummary testbed.TestResultsSummary,
+	processors map[string]string,
+	extensions map[string]string,
+) {
+	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
+	require.NoError(t, err)
+
+	options := testbed.LoadOptions{
+		DataItemsPerSecond: 10_000,
+		ItemsPerBatch:      100,
+		Parallel:           1,
+	}
+	agentProc := testbed.NewChildProcessCollector()
+
+	configStr := createConfigYaml(t, sender, receiver, resultDir, processors, extensions)
+	fmt.Println(configStr)
+	configCleanup, err := agentProc.PrepareConfig(configStr)
+	require.NoError(t, err)
+	defer configCleanup()
+
+	dataProvider := testbed.NewPerfTestDataProvider(options)
+	tc := testbed.NewTestCase(
+		t,
+		dataProvider,
+		sender,
+		receiver,
+		agentProc,
+		&testbed.PerfTestValidator{},
+		resultsSummary,
+		testbed.WithResourceLimits(resourceSpec),
+	)
+	defer tc.Stop()
+
+	// for some scenarios, the mockbackend isn't the same as the receiver
+	// therefore, the backend must be initialized with the correct receiver
+	tc.MockBackend = testbed.NewMockBackend(tc.ComposeTestResultFileName("backend.log"), backend)
+
+	tc.StartBackend()
+	tc.StartAgent()
+
+	tc.StartLoad(options)
+
+	tc.Sleep(tc.Duration)
+
+	tc.StopLoad()
+
+	tc.WaitFor(func() bool { return tc.LoadGenerator.DataItemsSent() > 0 }, "load generator started")
+	tc.WaitFor(func() bool { return tc.LoadGenerator.DataItemsSent() == tc.MockBackend.DataItemsReceived() },
+		"all data items received")
+
+	tc.StopAgent()
+
+	tc.ValidateData()
+}
+
 // TestCase for Scenario1kSPSWithAttrs func.
 type TestCase struct {
 	attrCount      int

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -38,15 +38,6 @@ func TestTrace10kSPS(t *testing.T) {
 		resourceSpec testbed.ResourceSpec
 	}{
 		{
-			"JaegerGRPC",
-			datasenders.NewJaegerGRPCDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
-			datareceivers.NewJaegerDataReceiver(testbed.GetAvailablePort(t)),
-			testbed.ResourceSpec{
-				ExpectedMaxCPU: 40,
-				ExpectedMaxRAM: 100,
-			},
-		},
-		{
 			"OpenCensus",
 			datasenders.NewOCTraceDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
 			datareceivers.NewOCDataReceiver(testbed.GetAvailablePort(t)),
@@ -157,6 +148,28 @@ func TestTrace10kSPS(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestTrace10kSPSJaegerGRPC(t *testing.T) {
+	port := testbed.GetAvailablePort(t)
+	receiver := datareceivers.NewJaegerDataReceiver(port)
+	Scenario10kItemsPerSecondAlternateBackend(
+		t,
+		datasenders.NewJaegerGRPCDataSender(testbed.DefaultHost, testbed.GetAvailablePort(t)),
+		receiver,
+		testbed.NewOTLPDataReceiver(port),
+		testbed.ResourceSpec{
+			ExpectedMaxCPU: 40,
+			ExpectedMaxRAM: 100,
+		},
+		performanceResultsSummary,
+		map[string]string{
+			"batch": `
+  batch:
+`,
+		},
+		nil,
+	)
 }
 
 func TestTraceNoBackend10kSPS(t *testing.T) {


### PR DESCRIPTION
Since the removal of the jaeger exporter, the TestTrace10kSPS/JaegerGRPC has been failing. This was caused by the testbed expecting to be able to export data using the jaeger exporter. This changes the test to use OTLP and adds a new scenario method that supports specifying a different backend for this type of use-case.

Fixes #29310