### PR TITLE
[chore] make e2e tests more resilient

### DIFF
--- a/processor/k8sattributesprocessor/testdata/e2e/collector/deployment.yaml
+++ b/processor/k8sattributesprocessor/testdata/e2e/collector/deployment.yaml
@@ -37,10 +37,14 @@ spec:
             httpGet:
               path: /
               port: 13133
+            initialDelaySeconds: 3
+            periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /
               port: 13133
+            initialDelaySeconds: 3
+            periodSeconds: 3
           resources:
             limits:
               cpu: 128m

--- a/receiver/k8sclusterreceiver/testdata/e2e/collector/configmap.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/collector/configmap.yaml
@@ -15,6 +15,7 @@ data:
     processors:
     receivers:
       k8s_cluster:
+        collection_interval: 1s
         
     service:
       telemetry:

--- a/receiver/k8sclusterreceiver/testdata/e2e/collector/deployment.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/collector/deployment.yaml
@@ -37,10 +37,14 @@ spec:
             httpGet:
               path: /
               port: 13133
+            initialDelaySeconds: 3
+            periodSeconds: 3
           readinessProbe:
             httpGet:
               path: /
               port: 13133
+            initialDelaySeconds: 3
+            periodSeconds: 3
           resources:
             limits:
               cpu: 128m


### PR DESCRIPTION
This PR does 2 things for both k8scluster and k8sattributes tests:
* Define and start the OTLP sink before the collector starts. This avoids getting connection errors and possibly issues in the logs which appear as red herrings. With substantial backoffs, this may also cause data from being transmitted in the time window of the test.
* Run those sinks and close them *after* the collector is removed. This way we also avoid noise in the logs about the sink being gone.
* Run the readiness and liveness probes with a period and initial delay: this is probably the real fix. When waiting a bit more and trying a few times, the collector has had time to come online.

Additionally, this PR changes the collection_interval to 1s for k8sclusterreceiver tests.