### PR TITLE
[chore] add more maintainers to splunk distribution

### DIFF
--- a/distributions.yaml
+++ b/distributions.yaml
@@ -18,9 +18,15 @@
    url: https://github.com/signalfx/splunk-otel-collector
    maintainers:
       - atoulme
+      - crobert-1
       - dmitryax
       - hughesjj
-      - rfitzpatrick
+      - jeffreyc-splunk
+      - jinja2
+      - jvoravong
+      - panotti
+      - rmfitzpatrick
+      - samiura
  - name: sumo
    url: https://github.com/SumoLogic/sumologic-otel-collector
  - name: liatrio

--- a/reports/distributions/splunk.yaml
+++ b/reports/distributions/splunk.yaml
@@ -2,9 +2,15 @@ name: splunk
 url: https://github.com/signalfx/splunk-otel-collector
 maintainers:
     - atoulme
+    - crobert-1
     - dmitryax
     - hughesjj
-    - rfitzpatrick
+    - jeffreyc-splunk
+    - jinja2
+    - jvoravong
+    - panotti
+    - rmfitzpatrick
+    - samiura
 components:
     connector:
         - spanmetrics


### PR DESCRIPTION
This PR adds more maintainers to the Splunk distributions and corrects the handle of @rmfitzpatrick , with my apologies.