### PR TITLE
updated connector structure

### DIFF
--- a/.chloggen/failover-PR4.yaml
+++ b/.chloggen/failover-PR4.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: new_component
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: failoverconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: PR updates connector structure to avoid exposing indexes outside of pipeline_selector
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [20766]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/failoverconnector/failover.go
+++ b/connector/failoverconnector/failover.go
@@ -4,9 +4,7 @@
 package failoverconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/failoverconnector"
 
 import (
-	"context"
 	"errors"
-	"time"
 
 	"go.opentelemetry.io/collector/component"
 
@@ -20,7 +18,6 @@ type failoverRouter[C any] struct {
 	cfg              *Config
 	pS               *state.PipelineSelector
 	consumers        []C
-	rS               *state.RetryState
 }
 
 var (
@@ -29,22 +26,25 @@ var (
 )
 
 func newFailoverRouter[C any](provider consumerProvider[C], cfg *Config) *failoverRouter[C] {
+	pSConstants := state.PSConstants{
+		RetryInterval: cfg.RetryInterval,
+		RetryGap:      cfg.RetryGap,
+		MaxRetries:    cfg.MaxRetries,
+	}
 	return &failoverRouter[C]{
 		consumerProvider: provider,
 		cfg:              cfg,
-		pS:               state.NewPipelineSelector(len(cfg.PipelinePriority), cfg.MaxRetries),
-		rS:               &state.RetryState{},
+		pS:               state.NewPipelineSelector(len(cfg.PipelinePriority), pSConstants),
 	}
 }
 
-func (f *failoverRouter[C]) getCurrentConsumer() (C, int, bool) {
-	// if currentIndex incremented passed bounds of pipeline list
+func (f *failoverRouter[C]) getCurrentConsumer() (C, chan bool, bool) {
 	var nilConsumer C
-	idx := f.pS.CurrentIndex()
-	if idx >= len(f.cfg.PipelinePriority) {
-		return nilConsumer, -1, false
+	pl, ch := f.pS.SelectedPipeline()
+	if pl >= len(f.cfg.PipelinePriority) {
+		return nilConsumer, nil, false
 	}
-	return f.consumers[idx], idx, true
+	return f.consumers[pl], ch, true
 }
 
 func (f *failoverRouter[C]) registerConsumers() error {
@@ -60,77 +60,8 @@ func (f *failoverRouter[C]) registerConsumers() error {
 	return nil
 }
 
-func (f *failoverRouter[C]) handlePipelineError(idx int) {
-	// avoids race condition in case of consumeSIGNAL invocations
-	// where index was updated during execution
-	if idx != f.pS.CurrentIndex() {
-		return
-	}
-	doRetry := f.pS.IndexIsStable(idx)
-	// UpdatePipelineIndex either increments the pipeline to the next priority
-	// or returns it to the stable
-	f.pS.UpdatePipelineIndex(idx)
-	// if the currentIndex is not the stableIndex, that means the currentIndex is a higher
-	// priority index that was set during a retry, in which case we don't want to start a
-	// new retry goroutine
-	if !doRetry {
-		return
-	}
-	// kill existing retry goroutine if error is from a stable pipeline that failed for the first time
-	ctx, cancel := context.WithCancel(context.Background())
-	f.rS.InvokeCancel()
-	f.rS.UpdateCancelFunc(cancel)
-	f.enableRetry(ctx)
-}
-
-func (f *failoverRouter[C]) enableRetry(ctx context.Context) {
-	go func() {
-		ticker := time.NewTicker(f.cfg.RetryInterval)
-		defer ticker.Stop()
-
-		stableIndex := f.pS.StableIndex()
-		var cancelFunc context.CancelFunc
-		// checkContinueRetry checks that any higher priority levels have retries remaining
-		// (have not exceeded their maxRetries)
-		for f.checkContinueRetry(stableIndex) {
-			select {
-			case <-ticker.C:
-				// When the nextRetry interval starts we kill the existing iteration through
-				// the higher priority pipelines if still in progress
-				if cancelFunc != nil {
-					cancelFunc()
-				}
-				cancelFunc = f.handleRetry(ctx, stableIndex)
-			case <-ctx.Done():
-				return
-			}
-		}
-		f.rS.InvokeCancel()
-	}()
-}
-
-// handleRetry is responsible for launching goroutine and returning cancelFunc for context to be called if new
-// interval starts in the middle of the execution
-func (f *failoverRouter[C]) handleRetry(parentCtx context.Context, stableIndex int) context.CancelFunc {
-	retryCtx, cancelFunc := context.WithCancel(parentCtx)
-	go f.pS.RetryHighPriorityPipelines(retryCtx, stableIndex, f.cfg.RetryGap)
-	return cancelFunc
-}
-
-// checkStopRetry checks if retry should be suspended if all higher priority levels have exceeded their max retries
-func (f *failoverRouter[C]) checkContinueRetry(index int) bool {
-	for i := 0; i < index; i++ {
-		if f.pS.IndexRetryCount(i) < f.cfg.MaxRetries {
-			return true
-		}
-	}
-	return false
-}
-
-// reportStable reports back to the failoverRouter that the current priority level that was called by Consume.SIGNAL was
-// stable
-func (f *failoverRouter[C]) reportStable(idx int) {
-	f.pS.ReportStable(idx)
+func (f *failoverRouter[C]) Shutdown() {
+	f.pS.RS.InvokeCancel()
 }
 
 // For Testing

--- a/connector/failoverconnector/internal/state/utils.go
+++ b/connector/failoverconnector/internal/state/utils.go
@@ -6,7 +6,14 @@ package state // import "github.com/open-telemetry/opentelemetry-collector-contr
 import (
 	"context"
 	"sync"
+	"time"
 )
+
+type PSConstants struct {
+	RetryInterval time.Duration
+	RetryGap      time.Duration
+	MaxRetries    int
+}
 
 type TryLock struct {
 	lock sync.Mutex

--- a/connector/failoverconnector/traces.go
+++ b/connector/failoverconnector/traces.go
@@ -25,6 +25,7 @@ type tracesFailover struct {
 	logger        *zap.Logger
 	errTryLock    *state.TryLock
 	stableTryLock *state.TryLock
+	done          chan struct{}
 }
 
 func (f *tracesFailover) Capabilities() consumer.Capabilities {
@@ -33,15 +34,13 @@ func (f *tracesFailover) Capabilities() consumer.Capabilities {
 
 // ConsumeTraces will try to export to the current set priority level and handle failover in the case of an error
 func (f *tracesFailover) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {
-	tc, idx, ok := f.failover.getCurrentConsumer()
+	tc, ch, ok := f.failover.getCurrentConsumer()
 	if !ok {
 		return errNoValidPipeline
 	}
 	err := tc.ConsumeTraces(ctx, td)
 	if err == nil {
-		// trylock to make sure for concurrent calls multiple invocations don't try to update the failover
-		// state simultaneously and don't wait to acquire lock in pipeline selector
-		f.stableTryLock.TryExecute(f.failover.reportStable, idx)
+		ch <- true
 		return nil
 	}
 	return f.FailoverTraces(ctx, td)
@@ -49,18 +48,13 @@ func (f *tracesFailover) ConsumeTraces(ctx context.Context, td ptrace.Traces) er
 
 // FailoverTraces is the function responsible for handling errors returned by the nextConsumer
 func (f *tracesFailover) FailoverTraces(ctx context.Context, td ptrace.Traces) error {
-	// loops through consumer list, until reaches end of list at which point no healthy pipelines remain
-	for tc, idx, ok := f.failover.getCurrentConsumer(); ok; tc, idx, ok = f.failover.getCurrentConsumer() {
+	for tc, ch, ok := f.failover.getCurrentConsumer(); ok; tc, ch, ok = f.failover.getCurrentConsumer() {
 		err := tc.ConsumeTraces(ctx, td)
 		if err != nil {
-			// in case of err handlePipelineError is called through tryLock
-			// tryLock is to avoid race conditions from concurrent calls to handlePipelineError, only first call should enter
-			// see state.TryLock
-			f.errTryLock.TryExecute(f.failover.handlePipelineError, idx)
+			ch <- false
 			continue
 		}
-		// when healthy pipeline is found, reported back to failover component
-		f.stableTryLock.TryExecute(f.failover.reportStable, idx)
+		ch <- true
 		return nil
 	}
 	f.logger.Error("All provided pipelines return errors, dropping data")
@@ -68,15 +62,16 @@ func (f *tracesFailover) FailoverTraces(ctx context.Context, td ptrace.Traces) e
 }
 
 func (f *tracesFailover) Shutdown(_ context.Context) error {
-	// call cancel mainly to shutdown tickers
 	if f.failover != nil {
-		f.failover.rS.InvokeCancel()
+		f.failover.Shutdown()
 	}
+	close(f.done)
 	return nil
 }
 
 func newTracesToTraces(set connector.CreateSettings, cfg component.Config, traces consumer.Traces) (connector.Traces, error) {
 	config := cfg.(*Config)
+	done := make(chan struct{})
 	tr, ok := traces.(connector.TracesRouter)
 	if !ok {
 		return nil, errors.New("consumer is not of type TracesRouter")
@@ -87,11 +82,13 @@ func newTracesToTraces(set connector.CreateSettings, cfg component.Config, trace
 	if err != nil {
 		return nil, err
 	}
+	go failover.pS.ListenToChannels(done)
 	return &tracesFailover{
 		config:        config,
 		failover:      failover,
 		logger:        set.TelemetrySettings.Logger,
 		errTryLock:    state.NewTryLock(),
 		stableTryLock: state.NewTryLock(),
+		done:          done,
 	}, nil
 }

--- a/connector/failoverconnector/traces_test.go
+++ b/connector/failoverconnector/traces_test.go
@@ -49,12 +49,11 @@ func TestTracesRegisterConsumers(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
-	tc, idx, ok := failoverConnector.failover.getCurrentConsumer()
+	tc, _, ok := failoverConnector.failover.getCurrentConsumer()
 	tc1 := failoverConnector.failover.GetConsumerAtIndex(1)
 	tc2 := failoverConnector.failover.GetConsumerAtIndex(2)
 
 	assert.True(t, ok)
-	require.Equal(t, idx, 0)
 	require.Implements(t, (*consumer.Traces)(nil), tc)
 	require.Implements(t, (*consumer.Traces)(nil), tc1)
 	require.Implements(t, (*consumer.Traces)(nil), tc2)
@@ -93,7 +92,8 @@ func TestTracesWithValidFailover(t *testing.T) {
 	tr := sampleTrace()
 
 	require.NoError(t, conn.ConsumeTraces(context.Background(), tr))
-	_, idx, ok := failoverConnector.failover.getCurrentConsumer()
+	_, ch, ok := failoverConnector.failover.getCurrentConsumer()
+	idx := failoverConnector.failover.pS.ChannelIndex(ch)
 	assert.True(t, ok)
 	require.Equal(t, idx, 1)
 }
@@ -168,7 +168,8 @@ func TestTracesWithFailoverRecovery(t *testing.T) {
 	tr := sampleTrace()
 
 	require.NoError(t, conn.ConsumeTraces(context.Background(), tr))
-	_, idx, ok := failoverConnector.failover.getCurrentConsumer()
+	_, ch, ok := failoverConnector.failover.getCurrentConsumer()
+	idx := failoverConnector.failover.pS.ChannelIndex(ch)
 
 	assert.True(t, ok)
 	require.Equal(t, idx, 1)
@@ -178,7 +179,8 @@ func TestTracesWithFailoverRecovery(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	_, idx, ok = failoverConnector.failover.getCurrentConsumer()
+	_, ch, ok = failoverConnector.failover.getCurrentConsumer()
+	idx = failoverConnector.failover.pS.ChannelIndex(ch)
 	assert.True(t, ok)
 	require.Equal(t, idx, 0)
 }


### PR DESCRIPTION
@djaglowski wanted to get your thoughts on this. I did some refactoring to improve the separation of concerns as we discussed in PR2. In this structure all retry logic and index manipulation logic has been moved to the pipelineSelector as to your point all of the retry logic is tightly coupled with the indexes. Now there are only two exposed methods in pipelineSelector, the main one just returning the current selected pipeline.

The issue I was having is that in order to avoid race conditions, we needed a way to get " a snapshot" of the indexes/state at the time that an error was triggered without inconsistent state or blocking. Which is why in the original design the index was returned from getCurrentConsumer, and then passed back into the failover component in reportStable and handlePipelineError. 

In the update I made getCurrentConsumer will now return a channel along with the consumer, and a bool value written to the channel will serve as the signal of whether or not an error was returned. And all of the retry logic will be contained in pipelineSelector based on the reads from the channels. 

The channels are mapped one to one to consumers/pipelines so they are dynamic in quantity. I implemented this with reflection which seemed better than alternatives like having a goroutine per channel. 