### PR TITLE
add support for loadbalancing with any resource attribute for log

### DIFF
--- a/.chloggen/loadbalancing_with_resource_attribute_log.yaml
+++ b/.chloggen/loadbalancing_with_resource_attribute_log.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/loadbalancingexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support for loadbalancing with any resource attribute for log."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29756]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -27,7 +27,7 @@ The options for `routing_key` are: `service`, `traceID`, `metric` (metric name),
 | ------------- |-----------|
 | service | logs, spans, metrics |
 | traceID | logs, spans |
-| resource | metrics |
+| resource | metrics, logs |
 | metric | metrics |
 
 If no `routing_key` is configured, the default routing mechanism is `traceID`  for traces, while `service` is the default for metrics. This means that spans belonging to the same `traceID` (or `service.name`, when `service` is used as the `routing_key`) will be sent to the same backend.
@@ -67,6 +67,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
 * The `routing_key` property is used to route spans to exporters based on different parameters. This functionality is currently enabled only for `trace` pipeline types. It supports one of the following values:
     * `service`: exports spans based on their service name. This is useful when using processors like the span metrics, so all spans for each service are sent to consistent collector instances for metric collection. Otherwise, metrics for the same services are sent to different collectors, making aggregations inaccurate. 
     * `traceID` (default): exports spans based on their `traceID`.
+    * `resource`: exports logs based on `resource_keys`. exports metric based on all resource attributes. 
     * If not configured, defaults to `traceID` based routing.
 
 Simple example
@@ -126,7 +127,9 @@ processors:
 
 exporters:
   loadbalancing:
