### PR TITLE
[chore][CI/CD] Fix github action for pinging code owners on some components

### DIFF
--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -24,7 +24,7 @@ RESULT=$(grep -c "${COMPONENT}" .github/CODEOWNERS || true)
 
 # there may be more than 1 component matching a label
 # if so, try to narrow things down by appending the component
-# or a forward slash.
+# or a forward slash to the label.
 if [[ ${RESULT} != 1 ]]; then
     COMPONENT_TYPE=$(echo "${COMPONENT}" | cut -f 1 -d '/')
     OWNERS="$(get_codeowners "${COMPONENT}${COMPONENT_TYPE}")"

--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -9,6 +9,10 @@
 
 set -euo pipefail
 
+get_codeowners() {
+  echo "$((grep -m 1 "${1}" .github/CODEOWNERS || true) | sed 's/   */ /g' | cut -f3- -d ' ')"
+}
+
 if [[ -z "${COMPONENT:-}" ]]; then
     echo "COMPONENT has not been set, please ensure it is set."
     exit 1
@@ -20,13 +24,16 @@ RESULT=$(grep -c "${COMPONENT}" .github/CODEOWNERS || true)
 
 # there may be more than 1 component matching a label
 # if so, try to narrow things down by appending the component
-# type to the label
+# or a forward slash.
 if [[ ${RESULT} != 1 ]]; then
     COMPONENT_TYPE=$(echo "${COMPONENT}" | cut -f 1 -d '/')
-    COMPONENT="${COMPONENT}${COMPONENT_TYPE}"
+    OWNERS="$(get_codeowners "${COMPONENT}${COMPONENT_TYPE}")"
+
+    if [[ -z "${OWNERS:-}" ]]; then
+        OWNERS="$(get_codeowners "${COMPONENT}/")"
+    fi
+else
+    OWNERS="$(get_codeowners $COMPONENT)"
 fi
 
-OWNERS=$( (grep -m 1 "${COMPONENT}" .github/CODEOWNERS || true) | sed 's/   */ /g' | cut -f3- -d ' ' )
-
 echo "${OWNERS}"
-

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -214,7 +214,7 @@ require (
 
 require (
 	bitbucket.org/atlassian/go-asap/v2 v2.6.0 // indirect
-	cloud.google.com/go v0.110.10 // indirect
+	cloud.google.com/go v0.111.0 // indirect
 	cloud.google.com/go/compute v1.23.3 // indirect
 	cloud.google.com/go/compute/metadata v0.2.4-0.20230617002413-005d2dfb6b68 // indirect
 	cloud.google.com/go/iam v1.1.5 // indirect

--- a/cmd/otelcontribcol/go.sum
+++ b/cmd/otelcontribcol/go.sum
@@ -22,8 +22,8 @@ cloud.google.com/go v0.75.0/go.mod h1:VGuuCn7PG0dwsd5XPVm2Mm3wlh3EL55/79EKB6hlPT
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
-cloud.google.com/go v0.110.10 h1:LXy9GEO+timppncPIAZoOj3l58LIU9k+kn48AN7IO3Y=
-cloud.google.com/go v0.110.10/go.mod h1:v1OoFqYxiBkUrruItNM3eT4lLByNjxmJSV/xDKJNnic=
+cloud.google.com/go v0.111.0 h1:YHLKNupSD1KqjDbQ3+LVdQ81h/UJbJyZG203cEfnQgM=
+cloud.google.com/go v0.111.0/go.mod h1:0mibmpKP1TyOOFYQY5izo0LnT+ecvOQ0Sg3OdmMiNRU=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=


### PR DESCRIPTION
### Description:

**Existing bug:**
This resolves a bug in pinging code owners that was hit when a base component doesn't end with its type, but has multiple sub-components. 

For example, when adding the label `extension/encoding` to issues code owners weren't being pinged. This is because there are multiple sub-components (e.g. `extension/encoding/jaegarencodingextension`, `extension/encoding/zipkinencodingextension`, etc), and `extension/encoding` doesn't end with its own type `extension`. 

**Solution:**
The solution to this bug is to also check if the original component can be found if a single `/` is appended to it. This finds the component in a determinate way and allows code owners to be pinged properly.

### Link to tracking Issue:
Resolves #29571

### Testing:
```
crobert$ ~/dev/opentelemetry-collector-contrib $ export COMPONENT=extension/encoding
crobert$ ~/dev/opentelemetry-collector-contrib $ .github/workflows/scripts/get-codeowners.sh 
@atoulme @dao-jun @dmitryax @MovieStoreGuy @VihasMakwana
crobert$ ~/dev/opentelemetry-collector-contrib $ export COMPONENT=extension/encoding/zipkinencoding
crobert$ ~/dev/opentelemetry-collector-contrib $ .github/workflows/scripts/get-codeowners.sh 
@MovieStoreGuy @dao-jun
crobert$ ~/dev/opentelemetry-collector-contrib $ export COMPONENT=processor/resourcedetection
crobert$ ~/dev/opentelemetry-collector-contrib $ .github/workflows/scripts/get-codeowners.sh 
@Aneurysm9 @dashpole
crobert$ ~/dev/opentelemetry-collector-contrib $ export COMPONENT=extension/observer
crobert$ ~/dev/opentelemetry-collector-contrib $ .github/workflows/scripts/get-codeowners.sh
@dmitryax @rmfitzpatrick
crobert$ ~/dev/opentelemetry-collector-contrib $ export COMPONENT=processor/resource
crobert$ ~/dev/opentelemetry-collector-contrib $ .github/workflows/scripts/get-codeowners.sh
@dmitryax
```
Previously, `extension/observer` and `extension/encoding` returned nothing, which was the bug this resolves.