### PR TITLE
[chore] improve conversion performance for carbonexporter

### DIFF
--- a/exporter/carbonexporter/exporter_test.go
+++ b/exporter/carbonexporter/exporter_test.go
@@ -52,7 +52,7 @@ func TestConsumeMetricsNoServer(t *testing.T) {
 
 func TestConsumeMetricsWithResourceToTelemetry(t *testing.T) {
 	addr := testutil.GetAvailableLocalAddress(t)
-	cs := newCarbonServer(t, addr, "test_0;k0=v0;k1=v1;service.name=test_carbon 0")
+	cs := newCarbonServer(t, addr, "test_0;key_0=value_0;key_1=value_1;key_2=value_2;service.name=carbon 0")
 	// Each metric point will generate one Carbon line, set up the wait
 	// for all of them.
 	cs.start(t, 1)
@@ -166,15 +166,16 @@ func generateMetricsBatch(size int) pmetric.Metrics {
 	ts := time.Now()
 	metrics := pmetric.NewMetrics()
 	rm := metrics.ResourceMetrics().AppendEmpty()
-	rm.Resource().Attributes().PutStr(conventions.AttributeServiceName, "test_carbon")
+	rm.Resource().Attributes().PutStr(conventions.AttributeServiceName, "carbon")
 	ms := rm.ScopeMetrics().AppendEmpty().Metrics()
 
 	for i := 0; i < size; i++ {
 		m := ms.AppendEmpty()
 		m.SetName("test_" + strconv.Itoa(i))
 		dp := m.SetEmptyGauge().DataPoints().AppendEmpty()
-		dp.Attributes().PutStr("k0", "v0")
-		dp.Attributes().PutStr("k1", "v1")
+		dp.Attributes().PutStr("key_0", "value_0")
+		dp.Attributes().PutStr("key_1", "value_1")
+		dp.Attributes().PutStr("key_2", "value_2")
 		dp.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 		dp.SetIntValue(int64(i))
 	}

--- a/exporter/carbonexporter/metricdata_to_plaintext.go
+++ b/exporter/carbonexporter/metricdata_to_plaintext.go
@@ -4,8 +4,10 @@
 package carbonexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter"
 
 import (
+	"bytes"
 	"strconv"
 	"strings"
+	"sync"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -19,6 +21,8 @@ const (
 	tagPrefix                = ";"
 	tagKeyValueSeparator     = "="
 	tagValueEmptyPlaceholder = "<empty>"
+	tagLineEmptySpace        = " "
+	tagLineNewLine           = "\n"
 
 	// Constants used when converting from distribution metrics to Carbon format.
 	distributionBucketSuffix             = ".bucket"
@@ -38,6 +42,13 @@ const (
 	// positive infinity as represented in Python.
 	infinityCarbonValue = "inf"
 )
+
+var writerPool = sync.Pool{
+	New: func() any {
+		// Start with a buffer of 1KB.
+		return bytes.NewBuffer(make([]byte, 0, 1024))
+	},
+}
 
 // metricDataToPlaintext converts internal metrics data to the Carbon plaintext
 // format as defined in https://graphite.readthedocs.io/en/latest/feeding-carbon.html#the-plaintext-protocol)
@@ -73,7 +84,9 @@ func metricDataToPlaintext(md pmetric.Metrics) string {
 		return ""
 	}
 
-	var sb strings.Builder
+	buf := writerPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer writerPool.Put(buf)
 
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
 		rm := md.ResourceMetrics().At(i)
@@ -87,22 +100,22 @@ func metricDataToPlaintext(md pmetric.Metrics) string {
 				}
 				switch metric.Type() {
 				case pmetric.MetricTypeGauge:
-					formatNumberDataPoints(&sb, metric.Name(), metric.Gauge().DataPoints())
+					writeNumberDataPoints(buf, metric.Name(), metric.Gauge().DataPoints())
 				case pmetric.MetricTypeSum:
-					formatNumberDataPoints(&sb, metric.Name(), metric.Sum().DataPoints())
+					writeNumberDataPoints(buf, metric.Name(), metric.Sum().DataPoints())
 				case pmetric.MetricTypeHistogram:
-					formatHistogramDataPoints(&sb, metric.Name(), metric.Histogram().DataPoints())
+					formatHistogramDataPoints(buf, metric.Name(), metric.Histogram().DataPoints())
 				case pmetric.MetricTypeSummary:
-					formatSummaryDataPoints(&sb, metric.Name(), metric.Summary().DataPoints())
+					formatSummaryDataPoints(buf, metric.Name(), metric.Summary().DataPoints())
 				}
 			}
 		}
 	}
 
-	return sb.String()
+	return buf.String()
 }
 
-func formatNumberDataPoints(sb *strings.Builder, metricName string, dps pmetric.NumberDataPointSlice) {
+func writeNumberDataPoints(buf *bytes.Buffer, metricName string, dps pmetric.NumberDataPointSlice) {
 	for i := 0; i < dps.Len(); i++ {
 		dp := dps.At(i)
 		var valueStr string
@@ -112,7 +125,11 @@ func formatNumberDataPoints(sb *strings.Builder, metricName string, dps pmetric.
 		case pmetric.NumberDataPointValueTypeDouble:
 			valueStr = formatFloatForValue(dp.DoubleValue())
 		}
-		sb.WriteString(buildLine(buildPath(metricName, dp.Attributes()), valueStr, formatTimestamp(dp.Timestamp())))
+		writeLine(
+			buf,
+			buildPath(metricName, dp.Attributes()),
+			valueStr,
+			formatTimestamp(dp.Timestamp()))
 	}
 }
 
@@ -131,7 +148,7 @@ func formatNumberDataPoints(sb *strings.Builder, metricName string, dps pmetric.
 // that bucket. This metric specifies the number of events with a value that is
 // less than or equal to the upper bound.
 func formatHistogramDataPoints(
-	sb *strings.Builder,
+	buf *bytes.Buffer,
 	metricName string,
 	dps pmetric.HistogramDataPointSlice,
 ) {
@@ -139,7 +156,7 @@ func formatHistogramDataPoints(
 		dp := dps.At(i)
 
 		timestampStr := formatTimestamp(dp.Timestamp())
-		formatCountAndSum(sb, metricName, dp.Attributes(), dp.Count(), dp.Sum(), timestampStr)
+		formatCountAndSum(buf, metricName, dp.Attributes(), dp.Count(), dp.Sum(), timestampStr)
 		if dp.ExplicitBounds().Len() == 0 {
 			continue
 		}
@@ -153,7 +170,11 @@ func formatHistogramDataPoints(
 
 		bucketPath := buildPath(metricName+distributionBucketSuffix, dp.Attributes())
 		for j := 0; j < dp.BucketCounts().Len(); j++ {
-			sb.WriteString(buildLine(bucketPath+distributionUpperBoundTagBeforeValue+carbonBounds[j], formatUint64(dp.BucketCounts().At(j)), timestampStr))
+			writeLine(
+				buf,
+				bucketPath+distributionUpperBoundTagBeforeValue+carbonBounds[j],
+				formatUint64(dp.BucketCounts().At(j)),
+				timestampStr)
 		}
 	}
 }
@@ -171,7 +192,7 @@ func formatHistogramDataPoints(
 // 3. Each quantile is represented by a metric named "<metricName>.quantile"
 // and will include a tag key "quantile" that specifies the quantile value.
 func formatSummaryDataPoints(
-	sb *strings.Builder,
+	buf *bytes.Buffer,
 	metricName string,
 	dps pmetric.SummaryDataPointSlice,
 ) {
@@ -179,7 +200,7 @@ func formatSummaryDataPoints(
 		dp := dps.At(i)
 
 		timestampStr := formatTimestamp(dp.Timestamp())
-		formatCountAndSum(sb, metricName, dp.Attributes(), dp.Count(), dp.Sum(), timestampStr)
+		formatCountAndSum(buf, metricName, dp.Attributes(), dp.Count(), dp.Sum(), timestampStr)
 
 		if dp.QuantileValues().Len() == 0 {
 			continue
@@ -187,10 +208,11 @@ func formatSummaryDataPoints(
 
 		quantilePath := buildPath(metricName+summaryQuantileSuffix, dp.Attributes())
 		for j := 0; j < dp.QuantileValues().Len(); j++ {
-			sb.WriteString(buildLine(
+			writeLine(
+				buf,
 				quantilePath+summaryQuantileTagBeforeValue+formatFloatForLabel(dp.QuantileValues().At(j).Quantile()*100),
 				formatFloatForValue(dp.QuantileValues().At(j).Value()),
-				timestampStr))
+				timestampStr)
 		}
 	}
 }
@@ -203,21 +225,25 @@ func formatSummaryDataPoints(
 //
 // 2. The total sum will be represented by a metruc with the original "<metricName>".
 func formatCountAndSum(
-	sb *strings.Builder,
+	buf *bytes.Buffer,
 	metricName string,
 	attributes pcommon.Map,
 	count uint64,
 	sum float64,
 	timestampStr string,
 ) {
-	// Build count and sum metrics.
-	countPath := buildPath(metricName+countSuffix, attributes)
-	valueStr := formatUint64(count)
-	sb.WriteString(buildLine(countPath, valueStr, timestampStr))
+	// Write count and sum metrics.
+	writeLine(
+		buf,
+		buildPath(metricName+countSuffix, attributes),
+		formatUint64(count),
+		timestampStr)
 
-	sumPath := buildPath(metricName, attributes)
-	valueStr = formatFloatForValue(sum)
-	sb.WriteString(buildLine(sumPath, valueStr, timestampStr))
+	writeLine(
+		buf,
+		buildPath(metricName, attributes),
+		formatFloatForValue(sum),
+		timestampStr)
 }
 
 // buildPath is used to build the <metric_path> per description above.
@@ -226,25 +252,35 @@ func buildPath(name string, attributes pcommon.Map) string {
 		return name
 	}
 
-	var sb strings.Builder
-	sb.WriteString(name)
+	buf := writerPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer writerPool.Put(buf)
 
+	buf.WriteString(name)
 	attributes.Range(func(k string, v pcommon.Value) bool {
 		value := v.AsString()
 		if value == "" {
 			value = tagValueEmptyPlaceholder
 		}
-		sb.WriteString(tagPrefix + sanitizeTagKey(k) + tagKeyValueSeparator + value)
+		buf.WriteString(tagPrefix)
+		buf.WriteString(sanitizeTagKey(k))
+		buf.WriteString(tagKeyValueSeparator)
+		buf.WriteString(value)
 		return true
 	})
 
-	return sb.String()
+	return buf.String()
 }
 
-// buildLine builds a single Carbon metric textual line, ie.: it already adds
+// writeLine builds a single Carbon metric textual line, ie.: it already adds
 // a new-line character at the end of the string.
-func buildLine(path, value, timestamp string) string {
-	return path + " " + value + " " + timestamp + "\n"
+func writeLine(buf *bytes.Buffer, path, value, timestamp string) {
+	buf.WriteString(path)
+	buf.WriteString(tagLineEmptySpace)
+	buf.WriteString(value)
+	buf.WriteString(tagLineEmptySpace)
+	buf.WriteString(timestamp)
+	buf.WriteString(tagLineNewLine)
 }
 
 // sanitizeTagKey removes any invalid character from the tag key, the invalid

--- a/exporter/carbonexporter/metricdata_to_plaintext_test.go
+++ b/exporter/carbonexporter/metricdata_to_plaintext_test.go
@@ -331,3 +331,12 @@ func expectedSummaryLines(
 	}
 	return lines
 }
+
+func BenchmarkConsumeMetricsDefault(b *testing.B) {
+	md := generateSmallBatch()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		assert.Len(b, metricDataToPlaintext(md), 62)
+	}
+}


### PR DESCRIPTION
**Before:**
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter
BenchmarkConsumeMetricsDefault
BenchmarkConsumeMetricsDefault-12    	 2372212	       489.7 ns/op	     240 B/op	       7 allocs/op
PASS
```

**After:**
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter
BenchmarkConsumeMetricsDefault
BenchmarkConsumeMetricsDefault-12    	 2658386	       434.7 ns/op	     144 B/op	       4 allocs/op
PASS
```