-    routing_key: "service"
+    routing_key: "resource"
+    resource_keys: 
+      - namespace
     protocol:
       otlp:
         # all options from the OTLP exporter are supported

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -20,9 +20,10 @@ const (
 
 // Config defines configuration for the exporter.
 type Config struct {
-	Protocol   Protocol         `mapstructure:"protocol"`
-	Resolver   ResolverSettings `mapstructure:"resolver"`
-	RoutingKey string           `mapstructure:"routing_key"`
+	Protocol     Protocol         `mapstructure:"protocol"`
+	Resolver     ResolverSettings `mapstructure:"resolver"`
+	RoutingKey   string           `mapstructure:"routing_key"`
+	ResourceKeys []string         `mapstructure:"resource_keys"`
 }
 
 // Protocol holds the individual protocol-specific settings. Only OTLP is supported at the moment.

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -5,8 +5,11 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,10 +30,20 @@ var _ exporter.Logs = (*logExporterImp)(nil)
 
 type logExporterImp struct {
 	loadBalancer loadBalancer
+	resourceKeys []string
 
-	started    bool
-	shutdownWg sync.WaitGroup
+	logConsumer logConsumer
+	started     bool
+	shutdownWg  sync.WaitGroup
 }
+
+type routingEntry struct {
+	routingKey routingKey
+	keyValue   string
+	log        plog.Logs
+}
+
+type logConsumer func(ctx context.Context, td plog.Logs) error
 
 // Create new logs exporter
 func newLogsExporter(params exporter.CreateSettings, cfg component.Config) (*logExporterImp, error) {
@@ -44,9 +57,21 @@ func newLogsExporter(params exporter.CreateSettings, cfg component.Config) (*log
 		return nil, err
 	}
 
-	return &logExporterImp{
-		loadBalancer: lb,
-	}, nil
+	logExporter := logExporterImp{loadBalancer: lb}
+
+	switch cfg.(*Config).RoutingKey {
+	case "service":
+		logExporter.logConsumer = logExporter.consumeLogsByResource
+		logExporter.resourceKeys = []string{"service.name"}
+	case "traceID", "":
+		logExporter.logConsumer = logExporter.consumeLogsById
+	case "resource":
+		logExporter.resourceKeys = cfg.(*Config).ResourceKeys
+		logExporter.logConsumer = logExporter.consumeLogsByResource
+	default:
+		return nil, fmt.Errorf("unsupported routing_key: %s", cfg.(*Config).RoutingKey)
+	}
+	return &logExporter, nil
 }
 
 func (e *logExporterImp) Capabilities() consumer.Capabilities {
@@ -67,40 +92,27 @@ func (e *logExporterImp) Shutdown(context.Context) error {
 	return nil
 }
 
-func (e *logExporterImp) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
-	var errs error
-	batches := batchpersignal.SplitLogs(ld)
-	for _, batch := range batches {
-		errs = multierr.Append(errs, e.consumeLog(ctx, batch))
-	}
-
-	return errs
+func (e *logExporterImp) ConsumeLogs(ctx context.Context, td plog.Logs) error {
+	return e.logConsumer(ctx, td)
 }
 
-func (e *logExporterImp) consumeLog(ctx context.Context, ld plog.Logs) error {
-	traceID := traceIDFromLogs(ld)
-	balancingKey := traceID
-	if traceID == pcommon.NewTraceIDEmpty() {
-		// every log may not contain a traceID
-		// generate a random traceID as balancingKey
-		// so the log can be routed to a random backend
-		balancingKey = random()
-	}
-
-	endpoint := e.loadBalancer.Endpoint(balancingKey[:])
+func (e *logExporterImp) consumeLog(ctx context.Context, td plog.Logs, rid string) error {
+	// Routes a single log via a given routing ID
+	endpoint := e.loadBalancer.Endpoint([]byte(rid))
 	exp, err := e.loadBalancer.Exporter(endpoint)
 	if err != nil {
 		return err
 	}
 
-	le, ok := exp.(exporter.Logs)
+	te, ok := exp.(exporter.Logs)
 	if !ok {
 		return fmt.Errorf("unable to export logs, unexpected exporter type: expected exporter.Logs but got %T", exp)
 	}
 
 	start := time.Now()
-	err = le.ConsumeLogs(ctx, ld)
+	err = te.ConsumeLogs(ctx, td)
 	duration := time.Since(start)
+
 	if err == nil {
 		_ = stats.RecordWithTags(
 			ctx,
@@ -112,27 +124,7 @@ func (e *logExporterImp) consumeLog(ctx context.Context, ld plog.Logs) error {
 			[]tag.Mutator{tag.Upsert(endpointTagKey, endpoint), successFalseMutator},
 			mBackendLatency.M(duration.Milliseconds()))
 	}
-
 	return err
-}
-
-func traceIDFromLogs(ld plog.Logs) pcommon.TraceID {
-	rl := ld.ResourceLogs()
-	if rl.Len() == 0 {
-		return pcommon.NewTraceIDEmpty()
-	}
-
-	sl := rl.At(0).ScopeLogs()
-	if sl.Len() == 0 {
-		return pcommon.NewTraceIDEmpty()
-	}
-
-	logs := sl.At(0).LogRecords()
-	if logs.Len() == 0 {
-		return pcommon.NewTraceIDEmpty()
-	}
-
-	return logs.At(0).TraceID()
 }
 
 func random() pcommon.TraceID {
@@ -141,4 +133,131 @@ func random() pcommon.TraceID {
 	v3 := uint8(rand.Intn(256))
 	v4 := uint8(rand.Intn(256))
 	return [16]byte{v1, v2, v3, v4}
+}
+
+func (e *logExporterImp) consumeLogsById(ctx context.Context, td plog.Logs) error {
+	var errs error
+	batches := batchpersignal.SplitLogs(td)
+
+	for _, t := range batches {
+		if tid, err := routeByTraceId(t); err == nil {
+			errs = multierr.Append(errs, e.consumeLog(ctx, t, tid))
+		} else {
+			return err
+		}
+	}
+	return errs
+}
+
+func (e *logExporterImp) consumeLogsByResource(ctx context.Context, td plog.Logs) error {
+	var errs error
+	routeBatches, err := splitLogsByResourceAttr(td, e.resourceKeys)
+	if err != nil {
+		return err
+	}
+	for _, batch := range routeBatches {
+		switch batch.routingKey {
+		case resourceRouting:
+			errs = multierr.Append(errs, e.consumeLog(ctx, batch.log, batch.keyValue))
+		case traceIDRouting:
+			errs = multierr.Append(errs, e.consumeLogsById(ctx, batch.log))
+		}
+	}
+	return errs
+
+}
+
+func getResourceAttrValue(rs plog.ResourceLogs, resourceKeys []string) (string, bool) {
+	found := false
+	if len(resourceKeys) == 0 {
+		for k := range rs.Resource().Attributes().AsRaw() {
+			resourceKeys = append(resourceKeys, k)
+		}
+		sort.Strings(resourceKeys)
+	}
+
+	attrsHash := getResourceAttrValues(rs.Resource().Attributes(), resourceKeys)
+	if len(attrsHash) > 0 { // as long as one of attribute exist
+		found = true
+	}
+	res := strings.Join(attrsHash, "")
+	return res, found
+}
+
+func getResourceAttrValues(attrs pcommon.Map, resourceKeys []string) []string {
+	attrsHash := make([]string, 0)
+	for _, k := range resourceKeys {
+		if v, ok := attrs.Get(k); ok {
+			attrsHash = append(attrsHash, v.AsString())
+		}
+	}
+	return attrsHash
+}
+
+func splitLogsByResourceAttr(batches plog.Logs, resourceKeys []string) ([]routingEntry, error) {
+	// This function batches all the ResourceLogs with the same routing resource attribute value into a single plog.Log
+	// This returns a list of routing entries which consists of the routing key, routing key value and the log
+	// There should be a 1:1 mapping between key value <-> log
+	// This is because we group all Resource Logs with the same key value under a single log
+	var result []routingEntry
+	rss := batches.ResourceLogs()
+
+	// This is a mapping between the resource attribute values found and the constructed log
+	routeMap := make(map[string]plog.Logs)
+
+	for i := 0; i < rss.Len(); i++ {
+		rs := rss.At(i)
+		if keyValue, ok := getResourceAttrValue(rs, resourceKeys); ok {
+			// Check if this keyValue has previously been seen
+			// if not it constructs an empty plog.Logs
+			if _, ok := routeMap[keyValue]; !ok {
+				routeMap[keyValue] = plog.NewLogs()
+			}
+			rs.CopyTo(routeMap[keyValue].ResourceLogs().AppendEmpty())
+		} else {
+			// If none of the resource attributes have been found
+			// We fallback to routing the given Resource Span by Trace ID
+			t := plog.NewLogs()
+			rs.CopyTo(t.ResourceLogs().AppendEmpty())
+			// We can't route this whole Resource Span by a single trace ID
+			// because it's possible for the spans under the RS to have different trace IDs
+			result = append(result, routingEntry{
+				routingKey: traceIDRouting,
+				log:        t,
+			})
+		}
+	}
+
+	// We convert the attr value:log mapping into a list of routingEntries
+	for key, log := range routeMap {
+		result = append(result, routingEntry{
+			routingKey: resourceRouting,
+			keyValue:   key,
+			log:        log,
+		})
+	}
+
+	return result, nil
+}
+
+func routeByTraceId(td plog.Logs) (string, error) {
+	// This function assumes that you are receiving a single log i.e. single traceId
+	// returns the traceId as the routing key
+	rs := td.ResourceLogs()
+	if rs.Len() == 0 {
+		return "", errors.New("empty resource logs")
+	}
+	if rs.Len() > 1 {
+		return "", errors.New("routeByTraceId must receive a plog.Logs with a single ResourceLog")
+	}
+	ils := rs.At(0).ScopeLogs()
+	if ils.Len() == 0 {
+		return "", errors.New("empty scope logs")
+	}
+	logs := ils.At(0).LogRecords()
+	if logs.Len() == 0 {
+		return "", errors.New("empty logs")
+	}
+	tid := logs.At(0).TraceID()
+	return string(tid[:]), nil
 }

--- a/exporter/loadbalancingexporter/testdata/config.yaml
+++ b/exporter/loadbalancingexporter/testdata/config.yaml
@@ -27,3 +27,28 @@ loadbalancing/3:
     dns:
       hostname: service-1
       port: 55690
+loadbalancing/4:
+  protocol:
+    otlp:
+  resolver:
+    dns:
+      hostname: service-1
+      port: 55690
+  routing_key: traceID
+loadbalancing/5:
+  protocol:
+    otlp:
+  resolver:
+    dns:
+      hostname: service-1
+      port: 55690
+  routing_key: service
+loadbalancing/6:
+  protocol:
+    otlp:
+  resolver:
+    dns:
+      hostname: service-1
+      port: 55690
+  routing_key: resource
+  resource_keys: ["resource.attribute", "service.name"]

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -581,6 +581,16 @@ func simpleConfig() *Config {
 	}
 }
 
+func attrBasedRoutingConfig() *Config {
+	return &Config{
+		Resolver: ResolverSettings{
+			Static: &StaticResolver{Hostnames: []string{"endpoint-1", "endpoint-2", "endpoint-3"}},
+		},
+		RoutingKey:   "resource",
+		ResourceKeys: []string{"service.name"},
+	}
+}
+
 func serviceBasedRoutingConfig() *Config {
 	return &Config{
 		Resolver: ResolverSettings{


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
For logs, it need to load balancing with resource keys, this can be used for further aggregation on logs just similar with what spanmetrics is doing

**Link to tracking Issue:** <Issue number if applicable>
This is for logs, there was a similar one for spans which not merged yet. https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/18769 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
Using below approach to load balancing logs with resource attribute `namespace`. 
```yaml
exporters:
  loadbalancing:
    routing_key: "resource"
    resource_keys: 
      - namespace
    protocol:
      otlp:
        # all options from the OTLP exporter are supported
        # except the endpoint
        timeout: 1s
    resolver:
      # use k8s service resolver, if collector runs in kubernetes environment
      k8s:
        service: lb-svc.kube-public
        ports:
          - 15317
          - 16317
```