### PR TITLE
[chore][pkg/stanza] Move common file testing utilities to new filetest package

### DIFF
--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
@@ -150,7 +151,7 @@ func BenchmarkFileInput(b *testing.B) {
 
 			var files []*benchFile
 			for _, path := range bench.paths {
-				file := openFile(b, filepath.Join(rootDir, path))
+				file := filetest.OpenFile(b, filepath.Join(rootDir, path))
 				files = append(files, simpleTextFile(b, file))
 			}
 

--- a/pkg/stanza/fileconsumer/internal/filetest/filetest.go
+++ b/pkg/stanza/fileconsumer/internal/filetest/filetest.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filetest // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func OpenFile(tb testing.TB, path string) *os.File {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = file.Close() })
+	return file
+}
+
+func OpenTemp(t testing.TB, tempDir string) *os.File {
+	return OpenTempWithPattern(t, tempDir, "")
+}
+
+func ReopenTemp(t testing.TB, name string) *os.File {
+	return OpenTempWithPattern(t, filepath.Dir(name), filepath.Base(name))
+}
+
+func OpenTempWithPattern(t testing.TB, tempDir, pattern string) *os.File {
+	file, err := os.CreateTemp(tempDir, pattern)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = file.Close() })
+	return file
+}
+
+func WriteString(t testing.TB, file *os.File, s string) {
+	_, err := file.WriteString(s)
+	require.NoError(t, err)
+}

--- a/pkg/stanza/fileconsumer/reader_test.go
+++ b/pkg/stanza/fileconsumer/reader_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/emittest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/header"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/reader"
@@ -27,7 +28,7 @@ func TestPersistFlusher(t *testing.T) {
 	flushPeriod := 100 * time.Millisecond
 	f, sink := testReaderFactory(t, split.Config{}, defaultMaxLogSize, flushPeriod)
 
-	temp := openTemp(t, t.TempDir())
+	temp := filetest.OpenTemp(t, t.TempDir())
 	fp, err := f.NewFingerprint(temp)
 	require.NoError(t, err)
 
@@ -113,7 +114,7 @@ func TestTokenization(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			f, sink := testReaderFactory(t, split.Config{}, defaultMaxLogSize, defaultFlushPeriod)
 
-			temp := openTemp(t, t.TempDir())
+			temp := filetest.OpenTemp(t, t.TempDir())
 			_, err := temp.Write(tc.fileContent)
 			require.NoError(t, err)
 
@@ -143,7 +144,7 @@ func TestTokenizationTooLong(t *testing.T) {
 
 	f, sink := testReaderFactory(t, split.Config{}, 10, defaultFlushPeriod)
 
-	temp := openTemp(t, t.TempDir())
+	temp := filetest.OpenTemp(t, t.TempDir())
 	_, err := temp.Write(fileContent)
 	require.NoError(t, err)
 
@@ -175,7 +176,7 @@ func TestTokenizationTooLongWithLineStartPattern(t *testing.T) {
 	sCfg.LineStartPattern = `\d+-\d+-\d+`
 	f, sink := testReaderFactory(t, sCfg, 15, defaultFlushPeriod)
 
-	temp := openTemp(t, t.TempDir())
+	temp := filetest.OpenTemp(t, t.TempDir())
 	_, err := temp.Write(fileContent)
 	require.NoError(t, err)
 
@@ -207,7 +208,7 @@ func TestHeaderFingerprintIncluded(t *testing.T) {
 	require.NoError(t, err)
 	f.HeaderConfig = h
 
-	temp := openTemp(t, t.TempDir())
+	temp := filetest.OpenTemp(t, t.TempDir())
 
 	fp, err := f.NewFingerprint(temp)
 	require.NoError(t, err)

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -5,8 +5,6 @@ package fileconsumer
 
 import (
 	"math/rand"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,33 +23,6 @@ func testManagerWithSink(t *testing.T, cfg *Config, sink *emittest.Sink) *Manage
 	require.NoError(t, err)
 	t.Cleanup(func() { input.closePreviousFiles() })
 	return input
-}
-
-func openFile(tb testing.TB, path string) *os.File {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
-	require.NoError(tb, err)
-	tb.Cleanup(func() { _ = file.Close() })
-	return file
-}
-
-func openTemp(t testing.TB, tempDir string) *os.File {
-	return openTempWithPattern(t, tempDir, "")
-}
-
-func reopenTemp(t testing.TB, name string) *os.File {
-	return openTempWithPattern(t, filepath.Dir(name), filepath.Base(name))
-}
-
-func openTempWithPattern(t testing.TB, tempDir, pattern string) *os.File {
-	file, err := os.CreateTemp(tempDir, pattern)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = file.Close() })
-	return file
-}
-
-func writeString(t testing.TB, file *os.File, s string) {
-	_, err := file.WriteString(s)
-	require.NoError(t, err)
 }
 
 func tokenWithLength(length int) []byte {


### PR DESCRIPTION
Follows #29643

Moves additional test utilities into a small dedicated package. This will allow sharing of this code between `fileconsumer` and `reader` packages. 