### PR TITLE
[receiver/activedirectoryds] Fix panic on Shutdown without corresponding Start call

### DIFF
--- a/.chloggen/fix-activedirectorydsreceiver-shutdown-without-start.yaml
+++ b/.chloggen/fix-activedirectorydsreceiver-shutdown-without-start.yaml
@@ -10,7 +10,7 @@ component: 'receiver/activedirectoryds'
 note: Fix shutdown of `activedirectorydsreceiver` when shutdown was called right after creation, without a corresponding start call.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [TBD]
+issues: [29505]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-activedirectorydsreceiver-shutdown-without-start.yaml
+++ b/.chloggen/fix-activedirectorydsreceiver-shutdown-without-start.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'receiver/activedirectoryds'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix shutdown of `activedirectorydsreceiver` when shutdown was called right after creation, without a corresponding start call.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [TBD]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/activedirectorydsreceiver/counters.go
+++ b/receiver/activedirectorydsreceiver/counters.go
@@ -70,7 +70,7 @@ func (w *watchers) Scrape(name string) (float64, error) {
 }
 
 func (w *watchers) Close() error {
-	if w.closed {
+	if w == nil || w.closed {
 		return nil
 	}
 

--- a/receiver/activedirectorydsreceiver/factory_windows_test.go
+++ b/receiver/activedirectorydsreceiver/factory_windows_test.go
@@ -39,5 +39,9 @@ func TestCreateMetricsReceiver(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, recv)
+
+		// The receiver must be able to shutdown cleanly without a Start call.
+		err = recv.Shutdown(context.Background())
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
**Description:**
The `activedirectorydsreceiver` is panicking when Shutdown is called without a previous call to Start. This can happen when some component fails to be created or started.

**Link to tracking Issue:**
Required for #28679

**Testing:**
Ran test locally and `Run Windows` on my fork.

**Documentation:**
.chloggen for bug fix.