### PR TITLE
[chore][cmd/mdatagen] Properly test bytes attribute type

### DIFF
--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -194,7 +194,7 @@ func (a attribute) TestValue() string {
 	case pcommon.ValueTypeSlice:
 		return fmt.Sprintf(`[]any{"%s-item1", "%s-item2"}`, a.FullName, a.FullName)
 	case pcommon.ValueTypeBytes:
-		return fmt.Sprintf(`bytes("%s-val")`, a.FullName)
+		return fmt.Sprintf(`[]byte("%s-val")`, a.FullName)
 	}
 	return ""
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Changes how attributes of type `bytes` are tested, as they were being initialized incorrectly before.

**Link to tracking Issue:** <Issue number if applicable>
Resolves #29923

**Testing:** <Describe what testing was performed and which tests were added.>
Fake attribute added for testing:
```
attributes:
  # Added a fake attribute in a metadata.yaml file
  fake:
    description: "Fake attribute for testing"
    type: bytes
```
Test case generated by `cmd/mdatagen`:
```
                                       attrVal, ok = dp.Attributes().Get("fake")
                                       assert.True(t, ok)
                                       assert.EqualValues(t, []byte("fake-val"), attrVal.Bytes())
```