### PR TITLE
[awsproxy] Expose service name as config option

### DIFF
--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsproxyextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Expose service_name as configurable option. Previously, it was hardcoded as xray."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29550]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/awsproxy/README.md
+++ b/extension/awsproxy/README.md
@@ -35,6 +35,7 @@ extensions:
     role_arn: ""
     aws_endpoint: ""
     local_mode: false
+    service_name: "xray"
 ```
 
 ### endpoint (Optional)
@@ -66,3 +67,5 @@ The IAM role used by this proxy when communicating with the AWS service. If non-
 ### aws_endpoint (Optional)
 The AWS service endpoint which this proxy forwards requests to. If not set, will default to the AWS X-Ray endpoint.
 
+### service_name (Optional)
+The AWS service name which this proxy forwards requests to. If not set, will default to "xray"

--- a/extension/awsproxy/config_test.go
+++ b/extension/awsproxy/config_test.go
@@ -44,6 +44,7 @@ func TestLoadConfig(t *testing.T) {
 					Region:      "us-west-1",
 					RoleARN:     "arn:aws:iam::123456789012:role/awesome_role",
 					AWSEndpoint: "https://another.aws.endpoint.com",
+					ServiceName: "es",
 				},
 			},
 		},

--- a/extension/awsproxy/testdata/config.yaml
+++ b/extension/awsproxy/testdata/config.yaml
@@ -8,3 +8,4 @@ awsproxy/1:
   region: "us-west-1"
   role_arn: "arn:aws:iam::123456789012:role/awesome_role"
   aws_endpoint: "https://another.aws.endpoint.com"
+  service_name: "es"

--- a/internal/aws/proxy/cfg.go
+++ b/internal/aws/proxy/cfg.go
@@ -40,6 +40,10 @@ type Config struct {
 	// will be called or not. Set to `true` to skip EC2 instance
 	// metadata check.
 	LocalMode bool `mapstructure:"local_mode"`
+
+	// ServiceName determines which service the requests are sent to.
+	// will be default to `xray`. This is mandatory for SigV4
+	ServiceName string `mapstructure:"service_name"`
 }
 
 func DefaultConfig() *Config {
@@ -55,5 +59,6 @@ func DefaultConfig() *Config {
 		Region:      "",
 		RoleARN:     "",
 		AWSEndpoint: "",
+		ServiceName: "xray",
 	}
 }

--- a/internal/aws/proxy/server_test.go
+++ b/internal/aws/proxy/server_test.go
@@ -241,7 +241,7 @@ func TestCanCreateTransport(t *testing.T) {
 }
 
 func TestGetServiceEndpointInvalidAWSConfig(t *testing.T) {
-	_, err := getServiceEndpoint(&aws.Config{})
+	_, err := getServiceEndpoint(&aws.Config{}, "")
 	assert.EqualError(t, err, "unable to generate endpoint from region with nil value")
 }
 

--- a/receiver/awsxrayreceiver/config_test.go
+++ b/receiver/awsxrayreceiver/config_test.go
@@ -51,6 +51,7 @@ func TestLoadConfig(t *testing.T) {
 					Region:      "",
 					RoleARN:     "",
 					AWSEndpoint: "",
+					ServiceName: "xray",
 				},
 			},
 		},
@@ -74,6 +75,7 @@ func TestLoadConfig(t *testing.T) {
 					RoleARN:     "arn:aws:iam::123456789012:role/awesome_role",
 					AWSEndpoint: "https://another.aws.endpoint.com",
 					LocalMode:   true,
+					ServiceName: "xray",
 				},
 			}},
 	}


### PR DESCRIPTION
awsproxy extension can be used as proxy to any service not just xray

**Description:** <Describe what has changed.>
The service name variable was hardcoded to "xray". This PR exposes it to be configurable in the config.yaml

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
Appropriate README of the extension has been updated to reflect the addition of new option