### PR TITLE
Fix statsd receiver aggregate metrics in various instruments.

### DIFF
--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -119,7 +119,8 @@ func (r *statsdReceiver) Start(ctx context.Context, host component.Host) error {
 					}
 				}
 			case metric := <-transferChan:
-				if err := r.parser.Aggregate(metric.Raw, metric.Addr); err != nil {
+				addr, _ := net.ResolveIPAddr(r.config.NetAddr.Transport, r.config.NetAddr.Endpoint)
+				if err := r.parser.Aggregate(metric.Raw, addr); err != nil {
 					r.reporter.OnDebugf("Error aggregating metric", zap.Error(err))
 				}
 			case <-ctx.Done():


### PR DESCRIPTION
The receiver uses each metric's address as the key to create instruments, but the port in the address of each metric is dynamically assigned. This results in the StatsD receiver creating numerous instruments and being unable to aggregate metrics together.

Fixes open-telemetry/opentelemetry-collector-contrib#29508, fixex open-telemetry/opentelemetry-collector-contrib#23809

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** #29508, #23809

**Testing:** 

***Config.yaml***
```
receivers:
  statsd:
    endpoint: "0.0.0.0:8125" # default
    aggregation_interval: 20s  # default
    enable_metric_type: false  # default
    is_monotonic_counter: true # default
    timer_histogram_mapping:
      - statsd_type: "timing"
        observer_type: "summary"
      - statsd_type: "distribution"
        observer_type: "histogram"
        histogram:
          max_size: 50

processors:
  batch:

exporters:
  file/tmp:
    path: /tmp/collector-output.json

  prometheus:
    endpoint: "0.0.0.0:9105"
    send_timestamps: false
    metric_expiration: 120m
    enable_open_metrics: false
    add_metric_suffixes: false
    resource_to_telemetry_conversion:
      enabled: true

service:
  telemetry:
    logs:
      level: debug
    metrics:
      address: ":8889"
  pipelines:
    metrics:
      receivers: [statsd]
      processors: [batch]      
      exporters: [prometheus, file/tmp]
```

***Run custom otelcol***
```
➜  ~/build  ./otelcol-charz --config config.yaml                     
2023-12-28T15:15:08.660+0800    info    service@v0.91.0/telemetry.go:86 Setting up own telemetry...
2023-12-28T15:15:08.660+0800    info    service@v0.91.0/telemetry.go:203        Serving Prometheus metrics      {"address": ":8889", "level": "Basic"}
2023-12-28T15:15:08.660+0800    debug   exporter@v0.91.0/exporter.go:273        Alpha component. May change in the future.      {"kind": "exporter", "data_type": "metrics", "name": "file/tmp"}
2023-12-28T15:15:08.661+0800    debug   exporter@v0.91.0/exporter.go:273        Beta component. May change in the future.       {"kind": "exporter", "data_type": "metrics", "name": "prometheus"}
2023-12-28T15:15:08.661+0800    debug   processor@v0.91.0/processor.go:287      Stable component.       {"kind": "processor", "name": "batch", "pipeline": "metrics"}
2023-12-28T15:15:08.661+0800    debug   receiver@v0.91.0/receiver.go:294        Beta component. May change in the future.       {"kind": "receiver", "name": "statsd", "data_type": "metrics"}
2023-12-28T15:15:08.661+0800    info    service@v0.91.0/service.go:145  Starting otelcol-charz...       {"Version": "1.0.0", "NumCPU": 10}
2023-12-28T15:15:08.661+0800    info    extensions/extensions.go:34     Starting extensions...
2023-12-28T15:15:08.661+0800    warn    internal@v0.91.0/warning.go:40  Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks        {"kind": "exporter", "data_type": "metrics", "name": "prometheus", "documentation": "https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks"}
2023-12-28T15:15:08.661+0800    info    service@v0.91.0/service.go:171  Everything is ready. Begin running and processing data.

2023-12-28T15:15:28.769+0800    debug   prometheusexporter@v0.88.0/accumulator.go:79    accumulating metric: test.metric        {"kind": "exporter", "data_type": "metrics", "name": "prometheus"}
2023-12-28T15:17:28.856+0800    debug   prometheusexporter@v0.88.0/accumulator.go:79    accumulating metric: test.metric.ts     {"kind": "exporter", "data_type": "metrics", "name": "prometheus"}
2023-12-28T15:17:35.643+0800    debug   prometheusexporter@v0.88.0/collector.go:362     collect called  {"kind": "exporter", "data_type": "metrics", "name": "prometheus"}
2023-12-28T15:17:35.643+0800    debug   prometheusexporter@v0.88.0/accumulator.go:268   Accumulator collect called      {"kind": "exporter", "data_type": "metrics", "name": "prometheus"}
2023-12-28T15:17:35.643+0800    debug   prometheusexporter@v0.88.0/collector.go:386     metric served: Desc{fqName: "test_metric", help: "", constLabels: {}, variableLabels: {myKey}}  {"kind": "exporter", "data_type": "metrics", "name": "prometheus"}
2023-12-28T15:17:35.643+0800    debug   prometheusexporter@v0.88.0/collector.go:386     metric served: Desc{fqName: "test_metric_ts", help: "", constLabels: {}, variableLabels: {myKey}}       {"kind": "exporter", "data_type": "metrics", "name": "prometheus"}
```

#23809 
```
➜  ~ echo "test.metric:10|c|#myKey:myVal" | nc -w 1 -u localhost 8125
➜  ~ echo "test.metric:20|c|#myKey:myVal" | nc -w 1 -u localhost 8125

➜  ~ cat /tmp/collector-output.json |jq; date
{
  "resourceMetrics": [
    {
      "resource": {},
      "scopeMetrics": [
        {
          "scope": {
            "name": "otelcol/statsdreceiver",
            "version": "1.0.0"
          },
          "metrics": [
            {
              "name": "test.metric",
              "sum": {
                "dataPoints": [
                  {
                    "attributes": [
                      {
                        "key": "myKey",
                        "value": {
                          "stringValue": "myVal"
                        }
                      }
                    ],
                    "startTimeUnixNano": "1703747708661566000",
                    "timeUnixNano": "1703747728661899000",
                    "asInt": "30"
                  }
                ],
                "aggregationTemporality": 1,
                "isMonotonic": true
              }
            }
          ]
        }
      ]
    }
  ]
}
Thu Dec 28 15:15:32 CST 2023
```

#29508 
```
➜  ~  echo "test.metric.ts:1|ms|@1|#myKey:myVal" | nc -w 1 -u 127.0.0.1 8125;
➜  ~ echo "test.metric.ts:2|ms|@1|#myKey:myVal" | nc -w 1 -u 127.0.0.1 8125;
➜  ~ echo "test.metric.ts:22|ms|@1|#myKey:myVal" | nc -w 1 -u 127.0.0.1 8125;
➜  ~ curl -sS 127.0.0.1:9105/metrics |grep test.metric.ts; date
# HELP test_metric_ts
# TYPE test_metric_ts summary
test_metric_ts{myKey="myVal",quantile="0"} 1
test_metric_ts{myKey="myVal",quantile="0.1"} 1
test_metric_ts{myKey="myVal",quantile="0.5"} 2
test_metric_ts{myKey="myVal",quantile="0.9"} 22
test_metric_ts{myKey="myVal",quantile="0.95"} 22
test_metric_ts{myKey="myVal",quantile="1"} 22
test_metric_ts_sum{myKey="myVal"} 25
test_metric_ts_count{myKey="myVal"} 3
Thu Dec 28 15:17:35 CST 2023
```

**Documentation:** None