### PR TITLE
[renovate] Ignore github.com/DataDog/datadog-agent/pkg/trace/exportable updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,7 @@
       }
     ],
     "ignoreDeps": [
-      "github.com/mattn/go-ieproxy"
+      "github.com/mattn/go-ieproxy",
+      "github.com/DataDog/datadog-agent/pkg/trace/exportable"
     ]
   }


### PR DESCRIPTION
**Description:** Ignores updates to `github.com/DataDog/datadog-agent/pkg/trace/exportable` since:
- It is a deprecated module for which we won't make any updates
- It is causing trouble with renovatebot

**Link to tracking Issue:** Relates to #29635, should unblock #29411