### PR TITLE
[cmd/opampsupervisor] Implement Collector bootstrapping

### DIFF
--- a/.chloggen/supervisor-bootstrapping.yaml
+++ b/.chloggen/supervisor-bootstrapping.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use a bootstrapping flow to get the Collector's agent description.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [21071]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path"
 	"runtime"
 	"strings"
@@ -23,12 +24,18 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/file"
+	"github.com/knadh/koanf/providers/rawbytes"
+	"github.com/knadh/koanf/v2"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/open-telemetry/opamp-go/server"
 	"github.com/open-telemetry/opamp-go/server/types"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	semconv "go.opentelemetry.io/collector/semconv/v1.21.0"
 	"go.uber.org/zap"
 )
 
@@ -122,6 +129,14 @@ func newOpAMPServer(t *testing.T, connectingCallback onConnectingFuncFactory, ca
 }
 
 func newSupervisor(t *testing.T, configType string, extraConfigData map[string]string) *supervisor.Supervisor {
+	cfgFile := getSupervisorConfig(t, configType, extraConfigData)
+	s, err := supervisor.NewSupervisor(zap.NewNop(), cfgFile.Name())
+	require.NoError(t, err)
+
+	return s
+}
+
+func getSupervisorConfig(t *testing.T, configType string, extraConfigData map[string]string) *os.File {
 	tpl, err := os.ReadFile(path.Join("testdata", "supervisor", "supervisor_"+configType+".yaml"))
 	require.NoError(t, err)
 
@@ -148,10 +163,7 @@ func newSupervisor(t *testing.T, configType string, extraConfigData map[string]s
 	_, err = cfgFile.Write(buf.Bytes())
 	require.NoError(t, err)
 
-	s, err := supervisor.NewSupervisor(zap.NewNop(), cfgFile.Name())
-	require.NoError(t, err)
-
-	return s
+	return cfgFile
 }
 
 func TestSupervisorStartsCollectorWithRemoteConfig(t *testing.T) {
@@ -320,6 +332,78 @@ func TestSupervisorConfiguresCapabilities(t *testing.T) {
 		cap := capabilities.Load()
 
 		return cap == uint64(protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus)
+	}, 5*time.Second, 250*time.Millisecond)
+}
+
+func TestSupervisorBootstrapsCollector(t *testing.T) {
+	agentDescription := atomic.Value{}
+
+	// Load the Supervisor config so we can get the location of
+	// the Collector that will be run.
+	var cfg config.Supervisor
+	cfgFile := getSupervisorConfig(t, "nocap", map[string]string{})
+	k := koanf.New("::")
+	err := k.Load(file.Provider(cfgFile.Name()), yaml.Parser())
+	require.NoError(t, err)
+	err = k.UnmarshalWithConf("", &cfg, koanf.UnmarshalConf{
+		Tag: "mapstructure",
+	})
+	require.NoError(t, err)
+
+	// Get the binary name and version from the Collector binary
+	// using the `components` command that prints a YAML-encoded
+	// map of information about the Collector build. Some of this
+	// information will be used as defaults for the telemetry
+	// attributes.
+	agentPath := cfg.Agent.Executable
+	componentsInfo, err := exec.Command(agentPath, "components").Output()
+	require.NoError(t, err)
+	k = koanf.New("::")
+	err = k.Load(rawbytes.Provider(componentsInfo), yaml.Parser())
+	require.NoError(t, err)
+	buildinfo := k.StringMap("buildinfo")
+	command := buildinfo["command"]
+	version := buildinfo["version"]
+
+	server := newOpAMPServer(
+		t,
+		defaultConnectingHandler,
+		server.ConnectionCallbacksStruct{
+			OnMessageFunc: func(_ types.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+				if message.AgentDescription != nil {
+					agentDescription.Store(message.AgentDescription)
+				}
+
+				return &protobufs.ServerToAgent{}
+			},
+		})
+
+	s := newSupervisor(t, "nocap", map[string]string{"url": server.addr})
+	defer s.Shutdown()
+
+	waitForSupervisorConnection(server.supervisorConnected, true)
+
+	require.Eventually(t, func() bool {
+		ad, ok := agentDescription.Load().(*protobufs.AgentDescription)
+		if !ok {
+			return false
+		}
+
+		var agentName, agentVersion string
+		identAttr := ad.IdentifyingAttributes
+		for _, attr := range identAttr {
+			switch attr.Key {
+			case semconv.AttributeServiceName:
+				agentName = attr.Value.GetStringValue()
+			case semconv.AttributeServiceVersion:
+				agentVersion = attr.Value.GetStringValue()
+			}
+		}
+
+		// By default the Collector should report its name and version
+		// from the component.BuildInfo struct built into the Collector
+		// binary.
+		return agentName == command && agentVersion == version
 	}, 5*time.Second, 250*time.Millisecond)
 }
 

