### PR TITLE
Fix filelog parser configuration in testbed senders

### DIFF
--- a/testbed/datasenders/stanza.go
+++ b/testbed/datasenders/stanza.go
@@ -116,10 +116,10 @@ func (f *FileLogWriter) GenConfigYAMLStr() string {
       - type: regex_parser
         regex: '^(?P<time>\d{4}-\d{2}-\d{2}) (?P<sev>[A-Z0-9]*) (?P<msg>.*)$'
         timestamp:
-          parse_from: body.time
+          parse_from: attributes.time
           layout: '%%Y-%%m-%%d'
         severity:
-          parse_from: body.sev
+          parse_from: attributes.sev
 `, f.file.Name())
 }
 


### PR DESCRIPTION
**Description:**

Filelog senders in testbed have incorrect parsing configurations, leading to lots of parse errors:

```
2023-12-16T18:19:53.515+0100	error	helper/transformer.go:98	Failed to process entry	{"kind": "receiver", "name": "filelog", "data_type": "logs", "operator_id": "regex_parser", "operator_type": "regex_parser", "error": {"description": "time parser: log entry does not have the expected parse_from field", "suggestion": "ensure that all entries forwarded to this parser contain the parse_from field", "details": {"parse_from": "body.time"}}, "action": "send", "entry": {"observed_timestamp":"2023-12-16T18:19:53.515753831+01:00","timestamp":"0001-01-01T00:00:00Z","body":"2023-12-16 INFO3 Load Generator Counter #0 batch_index=batch_1 item_index=item_1 a=test b=5 c=3 d=true","attributes":{"log.file.name":"perf-logs.log2985945617","msg":"Load Generator Counter #0 batch_index=batch_1 item_index=item_1 a=test b=5 c=3 d=true","sev":"INFO3","time":"2023-12-16"},"severity":0,"scope_name":""}}
```

This change fixes the errors.

Note that there's going to be a change in benchmark results, as right now the error handling methods figure prominently in the benchmark. While it's not invalid to benchmark these, in general I think we'd prefer to check the happy path instead.

**Testing:**
Reran the testbed tests, saw no errors in agent logs.