### PR TITLE
[receiver/snowflake] Fix storage metric reporting bug

### DIFF
--- a/.chloggen/snowflake-receiver-bugfix.yaml
+++ b/.chloggen/snowflake-receiver-bugfix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: snowflakereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixed bug where storage metrics for snowflake were not being reported"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29750]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/stanza/operator/input/windows/operator.go
+++ b/pkg/stanza/operator/input/windows/operator.go
@@ -12,9 +12,10 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
-	"go.uber.org/zap"
 )
 
 func init() {

--- a/pkg/stanza/operator/input/windows/operator.go
+++ b/pkg/stanza/operator/input/windows/operator.go
@@ -12,10 +12,9 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
+	"go.uber.org/zap"
 )
 
 func init() {

--- a/receiver/snowflakereceiver/client.go
+++ b/receiver/snowflakereceiver/client.go
@@ -398,15 +398,15 @@ func (c snowflakeClient) FetchStorageMetrics(ctx context.Context) (*[]storageMet
 	var res []storageMetric
 
 	for rows.Next() {
-		var storageBytes, stageBytes, failsafeBytes int64
+		var storageBytes, stageBytes, failsafeBytes float64
 		err := rows.Scan(&storageBytes, &stageBytes, &failsafeBytes)
 		if err != nil {
 			return nil, err
 		}
 		res = append(res, storageMetric{
-			storageBytes:  storageBytes,
-			stageBytes:    stageBytes,
-			failsafeBytes: failsafeBytes,
+			storageBytes:  int64(storageBytes),
+			stageBytes:    int64(stageBytes),
+			failsafeBytes: int64(failsafeBytes),
 		})
 	}
 	return &res, nil

--- a/receiver/snowflakereceiver/client_test.go
+++ b/receiver/snowflakereceiver/client_test.go
@@ -242,7 +242,7 @@ func TestMetricQueries(t *testing.T) {
 			desc:    "FetchStorageMetrics",
 			query:   storageMetricsQuery,
 			columns: []string{"storage_bytes", "stage_bytes", "failsafe_bytes"},
-			params:  []driver.Value{1, 2, 3},
+			params:  []driver.Value{1.0, 2.0, 3.0},
 			expect: storageMetric{
 				storageBytes:  1,
 				stageBytes:    2,


### PR DESCRIPTION
**Description:** Identified and fixed an issue with the function responsible for querying storage metrics in `client.go`. The issue was that `sql.Rows.Scan()` was receiving a `float64` instead of an `int64` as previously thought and so trying to copy the column values into the provided variable pointers was causing a type error. To fix this the type of the variables passed into `sql.Rows.Scan()` was changed to `float64` and then recast as `int64` when inserting into the metric interface. This made more sense than potentially breaking existing pipelines by changing the metric type to `double` especially since the values for these metrics is always an integer (even if the database itself stores them as a float).

**Link to tracking Issue:** [29750](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29750)

**Testing:** Modified tests to expect float values from the mock database

**Documentation:** No change needed