### PR TITLE
[pkg/ottl] Implement Path/Key interfaces

### DIFF
--- a/.chloggen/ottl-update-to-use-new-paths.yaml
+++ b/.chloggen/ottl-update-to-use-new-paths.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change `Path` to be an Interface instead of the grammar struct.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29897]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Affects creators of custom contexts.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/ottl/boolean_value_test.go
+++ b/pkg/ottl/boolean_value_test.go
@@ -28,8 +28,8 @@ func valueFor(x any) value {
 		case v == "NAME":
 			// if the string is NAME construct a path of "name".
 			val.Literal = &mathExprLiteral{
-				Path: &Path{
-					Fields: []Field{
+				Path: &path{
+					Fields: []field{
 						{
 							Name: "name",
 						},
@@ -41,8 +41,8 @@ func valueFor(x any) value {
 			val.Enum = (*EnumSymbol)(ottltest.Strp(v))
 		case v == "dur1" || v == "dur2":
 			val.Literal = &mathExprLiteral{
-				Path: &Path{
-					Fields: []Field{
+				Path: &path{
+					Fields: []field{
 						{
 							Name: v,
 						},
@@ -51,8 +51,8 @@ func valueFor(x any) value {
 			}
 		case v == "time1" || v == "time2":
 			val.Literal = &mathExprLiteral{
-				Path: &Path{
-					Fields: []Field{
+				Path: &path{
+					Fields: []field{
 						{
 							Name: v,
 						},
@@ -93,7 +93,7 @@ func comparisonHelper(left any, right any, op string) *comparison {
 func Test_newComparisonEvaluator(t *testing.T) {
 	p, _ := NewParser(
 		defaultFunctionsForTests(),
-		testParsePath,
+		testParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)
@@ -185,7 +185,7 @@ func Test_newComparisonEvaluator(t *testing.T) {
 func Test_newConditionEvaluator_invalid(t *testing.T) {
 	p, _ := NewParser(
 		defaultFunctionsForTests(),
-		testParsePath,
+		testParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)
@@ -195,7 +195,7 @@ func Test_newConditionEvaluator_invalid(t *testing.T) {
 		comparison *comparison
 	}{
 		{
-			name: "unknown Path",
+			name: "unknown path",
 			comparison: &comparison{
 				Left: value{
 					Enum: (*EnumSymbol)(ottltest.Strp("SYMBOL_NOT_FOUND")),
@@ -233,7 +233,7 @@ func Test_newBooleanExpressionEvaluator(t *testing.T) {
 
 	p, _ := NewParser(
 		functions,
-		testParsePath,
+		testParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)
@@ -616,7 +616,7 @@ func Test_newBooleanExpressionEvaluator_invalid(t *testing.T) {
 
 	p, _ := NewParser(
 		functions,
-		testParsePath,
+		testParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)

--- a/pkg/ottl/contexts/internal/map.go
+++ b/pkg/ottl/contexts/internal/map.go
@@ -4,6 +4,7 @@
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 
 import (
+	"context"
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -11,33 +12,43 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func GetMapValue(m pcommon.Map, keys []ottl.Key) (any, error) {
-	if len(keys) == 0 {
+func GetMapValue[K any](ctx context.Context, tCtx K, m pcommon.Map, key ottl.Key[K]) (any, error) {
+	if key == nil {
 		return nil, fmt.Errorf("cannot get map value without key")
 	}
-	if keys[0].String == nil {
+
+	s, err := key.String(ctx, tCtx)
+	if err != nil {
+		return nil, err
+	}
+	if s == nil {
 		return nil, fmt.Errorf("non-string indexing is not supported")
 	}
 
-	val, ok := m.Get(*keys[0].String)
+	val, ok := m.Get(*s)
 	if !ok {
 		return nil, nil
 	}
-	return getIndexableValue(val, keys[1:])
+
+	return getIndexableValue[K](ctx, tCtx, val, key.Next())
 }
 
-func SetMapValue(m pcommon.Map, keys []ottl.Key, val any) error {
-	if len(keys) == 0 {
-		return fmt.Errorf("cannot set map value without key")
-	}
-	if keys[0].String == nil {
+func SetMapValue[K any](ctx context.Context, tCtx K, m pcommon.Map, key ottl.Key[K], val any) error {
+	if key == nil {
 		return fmt.Errorf("non-string indexing is not supported")
 	}
 
-	currentValue, ok := m.Get(*keys[0].String)
-	if !ok {
-		currentValue = m.PutEmpty(*keys[0].String)
+	s, err := key.String(ctx, tCtx)
+	if err != nil {
+		return err
+	}
+	if s == nil {
+		return fmt.Errorf("non-string indexing is not supported")
 	}
 
-	return setIndexableValue(currentValue, val, keys[1:])
+	currentValue, ok := m.Get(*s)
+	if !ok {
+		currentValue = m.PutEmpty(*s)
+	}
+	return setIndexableValue[K](ctx, tCtx, currentValue, val, key.Next())
 }

--- a/pkg/ottl/contexts/internal/map.go
+++ b/pkg/ottl/contexts/internal/map.go
@@ -35,7 +35,7 @@ func GetMapValue[K any](ctx context.Context, tCtx K, m pcommon.Map, key ottl.Key
 
 func SetMapValue[K any](ctx context.Context, tCtx K, m pcommon.Map, key ottl.Key[K], val any) error {
 	if key == nil {
-		return fmt.Errorf("non-string indexing is not supported")
+		return fmt.Errorf("cannot set map value without key")
 	}
 
 	s, err := key.String(ctx, tCtx)

--- a/pkg/ottl/contexts/internal/map_test.go
+++ b/pkg/ottl/contexts/internal/map_test.go
@@ -4,92 +4,76 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
 func Test_GetMapValue_Invalid(t *testing.T) {
 	tests := []struct {
 		name string
-		keys []ottl.Key
+		keys *TestKey[any]
 		err  error
 	}{
 		{
-			name: "no keys",
-			keys: []ottl.Key{},
-			err:  fmt.Errorf("cannot get map value without key"),
-		},
-		{
 			name: "first key not a string",
-			keys: []ottl.Key{
-				{
-					Int: ottltest.Intp(0),
-				},
+			keys: &TestKey[any]{
+				I: ottltest.Intp(0),
 			},
 			err: fmt.Errorf("non-string indexing is not supported"),
 		},
 		{
 			name: "index map with int",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("map"),
-				},
-				{
-					Int: ottltest.Intp(0),
+			keys: &TestKey[any]{
+				S: ottltest.Strp("map"),
+				NextKey: &TestKey[any]{
+					I: ottltest.Intp(0),
 				},
 			},
 			err: fmt.Errorf("map must be indexed by a string"),
 		},
 		{
 			name: "index slice with string",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("slice"),
-				},
-				{
-					String: ottltest.Strp("invalid"),
+			keys: &TestKey[any]{
+
+				S: ottltest.Strp("slice"),
+				NextKey: &TestKey[any]{
+					S: ottltest.Strp("invalid"),
 				},
 			},
 			err: fmt.Errorf("slice must be indexed by an int"),
 		},
 		{
 			name: "index too large",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("slice"),
-				},
-				{
-					Int: ottltest.Intp(1),
+			keys: &TestKey[any]{
+				S: ottltest.Strp("slice"),
+				NextKey: &TestKey[any]{
+					I: ottltest.Intp(1),
 				},
 			},
 			err: fmt.Errorf("index 1 out of bounds"),
 		},
 		{
 			name: "index too small",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("slice"),
-				},
-				{
-					Int: ottltest.Intp(-1),
+			keys: &TestKey[any]{
+				S: ottltest.Strp("slice"),
+				NextKey: &TestKey[any]{
+					I: ottltest.Intp(-1),
 				},
 			},
 			err: fmt.Errorf("index -1 out of bounds"),
 		},
 		{
 			name: "invalid type",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("string"),
-				},
-				{
-					String: ottltest.Strp("string"),
+			keys: &TestKey[any]{
+				S: ottltest.Strp("string"),
+				NextKey: &TestKey[any]{
+					S: ottltest.Strp("string"),
 				},
 			},
 			err: fmt.Errorf("type Str does not support string indexing"),
@@ -105,7 +89,7 @@ func Test_GetMapValue_Invalid(t *testing.T) {
 			s := m.PutEmptySlice("slice")
 			s.AppendEmpty()
 
-			_, err := GetMapValue(m, tt.keys)
+			_, err := GetMapValue[any](context.Background(), nil, m, tt.keys)
 			assert.Equal(t, tt.err, err)
 		})
 	}
@@ -114,95 +98,81 @@ func Test_GetMapValue_Invalid(t *testing.T) {
 func Test_GetMapValue_MissingKey(t *testing.T) {
 	m := pcommon.NewMap()
 	m.PutEmptyMap("map1").PutEmptyMap("map2")
-	keys := []ottl.Key{
-		{
-			String: ottltest.Strp("map1"),
-		},
-		{
-			String: ottltest.Strp("unknown key"),
+	keys := TestKey[any]{
+		S: ottltest.Strp("map1"),
+		NextKey: &TestKey[any]{
+			S: ottltest.Strp("unknown key"),
 		},
 	}
-	result, err := GetMapValue(m, keys)
+	result, err := GetMapValue[any](context.Background(), nil, m, &keys)
 	assert.Nil(t, err)
 	assert.Nil(t, result)
+}
+
+func Test_GetMapValue_NilKey(t *testing.T) {
+	_, err := GetMapValue[any](context.Background(), nil, pcommon.NewMap(), nil)
+	assert.Error(t, err)
 }
 
 func Test_SetMapValue_Invalid(t *testing.T) {
 	tests := []struct {
 		name string
-		keys []ottl.Key
+		keys *TestKey[any]
 		err  error
 	}{
 		{
-			name: "no keys",
-			keys: []ottl.Key{},
-			err:  fmt.Errorf("cannot set map value without key"),
-		},
-		{
 			name: "first key not a string",
-			keys: []ottl.Key{
-				{
-					Int: ottltest.Intp(0),
-				},
+			keys: &TestKey[any]{
+				I: ottltest.Intp(0),
 			},
 			err: fmt.Errorf("non-string indexing is not supported"),
 		},
 		{
 			name: "index map with int",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("map"),
-				},
-				{
-					Int: ottltest.Intp(0),
+			keys: &TestKey[any]{
+				S: ottltest.Strp("map"),
+				NextKey: &TestKey[any]{
+					I: ottltest.Intp(0),
 				},
 			},
 			err: fmt.Errorf("map must be indexed by a string"),
 		},
 		{
 			name: "index slice with string",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("slice"),
-				},
-				{
-					String: ottltest.Strp("map"),
+			keys: &TestKey[any]{
+				S: ottltest.Strp("slice"),
+				NextKey: &TestKey[any]{
+					S: ottltest.Strp("map"),
 				},
 			},
 			err: fmt.Errorf("slice must be indexed by an int"),
 		},
 		{
 			name: "slice index too large",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("slice"),
-				},
-				{
-					Int: ottltest.Intp(1),
+			keys: &TestKey[any]{
+				S: ottltest.Strp("slice"),
+				NextKey: &TestKey[any]{
+					I: ottltest.Intp(1),
 				},
 			},
 			err: fmt.Errorf("index 1 out of bounds"),
 		},
 		{
 			name: "slice index too small",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("slice"),
-				},
-				{
-					Int: ottltest.Intp(-1),
+			keys: &TestKey[any]{
+				S: ottltest.Strp("slice"),
+				NextKey: &TestKey[any]{
+					I: ottltest.Intp(-1),
 				},
 			},
 			err: fmt.Errorf("index -1 out of bounds"),
 		},
 		{
 			name: "slice index too small",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("string"),
-				},
-				{
-					String: ottltest.Strp("string"),
+			keys: &TestKey[any]{
+				S: ottltest.Strp("string"),
+				NextKey: &TestKey[any]{
+					S: ottltest.Strp("string"),
 				},
 			},
 			err: fmt.Errorf("type Str does not support string indexing"),
@@ -218,7 +188,7 @@ func Test_SetMapValue_Invalid(t *testing.T) {
 			s := m.PutEmptySlice("slice")
 			s.AppendEmpty()
 
-			err := SetMapValue(m, tt.keys, "value")
+			err := SetMapValue[any](context.Background(), nil, m, tt.keys, "value")
 			assert.Equal(t, tt.err, err)
 		})
 	}
@@ -227,18 +197,16 @@ func Test_SetMapValue_Invalid(t *testing.T) {
 func Test_SetMapValue_AddingNewSubMap(t *testing.T) {
 	m := pcommon.NewMap()
 	m.PutEmptyMap("map1").PutStr("test", "test")
-	keys := []ottl.Key{
-		{
-			String: ottltest.Strp("map1"),
-		},
-		{
-			String: ottltest.Strp("map2"),
-		},
-		{
-			String: ottltest.Strp("foo"),
+	keys := TestKey[any]{
+		S: ottltest.Strp("map1"),
+		NextKey: &TestKey[any]{
+			S: ottltest.Strp("map2"),
+			NextKey: &TestKey[any]{
+				S: ottltest.Strp("foo"),
+			},
 		},
 	}
-	err := SetMapValue(m, keys, "bar")
+	err := SetMapValue[any](context.Background(), nil, m, &keys, "bar")
 	assert.Nil(t, err)
 
 	expected := pcommon.NewMap()
@@ -251,22 +219,25 @@ func Test_SetMapValue_AddingNewSubMap(t *testing.T) {
 
 func Test_SetMapValue_EmptyMap(t *testing.T) {
 	m := pcommon.NewMap()
-	keys := []ottl.Key{
-		{
-			String: ottltest.Strp("map1"),
-		},
-		{
-			String: ottltest.Strp("map2"),
-		},
-		{
-			String: ottltest.Strp("foo"),
+	keys := TestKey[any]{
+		S: ottltest.Strp("map1"),
+		NextKey: &TestKey[any]{
+			S: ottltest.Strp("map2"),
+			NextKey: &TestKey[any]{
+				S: ottltest.Strp("foo"),
+			},
 		},
 	}
-	err := SetMapValue(m, keys, "bar")
+	err := SetMapValue[any](context.Background(), nil, m, &keys, "bar")
 	assert.Nil(t, err)
 
 	expected := pcommon.NewMap()
 	expected.PutEmptyMap("map1").PutEmptyMap("map2").PutStr("foo", "bar")
 
 	assert.Equal(t, expected, m)
+}
+
+func Test_SetMapValue_NilKey(t *testing.T) {
+	err := SetMapValue[any](context.Background(), nil, pcommon.NewMap(), nil, "bar")
+	assert.Error(t, err)
 }

--- a/pkg/ottl/contexts/internal/metric_test.go
+++ b/pkg/ottl/contexts/internal/metric_test.go
@@ -26,17 +26,15 @@ func Test_MetricPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[*metricContext]
 		orig     any
 		newVal   any
 		modified func(metric pmetric.Metric)
 	}{
 		{
 			name: "metric name",
-			path: []ottl.Field{
-				{
-					Name: "name",
-				},
+			path: &TestPath[*metricContext]{
+				N: "name",
 			},
 			orig:   "name",
 			newVal: "new name",
@@ -46,10 +44,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric description",
-			path: []ottl.Field{
-				{
-					Name: "description",
-				},
+			path: &TestPath[*metricContext]{
+				N: "description",
 			},
 			orig:   "description",
 			newVal: "new description",
@@ -59,10 +55,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric unit",
-			path: []ottl.Field{
-				{
-					Name: "unit",
-				},
+			path: &TestPath[*metricContext]{
+				N: "unit",
 			},
 			orig:   "unit",
 			newVal: "new unit",
@@ -72,10 +66,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric type",
-			path: []ottl.Field{
-				{
-					Name: "type",
-				},
+			path: &TestPath[*metricContext]{
+				N: "type",
 			},
 			orig:   int64(pmetric.MetricTypeSum),
 			newVal: int64(pmetric.MetricTypeSum),
@@ -84,10 +76,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric aggregation_temporality",
-			path: []ottl.Field{
-				{
-					Name: "aggregation_temporality",
-				},
+			path: &TestPath[*metricContext]{
+				N: "aggregation_temporality",
 			},
 			orig:   int64(2),
 			newVal: int64(1),
@@ -97,10 +87,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric is_monotonic",
-			path: []ottl.Field{
-				{
-					Name: "is_monotonic",
-				},
+			path: &TestPath[*metricContext]{
+				N: "is_monotonic",
 			},
 			orig:   true,
 			newVal: false,
@@ -110,10 +98,8 @@ func Test_MetricPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric data points",
-			path: []ottl.Field{
-				{
-					Name: "data_points",
-				},
+			path: &TestPath[*metricContext]{
+				N: "data_points",
 			},
 			orig:   refMetric.Sum().DataPoints(),
 			newVal: newDataPoints,

--- a/pkg/ottl/contexts/internal/path.go
+++ b/pkg/ottl/contexts/internal/path.go
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"context"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+var _ ottl.Path[any] = &TestPath[any]{}
+
+type TestPath[K any] struct {
+	N        string
+	Keys     ottl.Key[K]
+	NextPath *TestPath[K]
+}
+
+func (p *TestPath[K]) Name() string {
+	return p.N
+}
+
+func (p *TestPath[K]) Next() ottl.Path[K] {
+	if p.NextPath == nil {
+		return nil
+	}
+	return p.NextPath
+}
+
+func (p *TestPath[K]) Key() ottl.Key[K] {
+	return p.Keys
+}
+
+var _ ottl.Key[any] = &TestKey[any]{}
+
+type TestKey[K any] struct {
+	S       *string
+	I       *int64
+	NextKey *TestKey[K]
+}
+
+func (k *TestKey[K]) String(_ context.Context, _ K) (*string, error) {
+	return k.S, nil
+}
+
+func (k *TestKey[K]) Int(_ context.Context, _ K) (*int64, error) {
+	return k.I, nil
+}
+
+func (k *TestKey[K]) Next() ottl.Key[K] {
+	if k.NextKey == nil {
+		return nil
+	}
+	return k.NextKey
+}

--- a/pkg/ottl/contexts/internal/path.go
+++ b/pkg/ottl/contexts/internal/path.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package internal
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 
 import (
 	"context"

--- a/pkg/ottl/contexts/internal/resource.go
+++ b/pkg/ottl/contexts/internal/resource.go
@@ -16,22 +16,21 @@ type ResourceContext interface {
 	GetResource() pcommon.Resource
 }
 
-func ResourcePathGetSetter[K ResourceContext](path []ottl.Field) (ottl.GetSetter[K], error) {
-	if len(path) == 0 {
+func ResourcePathGetSetter[K ResourceContext](path ottl.Path[K]) (ottl.GetSetter[K], error) {
+	if path == nil {
 		return accessResource[K](), nil
 	}
-	switch path[0].Name {
+	switch path.Name() {
 	case "attributes":
-		mapKeys := path[0].Keys
-		if mapKeys == nil {
+		if path.Key() == nil {
 			return accessResourceAttributes[K](), nil
 		}
-		return accessResourceAttributesKey[K](mapKeys), nil
+		return accessResourceAttributesKey[K](path.Key()), nil
 	case "dropped_attributes_count":
 		return accessResourceDroppedAttributesCount[K](), nil
+	default:
+		return nil, fmt.Errorf("invalid resource path expression %v", path)
 	}
-
-	return nil, fmt.Errorf("invalid resource path expression %v", path)
 }
 
 func accessResource[K ResourceContext]() ottl.StandardGetSetter[K] {
@@ -62,13 +61,13 @@ func accessResourceAttributes[K ResourceContext]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessResourceAttributesKey[K ResourceContext](keys []ottl.Key) ottl.StandardGetSetter[K] {
+func accessResourceAttributesKey[K ResourceContext](keys ottl.Key[K]) ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			return GetMapValue(tCtx.GetResource().Attributes(), keys)
+			return GetMapValue[K](ctx, tCtx, tCtx.GetResource().Attributes(), keys)
 		},
 		Setter: func(ctx context.Context, tCtx K, val any) error {
-			return SetMapValue(tCtx.GetResource().Attributes(), keys, val)
+			return SetMapValue[K](ctx, tCtx, tCtx.GetResource().Attributes(), keys, val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/resource_test.go
+++ b/pkg/ottl/contexts/internal/resource_test.go
@@ -22,14 +22,14 @@ func TestResourcePathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[*resourceContext]
 		orig     any
 		newVal   any
 		modified func(resource pcommon.Resource)
 	}{
 		{
 			name:   "resource",
-			path:   []ottl.Field{},
+			path:   nil,
 			orig:   refResource,
 			newVal: pcommon.NewResource(),
 			modified: func(resource pcommon.Resource) {
@@ -38,10 +38,8 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
 			},
 			orig:   refResource.Attributes(),
 			newVal: newAttrs,
@@ -51,14 +49,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -69,14 +63,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -87,14 +77,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -105,14 +91,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   1.2,
@@ -123,14 +105,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -141,14 +119,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array empty",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_empty"),
-						},
-					},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("arr_empty"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -162,14 +136,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -183,14 +153,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -204,14 +170,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -225,14 +187,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -246,14 +204,10 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -267,18 +221,14 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("slice"),
+					NextKey: &TestKey[*resourceContext]{
+						I: ottltest.Intp(0),
+						NextKey: &TestKey[*resourceContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -295,18 +245,14 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &TestPath[*resourceContext]{
+				N: "attributes",
+				Keys: &TestKey[*resourceContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &TestKey[*resourceContext]{
+						I: ottltest.Intp(2),
+						NextKey: &TestKey[*resourceContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},
@@ -324,10 +270,8 @@ func TestResourcePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
-				},
+			path: &TestPath[*resourceContext]{
+				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
 			newVal: int64(20),

--- a/pkg/ottl/contexts/internal/scope.go
+++ b/pkg/ottl/contexts/internal/scope.go
@@ -16,27 +16,26 @@ type InstrumentationScopeContext interface {
 	GetInstrumentationScope() pcommon.InstrumentationScope
 }
 
-func ScopePathGetSetter[K InstrumentationScopeContext](path []ottl.Field) (ottl.GetSetter[K], error) {
-	if len(path) == 0 {
+func ScopePathGetSetter[K InstrumentationScopeContext](path ottl.Path[K]) (ottl.GetSetter[K], error) {
+	if path == nil {
 		return accessInstrumentationScope[K](), nil
 	}
-
-	switch path[0].Name {
+	switch path.Name() {
 	case "name":
 		return accessInstrumentationScopeName[K](), nil
 	case "version":
 		return accessInstrumentationScopeVersion[K](), nil
 	case "attributes":
-		mapKeys := path[0].Keys
+		mapKeys := path.Key()
 		if mapKeys == nil {
 			return accessInstrumentationScopeAttributes[K](), nil
 		}
 		return accessInstrumentationScopeAttributesKey[K](mapKeys), nil
 	case "dropped_attributes_count":
 		return accessInstrumentationScopeDroppedAttributesCount[K](), nil
+	default:
+		return nil, fmt.Errorf("invalid scope path expression %v", path)
 	}
-
-	return nil, fmt.Errorf("invalid scope path expression %v", path)
 }
 
 func accessInstrumentationScope[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
@@ -67,13 +66,13 @@ func accessInstrumentationScopeAttributes[K InstrumentationScopeContext]() ottl.
 	}
 }
 
-func accessInstrumentationScopeAttributesKey[K InstrumentationScopeContext](keys []ottl.Key) ottl.StandardGetSetter[K] {
+func accessInstrumentationScopeAttributesKey[K InstrumentationScopeContext](key ottl.Key[K]) ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			return GetMapValue(tCtx.GetInstrumentationScope().Attributes(), keys)
+			return GetMapValue[K](ctx, tCtx, tCtx.GetInstrumentationScope().Attributes(), key)
 		},
 		Setter: func(ctx context.Context, tCtx K, val any) error {
-			return SetMapValue(tCtx.GetInstrumentationScope().Attributes(), keys, val)
+			return SetMapValue[K](ctx, tCtx, tCtx.GetInstrumentationScope().Attributes(), key, val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/scope_test.go
+++ b/pkg/ottl/contexts/internal/scope_test.go
@@ -21,14 +21,14 @@ func TestScopePathGetSetter(t *testing.T) {
 	newAttrs.PutStr("hello", "world")
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[*instrumentationScopeContext]
 		orig     any
 		newVal   any
 		modified func(is pcommon.InstrumentationScope)
 	}{
 		{
 			name:   "instrumentation_scope",
-			path:   []ottl.Field{},
+			path:   nil,
 			orig:   refIS,
 			newVal: pcommon.NewInstrumentationScope(),
 			modified: func(is pcommon.InstrumentationScope) {
@@ -37,10 +37,8 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope name",
-			path: []ottl.Field{
-				{
-					Name: "name",
-				},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "name",
 			},
 			orig:   refIS.Name(),
 			newVal: "newname",
@@ -50,10 +48,8 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope version",
-			path: []ottl.Field{
-				{
-					Name: "version",
-				},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "version",
 			},
 			orig:   refIS.Version(),
 			newVal: "next",
@@ -63,10 +59,8 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
 			},
 			orig:   refIS.Attributes(),
 			newVal: newAttrs,
@@ -76,14 +70,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -94,10 +84,8 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
-				},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -107,14 +95,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -125,14 +109,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -143,14 +123,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   1.2,
@@ -161,14 +137,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -179,14 +151,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array empty",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_empty"),
-						},
-					},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("arr_empty"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -200,14 +168,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -222,14 +186,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -244,14 +204,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -266,14 +222,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -288,14 +240,10 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -310,18 +258,14 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("slice"),
+					NextKey: &TestKey[*instrumentationScopeContext]{
+						I: ottltest.Intp(0),
+						NextKey: &TestKey[*instrumentationScopeContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -338,18 +282,14 @@ func TestScopePathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &TestPath[*instrumentationScopeContext]{
+				N: "attributes",
+				Keys: &TestKey[*instrumentationScopeContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &TestKey[*instrumentationScopeContext]{
+						I: ottltest.Intp(2),
+						NextKey: &TestKey[*instrumentationScopeContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},

--- a/pkg/ottl/contexts/internal/slice.go
+++ b/pkg/ottl/contexts/internal/slice.go
@@ -4,6 +4,7 @@
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 
 import (
+	"context"
 	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -11,34 +12,46 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
-func GetSliceValue(s pcommon.Slice, keys []ottl.Key) (any, error) {
-	if len(keys) == 0 {
-		return nil, fmt.Errorf("cannot get slice value without key")
-	}
-	if keys[0].Int == nil {
+func GetSliceValue[K any](ctx context.Context, tCtx K, s pcommon.Slice, key ottl.Key[K]) (any, error) {
+	if key == nil {
 		return nil, fmt.Errorf("non-integer indexing is not supported")
 	}
-	idx := int(*keys[0].Int)
+
+	i, err := key.Int(ctx, tCtx)
+	if err != nil {
+		return nil, err
+	}
+	if i == nil {
+		return nil, fmt.Errorf("non-integer indexing is not supported")
+	}
+
+	idx := int(*i)
 
 	if idx < 0 || idx >= s.Len() {
 		return nil, fmt.Errorf("index %d out of bounds", idx)
 	}
 
-	return getIndexableValue(s.At(int(*keys[0].Int)), keys[1:])
+	return getIndexableValue[K](ctx, tCtx, s.At(idx), key.Next())
 }
 
-func SetSliceValue(s pcommon.Slice, keys []ottl.Key, val any) error {
-	if len(keys) == 0 {
-		return fmt.Errorf("cannot set slice value without key")
-	}
-	if keys[0].Int == nil {
+func SetSliceValue[K any](ctx context.Context, tCtx K, s pcommon.Slice, key ottl.Key[K], val any) error {
+	if key == nil {
 		return fmt.Errorf("non-integer indexing is not supported")
 	}
-	idx := int(*keys[0].Int)
+
+	i, err := key.Int(ctx, tCtx)
+	if err != nil {
+		return err
+	}
+	if i == nil {
+		return fmt.Errorf("non-integer indexing is not supported")
+	}
+
+	idx := int(*i)
 
 	if idx < 0 || idx >= s.Len() {
 		return fmt.Errorf("index %d out of bounds", idx)
 	}
 
-	return setIndexableValue(s.At(int(*keys[0].Int)), val, keys[1:])
+	return setIndexableValue[K](ctx, tCtx, s.At(idx), val, key.Next())
 }

--- a/pkg/ottl/contexts/internal/slice.go
+++ b/pkg/ottl/contexts/internal/slice.go
@@ -14,7 +14,7 @@ import (
 
 func GetSliceValue[K any](ctx context.Context, tCtx K, s pcommon.Slice, key ottl.Key[K]) (any, error) {
 	if key == nil {
-		return nil, fmt.Errorf("non-integer indexing is not supported")
+		return nil, fmt.Errorf("cannot get slice value without key")
 	}
 
 	i, err := key.Int(ctx, tCtx)
@@ -36,7 +36,7 @@ func GetSliceValue[K any](ctx context.Context, tCtx K, s pcommon.Slice, key ottl
 
 func SetSliceValue[K any](ctx context.Context, tCtx K, s pcommon.Slice, key ottl.Key[K], val any) error {
 	if key == nil {
-		return fmt.Errorf("non-integer indexing is not supported")
+		return fmt.Errorf("cannot set slice value without key")
 	}
 
 	i, err := key.Int(ctx, tCtx)

--- a/pkg/ottl/contexts/internal/slice_test.go
+++ b/pkg/ottl/contexts/internal/slice_test.go
@@ -4,6 +4,7 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -17,49 +18,36 @@ import (
 func Test_GetSliceValue_Invalid(t *testing.T) {
 	tests := []struct {
 		name string
-		keys []ottl.Key
+		keys ottl.Key[any]
 		err  error
 	}{
 		{
-			name: "no keys",
-			keys: []ottl.Key{},
-			err:  fmt.Errorf("cannot get slice value without key"),
-		},
-		{
 			name: "first key not an integer",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("key"),
-				},
+			keys: &TestKey[any]{
+				S: ottltest.Strp("key"),
 			},
 			err: fmt.Errorf("non-integer indexing is not supported"),
 		},
 		{
 			name: "index too large",
-			keys: []ottl.Key{
-				{
-					Int: ottltest.Intp(1),
-				},
+			keys: &TestKey[any]{
+				I: ottltest.Intp(1),
 			},
 			err: fmt.Errorf("index 1 out of bounds"),
 		},
 		{
 			name: "index too small",
-			keys: []ottl.Key{
-				{
-					Int: ottltest.Intp(-1),
-				},
+			keys: &TestKey[any]{
+				I: ottltest.Intp(-1),
 			},
 			err: fmt.Errorf("index -1 out of bounds"),
 		},
 		{
 			name: "invalid type",
-			keys: []ottl.Key{
-				{
-					Int: ottltest.Intp(0),
-				},
-				{
-					String: ottltest.Strp("string"),
+			keys: &TestKey[any]{
+				I: ottltest.Intp(0),
+				NextKey: &TestKey[any]{
+					S: ottltest.Strp("string"),
 				},
 			},
 			err: fmt.Errorf("type Str does not support string indexing"),
@@ -71,58 +59,50 @@ func Test_GetSliceValue_Invalid(t *testing.T) {
 			s := pcommon.NewSlice()
 			s.AppendEmpty().SetStr("val")
 
-			_, err := GetSliceValue(s, tt.keys)
+			_, err := GetSliceValue[any](context.Background(), nil, s, tt.keys)
 			assert.Equal(t, tt.err, err)
 		})
 	}
 }
 
+func Test_GetSliceValue_NilKey(t *testing.T) {
+	_, err := GetSliceValue[any](context.Background(), nil, pcommon.NewSlice(), nil)
+	assert.Error(t, err)
+}
+
 func Test_SetSliceValue_Invalid(t *testing.T) {
 	tests := []struct {
 		name string
-		keys []ottl.Key
+		keys ottl.Key[any]
 		err  error
 	}{
 		{
-			name: "no keys",
-			keys: []ottl.Key{},
-			err:  fmt.Errorf("cannot set slice value without key"),
-		},
-		{
 			name: "first key not an integer",
-			keys: []ottl.Key{
-				{
-					String: ottltest.Strp("key"),
-				},
+			keys: &TestKey[any]{
+				S: ottltest.Strp("key"),
 			},
 			err: fmt.Errorf("non-integer indexing is not supported"),
 		},
 		{
 			name: "index too large",
-			keys: []ottl.Key{
-				{
-					Int: ottltest.Intp(1),
-				},
+			keys: &TestKey[any]{
+				I: ottltest.Intp(1),
 			},
 			err: fmt.Errorf("index 1 out of bounds"),
 		},
 		{
 			name: "index too small",
-			keys: []ottl.Key{
-				{
-					Int: ottltest.Intp(-1),
-				},
+			keys: &TestKey[any]{
+				I: ottltest.Intp(-1),
 			},
 			err: fmt.Errorf("index -1 out of bounds"),
 		},
 		{
 			name: "invalid type",
-			keys: []ottl.Key{
-				{
-					Int: ottltest.Intp(0),
-				},
-				{
-					String: ottltest.Strp("string"),
+			keys: &TestKey[any]{
+				I: ottltest.Intp(0),
+				NextKey: &TestKey[any]{
+					S: ottltest.Strp("string"),
 				},
 			},
 			err: fmt.Errorf("type Str does not support string indexing"),
@@ -134,8 +114,13 @@ func Test_SetSliceValue_Invalid(t *testing.T) {
 			s := pcommon.NewSlice()
 			s.AppendEmpty().SetStr("val")
 
-			err := SetSliceValue(s, tt.keys, "value")
+			err := SetSliceValue[any](context.Background(), nil, s, tt.keys, "value")
 			assert.Equal(t, tt.err, err)
 		})
 	}
+}
+
+func Test_SetSliceValue_NilKey(t *testing.T) {
+	err := SetSliceValue[any](context.Background(), nil, pcommon.NewSlice(), nil, "value")
+	assert.Error(t, err)
 }

--- a/pkg/ottl/contexts/internal/span.go
+++ b/pkg/ottl/contexts/internal/span.go
@@ -33,50 +33,56 @@ var SpanSymbolTable = map[ottl.EnumSymbol]ottl.Enum{
 	"STATUS_CODE_ERROR":     ottl.Enum(ptrace.StatusCodeError),
 }
 
-func SpanPathGetSetter[K SpanContext](path []ottl.Field) (ottl.GetSetter[K], error) {
-	if len(path) == 0 {
+func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], error) {
+	if path == nil {
 		return accessSpan[K](), nil
 	}
-
-	switch path[0].Name {
+	switch path.Name() {
 	case "trace_id":
-		if len(path) == 1 {
+		if path.Next() != nil {
+			if path.Next().Name() == "string" {
+				return accessStringTraceID[K](), nil
+			}
+		} else {
 			return accessTraceID[K](), nil
 		}
-		if path[1].Name == "string" {
-			return accessStringTraceID[K](), nil
-		}
 	case "span_id":
-		if len(path) == 1 {
+		if path.Next() != nil {
+			if path.Next().Name() == "string" {
+				return accessStringSpanID[K](), nil
+			}
+		} else {
 			return accessSpanID[K](), nil
 		}
-		if path[1].Name == "string" {
-			return accessStringSpanID[K](), nil
-		}
 	case "trace_state":
-		mapKey := path[0].Keys
+		mapKey := path.Key()
 		if mapKey == nil {
 			return accessTraceState[K](), nil
 		}
 		return accessTraceStateKey[K](mapKey)
 	case "parent_span_id":
-		if len(path) == 1 {
+		if path.Next() != nil {
+			if path.Next().Name() == "string" {
+				return accessStringParentSpanID[K](), nil
+			}
+		} else {
 			return accessParentSpanID[K](), nil
-		}
-		if path[1].Name == "string" {
-			return accessStringParentSpanID[K](), nil
 		}
 	case "name":
 		return accessSpanName[K](), nil
 	case "kind":
-		if len(path) == 1 {
+		nextPath := path.Next()
+		if nextPath != nil {
+			switch path.Next().Name() {
+			case "string":
+				return accessStringKind[K](), nil
+			case "deprecated_string":
+				return accessDeprecatedStringKind[K](), nil
+			default:
+				return nil, fmt.Errorf("invalid span path expression %v", path.Next().Name())
+			}
+		} else {
 			return accessKind[K](), nil
-		}
-		if path[1].Name == "string" {
-			return accessStringKind[K](), nil
-		}
-		if path[1].Name == "deprecated_string" {
-			return accessDeprecatedStringKind[K](), nil
 		}
 	case "start_time_unix_nano":
 		return accessStartTimeUnixNano[K](), nil
@@ -87,7 +93,7 @@ func SpanPathGetSetter[K SpanContext](path []ottl.Field) (ottl.GetSetter[K], err
 	case "end_time":
 		return accessEndTime[K](), nil
 	case "attributes":
-		mapKeys := path[0].Keys
+		mapKeys := path.Key()
 		if mapKeys == nil {
 			return accessAttributes[K](), nil
 		}
@@ -103,17 +109,20 @@ func SpanPathGetSetter[K SpanContext](path []ottl.Field) (ottl.GetSetter[K], err
 	case "dropped_links_count":
 		return accessDroppedLinksCount[K](), nil
 	case "status":
-		if len(path) == 1 {
+		nextPath := path.Next()
+		if nextPath != nil {
+			switch path.Next().Name() {
+			case "code":
+				return accessStatusCode[K](), nil
+			case "message":
+				return accessStatusMessage[K](), nil
+			default:
+				return nil, fmt.Errorf("invalid span path expression %v", path.Next().Name())
+			}
+		} else {
 			return accessStatus[K](), nil
 		}
-		switch path[1].Name {
-		case "code":
-			return accessStatusCode[K](), nil
-		case "message":
-			return accessStatusMessage[K](), nil
-		}
 	}
-
 	return nil, fmt.Errorf("invalid span path expression %v", path)
 }
 
@@ -211,27 +220,35 @@ func accessTraceState[K SpanContext]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessTraceStateKey[K SpanContext](keys []ottl.Key) (ottl.StandardGetSetter[K], error) {
-	if len(keys) != 1 {
+func accessTraceStateKey[K SpanContext](keys ottl.Key[K]) (ottl.StandardGetSetter[K], error) {
+	if keys.Next() != nil {
 		return ottl.StandardGetSetter[K]{}, fmt.Errorf("must provide exactly 1 key when accessing trace_state")
-	}
-	if keys[0].String == nil {
-		return ottl.StandardGetSetter[K]{}, fmt.Errorf("trace_state indexing type must be a string")
 	}
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (any, error) {
 			if ts, err := trace.ParseTraceState(tCtx.GetSpan().TraceState().AsRaw()); err == nil {
-				if keys[0].String == nil {
+				s, err := keys.String(ctx, tCtx)
+				if err != nil {
 					return nil, err
 				}
-				return ts.Get(*keys[0].String), nil
+				if s == nil {
+					return nil, fmt.Errorf("trace_state indexing type must be a string")
+				}
+				return ts.Get(*s), nil
 			}
 			return nil, nil
 		},
 		Setter: func(ctx context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				if ts, err := trace.ParseTraceState(tCtx.GetSpan().TraceState().AsRaw()); err == nil {
-					if updated, err := ts.Insert(*keys[0].String, str); err == nil {
+					s, err := keys.String(ctx, tCtx)
+					if err != nil {
+						return err
+					}
+					if s == nil {
+						return fmt.Errorf("trace_state indexing type must be a string")
+					}
+					if updated, err := ts.Insert(*s, str); err == nil {
 						tCtx.GetSpan().TraceState().FromRaw(updated.String())
 					}
 				}
@@ -434,13 +451,13 @@ func accessAttributes[K SpanContext]() ottl.StandardGetSetter[K] {
 	}
 }
 
-func accessAttributesKey[K SpanContext](keys []ottl.Key) ottl.StandardGetSetter[K] {
+func accessAttributesKey[K SpanContext](keys ottl.Key[K]) ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
 		Getter: func(ctx context.Context, tCtx K) (any, error) {
-			return GetMapValue(tCtx.GetSpan().Attributes(), keys)
+			return GetMapValue[K](ctx, tCtx, tCtx.GetSpan().Attributes(), keys)
 		},
 		Setter: func(ctx context.Context, tCtx K, val any) error {
-			return SetMapValue(tCtx.GetSpan().Attributes(), keys, val)
+			return SetMapValue[K](ctx, tCtx, tCtx.GetSpan().Attributes(), keys, val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/internal/span.go
+++ b/pkg/ottl/contexts/internal/span.go
@@ -73,13 +73,13 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 	case "kind":
 		nextPath := path.Next()
 		if nextPath != nil {
-			switch path.Next().Name() {
+			switch nextPath.Name() {
 			case "string":
 				return accessStringKind[K](), nil
 			case "deprecated_string":
 				return accessDeprecatedStringKind[K](), nil
 			default:
-				return nil, fmt.Errorf("invalid span path expression %v", path.Next().Name())
+				return nil, fmt.Errorf("invalid span path expression %v", nextPath.Name())
 			}
 		} else {
 			return accessKind[K](), nil
@@ -111,13 +111,13 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 	case "status":
 		nextPath := path.Next()
 		if nextPath != nil {
-			switch path.Next().Name() {
+			switch nextPath.Name() {
 			case "code":
 				return accessStatusCode[K](), nil
 			case "message":
 				return accessStatusMessage[K](), nil
 			default:
-				return nil, fmt.Errorf("invalid span path expression %v", path.Next().Name())
+				return nil, fmt.Errorf("invalid span path expression %v", nextPath.Name())
 			}
 		} else {
 			return accessStatus[K](), nil

--- a/pkg/ottl/contexts/internal/span_test.go
+++ b/pkg/ottl/contexts/internal/span_test.go
@@ -41,17 +41,15 @@ func TestSpanPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[*spanContext]
 		orig     any
 		newVal   any
 		modified func(span ptrace.Span)
 	}{
 		{
 			name: "trace_id",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
-				},
+			path: &TestPath[*spanContext]{
+				N: "trace_id",
 			},
 			orig:   pcommon.TraceID(traceID),
 			newVal: pcommon.TraceID(traceID2),
@@ -61,10 +59,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
-				},
+			path: &TestPath[*spanContext]{
+				N: "span_id",
 			},
 			orig:   pcommon.SpanID(spanID),
 			newVal: pcommon.SpanID(spanID2),
@@ -74,12 +70,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id string",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
-				},
-				{
-					Name: "string",
+			path: &TestPath[*spanContext]{
+				N: "trace_id",
+				NextPath: &TestPath[*spanContext]{
+					N: "string",
 				},
 			},
 			orig:   hex.EncodeToString(traceID[:]),
@@ -90,12 +84,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id string",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
-				},
-				{
-					Name: "string",
+			path: &TestPath[*spanContext]{
+				N: "span_id",
+				NextPath: &TestPath[*spanContext]{
+					N: "string",
 				},
 			},
 			orig:   hex.EncodeToString(spanID[:]),
@@ -106,10 +98,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_state",
-			path: []ottl.Field{
-				{
-					Name: "trace_state",
-				},
+			path: &TestPath[*spanContext]{
+				N: "trace_state",
 			},
 			orig:   "key1=val1,key2=val2",
 			newVal: "key=newVal",
@@ -119,14 +109,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_state key",
-			path: []ottl.Field{
-				{
-					Name: "trace_state",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("key1"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "trace_state",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("key1"),
 				},
 			},
 			orig:   "val1",
@@ -137,10 +123,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "parent_span_id",
-			path: []ottl.Field{
-				{
-					Name: "parent_span_id",
-				},
+			path: &TestPath[*spanContext]{
+				N: "parent_span_id",
 			},
 			orig:   pcommon.SpanID(spanID2),
 			newVal: pcommon.SpanID(spanID),
@@ -150,12 +134,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "parent_span_id string",
-			path: []ottl.Field{
-				{
-					Name: "parent_span_id",
-				},
-				{
-					Name: "string",
+			path: &TestPath[*spanContext]{
+				N: "parent_span_id",
+				NextPath: &TestPath[*spanContext]{
+					N: "string",
 				},
 			},
 			orig:   hex.EncodeToString(spanID2[:]),
@@ -166,10 +148,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "name",
-			path: []ottl.Field{
-				{
-					Name: "name",
-				},
+			path: &TestPath[*spanContext]{
+				N: "name",
 			},
 			orig:   "bear",
 			newVal: "cat",
@@ -179,10 +159,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "kind",
-			path: []ottl.Field{
-				{
-					Name: "kind",
-				},
+			path: &TestPath[*spanContext]{
+				N: "kind",
 			},
 			orig:   int64(2),
 			newVal: int64(3),
@@ -192,12 +170,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "string kind",
-			path: []ottl.Field{
-				{
-					Name: "kind",
-				},
-				{
-					Name: "string",
+			path: &TestPath[*spanContext]{
+				N: "kind",
+				NextPath: &TestPath[*spanContext]{
+					N: "string",
 				},
 			},
 			orig:   "Server",
@@ -208,12 +184,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "deprecated string kind",
-			path: []ottl.Field{
-				{
-					Name: "kind",
-				},
-				{
-					Name: "deprecated_string",
+			path: &TestPath[*spanContext]{
+				N: "kind",
+				NextPath: &TestPath[*spanContext]{
+					N: "deprecated_string",
 				},
 			},
 			orig:   "SPAN_KIND_SERVER",
@@ -224,10 +198,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
-				},
+			path: &TestPath[*spanContext]{
+				N: "start_time_unix_nano",
 			},
 			orig:   int64(100_000_000),
 			newVal: int64(200_000_000),
@@ -237,10 +209,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "end_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "end_time_unix_nano",
-				},
+			path: &TestPath[*spanContext]{
+				N: "end_time_unix_nano",
 			},
 			orig:   int64(500_000_000),
 			newVal: int64(200_000_000),
@@ -250,10 +220,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
 			},
 			orig:   refSpan.Attributes(),
 			newVal: newAttrs,
@@ -263,14 +231,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -281,14 +245,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -299,14 +259,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -317,14 +273,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   float64(1.2),
@@ -335,14 +287,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -353,14 +301,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array empty",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_empty"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("arr_empty"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -374,14 +318,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -395,14 +335,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -416,14 +352,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -437,14 +369,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -458,14 +386,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -479,18 +403,14 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("slice"),
+					NextKey: &TestKey[*spanContext]{
+						I: ottltest.Intp(0),
+						NextKey: &TestKey[*spanContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -507,18 +427,14 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &TestPath[*spanContext]{
+				N: "attributes",
+				Keys: &TestKey[*spanContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &TestKey[*spanContext]{
+						I: ottltest.Intp(2),
+						NextKey: &TestKey[*spanContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},
@@ -536,10 +452,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
-				},
+			path: &TestPath[*spanContext]{
+				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -549,10 +463,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "events",
-			path: []ottl.Field{
-				{
-					Name: "events",
-				},
+			path: &TestPath[*spanContext]{
+				N: "events",
 			},
 			orig:   refSpan.Events(),
 			newVal: newEvents,
@@ -565,10 +477,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_events_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_events_count",
-				},
+			path: &TestPath[*spanContext]{
+				N: "dropped_events_count",
 			},
 			orig:   int64(20),
 			newVal: int64(30),
@@ -578,10 +488,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "links",
-			path: []ottl.Field{
-				{
-					Name: "links",
-				},
+			path: &TestPath[*spanContext]{
+				N: "links",
 			},
 			orig:   refSpan.Links(),
 			newVal: newLinks,
@@ -594,10 +502,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_links_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_links_count",
-				},
+			path: &TestPath[*spanContext]{
+				N: "dropped_links_count",
 			},
 			orig:   int64(30),
 			newVal: int64(40),
@@ -607,10 +513,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status",
-			path: []ottl.Field{
-				{
-					Name: "status",
-				},
+			path: &TestPath[*spanContext]{
+				N: "status",
 			},
 			orig:   refSpan.Status(),
 			newVal: newStatus,
@@ -620,12 +524,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status code",
-			path: []ottl.Field{
-				{
-					Name: "status",
-				},
-				{
-					Name: "code",
+			path: &TestPath[*spanContext]{
+				N: "status",
+				NextPath: &TestPath[*spanContext]{
+					N: "code",
 				},
 			},
 			orig:   int64(ptrace.StatusCodeOk),
@@ -636,12 +538,10 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status message",
-			path: []ottl.Field{
-				{
-					Name: "status",
-				},
-				{
-					Name: "message",
+			path: &TestPath[*spanContext]{
+				N: "status",
+				NextPath: &TestPath[*spanContext]{
+					N: "message",
 				},
 			},
 			orig:   "good span",
@@ -652,10 +552,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "start_time",
-			path: []ottl.Field{
-				{
-					Name: "start_time",
-				},
+			path: &TestPath[*spanContext]{
+				N: "start_time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
@@ -665,10 +563,8 @@ func TestSpanPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "end_time",
-			path: []ottl.Field{
-				{
-					Name: "end_time",
-				},
+			path: &TestPath[*spanContext]{
+				N: "end_time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 500000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),

--- a/pkg/ottl/contexts/internal/value.go
+++ b/pkg/ottl/contexts/internal/value.go
@@ -4,6 +4,7 @@
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -62,43 +63,49 @@ func SetValue(value pcommon.Value, val any) error {
 	case pcommon.Map:
 		v.CopyTo(value.SetEmptyMap())
 	case map[string]any:
-		value.SetEmptyMap()
-		for mk, mv := range v {
-			err = SetMapValue(value.Map(), []ottl.Key{{String: &mk}}, mv)
-		}
+		err = value.FromRaw(v)
 	}
 	return err
 }
 
-func getIndexableValue(value pcommon.Value, keys []ottl.Key) (any, error) {
-	val := value
+func getIndexableValue[K any](ctx context.Context, tCtx K, value pcommon.Value, key ottl.Key[K]) (any, error) {
+	val, currentKey := value, key
 	var ok bool
-	for i := 0; i < len(keys); i++ {
+	for currentKey != nil {
 		switch val.Type() {
 		case pcommon.ValueTypeMap:
-			if keys[i].String == nil {
+			s, err := currentKey.String(ctx, tCtx)
+			if err != nil {
+				return nil, err
+			}
+			if s == nil {
 				return nil, fmt.Errorf("map must be indexed by a string")
 			}
-			val, ok = val.Map().Get(*keys[i].String)
+			val, ok = val.Map().Get(*s)
 			if !ok {
 				return nil, nil
 			}
 		case pcommon.ValueTypeSlice:
-			if keys[i].Int == nil {
+			i, err := currentKey.Int(ctx, tCtx)
+			if err != nil {
+				return nil, err
+			}
+			if i == nil {
 				return nil, fmt.Errorf("slice must be indexed by an int")
 			}
-			if int(*keys[i].Int) >= val.Slice().Len() || int(*keys[i].Int) < 0 {
-				return nil, fmt.Errorf("index %v out of bounds", *keys[i].Int)
+			if int(*i) >= val.Slice().Len() || int(*i) < 0 {
+				return nil, fmt.Errorf("index %v out of bounds", *i)
 			}
-			val = val.Slice().At(int(*keys[i].Int))
+			val = val.Slice().At(int(*i))
 		default:
 			return nil, fmt.Errorf("type %v does not support string indexing", val.Type())
 		}
+		currentKey = currentKey.Next()
 	}
 	return ottlcommon.GetValue(val), nil
 }
 
-func setIndexableValue(currentValue pcommon.Value, val any, keys []ottl.Key) error {
+func setIndexableValue[K any](ctx context.Context, tCtx K, currentValue pcommon.Value, val any, key ottl.Key[K]) error {
 	var newValue pcommon.Value
 	switch val.(type) {
 	case []string, []bool, []int64, []float64, [][]byte, []any:
@@ -111,33 +118,50 @@ func setIndexableValue(currentValue pcommon.Value, val any, keys []ottl.Key) err
 		return err
 	}
 
-	for i := 0; i < len(keys); i++ {
+	currentKey := key
+	for currentKey != nil {
 		switch currentValue.Type() {
 		case pcommon.ValueTypeMap:
-			if keys[i].String == nil {
+			s, err := currentKey.String(ctx, tCtx)
+			if err != nil {
+				return err
+			}
+			if s == nil {
 				return errors.New("map must be indexed by a string")
 			}
-			potentialValue, ok := currentValue.Map().Get(*keys[i].String)
+			potentialValue, ok := currentValue.Map().Get(*s)
 			if !ok {
-				currentValue = currentValue.Map().PutEmpty(*keys[i].String)
+				currentValue = currentValue.Map().PutEmpty(*s)
 			} else {
 				currentValue = potentialValue
 			}
 		case pcommon.ValueTypeSlice:
-			if keys[i].Int == nil {
+			i, err := currentKey.Int(ctx, tCtx)
+			if err != nil {
+				return err
+			}
+			if i == nil {
 				return errors.New("slice must be indexed by an int")
 			}
-			if int(*keys[i].Int) >= currentValue.Slice().Len() || int(*keys[i].Int) < 0 {
-				return fmt.Errorf("index %v out of bounds", *keys[i].Int)
+			if int(*i) >= currentValue.Slice().Len() || int(*i) < 0 {
+				return fmt.Errorf("index %v out of bounds", *i)
 			}
-			currentValue = currentValue.Slice().At(int(*keys[i].Int))
+			currentValue = currentValue.Slice().At(int(*i))
 		case pcommon.ValueTypeEmpty:
+			s, err := currentKey.String(ctx, tCtx)
+			if err != nil {
+				return err
+			}
+			i, err := currentKey.Int(ctx, tCtx)
+			if err != nil {
+				return err
+			}
 			switch {
-			case keys[i].String != nil:
-				currentValue = currentValue.SetEmptyMap().PutEmpty(*keys[i].String)
-			case keys[i].Int != nil:
+			case s != nil:
+				currentValue = currentValue.SetEmptyMap().PutEmpty(*s)
+			case i != nil:
 				currentValue.SetEmptySlice()
-				for k := 0; k < int(*keys[i].Int); k++ {
+				for k := 0; k < int(*i); k++ {
 					currentValue.Slice().AppendEmpty()
 				}
 				currentValue = currentValue.Slice().AppendEmpty()
@@ -147,6 +171,7 @@ func setIndexableValue(currentValue pcommon.Value, val any, keys []ottl.Key) err
 		default:
 			return fmt.Errorf("type %v does not support string indexing", currentValue.Type())
 		}
+		currentKey = currentKey.Next()
 	}
 	newValue.CopyTo(currentValue)
 	return nil

--- a/pkg/ottl/contexts/internal/value_test.go
+++ b/pkg/ottl/contexts/internal/value_test.go
@@ -4,18 +4,15 @@
 package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
 func Test_SetIndexableValue_EmptyValueNoIndex(t *testing.T) {
-	keys := []ottl.Key{
-		{},
-	}
-	err := setIndexableValue(pcommon.NewValueEmpty(), nil, keys)
+	keys := TestKey[any]{}
+	err := setIndexableValue[any](context.Background(), nil, pcommon.NewValueEmpty(), nil, &keys)
 	assert.Error(t, err)
 }

--- a/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
@@ -22,19 +23,16 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		path      []ottl.Field
+		path      ottl.Path[TransformContext]
 		orig      any
 		newVal    any
 		modified  func(cache pcommon.Map)
 		valueType pmetric.NumberDataPointValueType
 	}{
-
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
@@ -44,14 +42,10 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("temp"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("temp"),
 				},
 			},
 			orig:   nil,
@@ -63,7 +57,8 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			numberDataPoint := createNumberDataPointTelemetry(tt.valueType)
@@ -101,7 +96,7 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		path      []ottl.Field
+		path      ottl.Path[TransformContext]
 		orig      any
 		newVal    any
 		modified  func(pmetric.NumberDataPoint)
@@ -109,10 +104,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "start_time_unix_nano",
 			},
 			orig:   int64(100_000_000),
 			newVal: int64(200_000_000),
@@ -122,10 +115,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "start_time",
-			path: []ottl.Field{
-				{
-					Name: "start_time",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "start_time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 86400000000000, time.UTC),
@@ -135,10 +126,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "time",
-			path: []ottl.Field{
-				{
-					Name: "time",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 500000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
@@ -148,10 +137,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "time_unix_nano",
 			},
 			orig:   int64(500_000_000),
 			newVal: int64(200_000_000),
@@ -161,10 +148,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "value_double",
-			path: []ottl.Field{
-				{
-					Name: "value_double",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "value_double",
 			},
 			orig:   1.1,
 			newVal: 2.2,
@@ -175,10 +160,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "value_int",
-			path: []ottl.Field{
-				{
-					Name: "value_int",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "value_int",
 			},
 			orig:   int64(1),
 			newVal: int64(2),
@@ -188,10 +171,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: []ottl.Field{
-				{
-					Name: "flags",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "flags",
 			},
 			orig:   int64(0),
 			newVal: int64(1),
@@ -201,10 +182,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "exemplars",
-			path: []ottl.Field{
-				{
-					Name: "exemplars",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "exemplars",
 			},
 			orig:   refNumberDataPoint.Exemplars(),
 			newVal: newExemplars,
@@ -214,10 +193,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
 			},
 			orig:   refNumberDataPoint.Attributes(),
 			newVal: newAttrs,
@@ -227,14 +204,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -245,14 +218,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -263,14 +232,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -281,14 +246,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   float64(1.2),
@@ -299,14 +260,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -317,14 +274,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -338,14 +291,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -359,14 +308,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -380,14 +325,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -401,14 +342,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -422,14 +359,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("pMap"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("pMap"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -445,14 +378,10 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("map"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("map"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -468,18 +397,14 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("slice"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(0),
+						NextKey: &internal.TestKey[TransformContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -496,18 +421,14 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(2),
+						NextKey: &internal.TestKey[TransformContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},
@@ -526,7 +447,8 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			numberDataPoint := createNumberDataPointTelemetry(tt.valueType)
@@ -583,17 +505,15 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[TransformContext]
 		orig     any
 		newVal   any
 		modified func(pmetric.HistogramDataPoint)
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "start_time_unix_nano",
 			},
 			orig:   int64(100_000_000),
 			newVal: int64(200_000_000),
@@ -603,10 +523,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "time_unix_nano",
 			},
 			orig:   int64(500_000_000),
 			newVal: int64(200_000_000),
@@ -616,10 +534,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: []ottl.Field{
-				{
-					Name: "flags",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "flags",
 			},
 			orig:   int64(0),
 			newVal: int64(1),
@@ -629,10 +545,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "count",
-			path: []ottl.Field{
-				{
-					Name: "count",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "count",
 			},
 			orig:   int64(2),
 			newVal: int64(3),
@@ -642,10 +556,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "sum",
-			path: []ottl.Field{
-				{
-					Name: "sum",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "sum",
 			},
 			orig:   10.1,
 			newVal: 10.2,
@@ -655,10 +567,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "bucket_counts",
-			path: []ottl.Field{
-				{
-					Name: "bucket_counts",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "bucket_counts",
 			},
 			orig:   []uint64{1, 1},
 			newVal: []uint64{1, 2},
@@ -668,10 +578,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "explicit_bounds",
-			path: []ottl.Field{
-				{
-					Name: "explicit_bounds",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "explicit_bounds",
 			},
 			orig:   []float64{1, 2},
 			newVal: []float64{1, 2, 3},
@@ -681,10 +589,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "exemplars",
-			path: []ottl.Field{
-				{
-					Name: "exemplars",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "exemplars",
 			},
 			orig:   refHistogramDataPoint.Exemplars(),
 			newVal: newExemplars,
@@ -694,10 +600,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
 			},
 			orig:   refHistogramDataPoint.Attributes(),
 			newVal: newAttrs,
@@ -707,14 +611,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -725,14 +625,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -743,14 +639,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -761,14 +653,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   float64(1.2),
@@ -779,14 +667,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -797,14 +681,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -818,14 +698,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -839,14 +715,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -860,14 +732,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -881,14 +749,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -902,14 +766,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("pMap"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("pMap"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -925,14 +785,10 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("map"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("map"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -948,18 +804,14 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("slice"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(0),
+						NextKey: &internal.TestKey[TransformContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -976,18 +828,14 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(2),
+						NextKey: &internal.TestKey[TransformContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},
@@ -1006,7 +854,8 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			histogramDataPoint := createHistogramDataPointTelemetry()
@@ -1068,17 +917,15 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[TransformContext]
 		orig     any
 		newVal   any
 		modified func(pmetric.ExponentialHistogramDataPoint)
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "start_time_unix_nano",
 			},
 			orig:   int64(100_000_000),
 			newVal: int64(200_000_000),
@@ -1088,10 +935,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "time_unix_nano",
 			},
 			orig:   int64(500_000_000),
 			newVal: int64(200_000_000),
@@ -1101,10 +946,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: []ottl.Field{
-				{
-					Name: "flags",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "flags",
 			},
 			orig:   int64(0),
 			newVal: int64(1),
@@ -1114,10 +957,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "count",
-			path: []ottl.Field{
-				{
-					Name: "count",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "count",
 			},
 			orig:   int64(2),
 			newVal: int64(3),
@@ -1127,10 +968,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "sum",
-			path: []ottl.Field{
-				{
-					Name: "sum",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "sum",
 			},
 			orig:   10.1,
 			newVal: 10.2,
@@ -1140,10 +979,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "scale",
-			path: []ottl.Field{
-				{
-					Name: "scale",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "scale",
 			},
 			orig:   int64(1),
 			newVal: int64(2),
@@ -1153,10 +990,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "zero_count",
-			path: []ottl.Field{
-				{
-					Name: "zero_count",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "zero_count",
 			},
 			orig:   int64(1),
 			newVal: int64(2),
@@ -1166,10 +1001,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "positive",
-			path: []ottl.Field{
-				{
-					Name: "positive",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "positive",
 			},
 			orig:   refExpoHistogramDataPoint.Positive(),
 			newVal: newPositive,
@@ -1179,12 +1012,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "positive offset",
-			path: []ottl.Field{
-				{
-					Name: "positive",
-				},
-				{
-					Name: "offset",
+			path: &internal.TestPath[TransformContext]{
+				N: "positive",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "offset",
 				},
 			},
 			orig:   int64(1),
@@ -1195,12 +1026,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "positive bucket_counts",
-			path: []ottl.Field{
-				{
-					Name: "positive",
-				},
-				{
-					Name: "bucket_counts",
+			path: &internal.TestPath[TransformContext]{
+				N: "positive",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "bucket_counts",
 				},
 			},
 			orig:   []uint64{1, 1},
@@ -1211,10 +1040,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "negative",
-			path: []ottl.Field{
-				{
-					Name: "negative",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "negative",
 			},
 			orig:   refExpoHistogramDataPoint.Negative(),
 			newVal: newPositive,
@@ -1224,12 +1051,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "negative offset",
-			path: []ottl.Field{
-				{
-					Name: "negative",
-				},
-				{
-					Name: "offset",
+			path: &internal.TestPath[TransformContext]{
+				N: "negative",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "offset",
 				},
 			},
 			orig:   int64(1),
@@ -1240,12 +1065,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "negative bucket_counts",
-			path: []ottl.Field{
-				{
-					Name: "negative",
-				},
-				{
-					Name: "bucket_counts",
+			path: &internal.TestPath[TransformContext]{
+				N: "negative",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "bucket_counts",
 				},
 			},
 			orig:   []uint64{1, 1},
@@ -1256,10 +1079,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "exemplars",
-			path: []ottl.Field{
-				{
-					Name: "exemplars",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "exemplars",
 			},
 			orig:   refExpoHistogramDataPoint.Exemplars(),
 			newVal: newExemplars,
@@ -1269,10 +1090,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
 			},
 			orig:   refExpoHistogramDataPoint.Attributes(),
 			newVal: newAttrs,
@@ -1282,14 +1101,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -1300,14 +1115,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -1318,14 +1129,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -1336,14 +1143,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   1.2,
@@ -1354,14 +1157,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -1372,14 +1171,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1393,14 +1188,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1414,14 +1205,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1435,14 +1222,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1456,14 +1239,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1477,14 +1256,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("pMap"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("pMap"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -1500,14 +1275,10 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("map"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("map"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -1523,18 +1294,14 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("slice"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(0),
+						NextKey: &internal.TestKey[TransformContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -1551,18 +1318,14 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(2),
+						NextKey: &internal.TestKey[TransformContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},
@@ -1581,7 +1344,8 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			expoHistogramDataPoint := createExpoHistogramDataPointTelemetry()
@@ -1644,17 +1408,15 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[TransformContext]
 		orig     any
 		newVal   any
 		modified func(pmetric.SummaryDataPoint)
 	}{
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "start_time_unix_nano",
 			},
 			orig:   int64(100_000_000),
 			newVal: int64(200_000_000),
@@ -1664,10 +1426,8 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "time_unix_nano",
 			},
 			orig:   int64(500_000_000),
 			newVal: int64(200_000_000),
@@ -1677,10 +1437,8 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: []ottl.Field{
-				{
-					Name: "flags",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "flags",
 			},
 			orig:   int64(0),
 			newVal: int64(1),
@@ -1690,10 +1448,8 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "count",
-			path: []ottl.Field{
-				{
-					Name: "count",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "count",
 			},
 			orig:   int64(2),
 			newVal: int64(3),
@@ -1703,10 +1459,8 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "sum",
-			path: []ottl.Field{
-				{
-					Name: "sum",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "sum",
 			},
 			orig:   10.1,
 			newVal: 10.2,
@@ -1716,10 +1470,8 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "quantile_values",
-			path: []ottl.Field{
-				{
-					Name: "quantile_values",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "quantile_values",
 			},
 			orig:   refSummaryDataPoint.QuantileValues(),
 			newVal: newQuartileValues,
@@ -1729,10 +1481,8 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
 			},
 			orig:   refSummaryDataPoint.Attributes(),
 			newVal: newAttrs,
@@ -1742,14 +1492,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -1760,14 +1506,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -1778,14 +1520,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -1796,14 +1534,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   1.2,
@@ -1814,14 +1548,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -1832,14 +1562,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1853,14 +1579,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1874,14 +1596,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1895,14 +1613,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1916,14 +1630,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -1937,14 +1647,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("pMap"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("pMap"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -1960,14 +1666,10 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("map"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("map"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -1983,18 +1685,14 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("slice"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(0),
+						NextKey: &internal.TestKey[TransformContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -2011,18 +1709,14 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(2),
+						NextKey: &internal.TestKey[TransformContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},
@@ -2041,7 +1735,8 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			summaryDataPoint := createSummaryDataPointTelemetry()
@@ -2122,17 +1817,15 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[TransformContext]
 		orig     any
 		newVal   any
 		modified func(metric pmetric.Metric)
 	}{
 		{
 			name: "metric",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "metric",
 			},
 			orig:   refMetric,
 			newVal: newMetric,
@@ -2142,12 +1835,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric name",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "name",
+			path: &internal.TestPath[TransformContext]{
+				N: "metric",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "name",
 				},
 			},
 			orig:   "name",
@@ -2158,12 +1849,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric description",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "description",
+			path: &internal.TestPath[TransformContext]{
+				N: "metric",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "description",
 				},
 			},
 			orig:   "description",
@@ -2174,12 +1863,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric unit",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "unit",
+			path: &internal.TestPath[TransformContext]{
+				N: "metric",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "unit",
 				},
 			},
 			orig:   "unit",
@@ -2190,12 +1877,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric type",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "type",
+			path: &internal.TestPath[TransformContext]{
+				N: "metric",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "type",
 				},
 			},
 			orig:   int64(pmetric.MetricTypeSum),
@@ -2205,12 +1890,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric aggregation_temporality",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "aggregation_temporality",
+			path: &internal.TestPath[TransformContext]{
+				N: "metric",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "aggregation_temporality",
 				},
 			},
 			orig:   int64(2),
@@ -2221,12 +1904,10 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		},
 		{
 			name: "metric is_monotonic",
-			path: []ottl.Field{
-				{
-					Name: "metric",
-				},
-				{
-					Name: "is_monotonic",
+			path: &internal.TestPath[TransformContext]{
+				N: "metric",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "is_monotonic",
 				},
 			},
 			orig:   true,
@@ -2238,7 +1919,8 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			metric := createMetricTelemetry()

--- a/pkg/ottl/contexts/ottllog/log_test.go
+++ b/pkg/ottl/contexts/ottllog/log_test.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
@@ -51,7 +52,7 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[TransformContext]
 		orig     any
 		newVal   any
 		modified func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map)
@@ -59,10 +60,8 @@ func Test_newPathGetSetter(t *testing.T) {
 	}{
 		{
 			name: "time",
-			path: []ottl.Field{
-				{
-					Name: "time",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
@@ -72,10 +71,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "time_unix_nano",
 			},
 			orig:   int64(100_000_000),
 			newVal: int64(200_000_000),
@@ -85,10 +82,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "observed_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "observed_time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "observed_time_unix_nano",
 			},
 			orig:   int64(500_000_000),
 			newVal: int64(200_000_000),
@@ -98,10 +93,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "observed time",
-			path: []ottl.Field{
-				{
-					Name: "observed_time",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "observed_time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 500000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
@@ -111,10 +104,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "severity_number",
-			path: []ottl.Field{
-				{
-					Name: "severity_number",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "severity_number",
 			},
 			orig:   int64(plog.SeverityNumberFatal),
 			newVal: int64(3),
@@ -124,10 +115,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "severity_text",
-			path: []ottl.Field{
-				{
-					Name: "severity_text",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "severity_text",
 			},
 			orig:   "blue screen of death",
 			newVal: "black screen of death",
@@ -137,10 +126,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "body",
-			path: []ottl.Field{
-				{
-					Name: "body",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "body",
 			},
 			orig:   "body",
 			newVal: "head",
@@ -150,10 +137,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "map body",
-			path: []ottl.Field{
-				{
-					Name: "body",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "body",
 			},
 			orig: func() pcommon.Map {
 				log, _, _ := createTelemetry("map")
@@ -167,14 +152,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "map body index",
-			path: []ottl.Field{
-				{
-					Name: "body",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("key"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "body",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("key"),
 				},
 			},
 			orig:   "val",
@@ -186,10 +167,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "slice body",
-			path: []ottl.Field{
-				{
-					Name: "body",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "body",
 			},
 			orig: func() pcommon.Slice {
 				log, _, _ := createTelemetry("slice")
@@ -206,14 +185,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "slice body index",
-			path: []ottl.Field{
-				{
-					Name: "body",
-					Keys: []ottl.Key{
-						{
-							Int: ottltest.Intp(0),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "body",
+				Keys: &internal.TestKey[TransformContext]{
+					I: ottltest.Intp(0),
 				},
 			},
 			orig:   "body",
@@ -225,12 +200,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "body string",
-			path: []ottl.Field{
-				{
-					Name: "body",
-				},
-				{
-					Name: "string",
+			path: &internal.TestPath[TransformContext]{
+				N: "body",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "string",
 				},
 			},
 			orig:   "1",
@@ -242,10 +215,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "flags",
-			path: []ottl.Field{
-				{
-					Name: "flags",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "flags",
 			},
 			orig:   int64(4),
 			newVal: int64(5),
@@ -255,10 +226,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "trace_id",
 			},
 			orig:   pcommon.TraceID(traceID),
 			newVal: pcommon.TraceID(traceID2),
@@ -268,10 +237,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "span_id",
 			},
 			orig:   pcommon.SpanID(spanID),
 			newVal: pcommon.SpanID(spanID2),
@@ -281,12 +248,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id string",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
-				},
-				{
-					Name: "string",
+			path: &internal.TestPath[TransformContext]{
+				N: "trace_id",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "string",
 				},
 			},
 			orig:   hex.EncodeToString(traceID[:]),
@@ -297,12 +262,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id string",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
-				},
-				{
-					Name: "string",
+			path: &internal.TestPath[TransformContext]{
+				N: "span_id",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "string",
 				},
 			},
 			orig:   hex.EncodeToString(spanID[:]),
@@ -313,10 +276,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
@@ -326,14 +287,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("temp"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("temp"),
 				},
 			},
 			orig:   nil,
@@ -344,10 +301,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
 			},
 			orig:   refLog.Attributes(),
 			newVal: newAttrs,
@@ -357,14 +312,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -375,14 +326,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -393,14 +340,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -411,14 +354,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   float64(1.2),
@@ -429,14 +368,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -447,14 +382,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -468,14 +399,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -489,14 +416,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -510,14 +433,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -531,14 +450,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -552,14 +467,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("pMap"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("pMap"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -575,14 +486,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("map"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("map"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -598,18 +505,14 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("slice"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(0),
+						NextKey: &internal.TestKey[TransformContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -626,18 +529,14 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(2),
+						NextKey: &internal.TestKey[TransformContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},
@@ -655,10 +554,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -668,10 +565,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope",
-			path: []ottl.Field{
-				{
-					Name: "instrumentation_scope",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "instrumentation_scope",
 			},
 			orig:   refIS,
 			newVal: pcommon.NewInstrumentationScope(),
@@ -681,10 +576,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "resource",
-			path: []ottl.Field{
-				{
-					Name: "resource",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "resource",
 			},
 			orig:   refResource,
 			newVal: pcommon.NewResource(),
@@ -695,7 +588,8 @@ func Test_newPathGetSetter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			log, il, resource := createTelemetry(tt.bodyType)
@@ -793,18 +687,15 @@ func createTelemetry(bodyType string) (plog.LogRecord, pcommon.InstrumentationSc
 }
 
 func Test_InvalidBodyIndexing(t *testing.T) {
-	path := []ottl.Field{
-		{
-			Name: "body",
-			Keys: []ottl.Key{
-				{
-					String: ottltest.Strp("key"),
-				},
-			},
+	path := internal.TestPath[TransformContext]{
+		N: "body",
+		Keys: &internal.TestKey[TransformContext]{
+			S: ottltest.Strp("key"),
 		},
 	}
 
-	accessor, err := newPathGetSetter(path)
+	pep := pathExpressionParser{}
+	accessor, err := pep.parsePath(&path)
 	assert.NoError(t, err)
 
 	log, il, resource := createTelemetry("string")

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
@@ -31,17 +32,15 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[TransformContext]
 		orig     any
 		newVal   any
 		modified func(metric pmetric.Metric, cache pcommon.Map)
 	}{
 		{
 			name: "metric name",
-			path: []ottl.Field{
-				{
-					Name: "name",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "name",
 			},
 			orig:   "name",
 			newVal: "new name",
@@ -51,10 +50,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric description",
-			path: []ottl.Field{
-				{
-					Name: "description",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "description",
 			},
 			orig:   "description",
 			newVal: "new description",
@@ -64,10 +61,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric unit",
-			path: []ottl.Field{
-				{
-					Name: "unit",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "unit",
 			},
 			orig:   "unit",
 			newVal: "new unit",
@@ -77,10 +72,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric type",
-			path: []ottl.Field{
-				{
-					Name: "type",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "type",
 			},
 			orig:   int64(pmetric.MetricTypeSum),
 			newVal: int64(pmetric.MetricTypeSum),
@@ -89,10 +82,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric aggregation_temporality",
-			path: []ottl.Field{
-				{
-					Name: "aggregation_temporality",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "aggregation_temporality",
 			},
 			orig:   int64(2),
 			newVal: int64(1),
@@ -102,10 +93,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric is_monotonic",
-			path: []ottl.Field{
-				{
-					Name: "is_monotonic",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "is_monotonic",
 			},
 			orig:   true,
 			newVal: false,
@@ -115,10 +104,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "metric data points",
-			path: []ottl.Field{
-				{
-					Name: "data_points",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "data_points",
 			},
 			orig:   refMetric.Sum().DataPoints(),
 			newVal: newDataPoints,
@@ -128,10 +115,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
@@ -141,14 +126,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("temp"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("temp"),
 				},
 			},
 			orig:   nil,
@@ -160,7 +141,8 @@ func Test_newPathGetSetter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			metric := createMetricTelemetry()

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -39,10 +39,10 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 }
 
 func NewParser(functions map[string]ottl.Factory[TransformContext], telemetrySettings component.TelemetrySettings, options ...Option) (ottl.Parser[TransformContext], error) {
-	pathExpressionParser := pathExpressionParser{telemetrySettings}
+	pep := pathExpressionParser{telemetrySettings}
 	p, err := ottl.NewParser[TransformContext](
 		functions,
-		pathExpressionParser.parsePath,
+		pep.parsePath,
 		telemetrySettings,
 		ottl.WithEnumParser[TransformContext](parseEnum),
 	)
@@ -95,21 +95,16 @@ type pathExpressionParser struct {
 	telemetrySettings component.TelemetrySettings
 }
 
-func (pep *pathExpressionParser) parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
-	if val != nil && len(val.Fields) > 0 {
-		return newPathGetSetter(val.Fields)
+func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ottl.GetSetter[TransformContext], error) {
+	if path == nil {
+		return nil, fmt.Errorf("path cannot be nil")
 	}
-	return nil, fmt.Errorf("bad path %v", val)
-}
-
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
-	switch path[0].Name {
+	switch path.Name() {
 	case "cache":
-		mapKey := path[0].Keys
-		if mapKey == nil {
+		if path.Key() == nil {
 			return accessCache(), nil
 		}
-		return accessCacheKey(mapKey), nil
+		return accessCacheKey(path.Key()), nil
 	default:
 		return internal.ResourcePathGetSetter[TransformContext](path)
 	}
@@ -129,13 +124,13 @@ func accessCache() ottl.StandardGetSetter[TransformContext] {
 	}
 }
 
-func accessCacheKey(keys []ottl.Key) ottl.StandardGetSetter[TransformContext] {
+func accessCacheKey(key ottl.Key[TransformContext]) ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
 		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
-			return internal.GetMapValue(tCtx.getCache(), keys)
+			return internal.GetMapValue[TransformContext](ctx, tCtx, tCtx.getCache(), key)
 		},
 		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
-			return internal.SetMapValue(tCtx.getCache(), keys, val)
+			return internal.SetMapValue[TransformContext](ctx, tCtx, tCtx.getCache(), key, val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
@@ -34,17 +35,15 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[TransformContext]
 		orig     any
 		newVal   any
 		modified func(resource pcommon.Resource, cache pcommon.Map)
 	}{
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
@@ -54,14 +53,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("temp"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("temp"),
 				},
 			},
 			orig:   nil,
@@ -72,10 +67,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
 			},
 			orig:   refResource.Attributes(),
 			newVal: newAttrs,
@@ -85,14 +78,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -103,14 +92,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -121,14 +106,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -139,14 +120,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   float64(1.2),
@@ -157,14 +134,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -175,14 +148,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -196,14 +165,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -217,14 +182,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -238,14 +199,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -259,14 +216,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -280,14 +233,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("pMap"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("pMap"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -303,14 +252,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes mpa[string]interface",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("map"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("map"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -326,18 +271,14 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("slice"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(0),
+						NextKey: &internal.TestKey[TransformContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -354,18 +295,14 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(2),
+						NextKey: &internal.TestKey[TransformContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},
@@ -383,10 +320,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -397,7 +332,8 @@ func Test_newPathGetSetter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			resource := createTelemetry()

--- a/pkg/ottl/contexts/ottlscope/scope.go
+++ b/pkg/ottl/contexts/ottlscope/scope.go
@@ -46,10 +46,10 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 }
 
 func NewParser(functions map[string]ottl.Factory[TransformContext], telemetrySettings component.TelemetrySettings, options ...Option) (ottl.Parser[TransformContext], error) {
-	pathExpressionParser := pathExpressionParser{telemetrySettings}
+	pep := pathExpressionParser{telemetrySettings}
 	p, err := ottl.NewParser[TransformContext](
 		functions,
-		pathExpressionParser.parsePath,
+		pep.parsePath,
 		telemetrySettings,
 		ottl.WithEnumParser[TransformContext](parseEnum),
 	)
@@ -102,23 +102,18 @@ type pathExpressionParser struct {
 	telemetrySettings component.TelemetrySettings
 }
 
-func (pep *pathExpressionParser) parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
-	if val != nil && len(val.Fields) > 0 {
-		return newPathGetSetter(val.Fields)
+func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ottl.GetSetter[TransformContext], error) {
+	if path == nil {
+		return nil, fmt.Errorf("path cannot be nil")
 	}
-	return nil, fmt.Errorf("bad path %v", val)
-}
-
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
-	switch path[0].Name {
+	switch path.Name() {
 	case "cache":
-		mapKey := path[0].Keys
-		if mapKey == nil {
+		if path.Key() == nil {
 			return accessCache(), nil
 		}
-		return accessCacheKey(mapKey), nil
+		return accessCacheKey(path.Key()), nil
 	case "resource":
-		return internal.ResourcePathGetSetter[TransformContext](path[1:])
+		return internal.ResourcePathGetSetter[TransformContext](path.Next())
 	default:
 		return internal.ScopePathGetSetter[TransformContext](path)
 	}
@@ -138,13 +133,13 @@ func accessCache() ottl.StandardGetSetter[TransformContext] {
 	}
 }
 
-func accessCacheKey(keys []ottl.Key) ottl.StandardGetSetter[TransformContext] {
+func accessCacheKey(key ottl.Key[TransformContext]) ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
 		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
-			return internal.GetMapValue(tCtx.getCache(), keys)
+			return internal.GetMapValue[TransformContext](ctx, tCtx, tCtx.getCache(), key)
 		},
 		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
-			return internal.SetMapValue(tCtx.getCache(), keys, val)
+			return internal.SetMapValue[TransformContext](ctx, tCtx, tCtx.getCache(), key, val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
@@ -34,17 +35,15 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[TransformContext]
 		orig     any
 		newVal   any
 		modified func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map)
 	}{
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
@@ -54,14 +53,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("temp"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("temp"),
 				},
 			},
 			orig:   nil,
@@ -72,10 +67,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
 			},
 			orig:   refIS.Attributes(),
 			newVal: newAttrs,
@@ -85,14 +78,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -103,14 +92,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -121,14 +106,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -139,14 +120,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   float64(1.2),
@@ -157,14 +135,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -175,14 +149,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -196,14 +166,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -217,14 +183,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -238,14 +200,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -259,14 +217,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -280,14 +234,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("pMap"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("pMap"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -303,14 +253,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("map"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("map"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -326,18 +272,14 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("slice"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(0),
+						NextKey: &internal.TestKey[TransformContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -354,18 +296,14 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(2),
+						NextKey: &internal.TestKey[TransformContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},
@@ -383,10 +321,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -396,10 +332,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "name",
-			path: []ottl.Field{
-				{
-					Name: "name",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "name",
 			},
 			orig:   refIS.Name(),
 			newVal: "newname",
@@ -409,10 +343,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "version",
-			path: []ottl.Field{
-				{
-					Name: "version",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "version",
 			},
 			orig:   refIS.Version(),
 			newVal: "next",
@@ -422,10 +354,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "resource",
-			path: []ottl.Field{
-				{
-					Name: "resource",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "resource",
 			},
 			orig:   refResource,
 			newVal: pcommon.NewResource(),
@@ -436,7 +366,8 @@ func Test_newPathGetSetter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			il, resource := createTelemetry()

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -53,10 +53,10 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 }
 
 func NewParser(functions map[string]ottl.Factory[TransformContext], telemetrySettings component.TelemetrySettings, options ...Option) (ottl.Parser[TransformContext], error) {
-	pathExpressionParser := pathExpressionParser{telemetrySettings}
+	pep := pathExpressionParser{telemetrySettings}
 	p, err := ottl.NewParser[TransformContext](
 		functions,
-		pathExpressionParser.parsePath,
+		pep.parsePath,
 		telemetrySettings,
 		ottl.WithEnumParser[TransformContext](parseEnum),
 	)
@@ -115,25 +115,20 @@ type pathExpressionParser struct {
 	telemetrySettings component.TelemetrySettings
 }
 
-func (pep *pathExpressionParser) parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
-	if val != nil && len(val.Fields) > 0 {
-		return newPathGetSetter(val.Fields)
+func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ottl.GetSetter[TransformContext], error) {
+	if path == nil {
+		return nil, fmt.Errorf("path cannot be nil")
 	}
-	return nil, fmt.Errorf("bad path %v", val)
-}
-
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
-	switch path[0].Name {
+	switch path.Name() {
 	case "cache":
-		mapKey := path[0].Keys
-		if mapKey == nil {
+		if path.Key() == nil {
 			return accessCache(), nil
 		}
-		return accessCacheKey(mapKey), nil
+		return accessCacheKey(path.Key()), nil
 	case "resource":
-		return internal.ResourcePathGetSetter[TransformContext](path[1:])
+		return internal.ResourcePathGetSetter[TransformContext](path.Next())
 	case "instrumentation_scope":
-		return internal.ScopePathGetSetter[TransformContext](path[1:])
+		return internal.ScopePathGetSetter[TransformContext](path.Next())
 	default:
 		return internal.SpanPathGetSetter[TransformContext](path)
 	}
@@ -153,13 +148,13 @@ func accessCache() ottl.StandardGetSetter[TransformContext] {
 	}
 }
 
-func accessCacheKey(keys []ottl.Key) ottl.StandardGetSetter[TransformContext] {
+func accessCacheKey(key ottl.Key[TransformContext]) ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
 		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
-			return internal.GetMapValue(tCtx.getCache(), keys)
+			return internal.GetMapValue[TransformContext](ctx, tCtx, tCtx.getCache(), key)
 		},
 		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
-			return internal.SetMapValue(tCtx.getCache(), keys, val)
+			return internal.SetMapValue[TransformContext](ctx, tCtx, tCtx.getCache(), key, val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/ottlspan/span_test.go
+++ b/pkg/ottl/contexts/ottlspan/span_test.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
@@ -53,17 +54,15 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[TransformContext]
 		orig     any
 		newVal   any
 		modified func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map)
 	}{
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
@@ -73,14 +72,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("temp"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("temp"),
 				},
 			},
 			orig:   nil,
@@ -91,10 +86,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "trace_id",
 			},
 			orig:   pcommon.TraceID(traceID),
 			newVal: pcommon.TraceID(traceID2),
@@ -104,10 +97,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "span_id",
 			},
 			orig:   pcommon.SpanID(spanID),
 			newVal: pcommon.SpanID(spanID2),
@@ -117,12 +108,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_id string",
-			path: []ottl.Field{
-				{
-					Name: "trace_id",
-				},
-				{
-					Name: "string",
+			path: &internal.TestPath[TransformContext]{
+				N: "trace_id",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "string",
 				},
 			},
 			orig:   hex.EncodeToString(traceID[:]),
@@ -133,12 +122,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span_id string",
-			path: []ottl.Field{
-				{
-					Name: "span_id",
-				},
-				{
-					Name: "string",
+			path: &internal.TestPath[TransformContext]{
+				N: "span_id",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "string",
 				},
 			},
 			orig:   hex.EncodeToString(spanID[:]),
@@ -149,10 +136,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_state",
-			path: []ottl.Field{
-				{
-					Name: "trace_state",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "trace_state",
 			},
 			orig:   "key1=val1,key2=val2",
 			newVal: "key=newVal",
@@ -162,14 +147,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "trace_state key",
-			path: []ottl.Field{
-				{
-					Name: "trace_state",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("key1"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "trace_state",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("key1"),
 				},
 			},
 			orig:   "val1",
@@ -180,10 +161,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "parent_span_id",
-			path: []ottl.Field{
-				{
-					Name: "parent_span_id",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "parent_span_id",
 			},
 			orig:   pcommon.SpanID(spanID2),
 			newVal: pcommon.SpanID(spanID),
@@ -193,10 +172,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "name",
-			path: []ottl.Field{
-				{
-					Name: "name",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "name",
 			},
 			orig:   "bear",
 			newVal: "cat",
@@ -206,10 +183,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "kind",
-			path: []ottl.Field{
-				{
-					Name: "kind",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "kind",
 			},
 			orig:   int64(2),
 			newVal: int64(3),
@@ -219,12 +194,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "string kind",
-			path: []ottl.Field{
-				{
-					Name: "kind",
-				},
-				{
-					Name: "string",
+			path: &internal.TestPath[TransformContext]{
+				N: "kind",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "string",
 				},
 			},
 			orig:   "Server",
@@ -235,12 +208,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "deprecated string kind",
-			path: []ottl.Field{
-				{
-					Name: "kind",
-				},
-				{
-					Name: "deprecated_string",
+			path: &internal.TestPath[TransformContext]{
+				N: "kind",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "deprecated_string",
 				},
 			},
 			orig:   "SPAN_KIND_SERVER",
@@ -251,10 +222,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "start_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "start_time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "start_time_unix_nano",
 			},
 			orig:   int64(100_000_000),
 			newVal: int64(200_000_000),
@@ -264,10 +233,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "end_time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "end_time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "end_time_unix_nano",
 			},
 			orig:   int64(500_000_000),
 			newVal: int64(200_000_000),
@@ -277,10 +244,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "start_time",
-			path: []ottl.Field{
-				{
-					Name: "start_time",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "start_time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
@@ -290,10 +255,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "end_time",
-			path: []ottl.Field{
-				{
-					Name: "end_time",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "end_time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 500000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
@@ -303,10 +266,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
 			},
 			orig:   refSpan.Attributes(),
 			newVal: newAttrs,
@@ -316,14 +277,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -334,14 +291,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -352,14 +305,11 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -370,14 +320,12 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   float64(1.2),
@@ -388,14 +336,12 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -406,14 +352,12 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -427,14 +371,12 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -448,14 +390,12 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -469,14 +409,12 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -490,14 +428,12 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -511,14 +447,12 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("pMap"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("pMap"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -534,14 +468,12 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("map"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("map"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -557,18 +489,16 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &internal.TestPath[TransformContext]{
+
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+
+					S: ottltest.Strp("slice"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(0),
+						NextKey: &internal.TestKey[TransformContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -585,18 +515,14 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(2),
+						NextKey: &internal.TestKey[TransformContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},
@@ -614,10 +540,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -627,10 +551,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "events",
-			path: []ottl.Field{
-				{
-					Name: "events",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "events",
 			},
 			orig:   refSpan.Events(),
 			newVal: newEvents,
@@ -643,10 +565,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_events_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_events_count",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "dropped_events_count",
 			},
 			orig:   int64(20),
 			newVal: int64(30),
@@ -656,10 +576,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "links",
-			path: []ottl.Field{
-				{
-					Name: "links",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "links",
 			},
 			orig:   refSpan.Links(),
 			newVal: newLinks,
@@ -672,10 +590,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_links_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_links_count",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "dropped_links_count",
 			},
 			orig:   int64(30),
 			newVal: int64(40),
@@ -685,10 +601,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status",
-			path: []ottl.Field{
-				{
-					Name: "status",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "status",
 			},
 			orig:   refSpan.Status(),
 			newVal: newStatus,
@@ -698,12 +612,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status code",
-			path: []ottl.Field{
-				{
-					Name: "status",
-				},
-				{
-					Name: "code",
+			path: &internal.TestPath[TransformContext]{
+				N: "status",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "code",
 				},
 			},
 			orig:   int64(ptrace.StatusCodeOk),
@@ -714,12 +626,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "status message",
-			path: []ottl.Field{
-				{
-					Name: "status",
-				},
-				{
-					Name: "message",
+			path: &internal.TestPath[TransformContext]{
+				N: "status",
+				NextPath: &internal.TestPath[TransformContext]{
+					N: "message",
 				},
 			},
 			orig:   "good span",
@@ -730,10 +640,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope",
-			path: []ottl.Field{
-				{
-					Name: "instrumentation_scope",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "instrumentation_scope",
 			},
 			orig:   refIS,
 			newVal: pcommon.NewInstrumentationScope(),
@@ -743,10 +651,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "resource",
-			path: []ottl.Field{
-				{
-					Name: "resource",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "resource",
 			},
 			orig:   refResource,
 			newVal: pcommon.NewResource(),
@@ -754,36 +660,11 @@ func Test_newPathGetSetter(t *testing.T) {
 				pcommon.NewResource().CopyTo(resource)
 			},
 		},
-		{
-			name: "start_time",
-			path: []ottl.Field{
-				{
-					Name: "start_time",
-				},
-			},
-			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
-			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
-				span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
-			},
-		},
-		{
-			name: "end_time",
-			path: []ottl.Field{
-				{
-					Name: "end_time",
-				},
-			},
-			orig:   time.Date(1970, 1, 1, 0, 0, 0, 500000000, time.UTC),
-			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
-				span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			span, il, resource := createTelemetry()

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -61,10 +61,10 @@ func (tCtx TransformContext) getCache() pcommon.Map {
 }
 
 func NewParser(functions map[string]ottl.Factory[TransformContext], telemetrySettings component.TelemetrySettings, options ...Option) (ottl.Parser[TransformContext], error) {
-	pathExpressionParser := pathExpressionParser{telemetrySettings}
+	pep := pathExpressionParser{telemetrySettings}
 	p, err := ottl.NewParser[TransformContext](
 		functions,
-		pathExpressionParser.parsePath,
+		pep.parsePath,
 		telemetrySettings,
 		ottl.WithEnumParser[TransformContext](parseEnum),
 	)
@@ -123,27 +123,22 @@ type pathExpressionParser struct {
 	telemetrySettings component.TelemetrySettings
 }
 
-func (pep *pathExpressionParser) parsePath(val *ottl.Path) (ottl.GetSetter[TransformContext], error) {
-	if val != nil && len(val.Fields) > 0 {
-		return newPathGetSetter(val.Fields)
+func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ottl.GetSetter[TransformContext], error) {
+	if path == nil {
+		return nil, fmt.Errorf("path cannot be nil")
 	}
-	return nil, fmt.Errorf("bad path %v", val)
-}
-
-func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], error) {
-	switch path[0].Name {
+	switch path.Name() {
 	case "cache":
-		mapKey := path[0].Keys
-		if mapKey == nil {
+		if path.Key() == nil {
 			return accessCache(), nil
 		}
-		return accessCacheKey(mapKey), nil
+		return accessCacheKey(path.Key()), nil
 	case "resource":
-		return internal.ResourcePathGetSetter[TransformContext](path[1:])
+		return internal.ResourcePathGetSetter[TransformContext](path.Next())
 	case "instrumentation_scope":
-		return internal.ScopePathGetSetter[TransformContext](path[1:])
+		return internal.ScopePathGetSetter[TransformContext](path.Next())
 	case "span":
-		return internal.SpanPathGetSetter[TransformContext](path[1:])
+		return internal.SpanPathGetSetter[TransformContext](path.Next())
 	case "time_unix_nano":
 		return accessSpanEventTimeUnixNano(), nil
 	case "time":
@@ -151,18 +146,16 @@ func newPathGetSetter(path []ottl.Field) (ottl.GetSetter[TransformContext], erro
 	case "name":
 		return accessSpanEventName(), nil
 	case "attributes":
-		mapKey := path[0].Keys
-		if mapKey == nil {
+		if path.Key() == nil {
 			return accessSpanEventAttributes(), nil
 		}
-		return accessSpanEventAttributesKey(mapKey), nil
+		return accessSpanEventAttributesKey(path.Key()), nil
 	case "dropped_attributes_count":
 		return accessSpanEventDroppedAttributeCount(), nil
 	}
 
 	return nil, fmt.Errorf("invalid scope path expression %v", path)
 }
-
 func accessCache() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
 		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
@@ -177,13 +170,13 @@ func accessCache() ottl.StandardGetSetter[TransformContext] {
 	}
 }
 
-func accessCacheKey(keys []ottl.Key) ottl.StandardGetSetter[TransformContext] {
+func accessCacheKey(key ottl.Key[TransformContext]) ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
 		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
-			return internal.GetMapValue(tCtx.getCache(), keys)
+			return internal.GetMapValue[TransformContext](ctx, tCtx, tCtx.getCache(), key)
 		},
 		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
-			return internal.SetMapValue(tCtx.getCache(), keys, val)
+			return internal.SetMapValue[TransformContext](ctx, tCtx, tCtx.getCache(), key, val)
 		},
 	}
 }
@@ -244,13 +237,13 @@ func accessSpanEventAttributes() ottl.StandardGetSetter[TransformContext] {
 	}
 }
 
-func accessSpanEventAttributesKey(keys []ottl.Key) ottl.StandardGetSetter[TransformContext] {
+func accessSpanEventAttributesKey(key ottl.Key[TransformContext]) ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
 		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
-			return internal.GetMapValue(tCtx.GetSpanEvent().Attributes(), keys)
+			return internal.GetMapValue[TransformContext](ctx, tCtx, tCtx.GetSpanEvent().Attributes(), key)
 		},
 		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
-			return internal.SetMapValue(tCtx.GetSpanEvent().Attributes(), keys, val)
+			return internal.SetMapValue[TransformContext](ctx, tCtx, tCtx.GetSpanEvent().Attributes(), key, val)
 		},
 	}
 }

--- a/pkg/ottl/contexts/ottlspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
@@ -49,17 +50,15 @@ func Test_newPathGetSetter(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		path     []ottl.Field
+		path     ottl.Path[TransformContext]
 		orig     any
 		newVal   any
 		modified func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map)
 	}{
 		{
 			name: "span event time",
-			path: []ottl.Field{
-				{
-					Name: "time",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "time",
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
@@ -69,10 +68,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
@@ -82,14 +79,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "cache access",
-			path: []ottl.Field{
-				{
-					Name: "cache",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("temp"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "cache",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("temp"),
 				},
 			},
 			orig:   nil,
@@ -100,10 +93,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "name",
-			path: []ottl.Field{
-				{
-					Name: "name",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "name",
 			},
 			orig:   "bear",
 			newVal: "cat",
@@ -113,10 +104,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "time_unix_nano",
-			path: []ottl.Field{
-				{
-					Name: "time_unix_nano",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "time_unix_nano",
 			},
 			orig:   int64(100_000_000),
 			newVal: int64(200_000_000),
@@ -126,10 +115,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
 			},
 			orig:   refSpanEvent.Attributes(),
 			newVal: newAttrs,
@@ -139,14 +126,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("str"),
 				},
 			},
 			orig:   "val",
@@ -157,14 +140,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bool"),
 				},
 			},
 			orig:   true,
@@ -175,14 +154,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("int"),
 				},
 			},
 			orig:   int64(10),
@@ -193,14 +168,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("double"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("double"),
 				},
 			},
 			orig:   float64(1.2),
@@ -211,14 +182,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("bytes"),
 				},
 			},
 			orig:   []byte{1, 3, 2},
@@ -229,14 +196,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array string",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_str"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_str"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -250,14 +213,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bool",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bool"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bool"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -271,14 +230,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array int",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_int"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_int"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -292,14 +247,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array float",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_float"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_float"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -313,14 +264,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes array bytes",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("arr_bytes"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("arr_bytes"),
 				},
 			},
 			orig: func() pcommon.Slice {
@@ -334,14 +281,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes pcommon.Map",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("pMap"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("pMap"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -357,14 +300,10 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes map[string]any",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("map"),
-						},
-					},
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("map"),
 				},
 			},
 			orig: func() pcommon.Map {
@@ -380,18 +319,14 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("slice"),
-						},
-						{
-							Int: ottltest.Intp(0),
-						},
-						{
-							String: ottltest.Strp("map"),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("slice"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(0),
+						NextKey: &internal.TestKey[TransformContext]{
+							S: ottltest.Strp("map"),
 						},
 					},
 				},
@@ -408,18 +343,14 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "attributes nested new values",
-			path: []ottl.Field{
-				{
-					Name: "attributes",
-					Keys: []ottl.Key{
-						{
-							String: ottltest.Strp("new"),
-						},
-						{
-							Int: ottltest.Intp(2),
-						},
-						{
-							Int: ottltest.Intp(0),
+			path: &internal.TestPath[TransformContext]{
+				N: "attributes",
+				Keys: &internal.TestKey[TransformContext]{
+					S: ottltest.Strp("new"),
+					NextKey: &internal.TestKey[TransformContext]{
+						I: ottltest.Intp(2),
+						NextKey: &internal.TestKey[TransformContext]{
+							I: ottltest.Intp(0),
 						},
 					},
 				},
@@ -437,10 +368,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "dropped_attributes_count",
-			path: []ottl.Field{
-				{
-					Name: "dropped_attributes_count",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "dropped_attributes_count",
 			},
 			orig:   int64(10),
 			newVal: int64(20),
@@ -450,10 +379,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "instrumentation_scope",
-			path: []ottl.Field{
-				{
-					Name: "instrumentation_scope",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "instrumentation_scope",
 			},
 			orig:   refIS,
 			newVal: pcommon.NewInstrumentationScope(),
@@ -463,10 +390,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "resource",
-			path: []ottl.Field{
-				{
-					Name: "resource",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "resource",
 			},
 			orig:   refResource,
 			newVal: pcommon.NewResource(),
@@ -476,10 +401,8 @@ func Test_newPathGetSetter(t *testing.T) {
 		},
 		{
 			name: "span",
-			path: []ottl.Field{
-				{
-					Name: "span",
-				},
+			path: &internal.TestPath[TransformContext]{
+				N: "span",
 			},
 			orig:   refSpan,
 			newVal: ptrace.NewSpan(),
@@ -490,7 +413,8 @@ func Test_newPathGetSetter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			accessor, err := newPathGetSetter(tt.path)
+			pep := pathExpressionParser{}
+			accessor, err := pep.parsePath(tt.path)
 			assert.NoError(t, err)
 
 			spanEvent, span, il, resource := createTelemetry()

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -63,7 +63,7 @@ func (l literal[K]) Get(context.Context, K) (any, error) {
 
 type exprGetter[K any] struct {
 	expr Expr[K]
-	keys []Key
+	keys []key
 }
 
 func (g exprGetter[K]) Get(ctx context.Context, tCtx K) (any, error) {
@@ -631,7 +631,7 @@ func (p *Parser[K]) newGetter(val value) (Getter[K], error) {
 			return &literal[K]{value: *i}, nil
 		}
 		if eL.Path != nil {
-			return p.pathParser(eL.Path)
+			return p.pathParser(newPath[K](eL.Path.Fields))
 		}
 		if eL.Converter != nil {
 			return p.newGetterFromConverter(*eL.Converter)

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -116,8 +116,8 @@ func Test_newGetter(t *testing.T) {
 			name: "path expression",
 			val: value{
 				Literal: &mathExprLiteral{
-					Path: &Path{
-						Fields: []Field{
+					Path: &path{
+						Fields: []field{
 							{
 								Name: "name",
 							},
@@ -131,11 +131,11 @@ func Test_newGetter(t *testing.T) {
 			name: "complex path expression",
 			val: value{
 				Literal: &mathExprLiteral{
-					Path: &Path{
-						Fields: []Field{
+					Path: &path{
+						Fields: []field{
 							{
 								Name: "attributes",
-								Keys: []Key{
+								Keys: []key{
 									{
 										String: ottltest.Strp("foo"),
 									},
@@ -167,7 +167,7 @@ func Test_newGetter(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "PMap",
-						Keys: []Key{
+						Keys: []key{
 							{
 								String: ottltest.Strp("foo"),
 							},
@@ -186,7 +186,7 @@ func Test_newGetter(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "Map",
-						Keys: []Key{
+						Keys: []key{
 							{
 								String: ottltest.Strp("foo"),
 							},
@@ -205,7 +205,7 @@ func Test_newGetter(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "PSlice",
-						Keys: []Key{
+						Keys: []key{
 							{
 								Int: ottltest.Intp(0),
 							},
@@ -224,7 +224,7 @@ func Test_newGetter(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "Slice",
-						Keys: []Key{
+						Keys: []key{
 							{
 								Int: ottltest.Intp(0),
 							},
@@ -348,8 +348,8 @@ func Test_newGetter(t *testing.T) {
 					Values: []value{
 						{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -426,7 +426,7 @@ func Test_newGetter(t *testing.T) {
 
 	p, _ := NewParser[any](
 		functions,
-		testParsePath,
+		testParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)
@@ -465,7 +465,7 @@ func Test_exprGetter_Get_Invalid(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "PMap",
-						Keys: []Key{
+						Keys: []key{
 							{
 								String: ottltest.Strp("unknown key"),
 							},
@@ -481,7 +481,7 @@ func Test_exprGetter_Get_Invalid(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "Map",
-						Keys: []Key{
+						Keys: []key{
 							{
 								String: ottltest.Strp("unknown key"),
 							},
@@ -497,7 +497,7 @@ func Test_exprGetter_Get_Invalid(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "PSlice",
-						Keys: []Key{
+						Keys: []key{
 							{
 								Int: ottltest.Intp(100),
 							},
@@ -513,7 +513,7 @@ func Test_exprGetter_Get_Invalid(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "PSlice",
-						Keys: []Key{
+						Keys: []key{
 							{
 								Int: ottltest.Intp(-1),
 							},
@@ -529,7 +529,7 @@ func Test_exprGetter_Get_Invalid(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "Slice",
-						Keys: []Key{
+						Keys: []key{
 							{
 								Int: ottltest.Intp(100),
 							},
@@ -545,7 +545,7 @@ func Test_exprGetter_Get_Invalid(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "Slice",
-						Keys: []Key{
+						Keys: []key{
 							{
 								Int: ottltest.Intp(-1),
 							},
@@ -561,7 +561,7 @@ func Test_exprGetter_Get_Invalid(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "Hello",
-						Keys: []Key{
+						Keys: []key{
 							{
 								Int: ottltest.Intp(-1),
 							},
@@ -577,7 +577,7 @@ func Test_exprGetter_Get_Invalid(t *testing.T) {
 				Literal: &mathExprLiteral{
 					Converter: &converter{
 						Function: "Hello",
-						Keys: []Key{
+						Keys: []key{
 							{
 								String: ottltest.Strp("test"),
 							},
@@ -599,7 +599,7 @@ func Test_exprGetter_Get_Invalid(t *testing.T) {
 
 	p, _ := NewParser[any](
 		functions,
-		testParsePath,
+		testParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -83,7 +83,7 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 
 	p, _ := NewParser(
 		functions,
-		testParsePath,
+		testParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)
@@ -150,8 +150,8 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 					{
 						Value: value{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -176,8 +176,8 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 					{
 						Value: value{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -283,8 +283,8 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 						Name: "get_setter_arg",
 						Value: value{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -323,8 +323,8 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 					{
 						Value: value{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -407,7 +407,7 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 func Test_NewFunctionCall(t *testing.T) {
 	p, _ := NewParser(
 		defaultFunctionsForTests(),
-		testParsePath,
+		testParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)
@@ -542,8 +542,8 @@ func Test_NewFunctionCall(t *testing.T) {
 								Values: []value{
 									{
 										Literal: &mathExprLiteral{
-											Path: &Path{
-												Fields: []Field{
+											Path: &path{
+												Fields: []field{
 													{
 														Name: "name",
 													},
@@ -620,8 +620,8 @@ func Test_NewFunctionCall(t *testing.T) {
 													{
 														Value: value{
 															Literal: &mathExprLiteral{
-																Path: &Path{
-																	Fields: []Field{
+																Path: &path{
+																	Fields: []field{
 																		{
 																			Name: "name",
 																		},
@@ -766,8 +766,8 @@ func Test_NewFunctionCall(t *testing.T) {
 								Values: []value{
 									{
 										Literal: &mathExprLiteral{
-											Path: &Path{
-												Fields: []Field{
+											Path: &path{
+												Fields: []field{
 													{
 														Name: "name",
 													},
@@ -777,8 +777,8 @@ func Test_NewFunctionCall(t *testing.T) {
 									},
 									{
 										Literal: &mathExprLiteral{
-											Path: &Path{
-												Fields: []Field{
+											Path: &path{
+												Fields: []field{
 													{
 														Name: "name",
 													},
@@ -877,8 +877,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Value: value{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -899,8 +899,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Value: value{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -921,8 +921,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Value: value{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -979,8 +979,8 @@ func Test_NewFunctionCall(t *testing.T) {
 									},
 									{
 										Literal: &mathExprLiteral{
-											Path: &Path{
-												Fields: []Field{
+											Path: &path{
+												Fields: []field{
 													{
 														Name: "name",
 													},
@@ -996,8 +996,8 @@ func Test_NewFunctionCall(t *testing.T) {
 													{
 														Value: value{
 															Literal: &mathExprLiteral{
-																Path: &Path{
-																	Fields: []Field{
+																Path: &path{
+																	Fields: []field{
 																		{
 																			Name: "name",
 																		},
@@ -1168,8 +1168,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Value: value{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -1264,8 +1264,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Value: value{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -1305,8 +1305,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Value: value{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -1344,8 +1344,8 @@ func Test_NewFunctionCall(t *testing.T) {
 					{
 						Value: value{
 							Literal: &mathExprLiteral{
-								Path: &Path{
-									Fields: []Field{
+								Path: &path{
+									Fields: []field{
 										{
 											Name: "name",
 										},
@@ -1414,7 +1414,7 @@ func Test_ArgumentsNotMutated(t *testing.T) {
 	)
 	p, _ := NewParser(
 		CreateFactoryMap[any](fact),
-		testParsePath,
+		testParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)
@@ -1425,8 +1425,8 @@ func Test_ArgumentsNotMutated(t *testing.T) {
 			{
 				Value: value{
 					Literal: &mathExprLiteral{
-						Path: &Path{
-							Fields: []Field{
+						Path: &path{
+							Fields: []field{
 								{
 									Name: "name",
 								},
@@ -1461,8 +1461,8 @@ func Test_ArgumentsNotMutated(t *testing.T) {
 			{
 				Value: value{
 					Literal: &mathExprLiteral{
-						Path: &Path{
-							Fields: []Field{
+						Path: &path{
+							Fields: []field{
 								{
 									Name: "name",
 								},
@@ -2220,7 +2220,7 @@ func Test_basePath_NextWithIsComplete(t *testing.T) {
 }
 
 func Test_newPath(t *testing.T) {
-	fields := []Field{
+	fields := []field{
 		{
 			Name: "body",
 		},
@@ -2229,10 +2229,12 @@ func Test_newPath(t *testing.T) {
 		},
 	}
 	p := newPath[any](fields)
-	assert.Equal(t, "body", p.name)
-	p = p.nextPath
-	assert.Equal(t, "string", p.name)
-	assert.Nil(t, p.nextPath)
+	assert.Equal(t, "body", p.Name())
+	assert.Nil(t, p.Key())
+	p = p.Next()
+	assert.Equal(t, "string", p.Name())
+	assert.Nil(t, p.Key())
+	assert.Nil(t, p.Next())
 }
 
 func Test_baseKey_String(t *testing.T) {
@@ -2365,7 +2367,7 @@ func Test_baseKey_NextWithIsComplete(t *testing.T) {
 }
 
 func Test_newKey(t *testing.T) {
-	keys := []Key{
+	keys := []key{
 		{
 			String: ottltest.Strp("foo"),
 		},
@@ -2374,8 +2376,14 @@ func Test_newKey(t *testing.T) {
 		},
 	}
 	k := newKey[any](keys)
-	assert.Equal(t, "foo", *k.s)
-	k = k.nextKey
-	assert.Equal(t, "bar", *k.s)
-	assert.Nil(t, k.nextKey)
+	s, err := k.String(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, s)
+	assert.Equal(t, "foo", *s)
+	k = k.Next()
+	s, err = k.String(context.Background(), nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, s)
+	assert.Equal(t, "bar", *s)
+	assert.Nil(t, k.Next())
 }

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -192,7 +192,7 @@ type editor struct {
 	Function  string     `parser:"@(Lowercase(Uppercase | Lowercase)*)"`
 	Arguments []argument `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
 	// If keys are matched return an error
-	Keys []Key `parser:"( @@ )*"`
+	Keys []key `parser:"( @@ )*"`
 }
 
 func (i *editor) checkForCustomError() error {
@@ -214,7 +214,7 @@ func (i *editor) checkForCustomError() error {
 type converter struct {
 	Function  string     `parser:"@(Uppercase(Uppercase | Lowercase)*)"`
 	Arguments []argument `parser:"'(' ( @@ ( ',' @@ )* )? ')'"`
-	Keys      []Key      `parser:"( @@ )*"`
+	Keys      []key      `parser:"( @@ )*"`
 }
 
 type argument struct {
@@ -250,18 +250,18 @@ func (v *value) checkForCustomError() error {
 	return nil
 }
 
-// Path represents a telemetry path mathExpression.
-type Path struct {
-	Fields []Field `parser:"@@ ( '.' @@ )*"`
+// path represents a telemetry path mathExpression.
+type path struct {
+	Fields []field `parser:"@@ ( '.' @@ )*"`
 }
 
-// Field is an item within a Path.
-type Field struct {
+// field is an item within a path.
+type field struct {
 	Name string `parser:"@Lowercase"`
-	Keys []Key  `parser:"( @@ )*"`
+	Keys []key  `parser:"( @@ )*"`
 }
 
-type Key struct {
+type key struct {
 	String *string `parser:"'[' (@String "`
 	Int    *int64  `parser:"| @Int) ']'"`
 }
@@ -305,7 +305,7 @@ type mathExprLiteral struct {
 	Converter *converter `parser:"| @@"`
 	Float     *float64   `parser:"| @Float"`
 	Int       *int64     `parser:"| @Int"`
-	Path      *Path      `parser:"| @@ )"`
+	Path      *path      `parser:"| @@ )"`
 }
 
 func (m *mathExprLiteral) checkForCustomError() error {

--- a/pkg/ottl/math_test.go
+++ b/pkg/ottl/math_test.go
@@ -18,29 +18,29 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottltest"
 )
 
-func mathParsePath(val *Path) (GetSetter[any], error) {
-	if val != nil && len(val.Fields) > 0 && val.Fields[0].Name == "one" {
+func mathParsePath[K any](p Path[K]) (GetSetter[any], error) {
+	if p != nil && p.Name() == "one" {
 		return &StandardGetSetter[any]{
 			Getter: func(context.Context, any) (any, error) {
 				return int64(1), nil
 			},
 		}, nil
 	}
-	if val != nil && len(val.Fields) > 0 && val.Fields[0].Name == "two" {
+	if p != nil && p.Name() == "two" {
 		return &StandardGetSetter[any]{
 			Getter: func(context.Context, any) (any, error) {
 				return int64(2), nil
 			},
 		}, nil
 	}
-	if val != nil && len(val.Fields) > 0 && val.Fields[0].Name == "three" && val.Fields[1].Name == "one" {
+	if p != nil && p.Name() == "three" && p.Next() != nil && p.Next().Name() == "one" {
 		return &StandardGetSetter[any]{
 			Getter: func(context.Context, any) (any, error) {
 				return 3.1, nil
 			},
 		}, nil
 	}
-	return nil, fmt.Errorf("bad path %v", val)
+	return nil, fmt.Errorf("bad path %v", p)
 }
 
 func one[K any]() (ExprFunc[K], error) {
@@ -234,7 +234,7 @@ func Test_evaluateMathExpression(t *testing.T) {
 
 	p, _ := NewParser[any](
 		functions,
-		mathParsePath,
+		mathParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)
@@ -556,7 +556,7 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 
 	p, _ := NewParser[any](
 		functions,
-		mathParsePath,
+		mathParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)
@@ -606,7 +606,7 @@ func Test_evaluateMathExpressionTimeDuration(t *testing.T) {
 
 	p, _ := NewParser(
 		functions,
-		mathParsePath,
+		mathParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -105,8 +105,8 @@ func Test_parse(t *testing.T) {
 											{
 												Value: value{
 													Literal: &mathExprLiteral{
-														Path: &Path{
-															Fields: []Field{
+														Path: &path{
+															Fields: []field{
 																{
 																	Name: "bear",
 																},
@@ -138,14 +138,14 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "foo",
 											},
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("bar"),
 													},
@@ -179,11 +179,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("message"),
 													},
@@ -202,11 +202,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("device_name"),
 													},
@@ -237,11 +237,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("message"),
 													},
@@ -272,11 +272,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("message"),
 													},
@@ -307,14 +307,14 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "foo",
 											},
 											{
 												Name: "bar",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("x"),
 													},
@@ -336,7 +336,7 @@ func Test_parse(t *testing.T) {
 								Literal: &mathExprLiteral{
 									Converter: &converter{
 										Function: "Test",
-										Keys: []Key{
+										Keys: []key{
 											{
 												Int: ottltest.Intp(0),
 											},
@@ -363,14 +363,14 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "foo",
 											},
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("bar"),
 													},
@@ -397,8 +397,8 @@ func Test_parse(t *testing.T) {
 							Comparison: &comparison{
 								Left: value{
 									Literal: &mathExprLiteral{
-										Path: &Path{
-											Fields: []Field{
+										Path: &path{
+											Fields: []field{
 												{
 													Name: "name",
 												},
@@ -426,14 +426,14 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "foo",
 											},
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("bar"),
 													},
@@ -460,8 +460,8 @@ func Test_parse(t *testing.T) {
 							Comparison: &comparison{
 								Left: value{
 									Literal: &mathExprLiteral{
-										Path: &Path{
-											Fields: []Field{
+										Path: &path{
+											Fields: []field{
 												{
 													Name: "name",
 												},
@@ -489,14 +489,14 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "foo",
 											},
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("bar"),
 													},
@@ -523,8 +523,8 @@ func Test_parse(t *testing.T) {
 							Comparison: &comparison{
 								Left: value{
 									Literal: &mathExprLiteral{
-										Path: &Path{
-											Fields: []Field{
+										Path: &path{
+											Fields: []field{
 												{
 													Name: "name",
 												},
@@ -613,11 +613,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("bytes"),
 													},
@@ -648,11 +648,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("test"),
 													},
@@ -683,11 +683,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("test"),
 													},
@@ -718,11 +718,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("test"),
 													},
@@ -755,11 +755,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("test"),
 													},
@@ -796,11 +796,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("test"),
 													},
@@ -840,11 +840,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("test"),
 													},
@@ -911,11 +911,11 @@ func Test_parse(t *testing.T) {
 										},
 										{
 											Literal: &mathExprLiteral{
-												Path: &Path{
-													Fields: []Field{
+												Path: &path{
+													Fields: []field{
 														{
 															Name: "attributes",
-															Keys: []Key{
+															Keys: []key{
 																{
 																	String: ottltest.Strp("test"),
 																},
@@ -944,11 +944,11 @@ func Test_parse(t *testing.T) {
 						{
 							Value: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "attributes",
-												Keys: []Key{
+												Keys: []key{
 													{
 														String: ottltest.Strp("test"),
 													},
@@ -1029,8 +1029,8 @@ func Test_parse(t *testing.T) {
 										Left: &addSubTerm{
 											Left: &mathValue{
 												Literal: &mathExprLiteral{
-													Path: &Path{
-														Fields: []Field{
+													Path: &path{
+														Fields: []field{
 															{
 																Name: "three",
 															},
@@ -1103,8 +1103,8 @@ func Test_parseCondition_full(t *testing.T) {
 						Comparison: &comparison{
 							Left: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "name",
 											},
@@ -1130,8 +1130,8 @@ func Test_parseCondition_full(t *testing.T) {
 						Comparison: &comparison{
 							Left: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "name",
 											},
@@ -1194,8 +1194,8 @@ func Test_parseCondition_full(t *testing.T) {
 									Left: &addSubTerm{
 										Left: &mathValue{
 											Literal: &mathExprLiteral{
-												Path: &Path{
-													Fields: []Field{
+												Path: &path{
+													Fields: []field{
 														{
 															Name: "three",
 														},
@@ -1234,8 +1234,8 @@ func Test_parseCondition_full(t *testing.T) {
 	}
 }
 
-func testParsePath(val *Path) (GetSetter[any], error) {
-	if val != nil && len(val.Fields) > 0 && (val.Fields[0].Name == "name" || val.Fields[0].Name == "attributes") {
+func testParsePath[K any](p Path[K]) (GetSetter[any], error) {
+	if p != nil && (p.Name() == "name" || p.Name() == "attributes") {
 		return &StandardGetSetter[any]{
 			Getter: func(ctx context.Context, tCtx any) (any, error) {
 				return tCtx, nil
@@ -1246,14 +1246,14 @@ func testParsePath(val *Path) (GetSetter[any], error) {
 			},
 		}, nil
 	}
-	if val.Fields[0].Name == "dur1" || val.Fields[0].Name == "dur2" {
+	if p != nil && (p.Name() == "dur1" || p.Name() == "dur2") {
 		return &StandardGetSetter[any]{
 			Getter: func(ctx context.Context, tCtx any) (any, error) {
 				m, ok := tCtx.(map[string]time.Duration)
 				if !ok {
 					return nil, fmt.Errorf("unable to convert transform context to map of strings to times")
 				}
-				return m[val.Fields[0].Name], nil
+				return m[p.Name()], nil
 			},
 			Setter: func(ctx context.Context, tCtx any, val any) error {
 				reflect.DeepEqual(tCtx, val)
@@ -1261,14 +1261,14 @@ func testParsePath(val *Path) (GetSetter[any], error) {
 			},
 		}, nil
 	}
-	if val.Fields[0].Name == "time1" || val.Fields[0].Name == "time2" {
+	if p != nil && (p.Name() == "time1" || p.Name() == "time2") {
 		return &StandardGetSetter[any]{
 			Getter: func(ctx context.Context, tCtx any) (any, error) {
 				m, ok := tCtx.(map[string]time.Time)
 				if !ok {
 					return nil, fmt.Errorf("unable to convert transform context to map of strings to times")
 				}
-				return m[val.Fields[0].Name], nil
+				return m[p.Name()], nil
 			},
 			Setter: func(ctx context.Context, tCtx any, val any) error {
 				reflect.DeepEqual(tCtx, val)
@@ -1276,7 +1276,7 @@ func testParsePath(val *Path) (GetSetter[any], error) {
 			},
 		}, nil
 	}
-	return nil, fmt.Errorf("bad path %v", val)
+	return nil, fmt.Errorf("bad path %v", p)
 }
 
 // Helper for test cases where the WHERE clause is all that matters.
@@ -1289,8 +1289,8 @@ func setNameTest(b *booleanExpression) *parsedStatement {
 				{
 					Value: value{
 						Literal: &mathExprLiteral{
-							Path: &Path{
-								Fields: []Field{
+							Path: &path{
+								Fields: []field{
 									{
 										Name: "name",
 									},
@@ -1525,8 +1525,8 @@ func Test_parseWhere(t *testing.T) {
 						Comparison: &comparison{
 							Left: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "name",
 											},
@@ -1547,8 +1547,8 @@ func Test_parseWhere(t *testing.T) {
 								Comparison: &comparison{
 									Left: value{
 										Literal: &mathExprLiteral{
-											Path: &Path{
-												Fields: []Field{
+											Path: &path{
+												Fields: []field{
 													{
 														Name: "name",
 													},
@@ -1575,8 +1575,8 @@ func Test_parseWhere(t *testing.T) {
 						Comparison: &comparison{
 							Left: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "name",
 											},
@@ -1599,8 +1599,8 @@ func Test_parseWhere(t *testing.T) {
 								Comparison: &comparison{
 									Left: value{
 										Literal: &mathExprLiteral{
-											Path: &Path{
-												Fields: []Field{
+											Path: &path{
+												Fields: []field{
 													{
 														Name: "name",
 													},
@@ -1651,8 +1651,8 @@ func Test_parseWhere(t *testing.T) {
 						Comparison: &comparison{
 							Left: value{
 								Literal: &mathExprLiteral{
-									Path: &Path{
-										Fields: []Field{
+									Path: &path{
+										Fields: []field{
 											{
 												Name: "name",
 											},
@@ -1780,7 +1780,7 @@ func Test_ParseStatements_Error(t *testing.T) {
 
 	p, _ := NewParser(
 		CreateFactoryMap[any](),
-		testParsePath,
+		testParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)
@@ -1810,7 +1810,7 @@ func Test_ParseConditions_Error(t *testing.T) {
 
 	p, _ := NewParser(
 		CreateFactoryMap[any](),
-		testParsePath,
+		testParsePath[any],
 		componenttest.NewNopTelemetrySettings(),
 		WithEnumParser[any](testParseEnum),
 	)


### PR DESCRIPTION
This PR publicizes and implements the new `Path` and `Key` interfaces.  These interfaces allow contexts to get access to the parsed paths/keys without needed to export the grammar's structs. Since everything was using those structs before, this has significant breaking changes.

This PR should not change any functionality.

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22744