--- a/cmd/opampsupervisor/go.mod
+++ b/cmd/opampsupervisor/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/open-telemetry/opamp-go v0.10.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector/config/configtls v0.92.1-0.20240110091511-bf804d6c4ecc
+	go.opentelemetry.io/collector/semconv v0.92.1-0.20240110091511-bf804d6c4ecc
 	go.uber.org/zap v1.26.0
 )
 

--- a/cmd/opampsupervisor/go.sum
+++ b/cmd/opampsupervisor/go.sum
@@ -41,8 +41,6 @@ go.opentelemetry.io/collector/config/configopaque v0.92.1-0.20240110091511-bf804
 go.opentelemetry.io/collector/config/configopaque v0.92.1-0.20240110091511-bf804d6c4ecc/go.mod h1:dQK8eUXjIGKaw1RB7UIg2nqx56AueNxeKFCdB0P1ypg=
 go.opentelemetry.io/collector/config/configtls v0.92.1-0.20240110091511-bf804d6c4ecc h1:Md5yyTFQq2uvrVcJuRXQCtIEdJL7VyDxGanWJbzUIDA=
 go.opentelemetry.io/collector/config/configtls v0.92.1-0.20240110091511-bf804d6c4ecc/go.mod h1:rL9BH5Hyrkni4t+QOx/opuwD0CHq/ZIFTsh6QLLsbmA=
-go.opentelemetry.io/collector/semconv v0.91.0 h1:TRd+yDDfKQl+aNtS24wmEbJp1/QE/xAFV9SB5zWGxpE=
-go.opentelemetry.io/collector/semconv v0.91.0/go.mod h1:j/8THcqVxFna1FpvA2zYIsUperEtOaRaqoLYIN4doWw=
 go.opentelemetry.io/collector/semconv v0.92.1-0.20240110091511-bf804d6c4ecc h1:cfooQkd6CO0Q8HLeTFEuYvcN8UjjPsuRJtxmp5OZBA8=
 go.opentelemetry.io/collector/semconv v0.92.1-0.20240110091511-bf804d6c4ecc/go.mod h1:gZ0uzkXsN+J5NpiRcdp9xOhNGQDDui8Y62p15sKrlzo=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/cmd/opampsupervisor/go.sum
+++ b/cmd/opampsupervisor/go.sum
@@ -41,6 +41,10 @@ go.opentelemetry.io/collector/config/configopaque v0.92.1-0.20240110091511-bf804
 go.opentelemetry.io/collector/config/configopaque v0.92.1-0.20240110091511-bf804d6c4ecc/go.mod h1:dQK8eUXjIGKaw1RB7UIg2nqx56AueNxeKFCdB0P1ypg=
 go.opentelemetry.io/collector/config/configtls v0.92.1-0.20240110091511-bf804d6c4ecc h1:Md5yyTFQq2uvrVcJuRXQCtIEdJL7VyDxGanWJbzUIDA=
 go.opentelemetry.io/collector/config/configtls v0.92.1-0.20240110091511-bf804d6c4ecc/go.mod h1:rL9BH5Hyrkni4t+QOx/opuwD0CHq/ZIFTsh6QLLsbmA=
