### PR TITLE
[opampsupervisor] fix panic on shutdown

### DIFF
--- a/.chloggen/fix_panic_supervisor.yaml
+++ b/.chloggen/fix_panic_supervisor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix panic on agent shutdown
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29955]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/supervisor/commander/commander.go
+++ b/cmd/opampsupervisor/supervisor/commander/commander.go
@@ -138,7 +138,8 @@ func (c *Commander) Stop(ctx context.Context) error {
 		return nil
 	}
 
-	c.logger.Debug("Stopping agent process", zap.Int("pid", c.cmd.Process.Pid))
+	pid := c.cmd.Process.Pid
+	c.logger.Debug("Stopping agent process", zap.Int("pid", pid))
 
 	// Gracefully signal process to stop.
 	if err := c.cmd.Process.Signal(syscall.SIGTERM); err != nil {
@@ -154,14 +155,14 @@ func (c *Commander) Stop(ctx context.Context) error {
 		<-waitCtx.Done()
 
 		if !errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
-			c.logger.Debug("Agent process successfully stopped.", zap.Int("pid", c.cmd.Process.Pid))
+			c.logger.Debug("Agent process successfully stopped.", zap.Int("pid", pid))
 			return
 		}
 
 		// Time is out. Kill the process.
 		c.logger.Debug(
-			"Agent process is not responding to SIGTERM. Sending SIGKILL to kill forcedly.",
-			zap.Int("pid", c.cmd.Process.Pid))
+			"Agent process is not responding to SIGTERM. Sending SIGKILL to kill forcibly.",
+			zap.Int("pid", pid))
 		if innerErr = c.cmd.Process.Signal(syscall.SIGKILL); innerErr != nil {
 			return
 		}


### PR DESCRIPTION
**Description:** 
Fixes panic reported in https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/7236299619/job/19714748723?pr=29950
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8d5d84]

goroutine 49 [running]:
github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/commander.(*Commander).Stop.func1()
	/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/commander/commander.go:157 +0x1e4
created by github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/commander.(*Commander).Stop
	/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/commander/commander.go:153 +0x[21](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/7236299619/job/19714748723?pr=29950#step:8:22)a
exit status 2
FAIL	github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor	1.520s
```
