### PR TITLE
[chore][CI/CD] Ping code owners fix

### DIFF
--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -14,7 +14,13 @@ get_component_type() {
 }
 
 get_codeowners() {
-  echo "$((grep -m 1 "^${1}/\s" .github/CODEOWNERS || true) | \
+  # grep arguments explained:
+  #   -m 1: Match the first occurrence
+  #   ^: Match from the beginning of the line
+  #   ${1}: Insert first argument given to this function
+  #   [\/]\?: Match 0 or 1 instances of a forward slash
+  #   \s: Match any whitespace character
+  echo "$((grep -m 1 "^${1}[\/]\?\s" .github/CODEOWNERS || true) | \
         sed 's/   */ /g' | \
         cut -f3- -d ' ')"
 }

--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -24,11 +24,11 @@ if [[ -z "${COMPONENT:-}" ]]; then
     exit 1
 fi
 
-COMPONENT_TYPE=$(get_component_type "${COMPONENT}")
-OWNERS="$(get_codeowners "${COMPONENT}${COMPONENT_TYPE}")"
+OWNERS="$(get_codeowners "${COMPONENT}")"
 
 if [[ -z "${OWNERS:-}" ]]; then
-    OWNERS="$(get_codeowners "${COMPONENT}")"
+    COMPONENT_TYPE=$(get_component_type "${COMPONENT}")
+    OWNERS="$(get_codeowners "${COMPONENT}${COMPONENT_TYPE}")"
 fi
 
 echo "${OWNERS}"

--- a/.github/workflows/scripts/get-codeowners.sh
+++ b/.github/workflows/scripts/get-codeowners.sh
@@ -24,17 +24,8 @@ if [[ -z "${COMPONENT:-}" ]]; then
     exit 1
 fi
 
-# grep exits with status code 1 if there are no matches,
-# so we manually set RESULT to 0 if nothing is found.
-RESULT=$(grep -c "${COMPONENT}" .github/CODEOWNERS || true)
-
-# there may be more than 1 component matching a label
-# if so, try to narrow things down by appending the component
-# or a forward slash to the label.
-if [[ ${RESULT} != 1 ]]; then
-    COMPONENT_TYPE=$(get_component_type "${COMPONENT}")
-    OWNERS="$(get_codeowners "${COMPONENT}${COMPONENT_TYPE}")"
-fi
+COMPONENT_TYPE=$(get_component_type "${COMPONENT}")
+OWNERS="$(get_codeowners "${COMPONENT}${COMPONENT_TYPE}")"
 
 if [[ -z "${OWNERS:-}" ]]; then
     OWNERS="$(get_codeowners "${COMPONENT}")"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
A bug was introduced in #29746 where we did an explicit match on the entire component name. This resulted in never having multiple matches for a single component. We only would check for a component type appended to the component if there were multiple results, but we still need to check with the component type appended to the end, regardless of results.

