### PR TITLE
[chore] sanitize use of configopaque.String

### DIFF
--- a/exporter/logzioexporter/factory.go
+++ b/exporter/logzioexporter/factory.go
@@ -75,12 +75,12 @@ func getListenerURL(region string) string {
 }
 
 func generateEndpoint(cfg *Config) (string, error) {
-	defaultURL := fmt.Sprintf("%s/?token=%s", getListenerURL(""), cfg.Token)
+	defaultURL := fmt.Sprintf("%s/?token=%s", getListenerURL(""), string(cfg.Token))
 	switch {
 	case cfg.HTTPClientSettings.Endpoint != "":
 		return cfg.HTTPClientSettings.Endpoint, nil
 	case cfg.Region != "":
-		return fmt.Sprintf("%s/?token=%s", getListenerURL(cfg.Region), cfg.Token), nil
+		return fmt.Sprintf("%s/?token=%s", getListenerURL(cfg.Region), string(cfg.Token)), nil
 	case cfg.HTTPClientSettings.Endpoint == "" && cfg.Region == "":
 		return defaultURL, errors.New("failed to generate endpoint, Endpoint or Region must be set")
 	default:

--- a/receiver/elasticsearchreceiver/client.go
+++ b/receiver/elasticsearchreceiver/client.go
@@ -61,7 +61,7 @@ func newElasticsearchClient(settings component.TelemetrySettings, c Config, h co
 
 	var authHeader string
 	if c.Username != "" && c.Password != "" {
-		userPass := fmt.Sprintf("%s:%s", c.Username, c.Password)
+		userPass := fmt.Sprintf("%s:%s", c.Username, string(c.Password))
 		authb64 := base64.StdEncoding.EncodeToString([]byte(userPass))
 		authHeader = fmt.Sprintf("Basic %s", authb64)
 	}

--- a/receiver/saphanareceiver/client.go
+++ b/receiver/saphanareceiver/client.go
@@ -102,7 +102,7 @@ func newSapHanaClient(cfg *Config, factory sapHanaConnectionFactory) client {
 }
 
 func (c *sapHanaClient) Connect(ctx context.Context) error {
-	connector, err := sapdriver.NewDSNConnector(fmt.Sprintf("hdb://%s:%s@%s", c.receiverConfig.Username, c.receiverConfig.Password, c.receiverConfig.TCPAddr.Endpoint))
+	connector, err := sapdriver.NewDSNConnector(fmt.Sprintf("hdb://%s:%s@%s", c.receiverConfig.Username, string(c.receiverConfig.Password), c.receiverConfig.TCPAddr.Endpoint))
 	if err != nil {
 		return fmt.Errorf("error generating DSN for SAP HANA connection: %w", err)
 	}


### PR DESCRIPTION
**Description:**
Sanitize the use of configopaque.String ahead of its change to implement fmt.Stringer.

**Link to tracking Issue:**
See https://github.com/open-telemetry/opentelemetry-collector/pull/9214
