### PR TITLE
[receiver/postgresqlreceiver] add schema attribute to postgresqlreceiver

### DIFF
--- a/.chloggen/pgcol-add-schema-attribute.yaml
+++ b/.chloggen/pgcol-add-schema-attribute.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: postgresqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add schema attribute to postgresqlreceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [ 29559 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds a new resource attribute to the PSQL receiver to store the schema of the table or index
+  Existing table attributes are adjusted to not include the schema, which was inconsistently used
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [ user ]

--- a/receiver/postgresqlreceiver/documentation.md
+++ b/receiver/postgresqlreceiver/documentation.md
@@ -317,4 +317,5 @@ This metric requires WAL to be enabled with at least one replica.
 | ---- | ----------- | ------ | ------- |
 | postgresql.database.name | The name of the database. | Any Str | true |
 | postgresql.index.name | The name of the index on a table. | Any Str | true |
-| postgresql.table.name | The schema name followed by the table name. | Any Str | true |
+| postgresql.schema.name | The schema name. | Any Str | true |
+| postgresql.table.name | The table name. | Any Str | true |

--- a/receiver/postgresqlreceiver/integration_test.go
+++ b/receiver/postgresqlreceiver/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.opentelemetry.io/collector/component"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/scraperinttest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
 )
@@ -22,9 +23,17 @@ import (
 const postgresqlPort = "5432"
 
 func TestIntegration(t *testing.T) {
+	defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, false)()
 	t.Run("single_db", integrationTest("single_db", []string{"otel"}))
 	t.Run("multi_db", integrationTest("multi_db", []string{"otel", "otel2"}))
 	t.Run("all_db", integrationTest("all_db", []string{}))
+}
+
+func TestIntegrationWithSeparateSchemaAttr(t *testing.T) {
+	defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, true)()
+	t.Run("single_db_schemaattr", integrationTest("single_db_schemaattr", []string{"otel"}))
+	t.Run("multi_db_schemaattr", integrationTest("multi_db_schemaattr", []string{"otel", "otel2"}))
+	t.Run("all_db_schemaattr", integrationTest("all_db_schemaattr", []string{}))
 }
 
 func integrationTest(name string, databases []string) func(*testing.T) {

--- a/receiver/postgresqlreceiver/internal/metadata/generated_config.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_config.go
@@ -163,6 +163,7 @@ func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
 type ResourceAttributesConfig struct {
 	PostgresqlDatabaseName ResourceAttributeConfig `mapstructure:"postgresql.database.name"`
 	PostgresqlIndexName    ResourceAttributeConfig `mapstructure:"postgresql.index.name"`
+	PostgresqlSchemaName   ResourceAttributeConfig `mapstructure:"postgresql.schema.name"`
 	PostgresqlTableName    ResourceAttributeConfig `mapstructure:"postgresql.table.name"`
 }
 
@@ -172,6 +173,9 @@ func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 			Enabled: true,
 		},
 		PostgresqlIndexName: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		PostgresqlSchemaName: ResourceAttributeConfig{
 			Enabled: true,
 		},
 		PostgresqlTableName: ResourceAttributeConfig{

--- a/receiver/postgresqlreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_config_test.go
@@ -57,6 +57,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				ResourceAttributes: ResourceAttributesConfig{
 					PostgresqlDatabaseName: ResourceAttributeConfig{Enabled: true},
 					PostgresqlIndexName:    ResourceAttributeConfig{Enabled: true},
+					PostgresqlSchemaName:   ResourceAttributeConfig{Enabled: true},
 					PostgresqlTableName:    ResourceAttributeConfig{Enabled: true},
 				},
 			},
@@ -96,6 +97,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 				ResourceAttributes: ResourceAttributesConfig{
 					PostgresqlDatabaseName: ResourceAttributeConfig{Enabled: false},
 					PostgresqlIndexName:    ResourceAttributeConfig{Enabled: false},
+					PostgresqlSchemaName:   ResourceAttributeConfig{Enabled: false},
 					PostgresqlTableName:    ResourceAttributeConfig{Enabled: false},
 				},
 			},
@@ -135,6 +137,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				PostgresqlDatabaseName: ResourceAttributeConfig{Enabled: true},
 				PostgresqlIndexName:    ResourceAttributeConfig{Enabled: true},
+				PostgresqlSchemaName:   ResourceAttributeConfig{Enabled: true},
 				PostgresqlTableName:    ResourceAttributeConfig{Enabled: true},
 			},
 		},
@@ -143,6 +146,7 @@ func TestResourceAttributesConfig(t *testing.T) {
 			want: ResourceAttributesConfig{
 				PostgresqlDatabaseName: ResourceAttributeConfig{Enabled: false},
 				PostgresqlIndexName:    ResourceAttributeConfig{Enabled: false},
+				PostgresqlSchemaName:   ResourceAttributeConfig{Enabled: false},
 				PostgresqlTableName:    ResourceAttributeConfig{Enabled: false},
 			},
 		},

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics_test.go
@@ -161,6 +161,7 @@ func TestMetricsBuilder(t *testing.T) {
 			rb := mb.NewResourceBuilder()
 			rb.SetPostgresqlDatabaseName("postgresql.database.name-val")
 			rb.SetPostgresqlIndexName("postgresql.index.name-val")
+			rb.SetPostgresqlSchemaName("postgresql.schema.name-val")
 			rb.SetPostgresqlTableName("postgresql.table.name-val")
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))

--- a/receiver/postgresqlreceiver/internal/metadata/generated_resource.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_resource.go
@@ -35,6 +35,13 @@ func (rb *ResourceBuilder) SetPostgresqlIndexName(val string) {
 	}
 }
 
