### PR TITLE
[k8sclusterreceiver] deprecate k8s.kubeproxy.version resource attribute

### DIFF
--- a/.chloggen/deprecate-kubeproxy.yaml
+++ b/.chloggen/deprecate-kubeproxy.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sclusterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "deprecate optional k8s.kubeproxy.version resource attribute"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29748]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
@@ -2249,6 +2249,9 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 }
 
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSettings, options ...metricBuilderOption) *MetricsBuilder {
+	if mbc.ResourceAttributes.K8sKubeproxyVersion.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] `k8s.kubeproxy.version` should not be configured: k8s.kubeproxy.version resource attribute is deprecated and will be removed soon.")
+	}
 	mb := &MetricsBuilder{
 		config:                                  mbc,
 		startTime:                               pcommon.NewTimestampFromTime(time.Now()),

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_metrics_test.go
@@ -49,6 +49,10 @@ func TestMetricsBuilder(t *testing.T) {
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, test.name), settings, WithStartTime(start))
 
 			expectedWarnings := 0
+			if test.configSet == testSetAll || test.configSet == testSetNone {
+				assert.Equal(t, "[WARNING] `k8s.kubeproxy.version` should not be configured: k8s.kubeproxy.version resource attribute is deprecated and will be removed soon.", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
 
 			assert.Equal(t, expectedWarnings, observedLogs.Len())
 

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -166,6 +166,8 @@ resource_attributes:
     description: The version of Kube Proxy running on the node.
     type: string
     enabled: false
+    warnings:
+      if_configured: k8s.kubeproxy.version resource attribute is deprecated and will be removed soon.
 
   openshift.clusterquota.uid:
     description: The k8s ClusterResourceQuota uid.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Deprecating k8s.kubeproxy.version resource attribute 


**Link to tracking Issue:** <Issue number if applicable>

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29748

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>