### PR TITLE
[extension/bearertokenauthextension] Fix for extension Always return "401 Unauthorized" via HTTP connection #24656

### DIFF
--- a/.chloggen/naga_fix_24656-http-bearertokenauth-401.yaml
+++ b/.chloggen/naga_fix_24656-http-bearertokenauth-401.yaml
@@ -10,7 +10,7 @@ component: bearertokenauthextension
 note: "Http receiver trying to get the authorization with the lower case from headers, But The headers from Http is received as Authorization capitalcase even-though we sent in lower case and Always return 401 Unauthorized"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [29992]
+issues: [24656]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/naga_fix_24656-http-bearertokenauth-401.yaml
+++ b/.chloggen/naga_fix_24656-http-bearertokenauth-401.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: bearertokenauthextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Http receiver trying to get the authorization with the lower case from headers, But The headers from Http is received as Authorization capitalcase even-though we sent in lower case and Always return 401 Unauthorized"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29992]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/bearertokenauthextension/bearertokenauth.go
+++ b/extension/bearertokenauthextension/bearertokenauth.go
@@ -180,6 +180,9 @@ func (b *BearerTokenAuth) RoundTripper(base http.RoundTripper) (http.RoundTrippe
 // Authenticate checks whether the given context contains valid auth data.
 func (b *BearerTokenAuth) Authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
 	auth, ok := headers["authorization"]
+	if !ok {
+		auth, ok = headers["Authorization"]
+	}
 	if !ok || len(auth) == 0 {
 		return ctx, errors.New("authentication didn't succeed")
 	}


### PR DESCRIPTION
Fix for extension Always return "401 Unauthorized" via HTTP connection #24656

**Description:** We are always trying to get the `authorization` with the lower case from headers, But The headers from Http is received as `Authorization` capitalcase even-though we sent in lower case.

**Link to tracking Issue:** <[24656](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24656)>

**Testing:** Tested in the local
<img width="1060" alt="Screenshot 2023-12-17 at 5 28 26 PM" src="https://github.com/open-telemetry/opentelemetry-collector-contrib/assets/94837505/a7401d32-9ce2-4ac5-b4a4-94b43d1efcc8">
<img width="919" alt="Screenshot 2023-12-17 at 5 32 11 PM" src="https://github.com/open-telemetry/opentelemetry-collector-contrib/assets/94837505/b7778fc1-1dee-487a-8458-669b8bf5ec2e">
<img width="890" alt="Screenshot 2023-12-17 at 5 34 12 PM" src="https://github.com/open-telemetry/opentelemetry-collector-contrib/assets/94837505/369577d3-7ddf-45e9-be25-81e699e56e2a">