+go.opentelemetry.io/collector/semconv v0.91.0 h1:TRd+yDDfKQl+aNtS24wmEbJp1/QE/xAFV9SB5zWGxpE=
+go.opentelemetry.io/collector/semconv v0.91.0/go.mod h1:j/8THcqVxFna1FpvA2zYIsUperEtOaRaqoLYIN4doWw=
+go.opentelemetry.io/collector/semconv v0.92.1-0.20240110091511-bf804d6c4ecc h1:cfooQkd6CO0Q8HLeTFEuYvcN8UjjPsuRJtxmp5OZBA8=
+go.opentelemetry.io/collector/semconv v0.92.1-0.20240110091511-bf804d6c4ecc/go.mod h1:gZ0uzkXsN+J5NpiRcdp9xOhNGQDDui8Y62p15sKrlzo=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=

--- a/cmd/opampsupervisor/specification/README.md
+++ b/cmd/opampsupervisor/specification/README.md
@@ -220,8 +220,8 @@ configuration.
 To overcome this problem the Supervisor starts the Collector with an
 "noop" configuration that collects nothing but allows the opamp
 extension to be started. The "noop" configuration is a single pipeline
-with a filelog receiver that points to a non-existing file and a logging
-exporter and the opamp extension. The purpose of the "noop"
+with an OTLP receiver that listens on a random port and a debug
+exporter, and the opamp extension. The purpose of the "noop"
 configuration is to make sure the Collector starts and the opamp
 extension communicates with the Supervisor.
 

