### PR TITLE
[datadogreceiver] Fix set telemetry.sdk.language=dotnet instead of .NET

### DIFF
--- a/.chloggen/dd-receiver-language.yaml
+++ b/.chloggen/dd-receiver-language.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix set telemetry.sdk.language=dotnet instead of .NET"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29459]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/datadogreceiver/translator.go
+++ b/receiver/datadogreceiver/translator.go
@@ -43,7 +43,11 @@ func upsertHeadersAttributes(req *http.Request, attrs pcommon.Map) {
 		attrs.PutStr(semconv.AttributeTelemetrySDKVersion, "Datadog-"+ddTracerVersion)
 	}
 	if ddTracerLang := req.Header.Get("Datadog-Meta-Lang"); ddTracerLang != "" {
-		attrs.PutStr(semconv.AttributeTelemetrySDKLanguage, ddTracerLang)
+		otelLang := ddTracerLang
+		if ddTracerLang == ".NET" {
+			otelLang = "dotnet"
+		}
+		attrs.PutStr(semconv.AttributeTelemetrySDKLanguage, otelLang)
 	}
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Looks like DataDog's library uses ".NET" as value instead of "dotnet" in their instrumentation:

See: https://github.com/DataDog/dd-trace-dotnet/blob/ecb5d5949f6c29dbe99a451c7a3574013cfeb1bd/tracer/src/Datadog.Trace/AgentHttpHeaderNames.cs#L76

So we need to remap ".NET" to "dotnet" to follow OTEL semantic conventions.


**Link to tracking Issue:** 

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29459

**Testing:** <Describe what testing was performed and which tests were added.>
- added unit test

**Documentation:** <Describe the documentation added.>