### PR TITLE
[chore] fix update-otel makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,8 +291,7 @@ telemetrygen:
 
 .PHONY: update-otel
 update-otel:$(MULTIMOD)
-	$(MULTIMOD) sync -a=true -s=true -o ../opentelemetry-collector -m stable --commit-hash $(OTEL_STABLE_VERSION)
-	$(MULTIMOD) sync -a=true -s=true -o ../opentelemetry-collector -m beta --commit-hash $(OTEL_VERSION)
+	$(MULTIMOD) sync -a=true -s=true -o ../opentelemetry-collector --commit-hash $(OTEL_STABLE_VERSION)
 	$(MAKE) gotidy
 
 .PHONY: otel-from-tree


### PR DESCRIPTION
Don't need to run the command twice. In fact doing so fails because the first time through, modules are updated and the repo is no longer clean (as it contains changes).
