### PR TITLE
[chore] renovatebot skip govulncheck

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -134,6 +134,7 @@ jobs:
           - internal
           - pkg
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'renovate[bot]' }}
     timeout-minutes: 30
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Renovatebot PRs can never pass the govulncheck until the `go mod tidy` commit comes in.