### PR TITLE
[chore] Let renovatebot run actions

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -36,7 +36,7 @@ jobs:
           - cmd
           - other
     runs-on: windows-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push') }}
+    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push') }}
     env:
       # Limit memory usage via GC environment variables to avoid OOM on GH runners, especially for `cmd/otelcontribcol`,
       # see https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28682#issuecomment-1802296776
@@ -66,7 +66,7 @@ jobs:
       - name: Run Unit tests
         run: make -j2 gotest GROUP=${{ matrix.group }}
   windows-unittest:
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push') }}
+    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push') }}
     runs-on: windows-latest
     needs: [windows-unittest-matrix]
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
   setup-environment:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -105,7 +105,7 @@ jobs:
       - name: Lint
         run: make -j2 golint GROUP=${{ matrix.group }}
   lint:
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && always() }}
+    if: ${{ github.actor != 'dependabot[bot]' && always() }}
     runs-on: ubuntu-latest
     needs: [setup-environment, lint-matrix]
     steps:
@@ -134,7 +134,6 @@ jobs:
           - internal
           - pkg
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'renovate[bot]' }}
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
@@ -277,7 +276,7 @@ jobs:
           name: coverage-artifacts
           path: ${{ matrix.group }}-coverage.txt
   unittest:
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && always() }}
+    if: ${{ github.actor != 'dependabot[bot]' && always() }}
     runs-on: ubuntu-latest
     needs: [setup-environment, unittest-matrix]
     steps:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   changelog:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:
       md: ${{ steps.changes.outputs.md }}
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   CodeQL-Build:
     runs-on: macos-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     env:
       # Force CodeQL to run the extraction on the files compiled by our custom
       # build command, as opposed to letting the autobuilder figure it out.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   collector-build:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -19,7 +19,7 @@ jobs:
   setup-environment:
     timeout-minutes: 30
     runs-on: self-hosted
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     outputs:
       loadtest_matrix: ${{ steps.splitloadtest.outputs.loadtest_matrix }}
     steps:

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   prometheus-compliance-tests:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/telemetrygen.yml
+++ b/.github/workflows/telemetrygen.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   build-dev:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU


### PR DESCRIPTION
**Description:**
We ran into an issue today where https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30091 was mergable because [skipped tests count as success](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#overview).  If the CI had been allowed to run, the PR would not have been mergable.

So, despite this meaning we'll be running a bunch of useless actions for most renovatebot PRs, we are re-enabling actions for renovatebot for now to protect ourselves.