### PR TITLE
apachespark: propagate application list errors

### DIFF
--- a/.chloggen/sparkmarshaluperror.yaml
+++ b/.chloggen/sparkmarshaluperror.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: apachesparkreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: propagate application list errors to reveal underlying issue
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30278]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/apachesparkreceiver/scraper.go
+++ b/receiver/apachesparkreceiver/scraper.go
@@ -58,7 +58,7 @@ func (s *sparkScraper) scrape(_ context.Context) (pmetric.Metrics, error) {
 	// Call applications endpoint to get ids and names for all apps in the cluster
 	apps, err := s.client.Applications()
 	if err != nil {
-		return pmetric.NewMetrics(), errFailedAppIDCollection
+		return pmetric.NewMetrics(), errors.Join(errFailedAppIDCollection, err)
 	}
 
 	// Check apps against allowed app names from config

--- a/receiver/apachesparkreceiver/scraper_test.go
+++ b/receiver/apachesparkreceiver/scraper_test.go
@@ -53,7 +53,7 @@ func TestScraper(t *testing.T) {
 				return pmetric.NewMetrics()
 			},
 			config:      createDefaultConfig().(*Config),
-			expectedErr: errFailedAppIDCollection,
+			expectedErr: errors.Join(errFailedAppIDCollection, errors.New("could not retrieve app ids")),
 		},
 		{
 			desc: "No Matching Allowed Apps",


### PR DESCRIPTION
**Description:**
Fixing a bug - This change prevents application list retrieval errors from being swallowed, which makes it difficult to determine the underlying configuration or network issue.

**Testing:**
Updated existing case

**Documentation:**
none required