### PR TITLE
[receivercreator] fix typo in examples

### DIFF
--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -247,6 +247,8 @@ targeting it will have different variables available.
 extensions:
   # Configures the Kubernetes observer to watch for pod start and stop events.
   k8s_observer:
+    observe_nodes: true
+    observe_services: true
   host_observer:
 
 receivers:

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -43,7 +43,7 @@ instantiate that receiver.
 **receivers.&lt;receiver_type/id&gt;.rule**
 
 Rule expression using [expvar
-syntax](https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md).
+syntax](https://github.com/antonmedv/expr/blob/master/docs/language-definition.md).
 Variables available are detailed below in [Rule
 Expressions](#rule-expressions).
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
fix typo in examples, since the `observe_nodes`, `observe_services` is [default](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/observer/k8sobserver/README.md) to be `false`, so the receiver creator who wants to add endpoint of k8s.node and k8s.service will not work if the two config is `false`
