### PR TITLE
[chore] Suppress renovatebot edit notification

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -76,5 +76,6 @@
       "github.com/mattn/go-ieproxy",
       "github.com/DataDog/datadog-agent/pkg/trace/exportable"
     ],
-    "prConcurrentLimit": 50
+    "prConcurrentLimit": 50,
+    "suppressNotifications": ["prEditedNotification"]
   }


### PR DESCRIPTION
![image](https://github.com/open-telemetry/opentelemetry-collector-contrib/assets/12352919/0797a8fe-3eca-484d-b8d1-4f8a6e6994db)

That comment will appear on every single renovatebot PR since we use opentlemetrybot to do the `make gotidy`.  They don't provide value so this PR suppresses them.