+// SetPostgresqlSchemaName sets provided value as "postgresql.schema.name" attribute.
+func (rb *ResourceBuilder) SetPostgresqlSchemaName(val string) {
+	if rb.config.PostgresqlSchemaName.Enabled {
+		rb.res.Attributes().PutStr("postgresql.schema.name", val)
+	}
+}
+
 // SetPostgresqlTableName sets provided value as "postgresql.table.name" attribute.
 func (rb *ResourceBuilder) SetPostgresqlTableName(val string) {
 	if rb.config.PostgresqlTableName.Enabled {

--- a/receiver/postgresqlreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_resource_test.go
@@ -15,6 +15,7 @@ func TestResourceBuilder(t *testing.T) {
 			rb := NewResourceBuilder(cfg)
 			rb.SetPostgresqlDatabaseName("postgresql.database.name-val")
 			rb.SetPostgresqlIndexName("postgresql.index.name-val")
+			rb.SetPostgresqlSchemaName("postgresql.schema.name-val")
 			rb.SetPostgresqlTableName("postgresql.table.name-val")
 
 			res := rb.Emit()
@@ -22,9 +23,9 @@ func TestResourceBuilder(t *testing.T) {
 
 			switch test {
 			case "default":
-				assert.Equal(t, 3, res.Attributes().Len())
+				assert.Equal(t, 4, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 3, res.Attributes().Len())
+				assert.Equal(t, 4, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -41,6 +42,11 @@ func TestResourceBuilder(t *testing.T) {
 			assert.True(t, ok)
 			if ok {
 				assert.EqualValues(t, "postgresql.index.name-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("postgresql.schema.name")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "postgresql.schema.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("postgresql.table.name")
 			assert.True(t, ok)

--- a/receiver/postgresqlreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/postgresqlreceiver/internal/metadata/testdata/config.yaml
@@ -60,6 +60,8 @@ all_set:
       enabled: true
     postgresql.index.name:
       enabled: true
+    postgresql.schema.name:
+      enabled: true
     postgresql.table.name:
       enabled: true
 none_set:
@@ -122,6 +124,8 @@ none_set:
     postgresql.database.name:
       enabled: false
     postgresql.index.name:
+      enabled: false
+    postgresql.schema.name:
       enabled: false
     postgresql.table.name:
       enabled: false

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -13,8 +13,12 @@ resource_attributes:
     description: The name of the database.
     enabled: true
     type: string
+  postgresql.schema.name:
+    description: The schema name.
+    enabled: true
+    type: string
   postgresql.table.name:
-    description: The schema name followed by the table name.
+    description: The table name.
     enabled: true
     type: string
   postgresql.index.name:

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
@@ -19,13 +20,31 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver/internal/metadata"
 )
 
+const (
+	readmeURL            = "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.88.0/receiver/postgresqlreceiver/README.md"
+	separateSchemaAttrID = "receiver.postgresql.separateSchemaAttr"
+)
+
+var (
+	separateSchemaAttrGate = featuregate.GlobalRegistry().MustRegister(
+		separateSchemaAttrID,
+		featuregate.StageAlpha,
+		featuregate.WithRegisterDescription("Moves Schema Names into dedicated Attribute"),
+		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29559"),
+	)
+)
+
 type postgreSQLScraper struct {
 	logger        *zap.Logger
 	config        *Config
 	clientFactory postgreSQLClientFactory
 	mb            *metadata.MetricsBuilder
 	excludes      map[string]struct{}
+
+	// if enabled, uses a separated attribute for the schema
+	separateSchemaAttr bool
 }
+
 type errsMux struct {
 	sync.RWMutex
 	errs scrapererror.ScrapeErrors
@@ -74,12 +93,22 @@ func newPostgreSQLScraper(
 	for _, db := range config.ExcludeDatabases {
 		excludes[db] = struct{}{}
 	}
+	separateSchemaAttr := separateSchemaAttrGate.IsEnabled()
+
+	if !separateSchemaAttr {
+		settings.Logger.Warn(
+			fmt.Sprintf("Feature gate %s is not enabled. Please see the README for more information: %s", separateSchemaAttrID, readmeURL),
+		)
+	}
+
 	return &postgreSQLScraper{
 		logger:        settings.Logger,
 		config:        config,
 		clientFactory: clientFactory,
 		mb:            metadata.NewMetricsBuilder(config.MetricsBuilderConfig, settings),
 		excludes:      excludes,
+
+		separateSchemaAttr: separateSchemaAttr,
 	}
 }
 
@@ -222,8 +251,12 @@ func (p *postgreSQLScraper) collectTables(ctx context.Context, now pcommon.Times
 		}
 		rb := p.mb.NewResourceBuilder()
 		rb.SetPostgresqlDatabaseName(db)
-		rb.SetPostgresqlSchemaName(tm.schema)
-		rb.SetPostgresqlTableName(tm.table)
+		if p.separateSchemaAttr {
+			rb.SetPostgresqlSchemaName(tm.schema)
+			rb.SetPostgresqlTableName(tm.table)
+		} else {
+			rb.SetPostgresqlTableName(fmt.Sprintf("%s.%s", tm.schema, tm.table))
+		}
 		p.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
 	return int64(len(tableMetrics))
@@ -247,8 +280,12 @@ func (p *postgreSQLScraper) collectIndexes(
 		p.mb.RecordPostgresqlIndexSizeDataPoint(now, stat.size)
 		rb := p.mb.NewResourceBuilder()
 		rb.SetPostgresqlDatabaseName(database)
-		rb.SetPostgresqlTableName(stat.table)
-		rb.SetPostgresqlSchemaName(stat.schema)
+		if p.separateSchemaAttr {
+			rb.SetPostgresqlSchemaName(stat.schema)
+			rb.SetPostgresqlTableName(stat.table)
+		} else {
+			rb.SetPostgresqlTableName(stat.table)
+		}
 		rb.SetPostgresqlIndexName(stat.index)
 		p.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -222,6 +222,7 @@ func (p *postgreSQLScraper) collectTables(ctx context.Context, now pcommon.Times
 		}
 		rb := p.mb.NewResourceBuilder()
 		rb.SetPostgresqlDatabaseName(db)
+		rb.SetPostgresqlSchemaName(tm.schema)
 		rb.SetPostgresqlTableName(tm.table)
 		p.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
@@ -247,6 +248,7 @@ func (p *postgreSQLScraper) collectIndexes(
 		rb := p.mb.NewResourceBuilder()
 		rb.SetPostgresqlDatabaseName(database)
 		rb.SetPostgresqlTableName(stat.table)
+		rb.SetPostgresqlSchemaName(stat.schema)
 		rb.SetPostgresqlIndexName(stat.index)
 		p.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -305,17 +305,17 @@ func (m *mockClientFactory) getClient(_ *Config, database string) (client, error
 
 func (m *mockClientFactory) initMocks(databases []string) {
 	listClient := new(mockClient)
-	listClient.initMocks("", databases, 0)
+	listClient.initMocks("", "default", databases, 0)
 	m.On("getClient", "").Return(listClient, nil)
 
 	for index, db := range databases {
 		client := new(mockClient)
-		client.initMocks(db, databases, index)
+		client.initMocks(db, "default", databases, index)
 		m.On("getClient", db).Return(client, nil)
 	}
 }
 
-func (m *mockClient) initMocks(database string, databases []string, index int) {
+func (m *mockClient) initMocks(database string, schema string, databases []string, index int) {
 	m.On("Close").Return(nil)
 
 	if database == "" {
@@ -408,8 +408,9 @@ func (m *mockClient) initMocks(database string, databases []string, index int) {
 		table1 := "public.table1"
 		table2 := "public.table2"
 		tableMetrics := map[tableIdentifier]tableStats{
-			tableKey(database, table1): {
+			tableKey(database, schema, table1): {
 				database:    database,
+				schema:      schema,
 				table:       table1,
 				live:        int64(index + 7),
 				dead:        int64(index + 8),
@@ -421,8 +422,9 @@ func (m *mockClient) initMocks(database string, databases []string, index int) {
 				vacuumCount: int64(index + 44),
 				seqScans:    int64(index + 45),
 			},
-			tableKey(database, table2): {
+			tableKey(database, schema, table2): {
 				database:    database,
+				schema:      schema,
 				table:       table2,
 				live:        int64(index + 9),
 				dead:        int64(index + 10),
@@ -437,8 +439,9 @@ func (m *mockClient) initMocks(database string, databases []string, index int) {
 		}
 
 		blocksMetrics := map[tableIdentifier]tableIOStats{
-			tableKey(database, table1): {
+			tableKey(database, schema, table1): {
 				database:  database,
+				schema:    schema,
 				table:     table1,
 				heapRead:  int64(index + 19),
 				heapHit:   int64(index + 20),
@@ -449,8 +452,9 @@ func (m *mockClient) initMocks(database string, databases []string, index int) {
 				tidxRead:  int64(index + 25),
 				tidxHit:   int64(index + 26),
 			},
-			tableKey(database, table2): {
+			tableKey(database, schema, table2): {
 				database:  database,
+				schema:    schema,
 				table:     table2,
 				heapRead:  int64(index + 27),
 				heapHit:   int64(index + 28),
@@ -469,15 +473,17 @@ func (m *mockClient) initMocks(database string, databases []string, index int) {
 		index1 := fmt.Sprintf("%s_test1_pkey", database)
 		index2 := fmt.Sprintf("%s_test2_pkey", database)
 		indexStats := map[indexIdentifer]indexStat{
-			indexKey(database, table1, index1): {
+			indexKey(database, schema, table1, index1): {
 				database: database,
+				schema:   schema,
 				table:    table1,
 				index:    index1,
 				scans:    int64(index + 35),
 				size:     int64(index + 36),
 			},
-			indexKey(index2, table2, index2): {
+			indexKey(index2, schema, table2, index2): {
 				database: database,
+				schema:   schema,
 				table:    table2,
 				index:    index2,
 				scans:    int64(index + 37),

--- a/receiver/postgresqlreceiver/scraper_test.go
+++ b/receiver/postgresqlreceiver/scraper_test.go
@@ -36,196 +36,245 @@ func TestScraper(t *testing.T) {
 	factory := new(mockClientFactory)
 	factory.initMocks([]string{"otel"})
 
-	cfg := createDefaultConfig().(*Config)
-	cfg.Databases = []string{"otel"}
-	cfg.Metrics.PostgresqlDeadlocks.Enabled = true
-	cfg.Metrics.PostgresqlTempFiles.Enabled = true
-	cfg.Metrics.PostgresqlSequentialScans.Enabled = true
-	cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
-	scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, factory)
+	runTest := func(separateSchemaAttr bool, file string) {
+		defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, separateSchemaAttr)()
 
-	actualMetrics, err := scraper.scrape(context.Background())
-	require.NoError(t, err)
+		cfg := createDefaultConfig().(*Config)
+		cfg.Databases = []string{"otel"}
+		cfg.Metrics.PostgresqlDeadlocks.Enabled = true
+		cfg.Metrics.PostgresqlTempFiles.Enabled = true
+		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
+		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
 
-	expectedFile := filepath.Join("testdata", "scraper", "otel", "expected.yaml")
-	expectedMetrics, err := golden.ReadMetrics(expectedFile)
-	require.NoError(t, err)
+		scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, factory)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+		actualMetrics, err := scraper.scrape(context.Background())
+		require.NoError(t, err)
+
+		expectedFile := filepath.Join("testdata", "scraper", "otel", file)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		require.NoError(t, err)
+
+		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+	}
+
+	runTest(true, "expected_schemaattr.yaml")
+	runTest(false, "expected.yaml")
 }
 
 func TestScraperNoDatabaseSingle(t *testing.T) {
 	factory := new(mockClientFactory)
 	factory.initMocks([]string{"otel"})
 
-	cfg := createDefaultConfig().(*Config)
-	require.True(t, cfg.Metrics.PostgresqlDeadlocks.Enabled == false)
-	cfg.Metrics.PostgresqlDeadlocks.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlTempFiles.Enabled == false)
-	cfg.Metrics.PostgresqlTempFiles.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlSequentialScans.Enabled == false)
-	cfg.Metrics.PostgresqlSequentialScans.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled == false)
-	cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
-	scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, factory)
+	runTest := func(separateSchemaAttr bool, file string, fileDefault string) {
+		defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, separateSchemaAttr)()
 
-	actualMetrics, err := scraper.scrape(context.Background())
-	require.NoError(t, err)
+		cfg := createDefaultConfig().(*Config)
+		require.True(t, cfg.Metrics.PostgresqlDeadlocks.Enabled == false)
+		cfg.Metrics.PostgresqlDeadlocks.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlTempFiles.Enabled == false)
+		cfg.Metrics.PostgresqlTempFiles.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlSequentialScans.Enabled == false)
+		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled == false)
+		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
 
-	expectedFile := filepath.Join("testdata", "scraper", "otel", "expected.yaml")
-	expectedMetrics, err := golden.ReadMetrics(expectedFile)
-	require.NoError(t, err)
+		scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, factory)
+		actualMetrics, err := scraper.scrape(context.Background())
+		require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+		expectedFile := filepath.Join("testdata", "scraper", "otel", file)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		require.NoError(t, err)
 
-	cfg.Metrics.PostgresqlDeadlocks.Enabled = false
-	cfg.Metrics.PostgresqlTempFiles.Enabled = false
-	cfg.Metrics.PostgresqlSequentialScans.Enabled = false
-	cfg.Metrics.PostgresqlDatabaseLocks.Enabled = false
+		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
 
-	scraper = newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, factory)
-	actualMetrics, err = scraper.scrape(context.Background())
-	require.NoError(t, err)
+		cfg.Metrics.PostgresqlDeadlocks.Enabled = false
+		cfg.Metrics.PostgresqlTempFiles.Enabled = false
+		cfg.Metrics.PostgresqlSequentialScans.Enabled = false
+		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = false
 
-	expectedFile = filepath.Join("testdata", "scraper", "otel", "expected_default_metrics.yaml")
-	expectedMetrics, err = golden.ReadMetrics(expectedFile)
-	require.NoError(t, err)
+		scraper = newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, factory)
+		actualMetrics, err = scraper.scrape(context.Background())
+		require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+		expectedFile = filepath.Join("testdata", "scraper", "otel", fileDefault)
+		expectedMetrics, err = golden.ReadMetrics(expectedFile)
+		require.NoError(t, err)
 
+		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+	}
+
+	runTest(true, "expected_schemaattr.yaml", "expected_default_metrics_schemaattr.yaml")
+	runTest(false, "expected.yaml", "expected_default_metrics.yaml")
 }
 
 func TestScraperNoDatabaseMultiple(t *testing.T) {
 	factory := mockClientFactory{}
 	factory.initMocks([]string{"otel", "open", "telemetry"})
 
-	cfg := createDefaultConfig().(*Config)
-	require.True(t, cfg.Metrics.PostgresqlDeadlocks.Enabled == false)
-	cfg.Metrics.PostgresqlDeadlocks.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlTempFiles.Enabled == false)
-	cfg.Metrics.PostgresqlTempFiles.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlSequentialScans.Enabled == false)
-	cfg.Metrics.PostgresqlSequentialScans.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled == false)
-	cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
-	scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, &factory)
+	runTest := func(separateSchemaAttr bool, file string) {
+		defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, separateSchemaAttr)()
 
-	actualMetrics, err := scraper.scrape(context.Background())
-	require.NoError(t, err)
+		cfg := createDefaultConfig().(*Config)
+		require.True(t, cfg.Metrics.PostgresqlDeadlocks.Enabled == false)
+		cfg.Metrics.PostgresqlDeadlocks.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlTempFiles.Enabled == false)
+		cfg.Metrics.PostgresqlTempFiles.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlSequentialScans.Enabled == false)
+		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled == false)
+		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
+		scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, &factory)
 
-	expectedFile := filepath.Join("testdata", "scraper", "multiple", "expected.yaml")
-	expectedMetrics, err := golden.ReadMetrics(expectedFile)
-	require.NoError(t, err)
+		actualMetrics, err := scraper.scrape(context.Background())
+		require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+		expectedFile := filepath.Join("testdata", "scraper", "multiple", file)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		require.NoError(t, err)
+
+		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+	}
+
+	runTest(true, "expected_schemaattr.yaml")
+	runTest(false, "expected.yaml")
 }
 
 func TestScraperNoDatabaseMultipleWithPreciseLagFeatureGate(t *testing.T) {
 	factory := mockClientFactory{}
 	factory.initMocks([]string{"otel", "open", "telemetry"})
 
-	cfg := createDefaultConfig().(*Config)
+	runTest := func(separateSchemaAttr bool, file string) {
+		defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, separateSchemaAttr)()
 
-	testutil.SetFeatureGateForTest(t, preciseLagMetricsFg, true)
-	cfg.Metrics.PostgresqlWalDelay.Enabled = true
-	defer testutil.SetFeatureGateForTest(t, preciseLagMetricsFg, false)
+		cfg := createDefaultConfig().(*Config)
 
-	require.True(t, cfg.Metrics.PostgresqlDeadlocks.Enabled == false)
-	cfg.Metrics.PostgresqlDeadlocks.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlTempFiles.Enabled == false)
-	cfg.Metrics.PostgresqlTempFiles.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlSequentialScans.Enabled == false)
-	cfg.Metrics.PostgresqlSequentialScans.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled == false)
-	cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
-	scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, &factory)
+		testutil.SetFeatureGateForTest(t, preciseLagMetricsFg, true)
+		cfg.Metrics.PostgresqlWalDelay.Enabled = true
+		defer testutil.SetFeatureGateForTest(t, preciseLagMetricsFg, false)
 
-	actualMetrics, err := scraper.scrape(context.Background())
-	require.NoError(t, err)
+		require.True(t, cfg.Metrics.PostgresqlDeadlocks.Enabled == false)
+		cfg.Metrics.PostgresqlDeadlocks.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlTempFiles.Enabled == false)
+		cfg.Metrics.PostgresqlTempFiles.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlSequentialScans.Enabled == false)
+		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled == false)
+		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
+		scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, &factory)
 
-	expectedFile := filepath.Join("testdata", "scraper", "multiple", "expected_precise_lag.yaml")
-	expectedMetrics, err := golden.ReadMetrics(expectedFile)
-	require.NoError(t, err)
-	fmt.Println(actualMetrics.ResourceMetrics())
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+		actualMetrics, err := scraper.scrape(context.Background())
+		require.NoError(t, err)
+
+		expectedFile := filepath.Join("testdata", "scraper", "multiple", file)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		require.NoError(t, err)
+		fmt.Println(actualMetrics.ResourceMetrics())
+		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+	}
+
+	runTest(true, "expected_precise_lag_schemaattr.yaml")
+	runTest(false, "expected_precise_lag.yaml")
 }
 
 func TestScraperWithResourceAttributeFeatureGate(t *testing.T) {
 	factory := mockClientFactory{}
 	factory.initMocks([]string{"otel", "open", "telemetry"})
 
-	cfg := createDefaultConfig().(*Config)
-	require.True(t, cfg.Metrics.PostgresqlDeadlocks.Enabled == false)
-	cfg.Metrics.PostgresqlDeadlocks.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlTempFiles.Enabled == false)
-	cfg.Metrics.PostgresqlTempFiles.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlSequentialScans.Enabled == false)
-	cfg.Metrics.PostgresqlSequentialScans.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled == false)
-	cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
-	scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, &factory)
+	runTest := func(separateSchemaAttr bool, file string) {
+		defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, separateSchemaAttr)()
 
