### PR TITLE
[chore][pkg/stanza] Move more tests into reader package

### DIFF
--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -28,7 +28,7 @@ type benchFile struct {
 }
 
 func simpleTextFile(b *testing.B, file *os.File) *benchFile {
-	line := string(tokenWithLength(49)) + "\n"
+	line := string(filetest.TokenWithLength(49)) + "\n"
 	return &benchFile{
 		File: file,
 		log: func(_ int) {

--- a/pkg/stanza/fileconsumer/internal/filetest/filetest.go
+++ b/pkg/stanza/fileconsumer/internal/filetest/filetest.go
@@ -4,6 +4,7 @@
 package filetest // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
 
 import (
+	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,4 +37,13 @@ func OpenTempWithPattern(t testing.TB, tempDir, pattern string) *os.File {
 func WriteString(t testing.TB, file *os.File, s string) {
 	_, err := file.WriteString(s)
 	require.NoError(t, err)
+}
+
+func TokenWithLength(length int) []byte {
+	charset := "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return b
 }

--- a/pkg/stanza/fileconsumer/internal/reader/factory_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/factory_test.go
@@ -8,8 +8,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/unicode"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/emittest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
@@ -18,32 +19,82 @@ import (
 )
 
 const (
-	defaultMaxLogSize         = 1024 * 1024
-	defaultMaxConcurrentFiles = 1024
-	defaultEncoding           = "utf-8"
-	defaultPollInterval       = 200 * time.Millisecond
-	defaultFlushPeriod        = 500 * time.Millisecond
+	defaultMaxLogSize  = 1024 * 1024
+	defaultFlushPeriod = 500 * time.Millisecond
 )
 
-func testFactory(t *testing.T, sCfg split.Config, maxLogSize int, flushPeriod time.Duration) (*Factory, *emittest.Sink) {
-	enc, err := decode.LookupEncoding(defaultEncoding)
+func testFactory(t *testing.T, opts ...testFactoryOpt) (*Factory, *emittest.Sink) {
+	cfg := &testFactoryCfg{
+		fingerprintSize:    fingerprint.DefaultSize,
+		fromBeginning:      true,
+		maxLogSize:         defaultMaxLogSize,
+		encoding:           unicode.UTF8,
+		trimFunc:           trim.Whitespace,
+		flushPeriod:        defaultFlushPeriod,
+		sinkCallBufferSize: 100,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	splitFunc, err := cfg.splitCfg.Func(cfg.encoding, false, cfg.maxLogSize)
 	require.NoError(t, err)
 
-	splitFunc, err := sCfg.Func(enc, false, maxLogSize)
-	require.NoError(t, err)
-
-	sink := emittest.NewSink()
+	sink := emittest.NewSink(emittest.WithCallBuffer(cfg.sinkCallBufferSize))
 	return &Factory{
 		SugaredLogger: testutil.Logger(t),
 		Config: &Config{
-			FingerprintSize: fingerprint.DefaultSize,
-			MaxLogSize:      maxLogSize,
+			FingerprintSize: cfg.fingerprintSize,
+			MaxLogSize:      cfg.maxLogSize,
+			FlushTimeout:    cfg.flushPeriod,
 			Emit:            sink.Callback,
-			FlushTimeout:    flushPeriod,
 		},
-		FromBeginning: true,
-		Encoding:      enc,
+		FromBeginning: cfg.fromBeginning,
+		Encoding:      cfg.encoding,
 		SplitFunc:     splitFunc,
-		TrimFunc:      trim.Whitespace,
+		TrimFunc:      cfg.trimFunc,
 	}, sink
+}
+
+type testFactoryOpt func(*testFactoryCfg)
+
+type testFactoryCfg struct {
+	fingerprintSize    int
+	fromBeginning      bool
+	maxLogSize         int
+	encoding           encoding.Encoding
+	splitCfg           split.Config
+	trimFunc           trim.Func
+	flushPeriod        time.Duration
+	sinkCallBufferSize int
+}
+
+func withFingerprintSize(size int) testFactoryOpt {
+	return func(c *testFactoryCfg) {
+		c.fingerprintSize = size
+	}
+}
+
+func withSplitConfig(cfg split.Config) testFactoryOpt {
+	return func(c *testFactoryCfg) {
+		c.splitCfg = cfg
+	}
+}
+
+func withMaxLogSize(maxLogSize int) testFactoryOpt {
+	return func(c *testFactoryCfg) {
+		c.maxLogSize = maxLogSize
+	}
+}
+
+func withFlushPeriod(flushPeriod time.Duration) testFactoryOpt {
+	return func(c *testFactoryCfg) {
+		c.flushPeriod = flushPeriod
+	}
+}
+
+func withSinkBufferSize(n int) testFactoryOpt {
+	return func(c *testFactoryCfg) {
+		c.sinkCallBufferSize = n
+	}
 }

--- a/pkg/stanza/fileconsumer/internal/reader/reader_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader_test.go
@@ -1,0 +1,182 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package reader
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
+)
+
+func TestFileReader_FingerprintUpdated(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	temp := filetest.OpenTemp(t, tempDir)
+	tempCopy := filetest.OpenFile(t, temp.Name())
+
+	f, sink := testFactory(t)
+	fp, err := f.NewFingerprint(temp)
+	require.NoError(t, err)
+
+	reader, err := f.NewReader(tempCopy, fp)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	filetest.WriteString(t, temp, "testlog1\n")
+	reader.ReadToEnd(context.Background())
+	sink.ExpectToken(t, []byte("testlog1"))
+	require.Equal(t, []byte("testlog1\n"), reader.Fingerprint.FirstBytes)
+}
+
+// Test that a fingerprint:
+// - Starts empty
+// - Updates as a file is read
+// - Stops updating when the max fingerprint size is reached
+// - Stops exactly at max fingerprint size, regardless of content
+func TestFingerprintGrowsAndStops(t *testing.T) {
+	t.Parallel()
+
+	// Use a number with many factors.
+	// Sometimes fingerprint length will align with
+	// the end of a line, sometimes not. Test both.
+	fpSize := 360
+
+	// Use prime numbers to ensure variation in
+	// whether or not they are factors of fpSize
+	lineLens := []int{3, 5, 7, 11, 13, 17, 19, 23, 27}
+
+	for _, lineLen := range lineLens {
+		lineLen := lineLen
+		t.Run(fmt.Sprintf("%d", lineLen), func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			temp := filetest.OpenTemp(t, tempDir)
+			tempCopy := filetest.OpenFile(t, temp.Name())
+
+			f, _ := testFactory(t, withSinkBufferSize(3*fpSize/lineLen), withFingerprintSize(fpSize))
+			fp, err := f.NewFingerprint(temp)
+			require.NoError(t, err)
+			require.Equal(t, []byte(""), fp.FirstBytes)
+
+			reader, err := f.NewReader(tempCopy, fp)
+			require.NoError(t, err)
+			defer reader.Close()
+
+			// keep track of what has been written to the file
+			var fileContent []byte
+
+			// keep track of expected fingerprint size
+			expectedFP := 0
+
+			// Write lines until file is much larger than the length of the fingerprint
+			for len(fileContent) < 2*fpSize {
+				expectedFP += lineLen
+				if expectedFP > fpSize {
+					expectedFP = fpSize
+				}
+
+				line := string(filetest.TokenWithLength(lineLen-1)) + "\n"
+				fileContent = append(fileContent, []byte(line)...)
+
+				filetest.WriteString(t, temp, line)
+				reader.ReadToEnd(context.Background())
+				require.Equal(t, fileContent[:expectedFP], reader.Fingerprint.FirstBytes)
+			}
+		})
+	}
+}
+
+// This is same test like TestFingerprintGrowsAndStops, but with additional check for fingerprint size check
+// Test that a fingerprint:
+// - Starts empty
+// - Updates as a file is read
+// - Stops updating when the max fingerprint size is reached
+// - Stops exactly at max fingerprint size, regardless of content
+// - Do not change size after fingerprint configuration change
+func TestFingerprintChangeSize(t *testing.T) {
+	t.Parallel()
+
+	// Use a number with many factors.
+	// Sometimes fingerprint length will align with
+	// the end of a line, sometimes not. Test both.
+	fpSize := 360
+
+	// Use prime numbers to ensure variation in
+	// whether or not they are factors of fpSize
+	lineLens := []int{3, 5, 7, 11, 13, 17, 19, 23, 27}
+
+	for _, lineLen := range lineLens {
+		lineLen := lineLen
+		t.Run(fmt.Sprintf("%d", lineLen), func(t *testing.T) {
+			t.Parallel()
+
+			f, _ := testFactory(t, withSinkBufferSize(3*fpSize/lineLen), withFingerprintSize(fpSize))
+
+			tempDir := t.TempDir()
+			temp := filetest.OpenTemp(t, tempDir)
+
+			fp, err := f.NewFingerprint(temp)
+			require.NoError(t, err)
+			require.Equal(t, []byte(""), fp.FirstBytes)
+
+			reader, err := f.NewReader(filetest.OpenFile(t, temp.Name()), fp)
+			require.NoError(t, err)
+
+			// keep track of what has been written to the file
+			var fileContent []byte
+
+			// keep track of expected fingerprint size
+			expectedFP := 0
+
+			// Write lines until file is much larger than the length of the fingerprint
+			for len(fileContent) < 2*fpSize {
+				expectedFP += lineLen
+				if expectedFP > fpSize {
+					expectedFP = fpSize
+				}
+
+				line := string(filetest.TokenWithLength(lineLen-1)) + "\n"
+				fileContent = append(fileContent, []byte(line)...)
+
+				filetest.WriteString(t, temp, line)
+				reader.ReadToEnd(context.Background())
+				require.Equal(t, fileContent[:expectedFP], reader.Fingerprint.FirstBytes)
+			}
+
+			// Recreate the factory with a larger fingerprint size
+			f, _ = testFactory(t, withSinkBufferSize(3*fpSize/lineLen), withFingerprintSize(fpSize*lineLen/3))
+
+			// Recreate the reader with the new factory
+			reader, err = f.NewReaderFromMetadata(filetest.OpenFile(t, temp.Name()), reader.Close())
+			require.NoError(t, err)
+
+			line := string(filetest.TokenWithLength(lineLen-1)) + "\n"
+			fileContent = append(fileContent, []byte(line)...)
+
+			filetest.WriteString(t, temp, line)
+			reader.ReadToEnd(context.Background())
+			require.Equal(t, fileContent[:expectedFP], reader.Fingerprint.FirstBytes)
+
+			// Recreate the factory with a smaller fingerprint size
+			f, _ = testFactory(t, withSinkBufferSize(3*fpSize/lineLen), withFingerprintSize(fpSize/2))
+
+			// Recreate the reader with the new factory
+			reader, err = f.NewReaderFromMetadata(filetest.OpenFile(t, temp.Name()), reader.Close())
+			require.NoError(t, err)
+
+			line = string(filetest.TokenWithLength(lineLen-1)) + "\n"
+			fileContent = append(fileContent, []byte(line)...)
+
+			filetest.WriteString(t, temp, line)
+			reader.ReadToEnd(context.Background())
+			require.Equal(t, fileContent[:expectedFP], reader.Fingerprint.FirstBytes)
+		})
+	}
+}

--- a/pkg/stanza/fileconsumer/internal/reader/split_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/split_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestPersistFlusher(t *testing.T) {
 	flushPeriod := 100 * time.Millisecond
-	f, sink := testFactory(t, split.Config{}, defaultMaxLogSize, flushPeriod)
+	f, sink := testFactory(t, withFlushPeriod(flushPeriod))
 
 	temp := filetest.OpenTemp(t, t.TempDir())
 	fp, err := f.NewFingerprint(temp)
@@ -107,7 +107,7 @@ func TestTokenization(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-			f, sink := testFactory(t, split.Config{}, defaultMaxLogSize, defaultFlushPeriod)
+			f, sink := testFactory(t)
 
 			temp := filetest.OpenTemp(t, t.TempDir())
 			_, err := temp.Write(tc.fileContent)
@@ -137,7 +137,7 @@ func TestTokenizationTooLong(t *testing.T) {
 		[]byte("aaa"),
 	}
 
-	f, sink := testFactory(t, split.Config{}, 10, defaultFlushPeriod)
+	f, sink := testFactory(t, withMaxLogSize(10))
 
 	temp := filetest.OpenTemp(t, t.TempDir())
 	_, err := temp.Write(fileContent)
@@ -167,9 +167,8 @@ func TestTokenizationTooLongWithLineStartPattern(t *testing.T) {
 		[]byte("2023-01-01 2"),
 	}
 
-	sCfg := split.Config{}
-	sCfg.LineStartPattern = `\d+-\d+-\d+`
-	f, sink := testFactory(t, sCfg, 15, defaultFlushPeriod)
+	sCfg := split.Config{LineStartPattern: `\d+-\d+-\d+`}
+	f, sink := testFactory(t, withSplitConfig(sCfg), withMaxLogSize(15))
 
 	temp := filetest.OpenTemp(t, t.TempDir())
 	_, err := temp.Write(fileContent)
@@ -191,7 +190,7 @@ func TestTokenizationTooLongWithLineStartPattern(t *testing.T) {
 func TestHeaderFingerprintIncluded(t *testing.T) {
 	fileContent := []byte("#header-line\naaa\n")
 
-	f, _ := testFactory(t, split.Config{}, 10, defaultFlushPeriod)
+	f, _ := testFactory(t, withMaxLogSize(10))
 
 	regexConf := regex.NewConfig()
 	regexConf.Regex = "^#(?P<header>.*)"

--- a/pkg/stanza/fileconsumer/rotation_test.go
+++ b/pkg/stanza/fileconsumer/rotation_test.go
@@ -275,7 +275,7 @@ func (rt rotationTest) run(tc rotationTest, copyTruncate, sequential bool) func(
 		logger := log.New(&rotator, "", 0)
 
 		expected := make([][]byte, 0, tc.totalLines)
-		baseStr := string(tokenWithLength(46)) // + ' 123'
+		baseStr := string(filetest.TokenWithLength(46)) // + ' 123'
 		for i := 0; i < tc.totalLines; i++ {
 			expected = append(expected, []byte(fmt.Sprintf("%s %3d", baseStr, i)))
 		}
@@ -626,9 +626,9 @@ func TestFileMovedWhileOff_BigFiles(t *testing.T) {
 	operator, sink := testManager(t, cfg)
 	persister := testutil.NewUnscopedMockPersister()
 
-	log1 := tokenWithLength(1001)
-	log2 := tokenWithLength(1002)
-	log3 := tokenWithLength(1003)
+	log1 := filetest.TokenWithLength(1001)
+	log2 := filetest.TokenWithLength(1002)
+	log3 := filetest.TokenWithLength(1003)
 
 	temp := filetest.OpenTemp(t, tempDir)
 	tempName := temp.Name()

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -4,7 +4,6 @@
 package fileconsumer
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,13 +22,4 @@ func testManagerWithSink(t *testing.T, cfg *Config, sink *emittest.Sink) *Manage
 	require.NoError(t, err)
 	t.Cleanup(func() { input.closePreviousFiles() })
 	return input
-}
-
-func tokenWithLength(length int) []byte {
-	charset := "abcdefghijklmnopqrstuvwxyz"
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
-	}
-	return b
 }


### PR DESCRIPTION
This also includes some related refactoring of test code:
- Moved `tokenWithLength` utility function to `filetest`, since it's not used by both `fileconsumer` and `reader` packages.
- Refactored `testFactory` to start with a default config and then apply options as necessary per test. I expect eventually the _actual_ `reader.Factory` will be cleaned up to support a similar pattern, but I'm trying to keep changes to test code until we have better coverage in the `reader` package.