### PR TITLE
[exporter/splunkhec] do not export HEC events with a nil event field value

### DIFF
--- a/.chloggen/hec_exporter_no_nil_value.yaml
+++ b/.chloggen/hec_exporter_no_nil_value.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not send null event field values in HEC events. Replace null values with an empty string.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29551]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/splunkhecexporter/logdata_to_splunk.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk.go
@@ -83,13 +83,18 @@ func mapLogRecordToSplunkEvent(res pcommon.Resource, lr plog.LogRecord, config *
 		return true
 	})
 
+	body := lr.Body().AsRaw()
+	if body == nil {
+		body = ""
+	}
+
 	return &splunk.Event{
 		Time:       nanoTimestampToEpochMilliseconds(lr.Timestamp()),
 		Host:       host,
 		Source:     source,
 		SourceType: sourcetype,
 		Index:      index,
-		Event:      lr.Body().AsRaw(),
+		Event:      body,
 		Fields:     fields,
 	}
 }

--- a/exporter/splunkhecexporter/logdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk_test.go
@@ -188,7 +188,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				return config
 			},
 			wantSplunkEvents: []*splunk.Event{
-				commonLogSplunkEvent(nil, 0, map[string]any{}, "unknown", "source", "sourcetype"),
+				commonLogSplunkEvent("", 0, map[string]any{}, "unknown", "source", "sourcetype"),
 			},
 		},
 		{
@@ -207,7 +207,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				return config
 			},
 			wantSplunkEvents: func() []*splunk.Event {
-				event := commonLogSplunkEvent(nil, 0, map[string]any{}, "unknown", "source", "sourcetype")
+				event := commonLogSplunkEvent("", 0, map[string]any{}, "unknown", "source", "sourcetype")
 				event.Fields["span_id"] = "0000000000000032"
 				event.Fields["trace_id"] = "00000000000000000000000000000064"
 				return []*splunk.Event{event}
@@ -330,7 +330,7 @@ func Test_mapLogRecordToSplunkEvent(t *testing.T) {
 				return config
 			},
 			wantSplunkEvents: []*splunk.Event{
-				commonLogSplunkEvent(nil, ts, map[string]any{"custom": "custom"},
+				commonLogSplunkEvent("", ts, map[string]any{"custom": "custom"},
 					"myhost", "myapp", "myapp-type"),
 			},
 		},
@@ -454,7 +454,7 @@ func Test_emptyLogRecord(t *testing.T) {
 	assert.Zero(t, event.Source)
 	assert.Zero(t, event.SourceType)
 	assert.Zero(t, event.Index)
-	assert.Nil(t, event.Event)
+	assert.Equal(t, "", event.Event)
 	assert.Empty(t, event.Fields)
 }
 


### PR DESCRIPTION
**Description:**
Fixing a bug where Splunk rejects malformed HEC events with a nil event field.

**Link to tracking Issue:**
Fixes #29551 

**Testing:**
Changed unit tests to match