### PR TITLE
Replace jpkrohling with yurishkuro for Jaeger components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -102,7 +102,7 @@ extension/encoding/zipkinencodingextension/                             @open-te
 extension/headerssetterextension/                                       @open-telemetry/collector-contrib-approvers @jpkrohling
 extension/healthcheckextension/                                         @open-telemetry/collector-contrib-approvers @jpkrohling
 extension/httpforwarder/                                                @open-telemetry/collector-contrib-approvers @atoulme @rmfitzpatrick
-extension/jaegerremotesampling/                                         @open-telemetry/collector-contrib-approvers @jpkrohling @frzifus
+extension/jaegerremotesampling/                                         @open-telemetry/collector-contrib-approvers @yurishkuro @frzifus
 extension/oauth2clientauthextension/                                    @open-telemetry/collector-contrib-approvers @pavankrish123 @jpkrohling
 extension/observer/                                                     @open-telemetry/collector-contrib-approvers @dmitryax @rmfitzpatrick
 extension/observer/dockerobserver/                                      @open-telemetry/collector-contrib-approvers @MovieStoreGuy
@@ -219,7 +219,7 @@ receiver/hostmetricsreceiver/                                           @open-te
 receiver/httpcheckreceiver/                                             @open-telemetry/collector-contrib-approvers @codeboten
 receiver/iisreceiver/                                                   @open-telemetry/collector-contrib-approvers @Mrod1598 @djaglowski
 receiver/influxdbreceiver/                                              @open-telemetry/collector-contrib-approvers @jacobmarble
-receiver/jaegerreceiver/                                                @open-telemetry/collector-contrib-approvers @jpkrohling
+receiver/jaegerreceiver/                                                @open-telemetry/collector-contrib-approvers @yurishkuro
 receiver/jmxreceiver/                                                   @open-telemetry/collector-contrib-approvers @rmfitzpatrick
 receiver/journaldreceiver/                                              @open-telemetry/collector-contrib-approvers @sumo-drosiek @djaglowski
 receiver/k8sclusterreceiver/                                            @open-telemetry/collector-contrib-approvers @dmitryax @TylerHelmuth @povilasv

--- a/extension/jaegerremotesampling/README.md
+++ b/extension/jaegerremotesampling/README.md
@@ -5,7 +5,7 @@
 | Stability     | [alpha]  |
 | Distributions | [contrib], [grafana], [redhat], [sumo] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aextension%2Fjaegerremotesampling%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aextension%2Fjaegerremotesampling) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aextension%2Fjaegerremotesampling%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aextension%2Fjaegerremotesampling) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@jpkrohling](https://www.github.com/jpkrohling), [@frzifus](https://www.github.com/frzifus) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@yurishkuro](https://www.github.com/yurishkuro), [@frzifus](https://www.github.com/frzifus) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/extension/jaegerremotesampling/metadata.yaml
+++ b/extension/jaegerremotesampling/metadata.yaml
@@ -10,4 +10,4 @@ status:
   - redhat
   - sumo
   codeowners:
-    active: [jpkrohling, frzifus]
+    active: [yurishkuro, frzifus]

--- a/receiver/jaegerreceiver/README.md
+++ b/receiver/jaegerreceiver/README.md
@@ -6,7 +6,7 @@
 | Stability     | [beta]: traces   |
 | Distributions | [core], [contrib], [aws], [grafana], [observiq], [redhat], [splunk], [sumo] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fjaeger%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fjaeger) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fjaeger%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fjaeger) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@jpkrohling](https://www.github.com/jpkrohling) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@yurishkuro](https://www.github.com/yurishkuro) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol

--- a/receiver/jaegerreceiver/metadata.yaml
+++ b/receiver/jaegerreceiver/metadata.yaml
@@ -14,4 +14,4 @@ status:
   - splunk
   - sumo
   codeowners:
-    active: [jpkrohling]
+    active: [yurishkuro]


### PR DESCRIPTION
I need to resign from a few components, as I'm not doing a good job in keeping track of what needs to be done for them. Asking around, @yurishkuro volunteered to take over the Jaeger related ones.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
