### PR TITLE
fix: update reference link for language definition

### DIFF
--- a/pkg/stanza/docs/types/expression.md
+++ b/pkg/stanza/docs/types/expression.md
@@ -4,7 +4,7 @@ Expressions give the config flexibility by allowing dynamic business logic rules
 Most notably, expressions can be used to route log records and add new fields based on the contents of the log entry
 being processed.
 
-For reference documentation of the expression language, see [here](https://github.com/antonmedv/expr/blob/master/docs/Language-Definition.md).
+For reference documentation of the expression language, see [here](https://github.com/expr-lang/expr/blob/master/docs/language-definition.md).
 
 Available to the expressions are a few special variables:
 - `body` contains the entry's body

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -43,7 +43,7 @@ instantiate that receiver.
 **receivers.&lt;receiver_type/id&gt;.rule**
 
 Rule expression using [expvar
-syntax](https://github.com/antonmedv/expr/blob/master/docs/language-definition.md).
+syntax](https://github.com/expr-lang/expr/blob/master/docs/language-definition.md).
 Variables available are detailed below in [Rule
 Expressions](#rule-expressions).
 


### PR DESCRIPTION
**Description:**  The old one has been oudated and leads to a 404 page. This is the newly updated link.

**Link to tracking Issue:** n/a

**Testing:** n/a

**Documentation:** Refer to description.