### PR TITLE
Initial OAuth

### DIFF
--- a/.chloggen/add-kafka-oauth2.yaml
+++ b/.chloggen/add-kafka-oauth2.yaml
@@ -1,0 +1,10 @@
+# Use this changelog template to create an entry for release notes.
+
+change_type: enhancement
+component: kafkaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add OAuth2 token support to Sarama
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29494]

--- a/internal/kafka/authentication.go
+++ b/internal/kafka/authentication.go
@@ -181,6 +181,7 @@ func configureKerberos(config KerberosConfig, saramaConfig *sarama.Config) {
 
 func configureOauth2(config OAuth2, saramaConfig *sarama.Config) {
 	saramaConfig.Net.SASL.Enable = true
+	saramaConfig.Net.TLS.Enable = true
 	saramaConfig.Net.SASL.Mechanism = sarama.SASLTypeOAuth
 	provider := newTokenProvider(config)
 	saramaConfig.Net.SASL.TokenProvider = provider

--- a/internal/kafka/authentication.go
+++ b/internal/kafka/authentication.go
@@ -34,7 +34,7 @@ type OAuth2 struct {
 	ClientSecret string   `mapstructure:"client_secret"`
 	Audience     string   `mapstructure:"audience"`
 	Scopes       []string `mapstructure:"scopes"`
-	TokenURL     string   `mapstructure:"tokenURL"`
+	TokenURL     string   `mapstructure:"token_url"`
 }
 
 // PlainTextConfig defines plaintext authentication.
@@ -184,6 +184,7 @@ func configureOauth2(config OAuth2, saramaConfig *sarama.Config) {
 	saramaConfig.Net.SASL.Mechanism = sarama.SASLTypeOAuth
 	provider := newTokenProvider(config)
 	saramaConfig.Net.SASL.TokenProvider = provider
+
 }
 
 type TokenProvider struct {

--- a/internal/kafka/authentication_test.go
+++ b/internal/kafka/authentication_test.go
@@ -63,6 +63,13 @@ func TestAuthentication(t *testing.T) {
 	saramaKerberosKeyTabCfg.Net.SASL.GSSAPI.KeyTabPath = "/path"
 	saramaKerberosKeyTabCfg.Net.SASL.GSSAPI.AuthType = sarama.KRB5_KEYTAB_AUTH
 
+	saramaOauthCfg := &sarama.Config{}
+	saramaOauthCfg.Net.SASL.Enable = true
+	saramaOauthCfg.Net.SASL.Mechanism = sarama.SASLTypeOAuth
+	testOauth := &OAuth2{Scopes: []string{"test"}, TokenURL: "https://test-token", ClientID: "foo", ClientSecret: "bar"}
+	provider := newTokenProvider(*testOauth)
+	saramaOauthCfg.Net.SASL.TokenProvider = provider
+
 	tests := []struct {
 		auth         Authentication
 		saramaConfig *sarama.Config
@@ -126,6 +133,10 @@ func TestAuthentication(t *testing.T) {
 			auth:         Authentication{SASL: &SASLConfig{Username: "jdoe", Password: "pass", Mechanism: "SCRAM-SHA-512", Version: 2}},
 			saramaConfig: saramaSASLSCRAM512Config,
 			err:          "invalid SASL Protocol Version",
+		},
+		{
+			auth:         Authentication{OAuth2: testOauth},
+			saramaConfig: saramaOauthCfg,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Adds OAuth support to Kafka/Sarama

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>

To use it in the config under exporters:

```
  kafka/dev-oauth:
      topic: metrics
      brokers:
        - XXXX:9095
      auth:
        oauth2: 
          client_id: XXXXX
          client_secret: XXXXXXXXXXXXXXX
          token_url:  "https://XXXX/v1/token"
          scopes: ["some-scope"]
```