### PR TITLE
[chore] Switch back to upload-artifact v3

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -271,7 +271,7 @@ jobs:
       - name: Run Unit Tests With Coverage
         if: startsWith( matrix.go-version, '~1.20' ) # only run coverage on one version
         run: make gotest-with-cover GROUP=${{ matrix.group }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         if: startsWith( matrix.go-version, '~1.20' ) # only run coverage on one version
         with:
           name: coverage-artifacts
@@ -453,7 +453,7 @@ jobs:
       - name: Build Collector ${{ matrix.binary }}
         run: make GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM=${{ matrix.arm }} otelcontribcol
       - name: Upload Collector Binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: collector-binaries
           path: ./bin/*
@@ -501,7 +501,7 @@ jobs:
               ./internal/buildscripts/packaging/fpm/test.sh dist/otel-contrib-collector*x86_64.rpm examples/demo/otel-collector-config.yaml
           fi
       - name: Upload Packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: collector-packages
           path: ./dist/*
@@ -536,7 +536,7 @@ jobs:
       - name: Validate MSI
         run: .\internal\buildscripts\packaging\msi\make.ps1 Confirm-MSI
       - name: Upload MSI
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: collector-packages
           path: ./dist/*.msi

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build Collector
         run: make otelcontribcol
       - name: Upload Collector Binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: collector-binary
           path: ./bin/*
@@ -76,7 +76,7 @@ jobs:
         run: |
           docker save otelcontribcol:latest > /tmp/otelcontribcol.tar
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: otelcontribcol
           path: /tmp/otelcontribcol.tar

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: make install-tools
       - run: make oteltestbedcol
       - name: Upload Collector Binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: collector-binaries
           path: ./bin/*
@@ -103,12 +103,12 @@ jobs:
       - name: Upload Test Results
         if: ${{ failure() || success() }}
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           path: ./*.tar
       - run: cp testbed/tests/results/benchmarks.json testbed/tests/results/${{steps.filename.outputs.name}}.json
       - name: Upload benchmarks.json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: benchmark-results
           path: testbed/tests/results/${{steps.filename.outputs.name}}.json


### PR DESCRIPTION
**Description:** 
I think v4 is broken (or the way we are using the action is no longer supported in v4).  Switching back to v3 for now to fix our CI.

**Link to tracking Issue:** <Issue number if applicable>

I think https://github.com/actions/upload-artifact/issues/471

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>