### PR TITLE
[pkg/stanza] key_value_parser: Allow values that contain the delimiter string

### DIFF
--- a/.chloggen/stanza-allow-delimiter-in-value.yaml
+++ b/.chloggen/stanza-allow-delimiter-in-value.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow `key_value_parser` to parse values that contain the delimiter string.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29629]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue.go
@@ -106,7 +106,7 @@ func (kv *Parser) parser(input string, delimiter string) (map[string]any, error)
 
 	var err error
 	for _, raw := range kv.pairSplitFunc(input) {
-		m := strings.Split(raw, delimiter)
+		m := strings.SplitN(raw, delimiter, 2)
 		if len(m) != 2 {
 			e := fmt.Errorf("expected '%s' to split by '%s' into two items, got %d", raw, delimiter, len(m))
 			err = multierr.Append(err, e)

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
@@ -488,15 +488,33 @@ key=value`,
 			false,
 		},
 		{
-			"invalid-pair",
+			"value-contains-delimiter",
 			func(kv *Config) {},
 			&entry.Entry{
 				Body: `test=text=abc`,
 			},
 			&entry.Entry{
+				Attributes: map[string]any{
+					"test": "text=abc",
+				},
 				Body: `test=text=abc`,
 			},
-			true,
+			false,
+			false,
+		},
+		{
+			"quoted-value-contains-delimiter",
+			func(kv *Config) {},
+			&entry.Entry{
+				Body: `msg="Message successfully sent at 2023-12-04 06:47:31.204222276 +0000 UTC m=+5115.932279346"`,
+			},
+			&entry.Entry{
+				Attributes: map[string]any{
+					"msg": `Message successfully sent at 2023-12-04 06:47:31.204222276 +0000 UTC m=+5115.932279346`,
+				},
+				Body: `msg="Message successfully sent at 2023-12-04 06:47:31.204222276 +0000 UTC m=+5115.932279346"`,
+			},
+			false,
 			false,
 		},
 		{

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
@@ -518,6 +518,23 @@ key=value`,
 			false,
 		},
 		{
+			"multiple-values-contain-delimiter",
+			func(kv *Config) {},
+			&entry.Entry{
+				Body: `one=1=i two="2=ii" three=3=iii`,
+			},
+			&entry.Entry{
+				Attributes: map[string]any{
+					"one":   "1=i",
+					"two":   "2=ii",
+					"three": "3=iii",
+				},
+				Body: `one=1=i two="2=ii" three=3=iii`,
+			},
+			false,
+			false,
+		},
+		{
 			"empty-input",
 			func(kv *Config) {},
 			&entry.Entry{},


### PR DESCRIPTION
**Description:** <Describe what has changed.>

This PR fixes an issue in the `key_value_parser` operator wherein values containing the delimiter (`=`, by default), would cause a parse failure.

Given the log body:

    msg="Message successfully sent at 2023-12-04 06:47:31.204222276 +0000 UTC m=+5115.932279346"

The `key_value_parser` would fail with the following error:

    expected '...<snip>...' to split by '=' into two items, got 3

After this PR, the `key_value_parser` instead emits the following key/value pair:

    ("msg", "Message successfully sent at 2023-12-04 06:47:31.204222276 +0000 UTC m=+5115.932279346")

As a result of this change, it is now also possible to parse **unquoted** values that contain the delimiter. For example `foo=bar=spam` is parsed as `("foo", "bar=spam")`. Because there was an existing test case for this failure mode I had considered explicitly disallowing this behaviour for unquoted values. However, I couldn't think of a reason to *prefer* an error so I decided to float the PR as-is first. FWIW, this behaviour has some prior art, for example parsing of environment variables.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

I've added an additional test case named `quoted-value-contains-delimiter` that tests the problematic message I encountered in the wild.

I've also replaced the existing `invalid-pair` test as a result of the changed behaviour mentioned above.

**Documentation:** <Describe the documentation added.>