### PR TITLE
[chore][pkg/stanza] Localize one-off test utility code

### DIFF
--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -4,6 +4,7 @@
 package fileconsumer
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -161,7 +162,11 @@ func BenchmarkFileInput(b *testing.B) {
 
 			received := make(chan []byte)
 
-			op, err := cfg.Build(testutil.Logger(b), emitOnChan(received))
+			callback := func(_ context.Context, token []byte, _ map[string]any) error {
+				received <- token
+				return nil
+			}
+			op, err := cfg.Build(testutil.Logger(b), callback)
 			require.NoError(b, err)
 
 			// write half the lines before starting


### PR DESCRIPTION
This PR moves localizes some test utility code. These functions are either used only once, or only in one test file.

This is a step towards #29643, and ultimately towards sharing test utilities across multiple packages.