### PR TITLE
[pkg/ottl] Validate that all path elements are used

### DIFF
--- a/.chloggen/ottl-valid-path-used.yaml
+++ b/.chloggen/ottl-valid-path-used.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Now validates against extraneous path segements or keys that a context does not know how to use.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30042]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/ottl-valid-path-used.yaml
+++ b/.chloggen/ottl-valid-path-used.yaml
@@ -1,13 +1,13 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Now validates against extraneous path segements or keys that a context does not know how to use.
+note: Now validates against extraneous path segments or keys that a context does not know how to use.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [30042]

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -631,7 +631,11 @@ func (p *Parser[K]) newGetter(val value) (Getter[K], error) {
 			return &literal[K]{value: *i}, nil
 		}
 		if eL.Path != nil {
-			return p.pathParser(newPath[K](eL.Path.Fields))
+			np, err := newPath[K](eL.Path.Fields)
+			if err != nil {
+				return nil, err
+			}
+			return p.parsePath(np)
 		}
 		if eL.Converter != nil {
 			return p.newGetterFromConverter(*eL.Converter)

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -37,9 +37,19 @@ func newPath[K any](fields []field) (*basePath[K], error) {
 	return current, nil
 }
 
+// Path represents a chain of path parts in an OTTL statement, such as `body.string`.
+// A Path has a name, and potentially a set of keys.
+// If the path in the OTTL statement contains multiple parts (separated by a dot (`.`)), then the Path will have a link to the next Path.
 type Path[K any] interface {
+	// Name is the name of this segment of the path.
 	Name() string
+
+	// Next provides a link to the next path segment for this Path.
+	// Will return nil if there is no next path.
 	Next() Path[K]
+
+	// Key provides a link to the Key for this Path.
+	// Will return nil if there is no Key.
 	Key() Key[K]
 }
 
@@ -103,9 +113,22 @@ func newKey[K any](keys []key) *baseKey[K] {
 	return current
 }
 
+// Key represents a chain of keys in an OTTL statement, such as `attributes["foo"]["bar"]`.
+// A Key has a String or Int, and potentially a link to the next Key.
+// If the path in the OTTL statement contains multiple keys, then the Key will have a link to the next Key.
 type Key[K any] interface {
+	// String returns a pointer to the Key's string value.
+	// If the Key does not have a string value the returned value is nil.
+	// If Key experiences an error retrieving the value it is returned.
 	String(context.Context, K) (*string, error)
+
+	// Int returns a pointer to the Key's int value.
+	// If the Key does not have a int value the returned value is nil.
+	// If Key experiences an error retrieving the value it is returned.
 	Int(context.Context, K) (*int64, error)
+
+	// Next provides a link to the next Key.
+	// Will return nil if there is no next Key.
 	Next() Key[K]
 }
 

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -43,14 +43,7 @@ type Path[K any] interface {
 	Key() Key[K]
 }
 
-//type internalPath[K any] interface {
-//	Path[K]
-//	isComplete() error
-//}
-
 var _ Path[any] = &basePath[any]{}
-
-//var _ internalPath[any] = &basePath[any]{}
 
 type basePath[K any] struct {
 	name     string
@@ -116,14 +109,7 @@ type Key[K any] interface {
 	Next() Key[K]
 }
 
-//type internalKey[K any] interface {
-//	Key[K]
-//	isComplete() error
-//}
-
 var _ Key[any] = &baseKey[any]{}
-
-//var _ internalKey[any] = &baseKey[any]{}
 
 type baseKey[K any] struct {
 	s       *string

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -39,7 +39,7 @@ func newPath[K any](fields []field) (*basePath[K], error) {
 
 // Path represents a chain of path parts in an OTTL statement, such as `body.string`.
 // A Path has a name, and potentially a set of keys.
-// If the path in the OTTL statement contains multiple parts (separated by a dot (`.`)), then the Path will have a link to the next Path.
+// If the path in the OTTL statement contains multiple parts (separated by a dot (`.`)), then the Path will have a pointer to the next Path.
 type Path[K any] interface {
 	// Name is the name of this segment of the path.
 	Name() string
@@ -48,7 +48,7 @@ type Path[K any] interface {
 	// Will return nil if there is no next path.
 	Next() Path[K]
 
-	// Key provides a link to the Key for this Path.
+	// Key provides the Key for this Path.
 	// Will return nil if there is no Key.
 	Key() Key[K]
 }
@@ -114,8 +114,8 @@ func newKey[K any](keys []key) *baseKey[K] {
 }
 
 // Key represents a chain of keys in an OTTL statement, such as `attributes["foo"]["bar"]`.
-// A Key has a String or Int, and potentially a link to the next Key.
-// If the path in the OTTL statement contains multiple keys, then the Key will have a link to the next Key.
+// A Key has a String or Int, and potentially the next Key.
+// If the path in the OTTL statement contains multiple keys, then the Key will have a pointer to the next Key.
 type Key[K any] interface {
 	// String returns a pointer to the Key's string value.
 	// If the Key does not have a string value the returned value is nil.
@@ -127,7 +127,7 @@ type Key[K any] interface {
 	// If Key experiences an error retrieving the value it is returned.
 	Int(context.Context, K) (*int64, error)
 
-	// Next provides a link to the next Key.
+	// Next provides the next Key.
 	// Will return nil if there is no next Key.
 	Next() Key[K]
 }

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -44,7 +44,7 @@ type Path[K any] interface {
 	// Name is the name of this segment of the path.
 	Name() string
 
-	// Next provides a link to the next path segment for this Path.
+	// Next provides the next path segment for this Path.
 	// Will return nil if there is no next path.
 	Next() Path[K]
 

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -393,6 +393,56 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 				Function: "non_pointer",
 			},
 		},
+		{
+			name: "path parts not all used",
+			inv: editor{
+				Function: "testing_getsetter",
+				Arguments: []argument{
+					{
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &path{
+									Fields: []field{
+										{
+											Name: "name",
+										},
+										{
+											Name: "not-used",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "path keys not all used",
+			inv: editor{
+				Function: "testing_getsetter",
+				Arguments: []argument{
+					{
+						Value: value{
+							Literal: &mathExprLiteral{
+								Path: &path{
+									Fields: []field{
+										{
+											Name: "name",
+											Keys: []key{
+												{
+													String: ottltest.Strp("not-used"),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -2228,7 +2278,9 @@ func Test_newPath(t *testing.T) {
 			Name: "string",
 		},
 	}
-	p := newPath[any](fields)
+	np, err := newPath[any](fields)
+	assert.NoError(t, err)
+	p := Path[any](np)
 	assert.Equal(t, "body", p.Name())
 	assert.Nil(t, p.Key())
 	p = p.Next()
@@ -2375,7 +2427,7 @@ func Test_newKey(t *testing.T) {
 			String: ottltest.Strp("bar"),
 		},
 	}
-	k := newKey[any](keys)
+	k := Key[any](newKey[any](keys))
 	s, err := k.String(context.Background(), nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, s)

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -1236,6 +1236,14 @@ func Test_parseCondition_full(t *testing.T) {
 
 func testParsePath[K any](p Path[K]) (GetSetter[any], error) {
 	if p != nil && (p.Name() == "name" || p.Name() == "attributes") {
+
+		if bp, ok := p.(*basePath[K]); ok {
+			if bp.key != nil && bp.key.s != nil && *bp.key.s == "foo" && bp.key.nextKey != nil && bp.key.nextKey.s != nil && *bp.key.nextKey.s == "bar" {
+				bp.key.fetched = true
+				bp.key.nextKey.fetched = true
+			}
+		}
+
 		return &StandardGetSetter[any]{
 			Getter: func(ctx context.Context, tCtx any) (any, error) {
 				return tCtx, nil


### PR DESCRIPTION
**Description:** 
Updates OTTL to be able to detect when a context has not used all parts of a path and its keys. It only validates that each path/key was grabbed - it cannot validate that the context used the value "correctly".

An example error message, taken from the unit test, looks like:

```
error while parsing arguments for call to "testing_getsetter": invalid argument at position 0: the path section "not-used" was not used by the context - this likely means you are using extra path sections
```

**Link to tracking Issue:**
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22744

**Testing:**
Added new unit tests