### PR TITLE
[chore] pass factory context to the metrics

### DIFF
--- a/exporter/carbonexporter/exporter.go
+++ b/exporter/carbonexporter/exporter.go
@@ -19,13 +19,13 @@ import (
 )
 
 // newCarbonExporter returns a new Carbon exporter.
-func newCarbonExporter(cfg *Config, set exporter.CreateSettings) (exporter.Metrics, error) {
+func newCarbonExporter(ctx context.Context, cfg *Config, set exporter.CreateSettings) (exporter.Metrics, error) {
 	sender := carbonSender{
 		writer: newTCPConnPool(cfg.Endpoint, cfg.Timeout),
 	}
 
 	exp, err := exporterhelper.NewMetricsExporter(
-		context.TODO(),
+		ctx,
 		set,
 		cfg,
 		sender.pushMetricsData,

--- a/exporter/carbonexporter/exporter_test.go
+++ b/exporter/carbonexporter/exporter_test.go
@@ -32,13 +32,14 @@ import (
 
 func TestNewWithDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	got, err := newCarbonExporter(cfg, exportertest.NewNopCreateSettings())
+	got, err := newCarbonExporter(context.TODO(), cfg, exportertest.NewNopCreateSettings())
 	assert.NotNil(t, got)
 	assert.NoError(t, err)
 }
 
 func TestConsumeMetricsNoServer(t *testing.T) {
 	exp, err := newCarbonExporter(
+		context.TODO(),
 		&Config{
 			TCPAddr:         confignet.TCPAddr{Endpoint: testutil.GetAvailableLocalAddress(t)},
 			TimeoutSettings: exporterhelper.TimeoutSettings{Timeout: 5 * time.Second},
@@ -58,6 +59,7 @@ func TestConsumeMetricsWithResourceToTelemetry(t *testing.T) {
 	cs.start(t, 1)
 
 	exp, err := newCarbonExporter(
+		context.TODO(),
 		&Config{
 			TCPAddr:                   confignet.TCPAddr{Endpoint: addr},
 			TimeoutSettings:           exporterhelper.TimeoutSettings{Timeout: 5 * time.Second},
@@ -122,6 +124,7 @@ func TestConsumeMetrics(t *testing.T) {
 			cs.start(t, tt.numProducers*tt.writesPerProducer*tt.md.DataPointCount())
 
 			exp, err := newCarbonExporter(
+				context.TODO(),
 				&Config{
 					TCPAddr:         confignet.TCPAddr{Endpoint: addr},
 					TimeoutSettings: exporterhelper.TimeoutSettings{Timeout: 5 * time.Second},

--- a/exporter/carbonexporter/factory.go
+++ b/exporter/carbonexporter/factory.go
@@ -34,11 +34,11 @@ func createDefaultConfig() component.Config {
 }
 
 func createMetricsExporter(
-	_ context.Context,
+	ctx context.Context,
 	params exporter.CreateSettings,
 	config component.Config,
 ) (exporter.Metrics, error) {
-	exp, err := newCarbonExporter(config.(*Config), params)
+	exp, err := newCarbonExporter(ctx, config.(*Config), params)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Remove the use of context.TODO() in favor of passing the context from the factory function.