--- a/cmd/opampsupervisor/supervisor/server.go
+++ b/cmd/opampsupervisor/supervisor/server.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package supervisor
+
+import (
+	"net/http"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/open-telemetry/opamp-go/server"
+	serverTypes "github.com/open-telemetry/opamp-go/server/types"
+)
+
+type flattenedSettings struct {
+	onMessageFunc    func(conn serverTypes.Connection, message *protobufs.AgentToServer)
+	onConnectingFunc func(request *http.Request)
+	endpoint         string
+}
+
+func newServerSettings(fs flattenedSettings) server.StartSettings {
+	return server.StartSettings{
+		Settings: server.Settings{
+			Callbacks: server.CallbacksStruct{
+				OnConnectingFunc: func(request *http.Request) serverTypes.ConnectionResponse {
+					if fs.onConnectingFunc != nil {
+						fs.onConnectingFunc(request)
+					}
+					return serverTypes.ConnectionResponse{
+						Accept: true,
+						ConnectionCallbacks: server.ConnectionCallbacksStruct{
+							OnMessageFunc: func(conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+								if fs.onMessageFunc != nil {
+									fs.onMessageFunc(conn, message)
+								}
+
+								return &protobufs.ServerToAgent{}
+							},
+						},
+					}
+				},
+			},
+		},
+		ListenEndpoint: fs.endpoint,
+	}
+}

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -239,13 +239,12 @@ func (s *Supervisor) getBootstrapInfo() (err error) {
 		},
 		onMessageFunc: func(_ serverTypes.Connection, message *protobufs.AgentToServer) {
 			if message.AgentDescription != nil {
-				instanceIdSeen := false
+				instanceIDSeen := false
 				s.agentDescription = message.AgentDescription
 				identAttr := s.agentDescription.IdentifyingAttributes
 
 				for _, attr := range identAttr {
-					switch attr.Key {
-					case semconv.AttributeServiceInstanceID:
+					if attr.Key == semconv.AttributeServiceInstanceID {
 						// TODO: Consider whether to attempt restarting the Collector.
 						// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29864
 						if attr.Value.GetStringValue() != s.instanceID.String() {
@@ -255,11 +254,11 @@ func (s *Supervisor) getBootstrapInfo() (err error) {
 								s.instanceID.String())
 							return
 						}
-						instanceIdSeen = true
+						instanceIDSeen = true
 					}
 				}
 
-				if !instanceIdSeen {
+				if !instanceIDSeen {
 					done <- errors.New("the Collector did not specify an instance ID in its AgentDescription message")
 					return
 				}
@@ -293,7 +292,7 @@ func (s *Supervisor) getBootstrapInfo() (err error) {
 		} else {
 			return errors.New("collector's OpAMP client never connected to the Supervisor")
 		}
-	case err := <-done:
+	case err = <-done:
 		if err != nil {
 			return err
 		}

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -173,8 +173,7 @@ func NewSupervisor(logger *zap.Logger, configFile string) (*Supervisor, error) {
 
 func (s *Supervisor) createTemplates() error {
 	var err error
-	s.bootstrapTemplate, err = template.New("bootstrap").Parse(bootstrapConfTpl)
-	if err != nil {
+	if s.bootstrapTemplate, err = template.New("bootstrap").Parse(bootstrapConfTpl); err != nil {
 		return err
 	}
 

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -289,6 +289,7 @@ func (s *Supervisor) getBootstrapInfo() (err error) {
 	}
 
 	select {
+	// TODO make timeout configurable
 	case <-time.After(3 * time.Second):
 		if connected.Load() {
 			return errors.New("collector connected but never responded with an AgentDescription message")

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -255,8 +255,10 @@ func (s *Supervisor) getBootstrapInfo() (err error) {
 				for _, attr := range identAttr {
 					switch attr.Key {
 					case semconv.AttributeServiceInstanceID:
+						// TODO Consider this a critical error
+						// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29864
 						if attr.Value.GetStringValue() != s.instanceID.String() {
-							s.logger.Warn(
+							s.logger.Error(
 								"Client's instance ID does not match with the instance ID set by the Supervisor",
 								zap.String("expected", s.instanceID.String()),
 								zap.String("saw", attr.Value.GetStringValue()),

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -173,17 +173,14 @@ func NewSupervisor(logger *zap.Logger, configFile string) (*Supervisor, error) {
 
 func (s *Supervisor) createTemplates() error {
 	var err error
+
 	if s.bootstrapTemplate, err = template.New("bootstrap").Parse(bootstrapConfTpl); err != nil {
 		return err
 	}
-
-	s.extraConfigTemplate, err = template.New("bootstrap").Parse(extraConfigTpl)
-	if err != nil {
+	if s.extraConfigTemplate, err = template.New("extraconfig").Parse(extraConfigTpl); err != nil {
 		return err
 	}
-
-	s.ownTelemetryTemplate, err = template.New("bootstrap").Parse(ownTelemetryTpl)
-	if err != nil {
+	if s.ownTelemetryTemplate, err = template.New("owntelemetry").Parse(ownTelemetryTpl); err != nil {
 		return err
 	}
 

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -36,7 +36,7 @@ func Test_composeEffectiveConfig(t *testing.T) {
 		},
 	}
 
-	s.createTemplates()
+	require.NoError(t, s.createTemplates())
 	s.loadAgentEffectiveConfig()
 
 	configChanged, err := s.composeEffectiveConfig(&protobufs.AgentRemoteConfig{

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -1,0 +1,58 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package supervisor
+
+import (
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func Test_composeEffectiveConfig(t *testing.T) {
+	s := Supervisor{
+		logger:                       zap.NewNop(),
+		hasNewConfig:                 make(chan struct{}, 1),
+		effectiveConfigFilePath:      "effective.yaml",
+		agentConfigOwnMetricsSection: &atomic.Value{},
+		effectiveConfig:              &atomic.Value{},
+		agentHealthCheckEndpoint:     "localhost:8000",
+	}
+
+	s.agentDescription = &protobufs.AgentDescription{
+		IdentifyingAttributes: []*protobufs.KeyValue{
+			{
+				Key: "service.name",
+				Value: &protobufs.AnyValue{
+					Value: &protobufs.AnyValue_StringValue{
+						StringValue: "otelcol",
+					},
+				},
+			},
+		},
+	}
+
+	s.createTemplates()
+	s.loadAgentEffectiveConfig()
+
+	configChanged, err := s.composeEffectiveConfig(&protobufs.AgentRemoteConfig{
+		Config: &protobufs.AgentConfigMap{
+			ConfigMap: map[string]*protobufs.AgentConfigFile{
+				"": {
+					Body: []byte(""),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	expectedConfig, err := os.ReadFile("../testdata/collector/effective_config.yaml")
+	require.NoError(t, err)
+
+	require.True(t, configChanged)
+	require.Equal(t, string(expectedConfig), s.effectiveConfig.Load().(string))
+}

--- a/cmd/opampsupervisor/supervisor/templates/bootstrap.yaml
+++ b/cmd/opampsupervisor/supervisor/templates/bootstrap.yaml
@@ -1,0 +1,24 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "localhost:{{.EndpointPort}}"
+exporters:
+  debug:
+    verbosity: basic
+
+extensions:
+  opamp:
+    instance_uid: "{{.InstanceUid}}"
+    server:
+      ws:
+        endpoint: "ws://localhost:{{.SupervisorPort}}/v1/opamp"
+        tls:
+          insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+  extensions: [opamp]

--- a/cmd/opampsupervisor/supervisor/templates/extraconfig.yaml
+++ b/cmd/opampsupervisor/supervisor/templates/extraconfig.yaml
@@ -1,0 +1,18 @@
+service:
+  telemetry:
+    logs:
+      # Enables JSON log output for the Agent.
+      encoding: json
+    resource:
+      # Set resource attributes required by OpAMP spec.
+      # See https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionidentifying_attributes
+      service.name: "{{.ServiceName}}"
+      service.version: "{{.ServiceVersion}}"
+      service.instance.id: "{{.InstanceId}}"
+
+  # Enable extension to allow the Supervisor to check health.
+  extensions: [health_check]
+
+extensions:
+  health_check:
+    endpoint: "{{.Healthcheck}}"

--- a/cmd/opampsupervisor/supervisor/templates/extraconfig.yaml
+++ b/cmd/opampsupervisor/supervisor/templates/extraconfig.yaml
@@ -4,12 +4,10 @@ service:
       # Enables JSON log output for the Agent.
       encoding: json
     resource:
-      # Set resource attributes required by OpAMP spec.
-      # See https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescriptionidentifying_attributes
-      service.name: "{{.ServiceName}}"
-      service.version: "{{.ServiceVersion}}"
-      service.instance.id: "{{.InstanceId}}"
-
+      # Set resource attributes suggested by the OpAMP spec.
+      # See https://github.com/open-telemetry/opamp-spec/blob/main/specification.md#agentdescription-message
+      {{range $k, $v := .ResourceAttributes}}{{$k}}: "{{$v}}"
+      {{end}}
   # Enable extension to allow the Supervisor to check health.
   extensions: [health_check]
 

--- a/cmd/opampsupervisor/supervisor/templates/owntelemetry.yaml
+++ b/cmd/opampsupervisor/supervisor/templates/owntelemetry.yaml
@@ -1,0 +1,21 @@
+receivers:
+  # Collect own metrics
+  prometheus/own_metrics:
+    config:
+      scrape_configs:
+        - job_name: 'otel-collector'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ['0.0.0.0:{{.PrometheusPort}}']  
+exporters:
+  otlphttp/own_metrics:
+    metrics_endpoint: "{{.MetricsEndpoint}}"
+
+service:
+  telemetry:
+    metrics:
+      address: ":{{.PrometheusPort}}"
+  pipelines:
+    metrics/own_metrics:
+      receivers: [prometheus/own_metrics]
+      exporters: [otlphttp/own_metrics]

--- a/cmd/opampsupervisor/testdata/collector/effective_config.yaml
+++ b/cmd/opampsupervisor/testdata/collector/effective_config.yaml
@@ -1,0 +1,11 @@
+extensions:
+    health_check:
+        endpoint: localhost:8000
+service:
+    extensions:
+        - health_check
+    telemetry:
+        logs:
+            encoding: json
+        resource:
+            service.name: otelcol

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_test.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_test.yaml
@@ -1,0 +1,14 @@
+server:
+  endpoint: wss://127.0.0.1:4320/v1/opamp
+  tls:
+    insecure_skip_verify: true
+
+capabilities:
+  reports_effective_config: true
+  reports_own_metrics: true
+  reports_health: true
+  accepts_remote_config: true
+  reports_remote_config: true
+
+agent:
+  executable: ../../bin/otelcontribcol_darwin_arm64


### PR DESCRIPTION
**Description:**

Utilize the OpAMP extension to get identifying attributes from the Collector.

A few things I want to call out:
* I moved the Supervisor's various config fragments into separate files that are embedded into the binary. I think this makes them easier to edit. I can also move the changes for the existing fragments to a separate PR if it adds too much to the diff.
* I opted to use the OTLP receiver instead of the filelog receiver because it is included in both existing upstream distributions and I expect it is slightly more common. Ideally we should look at other approaches to solve this.

**Link to tracking Issue:**

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21071

**Testing:**

Added an integration test.