### PR TITLE
[chore]: fix linux packaging tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -458,8 +458,7 @@ jobs:
           path: ./bin/*
 
   build-package:
-    # Use 20.04.5 until https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16450 is resolved
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [cross-compile]
     strategy:
       fail-fast: false

--- a/internal/buildscripts/packaging/fpm/common.sh
+++ b/internal/buildscripts/packaging/fpm/common.sh
@@ -31,8 +31,8 @@ docker_cp() {
     local dest_dir="$( dirname "$dest" )"
 
     echo "Copying $src to $container:$dest ..."
-    docker exec $container mkdir -p "$dest_dir"
-    docker cp "$src" $container:"$dest"
+    podman exec $container mkdir -p "$dest_dir"
+    podman cp "$src" $container:"$dest"
 }
 
 install_pkg() {
@@ -43,9 +43,9 @@ install_pkg() {
     echo "Installing $pkg_base ..."
     docker_cp $container "$pkg_path" /tmp/$pkg_base
     if [[ "${pkg_base##*.}" = "deb" ]]; then
-        docker exec $container dpkg -i /tmp/$pkg_base
+        podman exec $container dpkg -i /tmp/$pkg_base
     else
-        docker exec $container rpm -ivh /tmp/$pkg_base
+        podman exec $container rpm -ivh /tmp/$pkg_base
     fi
 }
 
@@ -56,8 +56,8 @@ uninstall_pkg() {
 
     echo "Uninstalling $pkg_name ..."
     if [[ "$pkg_type" = "deb" ]]; then
-        docker exec $container dpkg -r $pkg_name
+        podman exec $container dpkg -r $pkg_name
     else
-        docker exec $container rpm -e $pkg_name
+        podman exec $container rpm -e $pkg_name
     fi
 }

--- a/internal/buildscripts/packaging/fpm/deb/Dockerfile.test
+++ b/internal/buildscripts/packaging/fpm/deb/Dockerfile.test
@@ -9,14 +9,6 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update ; \
     apt-get install -y systemd systemd-sysv procps; \
     apt-get clean ; \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ; \
-    rm -rf /lib/systemd/system/multi-user.target.wants/* ; \
-    rm -rf /etc/systemd/system/*.wants/* ; \
-    rm -rf /lib/systemd/system/local-fs.target.wants/* ; \
-    rm -rf /lib/systemd/system/sockets.target.wants/*udev* ; \
-    rm -rf /lib/systemd/system/sockets.target.wants/*initctl* ; \
-    rm -rf /lib/systemd/system/sysinit.target.wants/systemd-tmpfiles-setup* ; \
-    rm -rf /lib/systemd/system/systemd-update-utmp*
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-VOLUME [ "/sys/fs/cgroup" ]
 CMD ["/lib/systemd/systemd"]

--- a/internal/buildscripts/packaging/fpm/rpm/Dockerfile.test
+++ b/internal/buildscripts/packaging/fpm/rpm/Dockerfile.test
@@ -6,15 +6,4 @@ ENV container docker
 
 RUN dnf install -y initscripts
 
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \
-    "systemd-tmpfiles-setup.service" ] || rm -f $i; done); \
-    rm -f /lib/systemd/system/multi-user.target.wants/*;\
-    rm -f /lib/systemd/system/local-fs.target.wants/*; \
-    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-    rm -f /lib/systemd/system/basic.target.wants/*;\
-    rm -f /lib/systemd/system/anaconda.target.wants/*;
-
-VOLUME [ "/sys/fs/cgroup" ]
-
 CMD ["/usr/sbin/init"]

--- a/internal/buildscripts/packaging/fpm/test.sh
+++ b/internal/buildscripts/packaging/fpm/test.sh
@@ -30,47 +30,46 @@ if [[ ! "$pkg_type" =~ ^(deb|rpm)$ ]]; then
 fi
 image_name="otelcontribcol-$pkg_type-test"
 container_name="$image_name"
-docker_run="docker run --name $container_name -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro --privileged $image_name"
-docker_exec="docker exec $container_name"
+container_exec="podman exec $container_name"
 
-trap "docker rm -fv $container_name >/dev/null 2>&1 || true" EXIT
+trap "podman rm -fv $container_name >/dev/null 2>&1 || true" EXIT
 
-docker build -t $image_name -f "$SCRIPT_DIR/$pkg_type/Dockerfile.test" "$SCRIPT_DIR"
-docker rm -fv $container_name >/dev/null 2>&1 || true
+podman build -t $image_name -f "$SCRIPT_DIR/$pkg_type/Dockerfile.test" "$SCRIPT_DIR"
+podman rm -fv $container_name >/dev/null 2>&1 || true
 
 # test install
 echo
-$docker_run
+podman run --name $container_name -d $image_name
 install_pkg $container_name "$PKG_PATH"
 
 # ensure service has started and still running after 5 seconds
 sleep 5
 echo "Checking $SERVICE_NAME service status ..."
-$docker_exec systemctl --no-pager status $SERVICE_NAME
+$container_exec systemctl --no-pager status $SERVICE_NAME
 
 echo "Checking $PROCESS_NAME process ..."
-$docker_exec pgrep -a -u otel $PROCESS_NAME
+$container_exec pgrep -a -u otel $PROCESS_NAME
 
 # test uninstall
 echo
 uninstall_pkg $container_name $pkg_type
 
 echo "Checking $SERVICE_NAME service status after uninstall ..."
-if $docker_exec systemctl --no-pager status $SERVICE_NAME; then
+if $container_exec systemctl --no-pager status $SERVICE_NAME; then
     echo "$SERVICE_NAME service still running after uninstall" >&2
     exit 1
 fi
 echo "$SERVICE_NAME service successfully stopped after uninstall"
 
 echo "Checking $SERVICE_NAME service existence after uninstall ..."
-if $docker_exec systemctl list-unit-files --all | grep $SERVICE_NAME; then
+if $container_exec systemctl list-unit-files --all | grep $SERVICE_NAME; then
     echo "$SERVICE_NAME service still exists after uninstall" >&2
     exit 1
 fi
 echo "$SERVICE_NAME service successfully removed after uninstall"
 
 echo "Checking $PROCESS_NAME process after uninstall ..."
-if $docker_exec pgrep $PROCESS_NAME; then
+if $container_exec pgrep $PROCESS_NAME; then
     echo "$PROCESS_NAME process still running after uninstall"
     exit 1
 fi


### PR DESCRIPTION
Fixes open-telemetry/opentelemetry-collector-contrib#16450

The original packaging tests for the Linux packages (deb, rpm) that were
created in open-telemetry/opentelemetry-collector-contrib#405 used a bit of gnarly work around in order to allow very
limited Systemd functionality to be used in Docker/Containerd

At the time when those packaging tests were written, podman was already
able to run Systemd, but podman was not included in Ubuntu 20.04 yet ...

Now that Podman is available in Ubuntu 22.04, running SystemD in Podman
just works.

Signed-off-by: Christoph Wegener <cwegener@users.noreply.github.com>
