### PR TITLE
Remove call to metrics.WithResourceAttributesAsTags()

### DIFF
--- a/exporter/datadogexporter/metrics_exporter.go
+++ b/exporter/datadogexporter/metrics_exporter.go
@@ -65,10 +65,6 @@ func translatorFromConfig(logger *zap.Logger, cfg *Config, sourceProvider source
 		options = append(options, otlpmetrics.WithQuantiles())
 	}
 
-	if cfg.Metrics.ExporterConfig.ResourceAttributesAsTags {
-		options = append(options, otlpmetrics.WithResourceAttributesAsTags())
-	}
-
 	if cfg.Metrics.ExporterConfig.InstrumentationScopeMetadataAsTags {
 		options = append(options, otlpmetrics.WithInstrumentationScopeMetadataAsTags())
 	}


### PR DESCRIPTION
**Description:**
Removes call to `metrics.WithResourceAttributesAsTags()` which is a no-op. This option is picked up here: https://github.com/DataDog/datadog-agent/blob/main/comp/otelcol/otlp/internal/serializerexporter/factory.go#L60.

This option will been removed from `pkg/otlp/metrics` in this PR: https://github.com/DataDog/opentelemetry-mapping-go/pull/219

**Link to tracking Issue:**
Closes #29702


**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>