### PR TITLE
[chore] Update directions on adding a Code Owner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -365,6 +365,9 @@ Sometimes a component may be in need of a new or additional Code Owner. A few re
 - An existing Code Owner has become unresponsive. See [unmaintained stability status](https://github.com/open-telemetry/opentelemetry-collector#unmaintained).
 - The existing Code Owners are actively looking for new Code Owners to help.
 
+
+### Requirements
+
 If you would like to help and become a Code Owner you must meet the following requirements:
 
 1. [Be a member of the OpenTelemetry organization.](https://github.com/open-telemetry/community/blob/main/community-membership.md#member)
@@ -372,7 +375,13 @@ If you would like to help and become a Code Owner you must meet the following re
 
 Code Ownership is ultimately up to the judgement of the existing Code Owners and Collector Contrib Maintainers. Meeting the above requirements is not a guarantee to be granted Code Ownership.
 
-To become a Code Owner, open a PR with the CODEOWNERS file modified, adding your GitHub username to the component's row. Be sure to tag the existing Code Owners, if any, within the PR to ensure they receive a notification.
+### How to become a Code Owner
+
+To become a Code Owner, open a PR with the following changes:
+1. Add your GitHub username to the component's row in the [CODEOWNERS](.github/CODEOWNERS) file.
+2. Add your GitHub username to the active codeowners entry in the component's `metadata.yaml` file.
+
+Be sure to tag the existing Code Owners, if any, within the PR to ensure they receive a notification.
 
 ### Makefile Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,10 +377,7 @@ Code Ownership is ultimately up to the judgement of the existing Code Owners and
 
 ### How to become a Code Owner
 
-To become a Code Owner, open a PR with the following changes:
-1. Add your GitHub username to the component's row in the [CODEOWNERS](.github/CODEOWNERS) file.
-2. Add your GitHub username to the active codeowners entry in the component's `metadata.yaml` file.
-
+To become a Code Owner, open a PR adding your GitHub username to the active codeowners entry in the component's `metadata.yaml` file. 
 Be sure to tag the existing Code Owners, if any, within the PR to ensure they receive a notification.
 
 ### Makefile Guidelines


### PR DESCRIPTION
**Documentation:** <Describe the documentation added.>
The main change here is to add the step to directions of updating a component's `metadata.yaml` file, and removing the directions to update the CODEOWNERS file (since it's auto-generated now). Since I was changing this I decided to make some formatting changes while I was here.