-	actualMetrics, err := scraper.scrape(context.Background())
-	require.NoError(t, err)
+		cfg := createDefaultConfig().(*Config)
+		require.True(t, cfg.Metrics.PostgresqlDeadlocks.Enabled == false)
+		cfg.Metrics.PostgresqlDeadlocks.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlTempFiles.Enabled == false)
+		cfg.Metrics.PostgresqlTempFiles.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlSequentialScans.Enabled == false)
+		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled == false)
+		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
+		scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, &factory)
 
-	expectedFile := filepath.Join("testdata", "scraper", "multiple", "expected.yaml")
-	expectedMetrics, err := golden.ReadMetrics(expectedFile)
-	require.NoError(t, err)
+		actualMetrics, err := scraper.scrape(context.Background())
+		require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+		expectedFile := filepath.Join("testdata", "scraper", "multiple", file)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		require.NoError(t, err)
+
+		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+	}
+
+	runTest(true, "expected_schemaattr.yaml")
+	runTest(false, "expected.yaml")
 }
 
 func TestScraperWithResourceAttributeFeatureGateSingle(t *testing.T) {
 	factory := mockClientFactory{}
 	factory.initMocks([]string{"otel"})
 
-	cfg := createDefaultConfig().(*Config)
-	require.True(t, cfg.Metrics.PostgresqlDeadlocks.Enabled == false)
-	cfg.Metrics.PostgresqlDeadlocks.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlTempFiles.Enabled == false)
-	cfg.Metrics.PostgresqlTempFiles.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlSequentialScans.Enabled == false)
-	cfg.Metrics.PostgresqlSequentialScans.Enabled = true
-	require.True(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled == false)
-	cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
-	scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, &factory)
+	runTest := func(separateSchemaAttr bool, file string) {
+		defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, separateSchemaAttr)()
 
