### PR TITLE
[chore][CI/CD] Ping code owners even if one applies the label

### DIFF
--- a/.github/workflows/ping-codeowners-issues.yml
+++ b/.github/workflows/ping-codeowners-issues.yml
@@ -16,4 +16,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE: ${{ github.event.issue.number }}
           COMPONENT: ${{ github.event.label.name }}
-          SENDER: ${{ github.event.sender.login }}

--- a/.github/workflows/scripts/ping-codeowners-issues.sh
+++ b/.github/workflows/scripts/ping-codeowners-issues.sh
@@ -7,8 +7,8 @@
 
 set -euo pipefail
 
-if [[ -z "${COMPONENT:-}" || -z "${ISSUE:-}" || -z "${SENDER:-}" ]]; then
-    echo "At least one of COMPONENT, ISSUE, or SENDER has not been set, please ensure each is set."
+if [[ -z "${COMPONENT:-}" || -z "${ISSUE:-}" ]]; then
+    echo "Either COMPONENT or ISSUE has not been set, please ensure both are set."
     exit 0
 fi
 
@@ -17,11 +17,6 @@ CUR_DIRECTORY=$(dirname "$0")
 OWNERS=$(COMPONENT="${COMPONENT}" bash "${CUR_DIRECTORY}/get-codeowners.sh")
 
 if [[ -z "${OWNERS}" ]]; then
-    exit 0
-fi
-
-if [[ "${OWNERS}" =~ "${SENDER}" ]]; then
-    echo "Label applied by code owner ${SENDER}"
     exit 0
 fi
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Currently if a label is applied by a code owner of the label's component, we don't ping the component's code owners. This makes sense in the most simple case of one code owner but is less effective for multiple code owners. I believe we should remove this functionality for the following reasons:
1. Other code owners are currently not pinged if one owner places the label. There are components that currently have  4+ code owners, many working in different companies.
2. The code owner applying the label will not be pinged on updates, as applying labels on GitHub doesn't subscribe the user to notifications on the given issue.

Downside: This will mean someone applying a label will get pinged for their own action. I see the minor annoyance of this being worth the tradeoff of including other code owners.

This change is only relevant when labels are applied to existing issues.

**Alternative**
It may make sense to check if the label sender is the only code owner, and in that case don't ping. However, I still think it's best for them to be automatically subscribed to issue events, and pinging them does that. I think this alternative would make more sense for the creating new issues workflow, as the issue author wouldn't need pinged as the sole code owner.