### PR TITLE
[chore]check that path exists, not that it is a folder in CODEOWNERS

### DIFF
--- a/.github/workflows/scripts/check-codeowners.sh
+++ b/.github/workflows/scripts/check-codeowners.sh
@@ -63,7 +63,7 @@ check_component_existence() {
   do
     if [[ $line =~ ^[^#\*] ]]; then
       COMPONENT_PATH=$(echo "$line" | cut -d" " -f1)
-      if [ ! -d "$COMPONENT_PATH" ]; then
+      if [ ! -e "$COMPONENT_PATH" ]; then
         echo "\"$COMPONENT_PATH\" does not exist as specified in CODEOWNERS"
         ((NOT_EXIST_COMPONENTS=NOT_EXIST_COMPONENTS+1))
       fi


### PR DESCRIPTION
The current code enforces that all paths in CODEOWNERS have to be folders, but the logic should just check the path exists in git, not that it is a folder. This change relaxes the check to check on file existence only.