### PR TITLE
[chore] testbed: use available port for correctness internal metrics config

### DIFF
--- a/testbed/correctnesstests/metrics/correctness_test_case.go
+++ b/testbed/correctnesstests/metrics/correctness_test_case.go
@@ -34,7 +34,7 @@ func newCorrectnessTestCase(
 
 func (tc *correctnessTestCase) startCollector() {
 	tc.collector = testbed.NewInProcessCollector(componentFactories(tc.t))
-	_, err := tc.collector.PrepareConfig(correctnesstests.CreateConfigYaml(tc.sender, tc.receiver, nil, "metrics"))
+	_, err := tc.collector.PrepareConfig(correctnesstests.CreateConfigYaml(tc.t, tc.sender, tc.receiver, nil, "metrics"))
 	require.NoError(tc.t, err)
 	rd, err := newResultsDir(tc.t.Name())
 	require.NoError(tc.t, err)

--- a/testbed/correctnesstests/traces/correctness_test.go
+++ b/testbed/correctnesstests/traces/correctness_test.go
@@ -55,7 +55,7 @@ func testWithTracingGoldenDataset(
 	require.NoError(t, err, "default components resulted in: %v", err)
 	runner := testbed.NewInProcessCollector(factories)
 	validator := testbed.NewCorrectTestValidator(sender.ProtocolName(), receiver.ProtocolName(), dataProvider)
-	config := correctnesstests.CreateConfigYaml(sender, receiver, processors, "traces")
+	config := correctnesstests.CreateConfigYaml(t, sender, receiver, processors, "traces")
 	log.Println(config)
 	configCleanup, cfgErr := runner.PrepareConfig(config)
 	require.NoError(t, cfgErr, "collector configuration resulted in: %v", cfgErr)
@@ -123,7 +123,7 @@ func TestSporadicGoldenDataset(t *testing.T) {
     sending_queue:
       enabled: false
 `)
-		_, err = runner.PrepareConfig(correctnesstests.CreateConfigYaml(sender, receiver, nil, "traces"))
+		_, err = runner.PrepareConfig(correctnesstests.CreateConfigYaml(t, sender, receiver, nil, "traces"))
 		require.NoError(t, err, "collector configuration resulted in: %v", err)
 		validator := testbed.NewCorrectTestValidator(sender.ProtocolName(), receiver.ProtocolName(), dataProvider)
 		tc := testbed.NewTestCase(

--- a/testbed/correctnesstests/utils.go
+++ b/testbed/correctnesstests/utils.go
@@ -20,6 +20,7 @@ import (
 // processors, and a pipeline type. A collector created from the resulting yaml string should be able to talk
 // the specified sender and receiver.
 func CreateConfigYaml(
+	t testing.TB,
 	sender testbed.DataSender,
 	receiver testbed.DataReceiver,
 	processors map[string]string,
@@ -51,6 +52,9 @@ processors:
 extensions:
 
 service:
+  telemetry:
+    metrics:
+      address: 127.0.0.1:%d
   extensions:
   pipelines:
     %s:
@@ -64,6 +68,7 @@ service:
 		sender.GenConfigYAMLStr(),
 		receiver.GenConfigYAMLStr(),
 		processorsSections,
+		testbed.GetAvailablePort(t),
 		pipelineType,
 		sender.ProtocolName(),
 		processorsList,

--- a/testbed/testbed/utils.go
+++ b/testbed/testbed/utils.go
@@ -13,7 +13,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 )
 
-func GetAvailablePort(t *testing.T) int {
+func GetAvailablePort(t testing.TB) int {
 	endpoint := testutil.GetAvailableLocalAddress(t)
 	_, port, err := net.SplitHostPort(endpoint)
 	require.NoError(t, err)


### PR DESCRIPTION
**Description:**
Fixing a bug - these changes ensure that the correctness tests don't collide on internal metric server ports that currently prevent clean `make test` runs in the testbed directory.

They also relax the `testbed.GetAvailablePort()` parameter type to avoid type assertions and limiting the use of the helper.

**Testing:**
Before changes:

```bash
make test
go test -race -timeout 300s -parallel 4 --tags="" ./...
?   	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/correctnesstests	[no test files]
?   	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers	[no test files]
?   	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders	[no test files]
2024/01/04 14:57:41 starting testbed receiver
2024/01/04 14:57:41 starting collector
2024-01-04T14:57:41.145Z	info	service@v0.91.0/telemetry.go:86	Setting up own telemetry...
2024-01-04T14:57:41.147Z	info	service@v0.91.0/telemetry.go:203	Serving Prometheus metrics	{"address": ":8888", "level": "Basic"}
2024-01-04T14:57:41.149Z	info	service@v0.91.0/service.go:145	Starting otelcol...	{"Version": "latest", "NumCPU": 8}
2024-01-04T14:57:41.149Z	info	extensions/extensions.go:34	Starting extensions...
2024-01-04T14:57:41.151Z	info	otlpreceiver@v0.91.0/otlp.go:83	Starting GRPC server	{"kind": "receiver", "name": "otlp", "data_type": "metrics", "endpoint": "127.0.0.1:36701"}
2024-01-04T14:57:41.152Z	info	service@v0.91.0/service.go:171	Everything is ready. Begin running and processing data.
2024-01-04T14:57:41.153Z	error	otelcol@v0.91.0/collector.go:255	Asynchronous error received, terminating process	{"error": "listen tcp :8888: bind: address already in use"}
go.opentelemetry.io/collector/otelcol.(*Collector).Run
	/home/rmfitzpatrick.linux/go/pkg/mod/go.opentelemetry.io/collector/otelcol@v0.91.0/collector.go:255
github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed.(*inProcessCollector).Start.func2
	/opt/macos/work/opentelemetry-collector-contrib/testbed/testbed/in_process_collector.go:87
2024-01-04T14:57:41.153Z	info	service@v0.91.0/service.go:185	Starting shutdown...
2024-01-04T14:57:41.155Z	info	extensions/extensions.go:59	Stopping extensions...
2024-01-04T14:57:41.155Z	info	service@v0.91.0/service.go:199	Shutdown complete.
--- FAIL: TestHarness_MetricsGoldenData (1.02s)
    --- FAIL: TestHarness_MetricsGoldenData/otlp-otlp (1.01s)
        correctness_test_case.go:50:
            	Error Trace:	/opt/macos/work/opentelemetry-collector-contrib/testbed/correctnesstests/metrics/correctness_test_case.go:50
            	            				/opt/macos/work/opentelemetry-collector-contrib/testbed/correctnesstests/metrics/metrics_correctness_test.go:62
            	            				/opt/macos/work/opentelemetry-collector-contrib/testbed/correctnesstests/metrics/metrics_correctness_test.go:34
            	Error:      	Received unexpected error:
            	            	unable to start, otelcol state is 3
            	Test:       	TestHarness_MetricsGoldenData/otlp-otlp
FAIL
FAIL	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/correctnesstests/metrics	1.181s
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/correctnesstests/traces	0.171s
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/stabilitytests	0.162s
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed	1.231s
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/tests	0.157s
FAIL
make: *** [../Makefile.Common:118: test] Error 1
```

After:

```bash
$ make test
go test -race -timeout 300s -parallel 4 --tags="" ./...
?   	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/correctnesstests	[no test files]
?   	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datareceivers	[no test files]
?   	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/datasenders	[no test files]
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/correctnesstests/metrics	1.446s
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/correctnesstests/traces	0.166s
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/stabilitytests	0.178s
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed	1.313s
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/testbed/tests	0.156s
```


**Documentation:**
none needed