### PR TITLE
[k8sobjectsreceiver] fix receiver fails when some unrelated API is down

### DIFF
--- a/.chloggen/k8sobject-crash.yaml
+++ b/.chloggen/k8sobject-crash.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sobjectsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "fix k8sobjects receiver fails when some unrelated Kubernetes API is down"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29706]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/k8sobjectsreceiver/config.go
+++ b/receiver/k8sobjectsreceiver/config.go
@@ -128,7 +128,11 @@ func (c *Config) getValidObjects() (map[string][]*schema.GroupVersionResource, e
 
 	res, err := dc.ServerPreferredResources()
 	if err != nil {
-		return nil, err
+		// Check if Partial result is returned from discovery client, that means some API servers have issues,
+		// but we can still continue, as we check for the needed groups later in Validate function.
+		if res != nil && !discovery.IsGroupDiscoveryFailedError(err) {
+			return nil, err
+		}
 	}
 
 	validObjects := make(map[string][]*schema.GroupVersionResource)


### PR DESCRIPTION
**Description:** <Describe what has changed.>

This change allows passing validation even some of K8S APIs is down, we will look thru the groups and resources for the ones available.


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29706

**Testing:** <Describe what testing was performed and which tests were added.>
- manually in a kind cluster with metrics-server being down.

**Documentation:** <Describe the documentation added.>