### PR TITLE
[mdatagen] mark mdatagen in this repo deprecated

### DIFF
--- a/.chloggen/codeboten_deprecate-mdatagen.yaml
+++ b/.chloggen/codeboten_deprecate-mdatagen.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Component is being moved to core to allow it to be used there as well.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30173]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/README.md
+++ b/cmd/mdatagen/README.md
@@ -1,5 +1,7 @@
 # Metadata Generator
 
+> This module is being moved to https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/mdatagen and will be deprecated in this repository.
+
 Every component's documentation should include a brief description of the component and guidance on how to use it.
 There is also some information about the component (or metadata) that should be included to help end-users understand the current state of the component and whether it is right for their use case.
 Examples of this metadata about a component are:

--- a/cmd/mdatagen/go.mod
+++ b/cmd/mdatagen/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use go.opentelemetry.io/collector/cmd/mdatagen instead.
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen
 
 go 1.20


### PR DESCRIPTION
It's being moved to core to be utilized in both repositories.
