### PR TITLE
[pkg/ottl] Add private interface for path and key

### DIFF
--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -67,7 +67,7 @@ func (p *basePath) Key() key {
 
 func (p *basePath) isComplete() error {
 	if !p.fetched {
-		return fmt.Errorf("path section %q was not fetched", p.name)
+		return fmt.Errorf("the path section %q was not used by the context - this likely means you are using extra path sections", p.name)
 	}
 	if p.nextPath == nil {
 		return nil
@@ -129,7 +129,7 @@ func (k *baseKey) isComplete() error {
 		} else if k.i != nil {
 			val = *k.i
 		}
-		return fmt.Errorf("key section '%v' was not fetched", val)
+		return fmt.Errorf("the key %q was not used by the context during indexing", val)
 	}
 	if k.nextKey == nil {
 		return nil

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -19,23 +19,19 @@ type EnumParser func(*EnumSymbol) (*Enum, error)
 type Enum int64
 
 func newPath(fields []Field) *basePath {
-	p := newPathHelper(fields)
-	if p == nil {
-		return nil
-	}
-	p.fetched = true
-	return p
-}
-
-func newPathHelper(fields []Field) *basePath {
 	if len(fields) == 0 {
 		return nil
 	}
-	return &basePath{
-		name:     fields[0].Name,
-		key:      newKey(fields[0].Keys),
-		nextPath: newPath(fields[1:]),
+	var current *basePath
+	for i := len(fields) - 1; i >= 0; i-- {
+		current = &basePath{
+			name:     fields[i].Name,
+			key:      newKey(fields[i].Keys),
+			nextPath: current,
+		}
 	}
+	current.fetched = true
+	return current
 }
 
 type path interface {
@@ -83,11 +79,16 @@ func newKey(keys []Key) *baseKey {
 	if len(keys) == 0 {
 		return nil
 	}
-	return &baseKey{
-		s:       keys[0].String,
-		i:       keys[0].Int,
-		nextKey: newKey(keys[1:]),
+	var current *baseKey
+	for i := len(keys) - 1; i >= 0; i-- {
+		current = &baseKey{
+			s:       keys[i].String,
+			i:       keys[i].Int,
+			nextKey: current,
+		}
 	}
+	current.fetched = true
+	return current
 }
 
 type key interface {

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -118,6 +118,7 @@ func (k *baseKey) Next() key {
 	if k.nextKey == nil {
 		return nil
 	}
+	k.nextKey.fetched = true
 	return k.nextKey
 }
 

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -67,7 +67,7 @@ func (p *basePath) Key() key {
 
 func (p *basePath) isComplete() error {
 	if !p.fetched {
-		return fmt.Errorf("path section '%v' was not fetched", p.name)
+		return fmt.Errorf("path section %q was not fetched", p.name)
 	}
 	if p.nextPath == nil {
 		return nil

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -2168,3 +2168,35 @@ func Test_basePath_isComplete(t *testing.T) {
 		})
 	}
 }
+
+func Test_newPath(t *testing.T) {
+	fields := []Field{
+		{
+			Name: "body",
+		},
+		{
+			Name: "string",
+		},
+	}
+	p := newPath(fields)
+	assert.Equal(t, "body", p.name)
+	p = p.nextPath
+	assert.Equal(t, "string", p.name)
+	assert.Nil(t, p.nextPath)
+}
+
+func Test_newKey(t *testing.T) {
+	keys := []Key{
+		{
+			String: ottltest.Strp("foo"),
+		},
+		{
+			String: ottltest.Strp("bar"),
+		},
+	}
+	k := newKey(keys)
+	assert.Equal(t, "foo", *k.s)
+	k = k.nextKey
+	assert.Equal(t, "bar", *k.s)
+	assert.Nil(t, k.nextKey)
+}

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -2093,3 +2093,78 @@ func defaultFunctionsForTests() map[string]Factory[any] {
 		),
 	)
 }
+
+func Test_basePath_Name(t *testing.T) {
+	bp := basePath{
+		name: "test",
+	}
+	assert.Equal(t, "test", bp.Name())
+}
+
+func Test_basePath_Next(t *testing.T) {
+	bp := basePath{
+		nextPath: &basePath{},
+	}
+	next := bp.Next()
+	assert.NotNil(t, next)
+	assert.Nil(t, next.Next())
+}
+
+func Test_basePath_Key(t *testing.T) {
+	k := &baseKey{}
+	bp := basePath{
+		key: k,
+	}
+	assert.Equal(t, k, bp.Key())
+}
+
+func Test_basePath_isComplete(t *testing.T) {
+	tests := []struct {
+		name          string
+		p             basePath
+		expectedError bool
+	}{
+		{
+			name: "fetched no next",
+			p: basePath{
+				fetched: true,
+			},
+		},
+		{
+			name: "fetched with next",
+			p: basePath{
+				fetched: true,
+				nextPath: &basePath{
+					fetched: true,
+				},
+			},
+		},
+		{
+			name: "not fetched no next",
+			p: basePath{
+				fetched: false,
+			},
+			expectedError: true,
+		},
+		{
+			name: "not fetched with next",
+			p: basePath{
+				fetched: true,
+				nextPath: &basePath{
+					fetched: false,
+				},
+			},
+			expectedError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.p.isComplete()
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -2169,6 +2169,55 @@ func Test_basePath_isComplete(t *testing.T) {
 	}
 }
 
+func Test_basePath_NextWithIsComplete(t *testing.T) {
+	tests := []struct {
+		name          string
+		pathFunc      func() *basePath
+		expectedError bool
+	}{
+		{
+			name: "fetched",
+			pathFunc: func() *basePath {
+				bp := basePath{
+					fetched: true,
+					nextPath: &basePath{
+						fetched: false,
+					},
+				}
+				bp.Next()
+				return &bp
+			},
+		},
+		{
+			name: "not fetched enough",
+			pathFunc: func() *basePath {
+				bp := basePath{
+					fetched: true,
+					nextPath: &basePath{
+						fetched: false,
+						nextPath: &basePath{
+							fetched: false,
+						},
+					},
+				}
+				bp.Next()
+				return &bp
+			},
+			expectedError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.pathFunc().isComplete()
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func Test_newPath(t *testing.T) {
 	fields := []Field{
 		{
@@ -2250,6 +2299,55 @@ func Test_baseKey_isComplete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.p.isComplete()
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_baseKey_NextWithIsComplete(t *testing.T) {
+	tests := []struct {
+		name          string
+		keyFunc       func() *baseKey
+		expectedError bool
+	}{
+		{
+			name: "fetched",
+			keyFunc: func() *baseKey {
+				bk := baseKey{
+					fetched: true,
+					nextKey: &baseKey{
+						fetched: false,
+					},
+				}
+				bk.Next()
+				return &bk
+			},
+		},
+		{
+			name: "not fetched enough",
+			keyFunc: func() *baseKey {
+				bk := baseKey{
+					fetched: true,
+					nextKey: &baseKey{
+						fetched: false,
+						nextKey: &baseKey{
+							fetched: false,
+						},
+					},
+				}
+				bk.Next()
+				return &bk
+			},
+			expectedError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.keyFunc().isComplete()
 			if tt.expectedError {
 				assert.Error(t, err)
 			} else {

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -2185,6 +2185,80 @@ func Test_newPath(t *testing.T) {
 	assert.Nil(t, p.nextPath)
 }
 
+func Test_baseKey_String(t *testing.T) {
+	bp := baseKey{
+		s: ottltest.Strp("test"),
+	}
+	assert.Equal(t, "test", *bp.String())
+}
+
+func Test_baseKey_Int(t *testing.T) {
+	bp := baseKey{
+		i: ottltest.Intp(1),
+	}
+	assert.Equal(t, int64(1), *bp.Int())
+}
+
+func Test_baseKey_Next(t *testing.T) {
+	bp := baseKey{
+		nextKey: &baseKey{},
+	}
+	next := bp.Next()
+	assert.NotNil(t, next)
+	assert.Nil(t, next.Next())
+}
+
+func Test_baseKey_isComplete(t *testing.T) {
+	tests := []struct {
+		name          string
+		p             baseKey
+		expectedError bool
+	}{
+		{
+			name: "fetched no next",
+			p: baseKey{
+				fetched: true,
+			},
+		},
+		{
+			name: "fetched with next",
+			p: baseKey{
+				fetched: true,
+				nextKey: &baseKey{
+					fetched: true,
+				},
+			},
+		},
+		{
+			name: "not fetched no next",
+			p: baseKey{
+				fetched: false,
+			},
+			expectedError: true,
+		},
+		{
+			name: "not fetched with next",
+			p: baseKey{
+				fetched: true,
+				nextKey: &baseKey{
+					fetched: false,
+				},
+			},
+			expectedError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.p.isComplete()
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func Test_newKey(t *testing.T) {
 	keys := []Key{
 		{


### PR DESCRIPTION
**Description:**
This is the first PR working towards https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22744.

It adds 2 new interfaces, `path` and `key`, that will be given to contexts to use when interpreting the paths/keys passed from the grammar. Eventually we'll be able to use the `isComplete` functions during parsing to ensure that all parts of the path were used by the context.

By the end of that issue we'll have removed all public API's of OTTL's grammar, which is going to cause massive breaking changes to all our contexts and huge PRs.  To help decrease the amount of changes per PR these new interfaces are not yet exported and not yet implemented.  To see them partially in use checkout https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/29703.

**Link to tracking Issue:**

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22744

**Testing:**

Added unit tests

**Documentation:** <Describe the documentation added.>

I'll add godoc comments once these things are made public