### PR TITLE
[exporter/awsemf] Add feature gate to move descriptor and declaration cleaning out of config validate

### DIFF
--- a/.chloggen/awsemf_configWarning.yaml
+++ b/.chloggen/awsemf_configWarning.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsemfexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add feature gate to move metric descriptor and declaration validation to separate method
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24756]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -15,9 +15,9 @@ import (
 
 var useConfigCleanMethod = featuregate.GlobalRegistry().MustRegister("awsemf.configvalidation", featuregate.StageAlpha,
 	featuregate.WithRegisterFromVersion("v0.91.0"),
-	featuregate.WithRegisterDescription("Enabling this feature gate changes the default AWS EMF Exporter Config"+
-		" Validate method to no longer clean metric declaration and desciptor objects. Config.CleanDelcarationsAndDescriptors() "+
-		"must be called in addition to Validate()"))
+	featuregate.WithRegisterDescription("Enabling this feature gate changes the default awsemfexporter.Config.Validate()"+
+		" method to no longer clean metric declaration and desciptor objects. awsemfexporter.Config.CleanDelcarationsAndDescriptors() "+
+		"must be called in addition to Validate() if feature gate is enabled."))
 
 var (
 	// eMFSupportedUnits contains the unit collection supported by CloudWatch backend service.

--- a/exporter/awsemfexporter/config.go
+++ b/exporter/awsemfexporter/config.go
@@ -116,29 +116,7 @@ func (config *Config) Validate() error {
 	}
 
 	if !useConfigCleanMethod.IsEnabled() {
-		var validDeclarations []*MetricDeclaration
-		for _, declaration := range config.MetricDeclarations {
-			err := declaration.init(config.logger)
-			if err != nil {
-				config.logger.Warn("Dropped metric declaration.", zap.Error(err))
-			} else {
-				validDeclarations = append(validDeclarations, declaration)
-			}
-		}
-
-		config.MetricDeclarations = validDeclarations
-		var validDescriptors []MetricDescriptor
-		for _, descriptor := range config.MetricDescriptors {
-			if descriptor.MetricName == "" {
-				continue
-			}
-			if _, ok := eMFSupportedUnits[descriptor.Unit]; ok {
-				validDescriptors = append(validDescriptors, descriptor)
-			} else {
-				config.logger.Warn("Dropped unsupported metric desctriptor.", zap.String("unit", descriptor.Unit))
-			}
-		}
-		config.MetricDescriptors = validDescriptors
+		config.cleanDeclarationsAndDescriptors()
 	}
 
 	return cwlogs.ValidateTagsInput(config.Tags)
@@ -149,6 +127,10 @@ func (config *Config) Validate() error {
 // MUST be called at least once after delcarations and descriptors are set.
 // SHOULD be called after a logger is set on the config object.
 func (config *Config) CleanDeclarationsAndDescriptors() {
+	config.cleanDeclarationsAndDescriptors()
+}
+
+func (config *Config) cleanDeclarationsAndDescriptors() {
 	var validDeclarations []*MetricDeclaration
 	for _, declaration := range config.MetricDeclarations {
 		err := declaration.init(config.logger)

--- a/exporter/awsemfexporter/config_test.go
+++ b/exporter/awsemfexporter/config_test.go
@@ -132,17 +132,17 @@ func TestConfigValidate(t *testing.T) {
 	tests := []struct {
 		Name           string
 		SetFeatureGate func() error
-		Cleanup        func()
+		Cleanup        func() error
 	}{
 		{
 			"feature gate disabled",
 			func() error { return nil },
-			func() {},
+			func() error { return nil },
 		},
 		{
 			"feature gate enabled",
 			func() error { return featuregate.GlobalRegistry().Set("awsemf.configvalidation", true) },
-			func() { featuregate.GlobalRegistry().Set("awsemf.configvalidation", false) },
+			func() error { return featuregate.GlobalRegistry().Set("awsemf.configvalidation", false) },
 		},
 	}
 
@@ -159,7 +159,6 @@ func TestConfigValidate(t *testing.T) {
 				logger:                      zap.NewNop(),
 			}
 			assert.NoError(t, test.SetFeatureGate())
-			t.Cleanup(test.Cleanup)
 			if useConfigCleanMethod.IsEnabled() {
 				cfg.CleanDeclarationsAndDescriptors()
 			}
@@ -170,6 +169,7 @@ func TestConfigValidate(t *testing.T) {
 				{Unit: "Count", MetricName: "apiserver_total", Overwrite: true},
 				{Unit: "Megabytes", MetricName: "memory_usage"},
 			}, cfg.MetricDescriptors)
+			require.NoError(t, test.Cleanup())
 		})
 	}
 

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -48,7 +48,9 @@ func newEmfExporter(config *Config, set exporter.CreateSettings) (*emfExporter, 
 	}
 
 	config.logger = set.Logger
-
+	if useConfigCleanMethod.IsEnabled() {
+		config.CleanDeclarationsAndDescriptors()
+	}
 	// create AWS session
 	awsConfig, session, err := awsutil.GetAWSConfigSession(set.Logger, &awsutil.Conn{}, &config.AWSSessionSettings)
 	if err != nil {


### PR DESCRIPTION
**Description:** Feature gate is required because this will be a breaking change to the Config API. After feature gate is enabled by default the clean method must be called manually by the consumer or else invalid metric declarations or descriptors will exist. 

**Link to tracking Issue:** #24756 

**Testing:** Added unit test for feature gate

**Documentation:** n/a