### PR TITLE
[pkg/ottl] Fix bug where `IsBool` wasn't usable

### DIFF
--- a/.chloggen/ottl-add-bool-getters-to-switch.yaml
+++ b/.chloggen/ottl-add-bool-getters-to-switch.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where the Converter `IsBool` was not usable
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30151]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -454,6 +454,18 @@ func (p *Parser[K]) buildArg(argVal value, argType reflect.Type) (any, error) {
 			return nil, err
 		}
 		return StandardTimeGetter[K]{Getter: arg.Get}, nil
+	case strings.HasPrefix(name, "BoolGetter"):
+		arg, err := p.newGetter(argVal)
+		if err != nil {
+			return nil, err
+		}
+		return StandardBoolGetter[K]{Getter: arg.Get}, nil
+	case strings.HasPrefix(name, "BoolLikeGetter"):
+		arg, err := p.newGetter(argVal)
+		if err != nil {
+			return nil, err
+		}
+		return StandardBoolLikeGetter[K]{Getter: arg.Get}, nil
 	case name == "Enum":
 		arg, err := p.enumParser((*EnumSymbol)(argVal.Enum))
 		if err != nil {


### PR DESCRIPTION
**Description:** 
Found a bug where the `BoolGetter` and `BoolLikeGetter` types were not included in the function parser's switch statement.  This meant OTTL didn't know how to interpret that parameter type which mean `IsBool` is not actually usable.

I missed this while reviewing https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/27900

**Link to tracking Issue:** <Issue number if applicable>
Found while working on https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/28642 - issues like these are why these e2e tests will be useful.

**Testing:** 
Will add the e2e tests as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/28642