### PR TITLE
clarify labeling via comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,7 +356,7 @@ To delete a label, prepend the label with `-`. Note that you must make a new com
 Example label comment:
 
 ```
-/label receiver/prometheus help-wanted -exporter/prometheus
+/label receiver/prometheus -help-wanted
 ```
 
 ## Becoming a Code Owner


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Clarifies documentation in CONTRIBUTING.md, as I believe the current doc must be incorrect as the example doesn't align with instructions. The instructions say to prefix the label with `-` like `-{label-name}`. However the example shows following the label name with a similarly named component with `-`. Would like to see clearer instructions to help contributors.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
This is a small change to clarify documentation as described above.