### PR TITLE
[chore][connector/servicegraph][processor/servicegraph] Cleanup and copy configuration README

### DIFF
--- a/connector/servicegraphconnector/README.md
+++ b/connector/servicegraphconnector/README.md
@@ -128,15 +128,18 @@ The following settings are required:
 The following settings can be optionally configured:
 
 - `store`: defines the config for the in-memory store used to find requests between services by pairing spans.
-    - `ttl`: TTL is the time to live for items in the store.
-        - Default: `2s`
-    - `max_items`: MaxItems is the maximum number of items to keep in the store.
-        - Default: `1000`
+  - `ttl`: TTL is the time to live for items in the store.
+    - Default: `2s`
+  - `max_items`: MaxItems is the maximum number of items to keep in the store.
+    - Default: `1000`
 - `cache_loop`: the interval at which to clean the cache.
+  - Default: `1m`
 - `store_expiration_loop`: the time to expire old entries from the store periodically.
+  - Default: `2s`
 - `virtual_node_peer_attributes`: the list of attributes need to match for building virtual server node, the higher the front, the higher the priority.
-    - Default: `[db.name, net.sock.peer.addr, net.peer.name, rpc.service, net.sock.peer.name, net.peer.name, http.url, http.target]`
-- `metrics_flush_interval`: the interval at which metrics are flushed to the exporter. Metrics are flush on every received batch of traces by default.
+  - Default: `[db.name, net.sock.peer.addr, net.peer.name, rpc.service, net.sock.peer.name, net.peer.name, http.url, http.target]`
+- `metrics_flush_interval`: the interval at which metrics are flushed to the exporter.
+  - Default: Metrics are flushed on every received batch of traces.
 
 ## Example configuration
 

--- a/connector/servicegraphconnector/README.md
+++ b/connector/servicegraphconnector/README.md
@@ -116,6 +116,28 @@ datasources:
     version: 1
 ```
 
+## Configuration
+
+The following settings are required:
+
+- `metrics_exporter`: the name of the exporter that this processor will write metrics to. This exporter **must** be present in a pipeline.
+- `latency_histogram_buckets`: the list of durations defining the latency histogram buckets.
+    - Default: `[2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]`
+- `dimensions`: the list of dimensions to add together with the default dimensions defined above.
+
+The following settings can be optionally configured:
+
+- `store`: defines the config for the in-memory store used to find requests between services by pairing spans.
+    - `ttl`: TTL is the time to live for items in the store.
+        - Default: `2s`
+    - `max_items`: MaxItems is the maximum number of items to keep in the store.
+        - Default: `1000`
+- `cache_loop`: the interval at which to clean the cache.
+- `store_expiration_loop`: the time to expire old entries from the store periodically.
+- `virtual_node_peer_attributes`: the list of attributes need to match for building virtual server node, the higher the front, the higher the priority.
+    - Default: `[db.name, net.sock.peer.addr, net.peer.name, rpc.service, net.sock.peer.name, net.peer.name, http.url, http.target]`
+- `metrics_flush_interval`: the interval at which metrics are flushed to the exporter. Metrics are flush on every received batch of traces by default.
+
 ## Example configuration
 
 ```yaml

--- a/processor/servicegraphprocessor/README.md
+++ b/processor/servicegraphprocessor/README.md
@@ -117,15 +117,16 @@ The following settings are required:
 
 The following settings can be optionally configured:
 
-- `store` defines the config for the in-memory store used to find requests between services by pairing spans.
-    - `ttl` - TTL is the time to live for items in the store.
+- `store`: defines the config for the in-memory store used to find requests between services by pairing spans.
+    - `ttl`: TTL is the time to live for items in the store.
       - Default: `2s`
-    - `max_items` - MaxItems is the maximum number of items to keep in the store.
+    - `max_items`: MaxItems is the maximum number of items to keep in the store.
       - Default: `1000` 
-- `cache_loop` - the time to cleans the cache periodically
-- `store_expiration_loop`  the time to expire old entries from the store periodically.
-- `virtual_node_peer_attributes` the list of attributes need to match for building virtual server node, the higher the front, the higher the priority.
+- `cache_loop`: the interval at which to clean the cache.
+- `store_expiration_loop`: the time to expire old entries from the store periodically.
+- `virtual_node_peer_attributes`: the list of attributes need to match for building virtual server node, the higher the front, the higher the priority.
   - Default: `[db.name, net.sock.peer.addr, net.peer.name, rpc.service, net.sock.peer.name, net.peer.name, http.url, http.target]`
+- `metrics_flush_interval`: the interval at which metrics are flushed to the exporter. Metrics are flush on every received batch of traces by default.
 
 ## Example configuration
 


### PR DESCRIPTION
**Documentation:** <Describe the documentation added.>
#27879 recently added a new configuration option to the `servicegraph` components called `metrics_flush_interval`. I noticed this wasn't documented for either component, and the `connector/servicegraph` README doesn't include a configuration section. Since the connector is just a wrapper of the processor at this point, I cleaned up the processor's configuration section and copied it to the connector, adding an entry for the new `metrics_flush_interval` option.