### PR TITLE
[chore] skip lint for cmd/otelcontribcol cmd/oteltestbedcol

### DIFF
--- a/cmd/otelcontribcol/Makefile
+++ b/cmd/otelcontribcol/Makefile
@@ -1,1 +1,4 @@
 include ../../Makefile.Common
+
+lint: checklicense misspell
+	@echo "skipping lint: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29449"

--- a/cmd/oteltestbedcol/Makefile
+++ b/cmd/oteltestbedcol/Makefile
@@ -1,1 +1,4 @@
 include ../../Makefile.Common
+
+lint: checklicense misspell
+	@echo "skipping lint: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29449"


### PR DESCRIPTION
There isn't any value in linting these as their code is generated, includes modules that are themselves linted, and they take a long time to complete slowing down CI considerably.

Fixes #29449

The output looks something like:

```
make -C cmd/otelcontribcol lint
Makefile:4: warning: overriding commands for target `lint'
../../Makefile.Common:178: warning: ignoring old commands for target `lint'
running /Users/alex.boten/workspace/opentelemetry-collector-contrib/.tools/misspell -error
skipping lint
```