**Testing:** <Describe what testing was performed and which tests were added.>
Found in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29845. I've added every valid component determined by `get-components.sh` to my test, as well as some invalid ones.
```
flaky:
test:
azure:
tools:
cmd/configschema: @mx-psi @dmitryax @pmcollins
cmd/githubgen: @atoulme
cmd/mdatagen: @dmitryax
cmd/opampsupervisor: @evan-bradley @atoulme @tigrannajaryan
cmd/otelcontribcol:
cmd/oteltestbedcol:
cmd/telemetrygen: @mx-psi @codeboten
confmap/provider/s3provider: @Aneurysm9
connector/countconnector: @djaglowski @jpkrohling
connector/datadogconnector: @mx-psi @gbbr @dineshg13
connector/exceptionsconnector: @jpkrohling @marctc
connector/failoverconnector: @djaglowski @fatsheep9146
connector/routingconnector: @jpkrohling @mwear
connector/servicegraphconnector: @jpkrohling @mapno
connector/spanmetricsconnector: @albertteoh
examples/demo: @open-telemetry/collector-approvers
exporter/alertmanagerexporter: @jpkrohling @sokoide @mcube8
exporter/alibabacloudlogserviceexporter: @shabicheng @kongluoxing @qiansheng91
exporter/awscloudwatchlogsexporter: @boostchicken @bryan-aguilar @rapphil
exporter/awsemfexporter: @Aneurysm9 @shaochengwang @mxiamxia @bryan-aguilar
exporter/awskinesisexporter: @Aneurysm9 @MovieStoreGuy
exporter/awss3exporter: @atoulme @pdelewski
exporter/awsxrayexporter: @wangzlei @srprash
exporter/azuredataexplorerexporter: @asaharn @ag-ramachandran
exporter/azuremonitorexporter: @pcwiese
exporter/carbonexporter: @aboguszewski-sumo
exporter/cassandraexporter: @atoulme @emreyalvac
exporter/clickhouseexporter: @hanjm @dmitryax @Frapschen
exporter/coralogixexporter: @povilasv @matej-g
exporter/datadogexporter: @mx-psi @gbbr @dineshg13 @liustanley @songy23 @mackjmr
exporter/datasetexporter: @atoulme @martin-majlis-s1 @zdaratom @tomaz-s1
exporter/dynatraceexporter: @dyladan @arminru @evan-bradley
exporter/elasticsearchexporter: @JaredTan95
exporter/f5cloudexporter: @gramidt
exporter/fileexporter: @atingchen
exporter/googlecloudexporter: @aabmass @dashpole @jsuereth @punya @damemi @psx95
exporter/googlecloudpubsubexporter: @alexvanboxel
exporter/googlemanagedprometheusexporter: @aabmass @dashpole @jsuereth @punya @damemi @psx95
exporter/honeycombmarkerexporter: @TylerHelmuth @fchikwekwe
exporter/influxdbexporter: @jacobmarble
exporter/instanaexporter: @jpkrohling @hickeyma
exporter/kafkaexporter: @pavolloffay @MovieStoreGuy
exporter/kineticaexporter: @am-kinetica @TylerHelmuth
exporter/loadbalancingexporter: @jpkrohling
exporter/logicmonitorexporter: @bogdandrutu @khyatigandhi6 @avadhut123pisal
exporter/logzioexporter: @Doron-Bargo @yotamloe
exporter/lokiexporter: @gramidt @gouthamve @jpkrohling @mar4uk
exporter/mezmoexporter: @dashpole @billmeyer @gjanco
exporter/opencensusexporter: @open-telemetry/collector-approvers
exporter/opensearchexporter: @Aneurysm9 @MitchellGale @MaxKsyunz @YANG-DB
exporter/prometheusexporter: @Aneurysm9
exporter/prometheusremotewriteexporter: @Aneurysm9 @rapphil
exporter/pulsarexporter: @dmitryax @dao-jun
exporter/sapmexporter: @dmitryax @atoulme
exporter/sentryexporter: @AbhiPrasad
exporter/signalfxexporter: @dmitryax @crobert-1
exporter/skywalkingexporter: @liqiangz
exporter/splunkhecexporter: @atoulme @dmitryax
exporter/sumologicexporter: @sumo-drosiek
exporter/syslogexporter: @kkujawa-sumo @rnishtala-sumo @astencel-sumo
exporter/tanzuobservabilityexporter: @oppegard @thepeterstone @keep94
exporter/tencentcloudlogserviceexporter: @wgliang @yiyang5055
exporter/zipkinexporter: @MovieStoreGuy @astencel-sumo @crobert-1
extension/asapauthextension: @jamesmoessis @MovieStoreGuy
extension/awsproxy: @Aneurysm9 @mxiamxia
extension/basicauthextension: @jpkrohling @svrakitin @frzifus
extension/bearertokenauthextension: @jpkrohling @frzifus
extension/encoding: @atoulme @dao-jun @dmitryax @MovieStoreGuy @VihasMakwana
extension/encoding/jaegerencodingextension: @MovieStoreGuy @atoulme
extension/encoding/jsonlogencodingextension: @VihasMakwana @atoulme
extension/encoding/otlpencodingextension: @dao-jun @VihasMakwana
extension/encoding/textencodingextension: @MovieStoreGuy @atoulme
extension/encoding/zipkinencodingextension: @MovieStoreGuy @dao-jun
extension/headerssetterextension: @jpkrohling
extension/healthcheckextension: @jpkrohling
extension/httpforwarder: @atoulme @rmfitzpatrick
extension/jaegerremotesampling: @yurishkuro @frzifus
extension/oauth2clientauthextension: @pavankrish123 @jpkrohling
extension/observer: @dmitryax @rmfitzpatrick
extension/observer/dockerobserver: @MovieStoreGuy
extension/observer/ecsobserver: @dmitryax @rmfitzpatrick
extension/observer/ecstaskobserver: @rmfitzpatrick
extension/observer/hostobserver: @MovieStoreGuy
extension/observer/k8sobserver: @rmfitzpatrick @dmitryax
extension/oidcauthextension: @jpkrohling
extension/opampextension: @portertech @evan-bradley @tigrannajaryan
extension/pprofextension: @MovieStoreGuy
extension/remotetapextension: @atoulme
extension/sigv4authextension: @Aneurysm9 @erichsueh3
extension/storage: @dmitryax @atoulme @djaglowski
extension/storage/dbstorage: @dmitryax @atoulme
extension/storage/filestorage: @djaglowski
internal/aws: @Aneurysm9 @mxiamxia
internal/collectd: @atoulme
internal/coreinternal: @open-telemetry/collector-approvers
internal/datadog: @mx-psi @gbbr @dineshg13
internal/docker: @rmfitzpatrick @jamesmoessis
internal/filter: @open-telemetry/collector-approvers
internal/k8sconfig: @dmitryax
internal/k8stest: @crobert-1
internal/kafka: @pavolloffay @MovieStoreGuy
internal/kubelet: @dmitryax
internal/metadataproviders: @Aneurysm9 @dashpole
internal/sharedcomponent: @open-telemetry/collector-approvers
internal/splunk: @dmitryax
internal/tools:
pkg/batchperresourceattr: @atoulme @dmitryax
pkg/batchpersignal: @jpkrohling
pkg/experimentalmetricmetadata: @rmfitzpatrick
pkg/golden: @djaglowski @atoulme
pkg/ottl: @TylerHelmuth @kentquirk @bogdandrutu @evan-bradley
pkg/pdatatest: @djaglowski @fatsheep9146
pkg/pdatautil: @dmitryax
pkg/resourcetotelemetry: @mx-psi
pkg/stanza: @djaglowski
pkg/translator/azure: @open-telemetry/collector-approvers @atoulme @cparkins
pkg/translator/jaeger: @open-telemetry/collector-approvers @frzifus
pkg/translator/loki: @gouthamve @jpkrohling @mar4uk
pkg/translator/opencensus: @open-telemetry/collector-approvers
pkg/translator/prometheus: @dashpole @bertysentry
pkg/translator/prometheusremotewrite: @Aneurysm9
pkg/translator/signalfx: @dmitryax
pkg/translator/skywalking: @JaredTan95
pkg/translator/zipkin: @MovieStoreGuy @astencel-sumo @crobert-1
pkg/winperfcounters: @dashpole @Mrod1598 @BinaryFissionGames
processor/attributesprocessor: @boostchicken
processor/cumulativetodeltaprocessor: @TylerHelmuth
processor/datadogprocessor: @mx-psi @gbbr @dineshg13
processor/deltatorateprocessor: @Aneurysm9
processor/filterprocessor: @TylerHelmuth @boostchicken
processor/groupbyattrsprocessor: @rnishtala-sumo
processor/groupbytraceprocessor: @jpkrohling
processor/k8sattributesprocessor: @dmitryax @rmfitzpatrick @fatsheep9146 @TylerHelmuth
processor/logstransformprocessor: @djaglowski @dehaansa
processor/metricsgenerationprocessor: @Aneurysm9
processor/metricstransformprocessor: @dmitryax
processor/probabilisticsamplerprocessor: @jpkrohling
processor/redactionprocessor: @leonsp-ai @dmitryax @mx-psi @TylerHelmuth
processor/remotetapprocessor: @pmcollins
processor/resourcedetectionprocessor: @Aneurysm9 @dashpole
processor/resourcedetectionprocessor/internal/azure: @mx-psi
processor/resourcedetectionprocessor/internal/heroku: @atoulme
processor/resourcedetectionprocessor/internal/openshift: @frzifus
processor/resourceprocessor: @dmitryax
processor/routingprocessor: @jpkrohling
processor/schemaprocessor: @MovieStoreGuy
processor/servicegraphprocessor: @jpkrohling @mapno
processor/spanmetricsprocessor: @albertteoh
processor/spanprocessor: @boostchicken
processor/sumologicprocessor: @aboguszewski-sumo @astencel-sumo @sumo-drosiek
processor/tailsamplingprocessor: @jpkrohling
processor/transformprocessor: @TylerHelmuth @kentquirk @bogdandrutu @evan-bradley
receiver/activedirectorydsreceiver: @djaglowski @BinaryFissionGames
receiver/aerospikereceiver: @djaglowski @antonblock
receiver/apachereceiver: @djaglowski
receiver/apachesparkreceiver: @djaglowski @Caleb-Hurshman @mrsillydog
receiver/awscloudwatchmetricsreceiver: @jpkrohling
receiver/awscloudwatchreceiver: @djaglowski @schmikei
receiver/awscontainerinsightreceiver: @Aneurysm9 @pxaws
receiver/awsecscontainermetricsreceiver: @Aneurysm9
receiver/awsfirehosereceiver: @Aneurysm9
receiver/awsxrayreceiver: @wangzlei @srprash
receiver/azureblobreceiver: @eedorenko @mx-psi
receiver/azureeventhubreceiver: @atoulme @djaglowski
receiver/azuremonitorreceiver: @altuner @codeboten
receiver/bigipreceiver: @djaglowski @StefanKurek
receiver/carbonreceiver: @aboguszewski-sumo
receiver/chronyreceiver: @MovieStoreGuy @jamesmoessis
receiver/cloudflarereceiver: @dehaansa @djaglowski
receiver/cloudfoundryreceiver: @agoallikmaa @pellared @crobert-1
receiver/collectdreceiver: @atoulme
receiver/couchdbreceiver: @djaglowski
receiver/datadogreceiver: @boostchicken @gouthamve @jpkrohling @MovieStoreGuy
receiver/dockerstatsreceiver: @rmfitzpatrick @jamesmoessis
receiver/elasticsearchreceiver: @djaglowski @BinaryFissionGames
receiver/expvarreceiver: @jamesmoessis @MovieStoreGuy
receiver/filelogreceiver: @djaglowski
receiver/filereceiver: @pmcollins @djaglowski
receiver/filestatsreceiver: @atoulme
receiver/flinkmetricsreceiver: @JonathanWamsley @djaglowski
receiver/fluentforwardreceiver: @dmitryax
receiver/gitproviderreceiver: @adrielp @astencel-sumo
receiver/googlecloudpubsubreceiver: @alexvanboxel
receiver/googlecloudspannerreceiver: @architjugran @varunraiko @kiranmayib
receiver/haproxyreceiver: @atoulme @MovieStoreGuy
receiver/hostmetricsreceiver: @dmitryax @braydonk
receiver/httpcheckreceiver: @codeboten
receiver/iisreceiver: @Mrod1598 @djaglowski
receiver/influxdbreceiver: @jacobmarble
receiver/jaegerreceiver: @yurishkuro
receiver/jmxreceiver: @rmfitzpatrick
receiver/journaldreceiver: @sumo-drosiek @djaglowski
receiver/k8sclusterreceiver: @dmitryax @TylerHelmuth @povilasv
receiver/k8seventsreceiver: @dmitryax @TylerHelmuth
receiver/k8sobjectsreceiver: @dmitryax @hvaghani221 @TylerHelmuth
receiver/kafkametricsreceiver: @dmitryax
receiver/kafkareceiver: @pavolloffay @MovieStoreGuy
receiver/kubeletstatsreceiver: @dmitryax @TylerHelmuth
receiver/lokireceiver: @mar4uk @jpkrohling
receiver/memcachedreceiver: @djaglowski
receiver/mongodbatlasreceiver: @djaglowski @schmikei
receiver/mongodbreceiver: @djaglowski @schmikei
receiver/mysqlreceiver: @djaglowski
receiver/nginxreceiver: @djaglowski
receiver/nsxtreceiver: @dashpole @schmikei
receiver/opencensusreceiver: @open-telemetry/collector-approvers
receiver/oracledbreceiver: @dmitryax @crobert-1 @atoulme
receiver/otlpjsonfilereceiver: @djaglowski @atoulme
receiver/podmanreceiver: @rogercoll
receiver/postgresqlreceiver: @djaglowski
receiver/prometheusreceiver: @Aneurysm9 @dashpole
receiver/pulsarreceiver: @dmitryax @dao-jun
receiver/purefareceiver: @jpkrohling @dgoscn @chrroberts-pure
receiver/purefbreceiver: @jpkrohling @dgoscn @chrroberts-pure
receiver/rabbitmqreceiver: @djaglowski @cpheps
receiver/receivercreator: @rmfitzpatrick
receiver/redisreceiver: @dmitryax @hughesjj
receiver/riakreceiver: @djaglowski @armstrmi
receiver/saphanareceiver: @dehaansa
receiver/sapmreceiver: @atoulme
receiver/signalfxreceiver: @dmitryax
receiver/simpleprometheusreceiver: @fatsheep9146
receiver/skywalkingreceiver: @JaredTan95
receiver/snmpreceiver: @djaglowski @StefanKurek @tamir-michaeli
receiver/snowflakereceiver: @dmitryax @shalper2
receiver/solacereceiver: @djaglowski @mcardy
receiver/splunkenterprisereceiver: @shalper2 @MovieStoreGuy @greatestusername
receiver/splunkhecreceiver: @atoulme
receiver/sqlqueryreceiver: @dmitryax @pmcollins
receiver/sqlserverreceiver: @djaglowski @StefanKurek
receiver/sshcheckreceiver: @nslaughter @codeboten
receiver/statsdreceiver: @jmacd @dmitryax
receiver/syslogreceiver: @djaglowski
receiver/tcplogreceiver: @djaglowski
receiver/udplogreceiver: @djaglowski
receiver/vcenterreceiver: @djaglowski @schmikei
receiver/wavefrontreceiver: @samiura
receiver/webhookeventreceiver: @atoulme @shalper2
receiver/windowseventlogreceiver: @djaglowski @armstrmi @pjanotti
receiver/windowsperfcountersreceiver: @dashpole
receiver/zipkinreceiver: @MovieStoreGuy @astencel-sumo @crobert-1
receiver/zookeeperreceiver: @djaglowski
testbed: @open-telemetry/collector-approvers
testbed/mockdatareceivers/mockawsxrayreceiver: @wangzlei @srprash
testbed/mockdatasenders/mockdatadogagentexporter: @boostchicken
reports/distributions/core.yaml:
reports/distributions/contrib.yaml:
reports/distributions/aws.yaml:
reports/distributions/grafana.yaml:
reports/distributions/observiq.yaml:
reports/distributions/redhat.yaml:
reports/distributions/splunk.yaml: @atoulme @crobert-1 @dmitryax @hughesjj @jeffreyc-splunk @jinja2 @jvoravong @panotti @rmfitzpatrick @samiura
reports/distributions/sumo.yaml:
reports/distributions/liatrio.yaml:
```