### PR TITLE
[chore][receiver/googlecloudspanner] move codeowners to emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -205,7 +205,7 @@ receiver/flinkmetricsreceiver/                           @open-telemetry/collect
 receiver/fluentforwardreceiver/                          @open-telemetry/collector-contrib-approvers @dmitryax
 receiver/gitproviderreceiver/                            @open-telemetry/collector-contrib-approvers @adrielp @astencel-sumo
 receiver/googlecloudpubsubreceiver/                      @open-telemetry/collector-contrib-approvers @alexvanboxel
-receiver/googlecloudspannerreceiver/                     @open-telemetry/collector-contrib-approvers @architjugran @varunraiko @kiranmayib
+receiver/googlecloudspannerreceiver/                     @open-telemetry/collector-contrib-approvers @varunraiko
 receiver/haproxyreceiver/                                @open-telemetry/collector-contrib-approvers @atoulme @MovieStoreGuy
 receiver/hostmetricsreceiver/                            @open-telemetry/collector-contrib-approvers @dmitryax @braydonk
 receiver/httpcheckreceiver/                              @open-telemetry/collector-contrib-approvers @codeboten

--- a/cmd/githubgen/allowlist.txt
+++ b/cmd/githubgen/allowlist.txt
@@ -2,11 +2,9 @@ Caleb-Hurshman
 MaxKsyunz
 MitchellGale
 YANG-DB
-architjugran
 asaharn
 billmeyer
 emreyalvac
-kiranmayib
 shaochengwang
 yiyang5055
 am-kinetica

--- a/receiver/googlecloudspannerreceiver/README.md
+++ b/receiver/googlecloudspannerreceiver/README.md
@@ -6,7 +6,8 @@
 | Stability     | [beta]: metrics   |
 | Distributions | [contrib], [observiq], [sumo] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fgooglecloudspanner%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fgooglecloudspanner) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fgooglecloudspanner%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fgooglecloudspanner) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@architjugran](https://www.github.com/architjugran), [@varunraiko](https://www.github.com/varunraiko), [@kiranmayib](https://www.github.com/kiranmayib) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@varunraiko](https://www.github.com/varunraiko) |
+| Emeritus      | [@architjugran](https://www.github.com/architjugran), [@kiranmayib](https://www.github.com/kiranmayib) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/googlecloudspannerreceiver/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/metadata.yaml
@@ -6,6 +6,7 @@ status:
     beta: [metrics]
   distributions: [contrib, observiq, sumo]
   codeowners:
-    active: [architjugran, varunraiko, kiranmayib]
+    active: [varunraiko]
+    emeritus: [architjugran, kiranmayib]
 tests:
   config:


### PR DESCRIPTION
**Description:**
Move @architjugran and @kiranmayib to emeritus codeowners.

**Link to tracking Issue:**
Fixes #23393