-	actualMetrics, err := scraper.scrape(context.Background())
-	require.NoError(t, err)
+		cfg := createDefaultConfig().(*Config)
+		require.True(t, cfg.Metrics.PostgresqlDeadlocks.Enabled == false)
+		cfg.Metrics.PostgresqlDeadlocks.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlTempFiles.Enabled == false)
+		cfg.Metrics.PostgresqlTempFiles.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlSequentialScans.Enabled == false)
+		cfg.Metrics.PostgresqlSequentialScans.Enabled = true
+		require.True(t, cfg.Metrics.PostgresqlDatabaseLocks.Enabled == false)
+		cfg.Metrics.PostgresqlDatabaseLocks.Enabled = true
+		scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, &factory)
 
-	expectedFile := filepath.Join("testdata", "scraper", "otel", "expected.yaml")
-	expectedMetrics, err := golden.ReadMetrics(expectedFile)
-	require.NoError(t, err)
+		actualMetrics, err := scraper.scrape(context.Background())
+		require.NoError(t, err)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+		expectedFile := filepath.Join("testdata", "scraper", "otel", file)
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		require.NoError(t, err)
+
+		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+	}
+
+	runTest(true, "expected_schemaattr.yaml")
+	runTest(false, "expected.yaml")
 }
 
 func TestScraperExcludeDatabase(t *testing.T) {
 	factory := mockClientFactory{}
 	factory.initMocks([]string{"otel", "telemetry"})
 
-	cfg := createDefaultConfig().(*Config)
-	cfg.ExcludeDatabases = []string{"open"}
+	runTest := func(separateSchemaAttr bool, file string) {
+		defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, separateSchemaAttr)()
 
-	scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, &factory)
+		cfg := createDefaultConfig().(*Config)
+		cfg.ExcludeDatabases = []string{"open"}
 
-	actualMetrics, err := scraper.scrape(context.Background())
-	require.NoError(t, err)
+		scraper := newPostgreSQLScraper(receivertest.NewNopCreateSettings(), cfg, &factory)
 
-	expectedFile := filepath.Join("testdata", "scraper", "multiple", "exclude.yaml")
+		actualMetrics, err := scraper.scrape(context.Background())
+		require.NoError(t, err)
 
-	expectedMetrics, err := golden.ReadMetrics(expectedFile)
-	require.NoError(t, err)
+		expectedFile := filepath.Join("testdata", "scraper", "multiple", file)
 
-	require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+		expectedMetrics, err := golden.ReadMetrics(expectedFile)
+		require.NoError(t, err)
+
+		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreResourceMetricsOrder(),
+			pmetrictest.IgnoreMetricDataPointsOrder(), pmetrictest.IgnoreStartTimestamp(), pmetrictest.IgnoreTimestamp()))
+	}
+
+	runTest(true, "exclude_schemaattr.yaml")
+	runTest(false, "exclude.yaml")
 }
 
 type mockClientFactory struct{ mock.Mock }
