### PR TITLE
[chore][exporter/clickhouse] Fix broken makefile command for examples

### DIFF
--- a/exporter/clickhouseexporter/Makefile
+++ b/exporter/clickhouseexporter/Makefile
@@ -1,8 +1,8 @@
 include ../../Makefile.Common
 
 local-run-example:
-	cd ../../ && GOOS=linux go build -o ./local/otelcontribcol ./cmd/otelcontribcol
+	cd ../../cmd/otelcontribcol && GOOS=linux go build -o ../../local/otelcontribcol
 	cd example && docker-compose up -d
 recreate-otel-collector:
-	cd ../../ && GOOS=linux go build -o ./local/otelcontribcol ./cmd/otelcontribcol
+	cd ../../ && make otelcontribcol
 	cd example && docker-compose up --build otelcollector

--- a/exporter/clickhouseexporter/README.md
+++ b/exporter/clickhouseexporter/README.md
@@ -140,7 +140,7 @@ SELECT Timestamp as log_time,
        toString(Links.TraceId)
 FROM otel_traces
 WHERE ServiceName = 'clickhouse-exporter'
-  AND SpanAttributes['peer.service'] = 'tracegen-server'
+  AND SpanAttributes['peer.service'] = 'telemetrygen-server'
   AND Timestamp >= NOW() - INTERVAL 1 HOUR
 Limit 100;
 ```

--- a/exporter/clickhouseexporter/example/docker-compose.yml
+++ b/exporter/clickhouseexporter/example/docker-compose.yml
@@ -69,10 +69,11 @@ services:
     stop_signal: SIGKILL
 
   # Traces generator
-  tracegen:
+  telemetrygen:
     build:
-      context: ../../../cmd/tracegen/
+      context: ../../../cmd/telemetrygen/
     command:
+      - traces
       - --otlp-endpoint=otelcollector:4317
       - --otlp-insecure
       - --rate=100


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The ClickHouse exporter contains a docker example with `telemetrygen` generating traces to send to the otel collector, which then sends to the ClickHouse backend. Grafana is then used to view traces. The make commands were broken due being in the wrong directory when executing, as well as the deprecation of `tracegen` in favor of `telemetrygen traces`.

**Link to tracking Issue:** <Issue number if applicable>
Resolves #30159

**Testing:** <Describe what testing was performed and which tests were added.>
Both `make` commands are working and everything's up and running. Also confirmed `telemetrygen` is properly sending traces to the collector.
Note: I'm not familiar enough with Grafana or ClickHouse to be able to validate clickhouse exporter functionality in the example. A code owner or user will have to verify the example still works.