### PR TITLE
[chore][CI/CD] Fix bugs in get-codeowners.sh

### DIFF
--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -27,7 +27,7 @@ CUR_DIRECTORY=$(dirname "$0")
 VALID_COMPONENT=$(bash "${CUR_DIRECTORY}/get-components.sh" | grep -x "${COMPONENT}" || true)
 VALID_COMPONENT_WITH_TYPE=$(bash "${CUR_DIRECTORY}/get-components.sh" | grep -x "$COMPONENT$COMPONENT_TYPE" || true)
 
-if [ -z "${VALID_COMPONENT:-}" ] && [ -z "${VALID_COMPONENT_WITH_TYPE:-}" ]; then
+if [[ -z "${VALID_COMPONENT:-}" ]] && [[ -z "${VALID_COMPONENT_WITH_TYPE:-}" ]]; then
     echo ""
     exit 0
 fi

--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -14,7 +14,7 @@ get_component_type() {
 }
 
 get_codeowners() {
-  echo "$((grep -m 1 "^${1}/" .github/CODEOWNERS || true) | \
+  echo "$((grep -m 1 "^${1}/ " .github/CODEOWNERS || true) | \
         sed 's/   */ /g' | \
         cut -f3- -d ' ')"
 }

--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -18,6 +18,15 @@ if [[ -z "${COMPONENT:-}" ]]; then
     exit 1
 fi
 
+# For a component to be considered valid, it must match the entire component name
+CUR_DIRECTORY=$(dirname "$0")
+VALID_COMPONENT=$(bash "${CUR_DIRECTORY}/get-components.sh" | grep -x $COMPONENT)
+
+if [[ -z "${VALID_COMPONENT:-}" ]]; then
+    echo ""
+    exit 0
+fi
+
 # grep exits with status code 1 if there are no matches,
 # so we manually set RESULT to 0 if nothing is found.
 RESULT=$(grep -c "${COMPONENT}" .github/CODEOWNERS || true)

--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -14,7 +14,7 @@ get_component_type() {
 }
 
 get_codeowners() {
-  echo "$((grep -m 1 "^${1}/ " .github/CODEOWNERS || true) | \
+  echo "$((grep -m 1 "^${1}/\s" .github/CODEOWNERS || true) | \
         sed 's/   */ /g' | \
         cut -f3- -d ' ')"
 }
@@ -22,16 +22,6 @@ get_codeowners() {
 if [[ -z "${COMPONENT:-}" ]]; then
     echo "COMPONENT has not been set, please ensure it is set."
     exit 1
-fi
-
-COMPONENT_TYPE=$(get_component_type "${COMPONENT}")
-CUR_DIRECTORY=$(dirname "$0")
-VALID_COMPONENT=$(bash "${CUR_DIRECTORY}/get-components.sh" | grep -x "${COMPONENT}" || true)
-VALID_COMPONENT_WITH_TYPE=$(bash "${CUR_DIRECTORY}/get-components.sh" | grep -x "${COMPONENT}${COMPONENT_TYPE}" || true)
-
-if [[ -z "${VALID_COMPONENT:-}" ]] && [[ -z "${VALID_COMPONENT_WITH_TYPE:-}" ]]; then
-    echo ""
-    exit 0
 fi
 
 # grep exits with status code 1 if there are no matches,
@@ -42,6 +32,7 @@ RESULT=$(grep -c "${COMPONENT}" .github/CODEOWNERS || true)
 # if so, try to narrow things down by appending the component
 # or a forward slash to the label.
 if [[ ${RESULT} != 1 ]]; then
+    COMPONENT_TYPE=$(get_component_type "${COMPONENT}")
     OWNERS="$(get_codeowners "${COMPONENT}${COMPONENT_TYPE}")"
 fi
 

--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 get_codeowners() {
-  echo "$((grep -m 1 "${1}" .github/CODEOWNERS || true) | sed 's/   */ /g' | cut -f3- -d ' ')"
+  echo "$((grep -m 1 "^${1}" .github/CODEOWNERS || true) | sed 's/   */ /g' | cut -f3- -d ' ')"
 }
 
 if [[ -z "${COMPONENT:-}" ]]; then

--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -25,7 +25,7 @@ fi
 COMPONENT_TYPE=$(get_component_type "${COMPONENT}")
 CUR_DIRECTORY=$(dirname "$0")
 VALID_COMPONENT=$(bash "${CUR_DIRECTORY}/get-components.sh" | grep -x "${COMPONENT}" || true)
-VALID_COMPONENT_WITH_TYPE=$(bash "${CUR_DIRECTORY}/get-components.sh" | grep -x "$COMPONENT$COMPONENT_TYPE" || true)
+VALID_COMPONENT_WITH_TYPE=$(bash "${CUR_DIRECTORY}/get-components.sh" | grep -x "${COMPONENT}${COMPONENT_TYPE}" || true)
 
 if [[ -z "${VALID_COMPONENT:-}" ]] && [[ -z "${VALID_COMPONENT_WITH_TYPE:-}" ]]; then
     echo ""

--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -14,7 +14,9 @@ get_component_type() {
 }
 
 get_codeowners() {
-  echo "$((grep -m 1 "^${1}" .github/CODEOWNERS || true) | sed 's/   */ /g' | cut -f3- -d ' ')"
+  echo "$((grep -m 1 "^${1}/" .github/CODEOWNERS || true) | \
+        sed 's/   */ /g' | \
+        cut -f3- -d ' ')"
 }
 
 if [[ -z "${COMPONENT:-}" ]]; then
@@ -41,12 +43,10 @@ RESULT=$(grep -c "${COMPONENT}" .github/CODEOWNERS || true)
 # or a forward slash to the label.
 if [[ ${RESULT} != 1 ]]; then
     OWNERS="$(get_codeowners "${COMPONENT}${COMPONENT_TYPE}")"
+fi
 
-    if [[ -z "${OWNERS:-}" ]]; then
-        OWNERS="$(get_codeowners "${COMPONENT}/")"
-    fi
-else
-    OWNERS="$(get_codeowners $COMPONENT)"
+if [[ -z "${OWNERS:-}" ]]; then
+    OWNERS="$(get_codeowners "${COMPONENT}")"
 fi
 
 echo "${OWNERS}"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
There's a combination of bugs currently existing in `get-codeowners.sh` and the `Mark issues as stale` workflow. This implements proposed solution 2 of #29744
- Match component against beginning of line in code owners.

**Issues**
Resolves #29744

**Testing**
Basic spot checking script:
```
COMPONENTS=("azure" "processor/resourcedetection" "processor/resourcedetectionprocessor" "test" "testbed" "extension/observer" "internal/k8stest" "extension/encoding" "flaky" "pkg/translator" "tools" )

for EXAMPLE_COMPONENT in ${COMPONENTS[@]}; do
    OWNERS=$(COMPONENT=${EXAMPLE_COMPONENT} bash ".github/workflows/scripts/get-codeowners.sh")
    echo $EXAMPLE_COMPONENT: $OWNERS
done
```
Output:
```
azure:
processor/resourcedetection: @Aneurysm9 @dashpole
processor/resourcedetectionprocessor: @Aneurysm9 @dashpole
test:
testbed: @open-telemetry/collector-approvers
extension/observer: @dmitryax @rmfitzpatrick
internal/k8stest: @crobert-1
extension/encoding: @atoulme @dao-jun @dmitryax @MovieStoreGuy @VihasMakwana
flaky:
pkg/translator:
tools:
```
Reference [CODEOWNERS](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/CODEOWNERS) as source of truth.