@@ -305,12 +354,12 @@ func (m *mockClientFactory) getClient(_ *Config, database string) (client, error
 
 func (m *mockClientFactory) initMocks(databases []string) {
 	listClient := new(mockClient)
-	listClient.initMocks("", "default", databases, 0)
+	listClient.initMocks("", "public", databases, 0)
 	m.On("getClient", "").Return(listClient, nil)
 
 	for index, db := range databases {
 		client := new(mockClient)
-		client.initMocks(db, "default", databases, index)
+		client.initMocks(db, "public", databases, index)
 		m.On("getClient", db).Return(client, nil)
 	}
 }
@@ -405,8 +454,8 @@ func (m *mockClient) initMocks(database string, schema string, databases []strin
 			},
 		}, nil)
 	} else {
-		table1 := "public.table1"
-		table2 := "public.table2"
+		table1 := "table1"
+		table2 := "table2"
 		tableMetrics := map[tableIdentifier]tableStats{
 			tableKey(database, schema, table1): {
 				database:    database,

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_db_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_db_schemaattr.yaml
@@ -1,0 +1,1279 @@
+resourceMetrics:
+  - resource:
+      attributes: []
+    scopeMetrics:
+      - metrics:
+          - description: Number of buffers allocated.
+            name: postgresql.bgwriter.buffers.allocated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "477"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: Number of buffers written.
+            name: postgresql.bgwriter.buffers.writes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "60"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: The number of checkpoints performed.
+            name: postgresql.bgwriter.checkpoint.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: requested
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: scheduled
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{checkpoints}'
+          - description: Total time spent writing and syncing files to disk by checkpoints.
+            name: postgresql.bgwriter.duration
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 23
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asDouble: 16
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+            name: postgresql.bgwriter.maxwritten
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: Configured maximum number of client connections allowed
+            gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            name: postgresql.connection.max
+            unit: '{connections}'
+          - description: Number of user databases.
+            name: postgresql.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: '{databases}'
+          - description: The number of database locks.
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_relname_nsp_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_tblspc_relfilenode_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_locks
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_oid_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+            name: postgresql.database.locks
+            unit: '{lock}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+    scopeMetrics:
+      - metrics:
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "6"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7176708"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "{deadlock}"
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "{temp_file}" 
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+    scopeMetrics:
+      - metrics:
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7217668"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "{deadlock}"
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "{temp_file}"  
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: postgres
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "6"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7232024"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "{deadlock}"
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "{temp_file}"  
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "1"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "2"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "4"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "1"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.index.name
+          value:
+            stringValue: table1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.index.name
+          value:
+            stringValue: table2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.index.name
+          value:
+            stringValue: otel2index
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test2
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "16384"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.index.name
+          value:
+            stringValue: otelindex
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test1
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.index.name
+          value:
+            stringValue: test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test1
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.index.name
+          value:
+            stringValue: test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test2
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "16384"
+                  startTimeUnixNano: "1687780273472170000"
+                  timeUnixNano: "1687780274490198000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_schemaattr.yaml
@@ -1,0 +1,1202 @@
+resourceMetrics:
+  - resource:
+      attributes: []
+    scopeMetrics:
+      - metrics:
+          - description: Number of buffers allocated.
+            name: postgresql.bgwriter.buffers.allocated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "343"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: Number of buffers written.
+            name: postgresql.bgwriter.buffers.writes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "60"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: The number of checkpoints performed.
+            name: postgresql.bgwriter.checkpoint.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: requested
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: scheduled
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{checkpoints}'
+          - description: Total time spent writing and syncing files to disk by checkpoints.
+            name: postgresql.bgwriter.duration
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 32
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asDouble: 15
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+            name: postgresql.bgwriter.maxwritten
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: Configured maximum number of client connections allowed
+            gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            name: postgresql.connection.max
+            unit: '{connections}'
+          - description: Number of user databases.
+            name: postgresql.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: '{databases}'
+          - description: The number of database locks.
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_relname_nsp_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_tblspc_relfilenode_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_locks
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_oid_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+            name: postgresql.database.locks
+            unit: '{lock}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+    scopeMetrics:
+      - metrics:
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "6"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7168516"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "{deadlock}"
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "{temp_file}"
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+    scopeMetrics:
+      - metrics:
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7209476"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "{deadlock}"
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "{temp_file}"
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "1"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "2"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "4"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "1"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.index.name
+          value:
+            stringValue: table1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.index.name
+          value:
+            stringValue: table2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.index.name
+          value:
+            stringValue: otel2index
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test2
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "16384"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.index.name
+          value:
+            stringValue: otelindex
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test1
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.index.name
+          value:
+            stringValue: test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test1
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.index.name
+          value:
+            stringValue: test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: test2
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "16384"
+                  startTimeUnixNano: "1687780262696586000"
+                  timeUnixNano: "1687780263696969000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_single_db_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_single_db_schemaattr.yaml
@@ -1,5 +1,6 @@
 resourceMetrics:
-  - resource: {}
+  - resource:
+      attributes: []
     scopeMetrics:
       - metrics:
           - description: Number of buffers allocated.
@@ -7,9 +8,9 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "10"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "452"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: '{buffers}'
           - description: Number of buffers written.
@@ -17,34 +18,34 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "7"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: backend_fsync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
                 - asInt: "5"
                   attributes:
                     - key: source
                       value:
+                        stringValue: backend
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
                         stringValue: bgwriter
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "60"
                   attributes:
                     - key: source
                       value:
                         stringValue: checkpoints
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: '{buffers}'
           - description: The number of checkpoints performed.
@@ -52,20 +53,20 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1"
+                - asInt: "4"
                   attributes:
                     - key: type
                       value:
                         stringValue: requested
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "2"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: type
                       value:
                         stringValue: scheduled
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: '{checkpoints}'
           - description: Total time spent writing and syncing files to disk by checkpoints.
@@ -73,20 +74,20 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asDouble: 4.23
+                - asDouble: 31
                   attributes:
                     - key: type
                       value:
                         stringValue: sync
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 3.12
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asDouble: 16
                   attributes:
                     - key: type
                       value:
                         stringValue: write
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: ms
           - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
@@ -94,17 +95,17 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "11"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: "1"
           - description: Configured maximum number of client connections allowed
             gauge:
               dataPoints:
                 - asInt: "100"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
             name: postgresql.connection.max
             unit: '{connections}'
           - description: Number of user databases.
@@ -113,64 +114,79 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
             unit: '{databases}'
-          - description: The amount of data delayed in replication.
+          - description: The number of database locks.
             gauge:
               dataPoints:
-                - asInt: "1024"
+                - asInt: "1"
                   attributes:
-                    - key: replication_client
+                    - key: relation
                       value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.replication.data_delay
-            unit: By
-          - description: Age of the oldest WAL file.
-            gauge:
-              dataPoints:
-                - asInt: "3600"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.age
-            unit: s
-          - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
-            gauge:
-              dataPoints:
-                - asInt: "600"
+                        stringValue: pg_class_relname_nsp_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
                   attributes:
-                    - key: operation
+                    - key: relation
                       value:
-                        stringValue: flush
-                    - key: replication_client
+                        stringValue: pg_class_tblspc_relfilenode_index
+                    - key: mode
                       value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "700"
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
                   attributes:
-                    - key: operation
+                    - key: relation
                       value:
-                        stringValue: replay
-                    - key: replication_client
+                        stringValue: pg_locks
+                    - key: mode
                       value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "800"
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
                   attributes:
-                    - key: operation
+                    - key: relation
                       value:
-                        stringValue: write
-                    - key: replication_client
+                        stringValue: pg_class
+                    - key: mode
                       value:
-                        stringValue: unix
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.wal.lag
-            unit: s
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_oid_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1693418281967464598"
+                  timeUnixNano: "1693418340968890176"
+            name: postgresql.database.locks
+            unit: '{lock}'
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -181,23 +197,14 @@ resourceMetrics:
             stringValue: otel
     scopeMetrics:
       - metrics:
-          - description: The number of backends.
-            name: postgresql.backends
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "3"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
           - description: The number of commits.
             name: postgresql.commits
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "6"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: "1"
           - description: The database disk usage.
@@ -205,18 +212,28 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "7184900"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
             unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+              isMonotonic: true
+            unit: "{deadlock}"
           - description: The number of rollbacks.
             name: postgresql.rollbacks
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: "1"
           - description: Number of user tables in a database.
@@ -225,9 +242,19 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
             unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+              isMonotonic: true
+            unit: "{temp_file}"  
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -236,9 +263,12 @@ resourceMetrics:
         - key: postgresql.database.name
           value:
             stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -246,62 +276,62 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "20"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "19"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "22"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "21"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "26"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "25"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "24"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "23"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -309,34 +339,34 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "41"
+                - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "42"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "39"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "40"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -344,38 +374,48 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "8"
+                - asInt: "0"
                   attributes:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "7"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
             unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
           - description: Disk space used by a table.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "43"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "44"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -386,9 +426,12 @@ resourceMetrics:
         - key: postgresql.database.name
           value:
             stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -396,62 +439,62 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "28"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "27"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "30"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "29"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "34"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "33"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "32"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "31"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: "1"
           - description: The number of db row operations.
@@ -459,34 +502,34 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "45"
+                - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: del
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "46"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "43"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "44"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: "1"
           - description: The number of rows in the database.
@@ -494,38 +537,48 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "10"
+                - asInt: "0"
                   attributes:
                     - key: state
                       value:
                         stringValue: dead
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+                - asInt: "0"
                   attributes:
                     - key: state
                       value:
                         stringValue: live
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
             unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
           - description: Disk space used by a table.
             name: postgresql.table.size
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "47"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
             unit: By
           - description: Number of times a table has manually been vacuumed.
             name: postgresql.table.vacuum.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "48"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: '{vacuums}'
         scope:
@@ -538,7 +591,10 @@ resourceMetrics:
             stringValue: otel
         - key: postgresql.index.name
           value:
-            stringValue: otel_test1_pkey
+            stringValue: table1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table1
@@ -549,17 +605,17 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "35"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
-                - asInt: "36"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
             name: postgresql.index.size
             unit: By
         scope:
@@ -572,7 +628,10 @@ resourceMetrics:
             stringValue: otel
         - key: postgresql.index.name
           value:
-            stringValue: otel_test2_pkey
+            stringValue: table2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table2
@@ -583,17 +642,17 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "37"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
               isMonotonic: true
             unit: '{scans}'
           - description: The size of the index on disk.
             gauge:
               dataPoints:
-                - asInt: "38"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
+                - asInt: "8192"
+                  startTimeUnixNano: "1687780251831660000"
+                  timeUnixNano: "1687780252833095000"
             name: postgresql.index.size
             unit: By
         scope:

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude_schemaattr.yaml
@@ -293,9 +293,12 @@ resourceMetrics:
         - key: postgresql.database.name
           value:
             stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -443,9 +446,12 @@ resourceMetrics:
         - key: postgresql.database.name
           value:
             stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -593,9 +599,12 @@ resourceMetrics:
         - key: postgresql.database.name
           value:
             stringValue: telemetry
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -743,9 +752,12 @@ resourceMetrics:
         - key: postgresql.database.name
           value:
             stringValue: telemetry
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -896,6 +908,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: otel_test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table1
@@ -930,6 +945,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: otel_test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table2
@@ -964,6 +982,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: telemetry_test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table1
@@ -998,6 +1019,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: telemetry_test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table2

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
@@ -1406,7 +1406,7 @@ resourceMetrics:
             stringValue: open_test1_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.
@@ -1440,7 +1440,7 @@ resourceMetrics:
             stringValue: open_test2_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.
@@ -1474,7 +1474,7 @@ resourceMetrics:
             stringValue: otel_test1_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.
@@ -1508,7 +1508,7 @@ resourceMetrics:
             stringValue: otel_test2_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.
@@ -1542,7 +1542,7 @@ resourceMetrics:
             stringValue: telemetry_test1_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.
@@ -1576,7 +1576,7 @@ resourceMetrics:
             stringValue: telemetry_test2_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_precise_lag.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_precise_lag.yaml
@@ -1406,7 +1406,7 @@ resourceMetrics:
             stringValue: open_test1_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.
@@ -1440,7 +1440,7 @@ resourceMetrics:
             stringValue: open_test2_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.
@@ -1474,7 +1474,7 @@ resourceMetrics:
             stringValue: otel_test1_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.
@@ -1508,7 +1508,7 @@ resourceMetrics:
             stringValue: otel_test2_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.
@@ -1542,7 +1542,7 @@ resourceMetrics:
             stringValue: telemetry_test1_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.
@@ -1576,7 +1576,7 @@ resourceMetrics:
             stringValue: telemetry_test2_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_precise_lag_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_precise_lag_schemaattr.yaml
@@ -112,10 +112,41 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2"
+                - asInt: "3"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{databases}'
+          - description: The number of database locks.
+            gauge:
+              dataPoints:
+                - asInt: "3600"
+                  attributes:
+                    - key: "relation"
+                      value:
+                        stringValue: "pg_locks"
+                    - key: "mode"
+                      value:
+                        stringValue: "AccessShareLock"
+                    - key: "lock_type"
+                      value:
+                        stringValue: "relation"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5600"
+                  attributes:
+                    - key: "relation"
+                      value:
+                        stringValue: "pg_class"
+                    - key: "mode"
+                      value:
+                        stringValue: "AccessShareLock"
+                    - key: "lock_type"
+                      value:
+                        stringValue: "relation"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.database.locks
+            unit: '{lock}'
           - description: The amount of data delayed in replication.
             gauge:
               dataPoints:
@@ -139,7 +170,7 @@ resourceMetrics:
           - description: Time between flushing recent WAL locally and receiving notification that the standby server has completed an operation with it.
             gauge:
               dataPoints:
-                - asInt: "600"
+                - asDouble: "600.400"
                   attributes:
                     - key: operation
                       value:
@@ -149,7 +180,7 @@ resourceMetrics:
                         stringValue: unix
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "700"
+                - asDouble: "700.550"
                   attributes:
                     - key: operation
                       value:
@@ -159,7 +190,7 @@ resourceMetrics:
                         stringValue: unix
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "800"
+                - asDouble: "800.660"
                   attributes:
                     - key: operation
                       value:
@@ -169,8 +200,85 @@ resourceMetrics:
                         stringValue: unix
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: postgresql.wal.lag
+            name: postgresql.wal.delay
             unit: s
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: open
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{deadlock}'
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{temp_file}'
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -209,6 +317,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{deadlock}'
           - description: The number of rollbacks.
             name: postgresql.rollbacks
             sum:
@@ -228,6 +346,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{temp_file}'      
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -243,7 +371,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4"
+                - asInt: "5"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
@@ -252,7 +380,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2"
+                - asInt: "3"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -262,16 +390,26 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "5"
+                - asInt: "6"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{deadlock}'
           - description: The number of rollbacks.
             name: postgresql.rollbacks
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "3"
+                - asInt: "4"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -285,6 +423,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "6"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{temp_file}'  
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -292,10 +440,13 @@ resourceMetrics:
       attributes:
         - key: postgresql.database.name
           value:
-            stringValue: otel
+            stringValue: open
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -303,56 +454,56 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "20"
+                - asInt: "21"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_hit
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "19"
+                - asInt: "20"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "22"
+                - asInt: "23"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "21"
+                - asInt: "22"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "26"
+                - asInt: "27"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "25"
+                - asInt: "26"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "24"
+                - asInt: "25"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "23"
+                - asInt: "24"
                   attributes:
                     - key: source
                       value:
@@ -366,28 +517,28 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "41"
+                - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: del
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "42"
+                - asInt: "43"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "39"
+                - asInt: "40"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "40"
+                - asInt: "41"
                   attributes:
                     - key: operation
                       value:
@@ -401,14 +552,14 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "8"
+                - asInt: "9"
                   attributes:
                     - key: state
                       value:
                         stringValue: dead
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "7"
+                - asInt: "8"
                   attributes:
                     - key: state
                       value:
@@ -416,306 +567,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
-            name: postgresql.table.size
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "43"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: Number of times a table has manually been vacuumed.
-            name: postgresql.table.vacuum.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "44"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{vacuums}'
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: otel
-        - key: postgresql.table.name
-          value:
-            stringValue: public.table2
-    scopeMetrics:
-      - metrics:
-          - description: The number of blocks read.
-            name: postgresql.blocks_read
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "28"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "27"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "30"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "29"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "34"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "33"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "32"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "31"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of db row operations.
-            name: postgresql.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "45"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: del
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
                 - asInt: "46"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: hot_upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "44"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: "1"
-          - description: The number of rows in the database.
-            name: postgresql.rows
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "10"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: dead
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: live
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: Disk space used by a table.
-            name: postgresql.table.size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "47"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: Number of times a table has manually been vacuumed.
-            name: postgresql.table.vacuum.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "48"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{vacuums}'
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: telemetry
-        - key: postgresql.table.name
-          value:
-            stringValue: public.table1
-    scopeMetrics:
-      - metrics:
-          - description: The number of blocks read.
-            name: postgresql.blocks_read
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "21"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "20"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "23"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "22"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "27"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "26"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "25"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "24"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of db row operations.
-            name: postgresql.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "42"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: del
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: hot_upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "41"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of rows in the database.
-            name: postgresql.rows
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "9"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: dead
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: live
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
+            unit: "{sequential_scan}"
           - description: Disk space used by a table.
             name: postgresql.table.size
             sum:
@@ -742,10 +603,13 @@ resourceMetrics:
       attributes:
         - key: postgresql.database.name
           value:
-            stringValue: telemetry
+            stringValue: open
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -866,6 +730,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "50"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
           - description: Disk space used by a table.
             name: postgresql.table.size
             sum:
@@ -893,9 +767,738 @@ resourceMetrics:
         - key: postgresql.database.name
           value:
             stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "20"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "19"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "22"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "21"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "26"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "25"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "24"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "23"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "41"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "42"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "39"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "40"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "8"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "7"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "45"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "43"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "44"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "28"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "27"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "30"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "29"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "34"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "33"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "32"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "31"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "45"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "46"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "43"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "44"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "49"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "47"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "48"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: telemetry
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "22"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "21"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "24"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "23"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "28"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "27"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "26"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "25"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "43"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "44"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "41"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "42"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "47"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "45"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "46"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: telemetry
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "30"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "29"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "32"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "31"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "35"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "34"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "33"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "47"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "48"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "45"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "46"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "12"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "51"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "49"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "50"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: open
+        - key: postgresql.index.name
+          value:
+            stringValue: open_test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "36"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "37"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: open
+        - key: postgresql.index.name
+          value:
+            stringValue: open_test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "38"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "39"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
         - key: postgresql.index.name
           value:
             stringValue: otel_test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table1
@@ -930,6 +1533,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: otel_test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table2
@@ -964,6 +1570,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: telemetry_test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table1
@@ -974,7 +1583,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "36"
+                - asInt: "37"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -982,7 +1591,7 @@ resourceMetrics:
           - description: The size of the index on disk.
             gauge:
               dataPoints:
-                - asInt: "37"
+                - asInt: "38"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: postgresql.index.size
@@ -998,6 +1607,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: telemetry_test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table2
@@ -1008,7 +1620,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "38"
+                - asInt: "39"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -1016,7 +1628,7 @@ resourceMetrics:
           - description: The size of the index on disk.
             gauge:
               dataPoints:
-                - asInt: "39"
+                - asInt: "40"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: postgresql.index.size

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_schemaattr.yaml
@@ -112,10 +112,41 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2"
+                - asInt: "3"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{databases}'
+          - description: The number of database locks.
+            gauge:
+              dataPoints:
+                - asInt: "3600"
+                  attributes:
+                    - key: "relation"
+                      value:
+                        stringValue: "pg_locks"
+                    - key: "mode"
+                      value:
+                        stringValue: "AccessShareLock"
+                    - key: "lock_type"
+                      value:
+                        stringValue: "relation"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5600"
+                  attributes:
+                    - key: "relation"
+                      value:
+                        stringValue: "pg_class"
+                    - key: "mode"
+                      value:
+                        stringValue: "AccessShareLock"
+                    - key: "lock_type"
+                      value:
+                        stringValue: "relation"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.database.locks
+            unit: '{lock}'
           - description: The amount of data delayed in replication.
             gauge:
               dataPoints:
@@ -178,6 +209,83 @@ resourceMetrics:
       attributes:
         - key: postgresql.database.name
           value:
+            stringValue: open
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{deadlock}'
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{temp_file}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
             stringValue: otel
     scopeMetrics:
       - metrics:
@@ -209,6 +317,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{deadlock}'
           - description: The number of rollbacks.
             name: postgresql.rollbacks
             sum:
@@ -228,6 +346,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{temp_file}'      
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -243,7 +371,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4"
+                - asInt: "5"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
@@ -252,7 +380,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2"
+                - asInt: "3"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -262,16 +390,26 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "5"
+                - asInt: "6"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{deadlock}'
           - description: The number of rollbacks.
             name: postgresql.rollbacks
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "3"
+                - asInt: "4"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -285,6 +423,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "6"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{temp_file}'  
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -292,10 +440,13 @@ resourceMetrics:
       attributes:
         - key: postgresql.database.name
           value:
-            stringValue: otel
+            stringValue: open
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -303,56 +454,56 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "20"
+                - asInt: "21"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_hit
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "19"
+                - asInt: "20"
                   attributes:
                     - key: source
                       value:
                         stringValue: heap_read
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "22"
+                - asInt: "23"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_hit
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "21"
+                - asInt: "22"
                   attributes:
                     - key: source
                       value:
                         stringValue: idx_read
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "26"
+                - asInt: "27"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_hit
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "25"
+                - asInt: "26"
                   attributes:
                     - key: source
                       value:
                         stringValue: tidx_read
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "24"
+                - asInt: "25"
                   attributes:
                     - key: source
                       value:
                         stringValue: toast_hit
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "23"
+                - asInt: "24"
                   attributes:
                     - key: source
                       value:
@@ -366,28 +517,28 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "41"
+                - asInt: "42"
                   attributes:
                     - key: operation
                       value:
                         stringValue: del
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "42"
+                - asInt: "43"
                   attributes:
                     - key: operation
                       value:
                         stringValue: hot_upd
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "39"
+                - asInt: "40"
                   attributes:
                     - key: operation
                       value:
                         stringValue: ins
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "40"
+                - asInt: "41"
                   attributes:
                     - key: operation
                       value:
@@ -401,14 +552,14 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "8"
+                - asInt: "9"
                   attributes:
                     - key: state
                       value:
                         stringValue: dead
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "7"
+                - asInt: "8"
                   attributes:
                     - key: state
                       value:
@@ -416,306 +567,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
-            name: postgresql.table.size
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "43"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: Number of times a table has manually been vacuumed.
-            name: postgresql.table.vacuum.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "44"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{vacuums}'
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: otel
-        - key: postgresql.table.name
-          value:
-            stringValue: public.table2
-    scopeMetrics:
-      - metrics:
-          - description: The number of blocks read.
-            name: postgresql.blocks_read
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "28"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "27"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "30"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "29"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "34"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "33"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "32"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "31"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of db row operations.
-            name: postgresql.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "45"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: del
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
                 - asInt: "46"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: hot_upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "44"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
-            unit: "1"
-          - description: The number of rows in the database.
-            name: postgresql.rows
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "10"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: dead
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: live
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: Disk space used by a table.
-            name: postgresql.table.size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "47"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: Number of times a table has manually been vacuumed.
-            name: postgresql.table.vacuum.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "48"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{vacuums}'
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: telemetry
-        - key: postgresql.table.name
-          value:
-            stringValue: public.table1
-    scopeMetrics:
-      - metrics:
-          - description: The number of blocks read.
-            name: postgresql.blocks_read
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "21"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "20"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "23"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "22"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "27"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "26"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "25"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "24"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of db row operations.
-            name: postgresql.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "42"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: del
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: hot_upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "41"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of rows in the database.
-            name: postgresql.rows
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "9"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: dead
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: live
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
+            unit: "{sequential_scan}"
           - description: Disk space used by a table.
             name: postgresql.table.size
             sum:
@@ -742,10 +603,13 @@ resourceMetrics:
       attributes:
         - key: postgresql.database.name
           value:
-            stringValue: telemetry
+            stringValue: open
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -866,6 +730,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "50"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
           - description: Disk space used by a table.
             name: postgresql.table.size
             sum:
@@ -893,9 +767,738 @@ resourceMetrics:
         - key: postgresql.database.name
           value:
             stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "20"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "19"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "22"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "21"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "26"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "25"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "24"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "23"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "41"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "42"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "39"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "40"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "8"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "7"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "45"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "43"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "44"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "28"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "27"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "30"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "29"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "34"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "33"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "32"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "31"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "45"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "46"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "43"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "44"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "49"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "47"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "48"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: telemetry
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "22"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "21"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "24"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "23"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "28"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "27"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "26"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "25"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "43"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "44"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "41"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "42"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "47"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "45"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "46"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: telemetry
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "30"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "29"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "32"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "31"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "35"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "34"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "33"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "47"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "48"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "45"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "46"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "12"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "51"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "49"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "50"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: open
+        - key: postgresql.index.name
+          value:
+            stringValue: open_test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "36"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "37"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: open
+        - key: postgresql.index.name
+          value:
+            stringValue: open_test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "38"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "39"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
         - key: postgresql.index.name
           value:
             stringValue: otel_test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table1
@@ -930,6 +1533,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: otel_test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table2
@@ -964,6 +1570,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: telemetry_test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table1
@@ -974,7 +1583,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "36"
+                - asInt: "37"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -982,7 +1591,7 @@ resourceMetrics:
           - description: The size of the index on disk.
             gauge:
               dataPoints:
-                - asInt: "37"
+                - asInt: "38"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: postgresql.index.size
@@ -998,6 +1607,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: telemetry_test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table2
@@ -1008,7 +1620,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "38"
+                - asInt: "39"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -1016,7 +1628,7 @@ resourceMetrics:
           - description: The size of the index on disk.
             gauge:
               dataPoints:
-                - asInt: "39"
+                - asInt: "40"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: postgresql.index.size

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
@@ -612,7 +612,7 @@ resourceMetrics:
             stringValue: otel_test1_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.
@@ -646,7 +646,7 @@ resourceMetrics:
             stringValue: otel_test2_pkey
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of index scans on a table.

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics_schemaattr.yaml
@@ -112,7 +112,7 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2"
+                - asInt: "1"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{databases}'
@@ -235,67 +235,13 @@ resourceMetrics:
       attributes:
         - key: postgresql.database.name
           value:
-            stringValue: telemetry
-    scopeMetrics:
-      - metrics:
-          - description: The number of backends.
-            name: postgresql.backends
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "4"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: The number of commits.
-            name: postgresql.commits
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The database disk usage.
-            name: postgresql.db_size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "5"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: The number of rollbacks.
-            name: postgresql.rollbacks
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "3"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: Number of user tables in a database.
-            name: postgresql.table.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{table}'
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
             stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -443,9 +389,12 @@ resourceMetrics:
         - key: postgresql.database.name
           value:
             stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -581,306 +530,6 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "48"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{vacuums}'
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: telemetry
-        - key: postgresql.table.name
-          value:
-            stringValue: public.table1
-    scopeMetrics:
-      - metrics:
-          - description: The number of blocks read.
-            name: postgresql.blocks_read
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "21"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "20"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "23"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "22"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "27"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "26"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "25"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "24"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of db row operations.
-            name: postgresql.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "42"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: del
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: hot_upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "41"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of rows in the database.
-            name: postgresql.rows
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "9"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: dead
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: live
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: Disk space used by a table.
-            name: postgresql.table.size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "44"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: Number of times a table has manually been vacuumed.
-            name: postgresql.table.vacuum.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "45"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{vacuums}'
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: telemetry
-        - key: postgresql.table.name
-          value:
-            stringValue: public.table2
-    scopeMetrics:
-      - metrics:
-          - description: The number of blocks read.
-            name: postgresql.blocks_read
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "29"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "28"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "31"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "30"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "35"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "34"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "33"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "32"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of db row operations.
-            name: postgresql.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "46"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: del
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "47"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: hot_upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "44"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "45"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of rows in the database.
-            name: postgresql.rows
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "11"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: dead
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "10"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: live
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: Disk space used by a table.
-            name: postgresql.table.size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "48"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: Number of times a table has manually been vacuumed.
-            name: postgresql.table.vacuum.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "49"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -896,6 +545,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: otel_test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table1
@@ -930,6 +582,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: otel_test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table2
@@ -949,74 +604,6 @@ resourceMetrics:
             gauge:
               dataPoints:
                 - asInt: "38"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.index.size
-            unit: By
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: telemetry
-        - key: postgresql.index.name
-          value:
-            stringValue: telemetry_test1_pkey
-        - key: postgresql.table.name
-          value:
-            stringValue: table1
-    scopeMetrics:
-      - metrics:
-          - description: The number of index scans on a table.
-            name: postgresql.index.scans
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "36"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{scans}'
-          - description: The size of the index on disk.
-            gauge:
-              dataPoints:
-                - asInt: "37"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.index.size
-            unit: By
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: telemetry
-        - key: postgresql.index.name
-          value:
-            stringValue: telemetry_test2_pkey
-        - key: postgresql.table.name
-          value:
-            stringValue: table2
-    scopeMetrics:
-      - metrics:
-          - description: The number of index scans on a table.
-            name: postgresql.index.scans
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "38"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{scans}'
-          - description: The size of the index on disk.
-            gauge:
-              dataPoints:
-                - asInt: "39"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: postgresql.index.size

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_schemaattr.yaml
@@ -112,10 +112,41 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "2"
+                - asInt: "1"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{databases}'
+          - description: The number of database locks.
+            gauge:
+              dataPoints:
+                - asInt: "3600"
+                  attributes:
+                    - key: "relation"
+                      value:
+                        stringValue: "pg_locks"
+                    - key: "mode"
+                      value:
+                        stringValue: "AccessShareLock"
+                    - key: "lock_type"
+                      value:
+                        stringValue: "relation"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5600"
+                  attributes:
+                    - key: "relation"
+                      value:
+                        stringValue: "pg_class"
+                    - key: "mode"
+                      value:
+                        stringValue: "AccessShareLock"
+                    - key: "lock_type"
+                      value:
+                        stringValue: "relation"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: postgresql.database.locks
+            unit: '{lock}'
           - description: The amount of data delayed in replication.
             gauge:
               dataPoints:
@@ -209,65 +240,8 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: The number of rollbacks.
-            name: postgresql.rollbacks
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: Number of user tables in a database.
-            name: postgresql.table.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{table}'
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: telemetry
-    scopeMetrics:
-      - metrics:
-          - description: The number of backends.
-            name: postgresql.backends
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "4"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: The number of commits.
-            name: postgresql.commits
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The database disk usage.
-            name: postgresql.db_size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "5"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: The number of rollbacks.
-            name: postgresql.rollbacks
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
             sum:
               aggregationTemporality: 2
               dataPoints:
@@ -275,6 +249,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
+            unit: '{deadlock}'
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
             unit: "1"
           - description: Number of user tables in a database.
             name: postgresql.table.count
@@ -285,6 +269,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{temp_file}'
         scope:
           name: otelcol/postgresqlreceiver
           version: latest
@@ -293,9 +287,12 @@ resourceMetrics:
         - key: postgresql.database.name
           value:
             stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table1
+            stringValue: table1
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -416,6 +413,16 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "45"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
           - description: Disk space used by a table.
             name: postgresql.table.size
             sum:
@@ -443,9 +450,12 @@ resourceMetrics:
         - key: postgresql.database.name
           value:
             stringValue: otel
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
-            stringValue: public.table2
+            stringValue: table2
     scopeMetrics:
       - metrics:
           - description: The number of blocks read.
@@ -566,321 +576,31 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: "1"
-          - description: Disk space used by a table.
-            name: postgresql.table.size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "47"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: Number of times a table has manually been vacuumed.
-            name: postgresql.table.vacuum.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "48"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{vacuums}'
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: telemetry
-        - key: postgresql.table.name
-          value:
-            stringValue: public.table1
-    scopeMetrics:
-      - metrics:
-          - description: The number of blocks read.
-            name: postgresql.blocks_read
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "21"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "20"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "23"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "22"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "27"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "26"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "25"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "24"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of db row operations.
-            name: postgresql.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "42"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: del
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: hot_upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "41"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of rows in the database.
-            name: postgresql.rows
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "9"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: dead
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: live
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: Disk space used by a table.
-            name: postgresql.table.size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "44"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: Number of times a table has manually been vacuumed.
-            name: postgresql.table.vacuum.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "45"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{vacuums}'
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: telemetry
-        - key: postgresql.table.name
-          value:
-            stringValue: public.table2
-    scopeMetrics:
-      - metrics:
-          - description: The number of blocks read.
-            name: postgresql.blocks_read
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "29"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "28"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: heap_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "31"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "30"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: idx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "35"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "34"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: tidx_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "33"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_hit
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "32"
-                  attributes:
-                    - key: source
-                      value:
-                        stringValue: toast_read
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of db row operations.
-            name: postgresql.operations
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "46"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: del
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "47"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: hot_upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "44"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: ins
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "45"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: upd
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: "1"
-          - description: The number of rows in the database.
-            name: postgresql.rows
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "11"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: dead
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "10"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: live
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: "1"
-          - description: Disk space used by a table.
-            name: postgresql.table.size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "48"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: By
-          - description: Number of times a table has manually been vacuumed.
-            name: postgresql.table.vacuum.count
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
             sum:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "49"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: "{sequential_scan}"
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "47"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "48"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -896,6 +616,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: otel_test1_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table1
@@ -930,6 +653,9 @@ resourceMetrics:
         - key: postgresql.index.name
           value:
             stringValue: otel_test2_pkey
+        - key: postgresql.schema.name
+          value:
+            stringValue: public
         - key: postgresql.table.name
           value:
             stringValue: table2
@@ -949,74 +675,6 @@ resourceMetrics:
             gauge:
               dataPoints:
                 - asInt: "38"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.index.size
-            unit: By
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: telemetry
-        - key: postgresql.index.name
-          value:
-            stringValue: telemetry_test1_pkey
-        - key: postgresql.table.name
-          value:
-            stringValue: table1
-    scopeMetrics:
-      - metrics:
-          - description: The number of index scans on a table.
-            name: postgresql.index.scans
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "36"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{scans}'
-          - description: The size of the index on disk.
-            gauge:
-              dataPoints:
-                - asInt: "37"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: postgresql.index.size
-            unit: By
-        scope:
-          name: otelcol/postgresqlreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: postgresql.database.name
-          value:
-            stringValue: telemetry
-        - key: postgresql.index.name
-          value:
-            stringValue: telemetry_test2_pkey
-        - key: postgresql.table.name
-          value:
-            stringValue: table2
-    scopeMetrics:
-      - metrics:
-          - description: The number of index scans on a table.
-            name: postgresql.index.scans
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "38"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: '{scans}'
-          - description: The size of the index on disk.
-            gauge:
-              dataPoints:
-                - asInt: "39"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             name: postgresql.index.size


### PR DESCRIPTION
**Description:** 

Changes the postgresql statistics receiver so that a table or indices schema is stored in it's own attribute.

Currently the schema is stored as table name for *some* of the statistics, while others completely ignore what schema a statistic comes out of.

The code will allow computing things like sequential vs index scans against a table without having to pick apart the resource attribute.

**Link to tracking Issue:**  #29559 

**Testing:** I've built the docker container for otel contrib and have been running the result for a few days to observe that the attributes are properly propagated.

**Documentation:** Documentation for the new field was added to the metadata.yaml and documentation.md