### PR TITLE
[exporter/awsemf] Add StorageResolution config to support high-resolution metrics

### DIFF
--- a/.chloggen/awsemfexporter-high-resolution.yaml
+++ b/.chloggen/awsemfexporter-high-resolution.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsemfexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for high-resolution metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29506]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/awscloudwatchlogsexporter/config.go
+++ b/exporter/awscloudwatchlogsexporter/config.go
@@ -71,7 +71,6 @@ func (config *Config) Validate() error {
 	if retErr := cwlogs.ValidateRetentionValue(config.LogRetention); retErr != nil {
 		return retErr
 	}
-
 	return cwlogs.ValidateTagsInput(config.Tags)
 
 }

--- a/exporter/awscloudwatchlogsexporter/config.go
+++ b/exporter/awscloudwatchlogsexporter/config.go
@@ -41,6 +41,12 @@ type Config struct {
 	// Values must be between 1-256 characters and follow the regex pattern: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$
 	Tags map[string]*string `mapstructure:"tags"`
 
+	// StorageResolution is an OPTIONAL integer value representing the storage resolution for the corresponding metric. Setting this to 1 specifies this metric as
+	// a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second. Setting this to 60 specifies this metric as
+	// standard-resolution, which CloudWatch stores at 1-minute resolution. Values SHOULD be valid CloudWatch supported resolutions, 1 or 60. If a value is not
+	// provided, then a default value of 60 is assumed.
+	StorageResolution int `mapstructure:"storage_resolution"`
+
 	// Queue settings frm the exporterhelper
 	exporterhelper.QueueSettings `mapstructure:"sending_queue"`
 
@@ -71,6 +77,10 @@ func (config *Config) Validate() error {
 	if retErr := cwlogs.ValidateRetentionValue(config.LogRetention); retErr != nil {
 		return retErr
 	}
+	if retErr := cwlogs.ValidateStorageResolution(config.); retErr != nil {
+		return retErr
+	}
+
 	return cwlogs.ValidateTagsInput(config.Tags)
 
 }

--- a/exporter/awscloudwatchlogsexporter/config.go
+++ b/exporter/awscloudwatchlogsexporter/config.go
@@ -41,12 +41,6 @@ type Config struct {
 	// Values must be between 1-256 characters and follow the regex pattern: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$
 	Tags map[string]*string `mapstructure:"tags"`
 
-	// StorageResolution is an OPTIONAL integer value representing the storage resolution for the corresponding metric. Setting this to 1 specifies this metric as
-	// a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second. Setting this to 60 specifies this metric as
-	// standard-resolution, which CloudWatch stores at 1-minute resolution. Values SHOULD be valid CloudWatch supported resolutions, 1 or 60. If a value is not
-	// provided, then a default value of 60 is assumed.
-	StorageResolution int `mapstructure:"storage_resolution"`
-
 	// Queue settings frm the exporterhelper
 	exporterhelper.QueueSettings `mapstructure:"sending_queue"`
 
@@ -75,9 +69,6 @@ func (config *Config) Validate() error {
 	}
 
 	if retErr := cwlogs.ValidateRetentionValue(config.LogRetention); retErr != nil {
-		return retErr
-	}
-	if retErr := cwlogs.ValidateStorageResolution(config.); retErr != nil {
 		return retErr
 	}
 

--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -108,8 +108,6 @@ type MetricDescriptor struct {
 	StorageResolution int `mapstructure:"storage_resolution"`
 }
 
-type StorageResolution int
-
 var _ component.Config = (*Config)(nil)
 
 // Validate filters out invalid metricDeclarations and metricDescriptors

--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -87,13 +87,6 @@ type Config struct {
 	// Otherwise, sending metrics as Embedded Metric Format version 0 (without "_aws")
 	Version string `mapstructure:"version"`
 
-	// StorageResolution is an OPTIONAL integer value representing the storage resolution for the corresponding metric. Setting this to 1 specifies this metric as
-	// a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second. Setting this to 60 specifies this metric as
-	// standard-resolution, which CloudWatch stores at 1-minute resolution. Values SHOULD be valid CloudWatch supported resolutions, 1 or 60. If a value is not
-	// provided, then a default value of 60 is assumed.
-	// https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html#CloudWatch_Embedded_Metric_Format_Specification_structure_metricdefinition
-	StorageResolution int `mapstructure:"storage_resolution"`
-
 	// logger is the Logger used for writing error/warning logs
 	logger *zap.Logger
 }
@@ -106,7 +99,16 @@ type MetricDescriptor struct {
 	// Overwrite set to true means the existing metric descriptor will be overwritten or a new metric descriptor will be created; false means
 	// the descriptor will only be configured if empty.
 	Overwrite bool `mapstructure:"overwrite"`
+	// StorageResolution is an OPTIONAL integer value representing the storage resolution for the corresponding metric. Setting this to 1 specifies this metric as
+	// a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second. Setting this to 60 specifies this metric as
+	// standard-resolution, which CloudWatch stores at 1-minute resolution. Values SHOULD be valid CloudWatch supported resolutions, 1 or 60. If a value is not
+	// provided, then a default value of 60 is assumed.
+	// https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html#CloudWatch_Embedded_Metric_Format_Specification_structure_metricdefinition
+	// This setting can be overwritten by the StorageResolution value in the metric declaration.
+	StorageResolution int `mapstructure:"storage_resolution"`
 }
+
+type StorageResolution int
 
 var _ component.Config = (*Config)(nil)
 
@@ -128,19 +130,22 @@ func (config *Config) Validate() error {
 		if descriptor.MetricName == "" {
 			continue
 		}
+
+		if retErr := cwlogs.ValidateStorageResolution(descriptor.StorageResolution); retErr != nil {
+			config.logger.Warn("Dropped unsupported metric descriptor.", zap.String("storage_resolution", retErr.Error()))
+			continue
+		}
+
 		if _, ok := eMFSupportedUnits[descriptor.Unit]; ok {
 			validDescriptors = append(validDescriptors, descriptor)
 		} else {
-			config.logger.Warn("Dropped unsupported metric desctriptor.", zap.String("unit", descriptor.Unit))
+			config.logger.Warn("Dropped unsupported metric descriptor.", zap.String("unit", descriptor.Unit))
 		}
+
 	}
 	config.MetricDescriptors = validDescriptors
 
 	if retErr := cwlogs.ValidateRetentionValue(config.LogRetention); retErr != nil {
-		return retErr
-	}
-
-	if retErr := cwlogs.ValidateStorageResolution(config.StorageResolution); retErr != nil {
 		return retErr
 	}
 

--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -87,6 +87,13 @@ type Config struct {
 	// Otherwise, sending metrics as Embedded Metric Format version 0 (without "_aws")
 	Version string `mapstructure:"version"`
 
+	// StorageResolution is an OPTIONAL integer value representing the storage resolution for the corresponding metric. Setting this to 1 specifies this metric as
+	// a high-resolution metric, so that CloudWatch stores the metric with sub-minute resolution down to one second. Setting this to 60 specifies this metric as
+	// standard-resolution, which CloudWatch stores at 1-minute resolution. Values SHOULD be valid CloudWatch supported resolutions, 1 or 60. If a value is not
+	// provided, then a default value of 60 is assumed.
+	// https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html#CloudWatch_Embedded_Metric_Format_Specification_structure_metricdefinition
+	StorageResolution int `mapstructure:"storage_resolution"`
+
 	// logger is the Logger used for writing error/warning logs
 	logger *zap.Logger
 }
@@ -130,6 +137,10 @@ func (config *Config) Validate() error {
 	config.MetricDescriptors = validDescriptors
 
 	if retErr := cwlogs.ValidateRetentionValue(config.LogRetention); retErr != nil {
+		return retErr
+	}
+
+	if retErr := cwlogs.ValidateStorageResolution(config.StorageResolution); retErr != nil {
 		return retErr
 	}
 

--- a/exporter/awsemfexporter/config_test.go
+++ b/exporter/awsemfexporter/config_test.go
@@ -177,6 +177,35 @@ func TestRetentionValidateWrong(t *testing.T) {
 
 }
 
+func TestStorageResolutionValidateCorrect(t *testing.T) {
+	cfg := &Config{
+		AWSSessionSettings: awsutil.AWSSessionSettings{
+			RequestTimeoutSeconds: 30,
+			MaxRetries:            1,
+		},
+		DimensionRollupOption:       "ZeroAndSingleDimensionRollup",
+		ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
+		logger:                      zap.NewNop(),
+		StorageResolution:           1,
+	}
+	assert.NoError(t, component.ValidateConfig(cfg))
+}
+
+func TestStorageResolutionValidateWrong(t *testing.T) {
+	wrongcfg := &Config{
+		AWSSessionSettings: awsutil.AWSSessionSettings{
+			RequestTimeoutSeconds: 30,
+			MaxRetries:            1,
+		},
+		DimensionRollupOption:       "ZeroAndSingleDimensionRollup",
+		ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
+		logger:                      zap.NewNop(),
+		StorageResolution:           2,
+	}
+	assert.Error(t, component.ValidateConfig(wrongcfg))
+
+}
+
 func TestValidateTags(t *testing.T) {
 	// Create *string values for tags inputs
 	basicValue := "avalue"

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -71,12 +71,9 @@ func addToGroupedMetric(pmd pmetric.Metric, groupedMetrics map[any]*groupedMetri
 			}
 
 			metric := &metricInfo{
-				value: dp.value,
-				unit:  translateUnit(pmd, descriptor),
-			}
-
-			if config.StorageResolution == 1 {
-				metric.storageResolution = 1
+				value:             dp.value,
+				unit:              translateUnit(pmd, descriptor),
+				storageResolution: storageResolution(pmd, descriptor),
 			}
 
 			if dp.timestampMs > 0 {
@@ -183,9 +180,19 @@ func mapGetHelper(labels map[string]string, key string) string {
 	return ""
 }
 
-func translateUnit(metric pmetric.Metric, descriptor map[string]MetricDescriptor) string {
+func storageResolution(metric pmetric.Metric, descriptors map[string]MetricDescriptor) int {
+	if descriptor, exists := descriptors[metric.Name()]; exists {
+		if descriptor.StorageResolution > 0 {
+			return descriptor.StorageResolution
+		}
+	}
+
+	return 0
+}
+
+func translateUnit(metric pmetric.Metric, descriptors map[string]MetricDescriptor) string {
 	unit := metric.Unit()
-	if descriptor, exists := descriptor[metric.Name()]; exists {
+	if descriptor, exists := descriptors[metric.Name()]; exists {
 		if unit == "" || descriptor.Overwrite {
 			return descriptor.Unit
 		}

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -22,8 +22,9 @@ type groupedMetric struct {
 
 // metricInfo defines value and unit for OT Metrics
 type metricInfo struct {
-	value any
-	unit  string
+	value             any
+	unit              string
+	storageResolution int
 }
 
 // addToGroupedMetric processes OT metrics and adds them into GroupedMetric buckets
@@ -72,6 +73,10 @@ func addToGroupedMetric(pmd pmetric.Metric, groupedMetrics map[any]*groupedMetri
 			metric := &metricInfo{
 				value: dp.value,
 				unit:  translateUnit(pmd, descriptor),
+			}
+
+			if config.StorageResolution == 1 {
+				metric.storageResolution = 1
 			}
 
 			if dp.timestampMs > 0 {

--- a/exporter/awsemfexporter/metric_declaration_test.go
+++ b/exporter/awsemfexporter/metric_declaration_test.go
@@ -243,6 +243,32 @@ func TestMetricDeclarationInit(t *testing.T) {
 		assert.Equal(t, 2, len(m.Dimensions))
 	})
 
+	t.Run("with storageResolution", func(t *testing.T) {
+		m := &MetricDeclaration{
+			Dimensions: [][]string{
+				{"foo"},
+				{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+			},
+			MetricNameSelectors: []string{"a.*", "b$", "aa+"},
+			StorageResolution:   1,
+		}
+		err := m.init(logger)
+		assert.Nil(t, err)
+	})
+
+	t.Run("with invalid storageResolution", func(t *testing.T) {
+		m := &MetricDeclaration{
+			Dimensions: [][]string{
+				{"foo"},
+				{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+			},
+			MetricNameSelectors: []string{"a.*", "b$", "aa+"},
+			StorageResolution:   2,
+		}
+		err := m.init(logger)
+		assert.NotNil(t, err)
+	})
+
 	// Test removal of dimension sets with more than 10 elements
 	t.Run("dimension set with more than 10 elements", func(t *testing.T) {
 		m := &MetricDeclaration{

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -237,6 +237,10 @@ func groupedMetricToCWMeasurement(groupedMetric *groupedMetric, config *Config) 
 		if metricInfo.unit != "" {
 			metrics[idx]["Unit"] = metricInfo.unit
 		}
+		if metricInfo.storageResolution == 1 {
+			metrics[idx]["StorageResolution"] = "1"
+		}
+
 		idx++
 	}
 
@@ -304,6 +308,9 @@ func groupedMetricToCWMeasurementsWithFilters(groupedMetric *groupedMetric, conf
 		}
 		if metricInfo.unit != "" {
 			metric["Unit"] = metricInfo.unit
+		}
+		if metricInfo.storageResolution == 1 {
+			metric["StorageResolution"] = "1"
 		}
 		metricDeclKey := fmt.Sprint(metricDeclIdx)
 		if group, ok := metricDeclGroups[metricDeclKey]; ok {

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -1259,6 +1259,39 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 			},
 		},
 		{
+			"single metric declaration with storage resolution",
+			[]*MetricDeclaration{
+				{
+					Dimensions:          [][]string{{"a"}, {"a", "c"}, {"b", "d"}},
+					MetricNameSelectors: []string{"metric.*"},
+					StorageResolution:   1,
+				},
+			},
+			[]cWMeasurement{
+				{
+					Namespace:  namespace,
+					Dimensions: [][]string{{"a"}, {"a", "c"}},
+					Metrics: []map[string]string{
+						{
+							"Name":              "metric1",
+							"Unit":              "Count",
+							"StorageResolution": "1",
+						},
+						{
+							"Name":              "metric2",
+							"Unit":              "Count",
+							"StorageResolution": "1",
+						},
+						{
+							"Name":              "metric3",
+							"Unit":              "Seconds",
+							"StorageResolution": "1",
+						},
+					},
+				},
+			},
+		},
+		{
 			"multiple metric declarations, all unique",
 			[]*MetricDeclaration{
 				{
@@ -1298,6 +1331,72 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 				{
 					Namespace:  namespace,
 					Dimensions: [][]string{{"a"}},
+					Metrics: []map[string]string{
+						{
+							"Name": "metric3",
+							"Unit": "Seconds",
+						},
+					},
+				},
+			},
+		},
+
+		{
+			"multiple metric declarations, with mixed storage resolution",
+			[]*MetricDeclaration{
+				{
+					Dimensions:          [][]string{{"a", "c"}, {"b", "d"}},
+					MetricNameSelectors: []string{"metric1"},
+					StorageResolution:   1,
+				},
+				{
+					Dimensions:          [][]string{{"a"}, {"b"}, {"b", "d"}},
+					MetricNameSelectors: []string{"metric(1|2)"},
+					StorageResolution:   60,
+				},
+				{
+					Dimensions:          [][]string{{"a", "b"}},
+					MetricNameSelectors: []string{"metric3"},
+					StorageResolution:   0,
+				},
+			},
+			[]cWMeasurement{
+				{
+					Namespace:  namespace,
+					Dimensions: [][]string{{"a"}, {"b"}},
+					Metrics: []map[string]string{
+						{
+							"Name":              "metric1",
+							"Unit":              "Count",
+							"StorageResolution": "60",
+						},
+					},
+				},
+				{
+					Namespace:  namespace,
+					Dimensions: [][]string{{"a", "c"}},
+					Metrics: []map[string]string{
+						{
+							"Name":              "metric1",
+							"Unit":              "Count",
+							"StorageResolution": "1",
+						},
+					},
+				},
+				{
+					Namespace:  namespace,
+					Dimensions: [][]string{{"a"}, {"b"}},
+					Metrics: []map[string]string{
+						{
+							"Name":              "metric2",
+							"Unit":              "Count",
+							"StorageResolution": "60",
+						},
+					},
+				},
+				{
+					Namespace:  namespace,
+					Dimensions: [][]string{{"a", "b"}},
 					Metrics: []map[string]string{
 						{
 							"Name": "metric3",

--- a/internal/aws/cwlogs/utils.go
+++ b/internal/aws/cwlogs/utils.go
@@ -78,5 +78,5 @@ func ValidateStorageResolution(input int) error {
 		60:
 		return nil
 	}
-	return errors.New("invalid value for storage resolution.  Please make sure to use the following values: 1 or 60")
+	return errors.New("invalid value for storage resolution. Please make sure to use the following values: 1 or 60")
 }

--- a/internal/aws/cwlogs/utils.go
+++ b/internal/aws/cwlogs/utils.go
@@ -68,3 +68,15 @@ func ValidateTagsInput(input map[string]*string) error {
 
 	return nil
 }
+
+// ValidateStorageResolution checks if the storage resolution input is valid.
+func ValidateStorageResolution(input int) error {
+	switch input {
+	case
+		0,
+		1,
+		60:
+		return nil
+	}
+	return errors.New("invalid value for storage resolution.  Please make sure to use the following values: 1 or 60")
+}


### PR DESCRIPTION
**Description:** Add StorageResolution config to support high-resolution metrics

**Link to tracking Issue:** [29506](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29506)

**Testing:** I added code tests. Also tested the workings locally, and successfully pushed high-resolution metrics to CloudWatch.

**Documentation:** -