### PR TITLE
[chore] remove setenv function, unused

### DIFF
--- a/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity.go
@@ -24,9 +24,7 @@ type nodeCapacity struct {
 	logger      *zap.Logger
 
 	// osLstat returns a FileInfo describing the named file.
-	osLstat func(name string) (os.FileInfo, error)
-	// osSetenv sets the value of the environment variable named by the key
-	osSetenv      func(key string, value string) error
+	osLstat       func(name string) (os.FileInfo, error)
 	virtualMemory func(ctx context.Context) (*mem.VirtualMemoryStat, error)
 	cpuInfo       func(ctx context.Context) ([]cpu.InfoStat, error)
 }
@@ -37,7 +35,6 @@ func newNodeCapacity(logger *zap.Logger, options ...nodeCapacityOption) (nodeCap
 	nc := &nodeCapacity{
 		logger:        logger,
 		osLstat:       os.Lstat,
-		osSetenv:      os.Setenv,
 		virtualMemory: mem.VirtualMemoryWithContext,
 		cpuInfo:       cpu.InfoWithContext,
 	}

--- a/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
@@ -33,12 +33,6 @@ func TestNodeCapacity(t *testing.T) {
 		}
 	}
 
-	// can't parse cpu and mem info
-	setEnvOption := func(nc *nodeCapacity) {
-		nc.osSetenv = func(key, value string) error {
-			return nil
-		}
-	}
 	virtualMemOption := func(nc *nodeCapacity) {
 		nc.virtualMemory = func(ctx context.Context) (*mem.VirtualMemoryStat, error) {
 			return nil, errors.New("error")
@@ -49,7 +43,7 @@ func TestNodeCapacity(t *testing.T) {
 			return nil, errors.New("error")
 		}
 	}
-	nc, err = newNodeCapacity(zap.NewNop(), lstatOption, setEnvOption, virtualMemOption, cpuInfoOption)
+	nc, err = newNodeCapacity(zap.NewNop(), lstatOption, virtualMemOption, cpuInfoOption)
 	assert.NotNil(t, nc)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(0), nc.getMemoryCapacity())
@@ -71,7 +65,7 @@ func TestNodeCapacity(t *testing.T) {
 			}, nil
 		}
 	}
-	nc, err = newNodeCapacity(zap.NewNop(), lstatOption, setEnvOption, virtualMemOption, cpuInfoOption)
+	nc, err = newNodeCapacity(zap.NewNop(), lstatOption, virtualMemOption, cpuInfoOption)
 	assert.NotNil(t, nc)
 	assert.Nil(t, err)
 	assert.Equal(t, int64(1024), nc.getMemoryCapacity())


### PR DESCRIPTION
This function is no longer used as we set gopsutil variable via context instead of env vars.