### PR TITLE
[chore][CONTRIBUTING.md] Update make targets for adding a new code owner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -379,9 +379,9 @@ Code Ownership is ultimately up to the judgement of the existing Code Owners and
 To become a Code Owner, open a PR with the following changes:
 
 1. Add your GitHub username to the active codeowners entry in the component's `metadata.yaml` file.
-2. Run the command `make update-codeowners`. This will add your GitHub username to the component's row in the [CODEOWNERS](.github/CODEOWNERS) file.
+2. Run the command `make update-codeowners`.
       * Note: A GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) must be configured for this command to work.
-      * If this command is unsuccessful, manually update the component's row in the [CODEOWNERS](.github/CODEOWNERS) file, and then run `make generate`.
+      * If this command is unsuccessful, manually update the component's row in the [CODEOWNERS](.github/CODEOWNERS) file, and then run `make generate` to regenerate the component's README header.
 
 Be sure to tag the existing Code Owners, if any, within the PR to ensure they receive a notification.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -379,8 +379,9 @@ Code Ownership is ultimately up to the judgement of the existing Code Owners and
 To become a Code Owner, open a PR with the following changes:
 
 1. Add your GitHub username to the active codeowners entry in the component's `metadata.yaml` file.
-2. Run the command `make gengithub`. This will add your GitHub username to the component's row in the [CODEOWNERS](.github/CODEOWNERS) file. You can do this update manually if the command is unsuccessful.
-   * Note: A GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) must be configured for this command to work.
+2. Run the command `make update-codeowners`. This will add your GitHub username to the component's row in the [CODEOWNERS](.github/CODEOWNERS) file.
+      * Note: A GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) must be configured for this command to work.
+      * If this command is unsuccessful, manually update the component's row in the [CODEOWNERS](.github/CODEOWNERS) file, and then run `make generate`.
 
 Be sure to tag the existing Code Owners, if any, within the PR to ensure they receive a notification.
 


### PR DESCRIPTION
**Documentation:** <Describe the documentation added.>
Yet another change to code owners documentation, I found the `make update-codeowners` target in the `Makefile` so I'm updating the doc to point to this. 

Also, moved extra context of what's actually happening in this command to the workaround description, and added the `make generate` command to the manual workaround.