### PR TITLE
[exporter/zipkin] use confighttp.DefaultHTTPClientSettings

### DIFF
--- a/.chloggen/zipkinexporter_clientsettings.yaml
+++ b/.chloggen/zipkinexporter_clientsettings.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: zipkinexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use default client HTTP settings in zipkinexporter, move validation to config validation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29931]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/zipkinexporter/config.go
+++ b/exporter/zipkinexporter/config.go
@@ -4,6 +4,8 @@
 package zipkinexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter"
 
 import (
+	"errors"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -27,5 +29,8 @@ var _ component.Config = (*Config)(nil)
 
 // Validate checks if the exporter configuration is valid
 func (cfg *Config) Validate() error {
+	if cfg.HTTPClientSettings.Endpoint == "" {
+		return errors.New("endpoint required")
+	}
 	return nil
 }

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -29,6 +29,7 @@ func TestLoadConfig(t *testing.T) {
 	// URL doesn't have a default value so set it directly.
 	defaultCfg := createDefaultConfig().(*Config)
 	defaultCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
+	httpDefaultClientSettings := confighttp.NewDefaultHTTPClientSettings()
 
 	tests := []struct {
 		id       component.ID
@@ -61,6 +62,8 @@ func TestLoadConfig(t *testing.T) {
 					TLSSetting: configtls.TLSClientSetting{
 						InsecureSkipVerify: true,
 					},
+					MaxIdleConns:    httpDefaultClientSettings.MaxIdleConns,
+					IdleConnTimeout: httpDefaultClientSettings.IdleConnTimeout,
 				},
 				Format:             "proto",
 				DefaultServiceName: "test_name",

--- a/exporter/zipkinexporter/config_test.go
+++ b/exporter/zipkinexporter/config_test.go
@@ -29,7 +29,8 @@ func TestLoadConfig(t *testing.T) {
 	// URL doesn't have a default value so set it directly.
 	defaultCfg := createDefaultConfig().(*Config)
 	defaultCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
-	httpDefaultClientSettings := confighttp.NewDefaultHTTPClientSettings()
+	maxIdleConns := 50
+	idleConnTimeout := 5 * time.Second
 
 	tests := []struct {
 		id       component.ID
@@ -62,8 +63,8 @@ func TestLoadConfig(t *testing.T) {
 					TLSSetting: configtls.TLSClientSetting{
 						InsecureSkipVerify: true,
 					},
-					MaxIdleConns:    httpDefaultClientSettings.MaxIdleConns,
-					IdleConnTimeout: httpDefaultClientSettings.IdleConnTimeout,
+					MaxIdleConns:    &maxIdleConns,
+					IdleConnTimeout: &idleConnTimeout,
 				},
 				Format:             "proto",
 				DefaultServiceName: "test_name",

--- a/exporter/zipkinexporter/factory_test.go
+++ b/exporter/zipkinexporter/factory_test.go
@@ -21,16 +21,10 @@ func TestCreateDefaultConfig(t *testing.T) {
 func TestCreateInstanceViaFactory(t *testing.T) {
 	cfg := createDefaultConfig()
 
-	// Default config doesn't have default endpoint so creating from it should
-	// fail.
-	ze, err := createTracesExporter(context.Background(), exportertest.NewNopCreateSettings(), cfg)
-	assert.Error(t, err)
-	assert.Nil(t, ze)
-
 	// URL doesn't have a default value so set it directly.
 	zeCfg := cfg.(*Config)
 	zeCfg.Endpoint = "http://some.location.org:9411/api/v2/spans"
-	ze, err = createTracesExporter(context.Background(), exportertest.NewNopCreateSettings(), cfg)
+	ze, err := createTracesExporter(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, ze)
 }

--- a/exporter/zipkinexporter/testdata/config.yaml
+++ b/exporter/zipkinexporter/testdata/config.yaml
@@ -4,6 +4,8 @@ zipkin/2:
   endpoint: "https://somedest:1234/api/v2/spans"
   format: proto
   default_service_name: test_name
+  idle_conn_timeout: 5s
+  max_idle_conns: 50
   sending_queue:
     enabled: true
     num_consumers: 2


### PR DESCRIPTION
**Description:**
Modernize the logic of validation by moving to config Validate from the Start function
Use the HTTPClientDefaultSettings defaults when setting the config.

**Link to tracking Issue:**
#6641

**Testing:**
Updated tests.