### PR TITLE
[receiver/hostmetrics] Add system.memory.limit metric

### DIFF
--- a/.chloggen/mx-psi_system.memory.limit.yaml
+++ b/.chloggen/mx-psi_system.memory.limit.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `system.memory.limit` metric reporting the total memory available."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30306]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+    This metric is opt-in. To enable it, set `scrapers::memory::metrics::system.memory.limit::enabled` to `true` in the hostmetrics config.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/documentation.md
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/documentation.md
@@ -46,6 +46,14 @@ An estimate of how much memory is available for starting new applications, witho
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | By | Sum | Int | Cumulative | false |
 
+### system.memory.limit
+
+Total bytes of memory available.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| By | Sum | Int | Cumulative | false |
+
 ### system.memory.utilization
 
 Percentage of memory bytes in use.

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_config.go
@@ -26,6 +26,7 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 // MetricsConfig provides config for hostmetricsreceiver/memory metrics.
 type MetricsConfig struct {
 	SystemLinuxMemoryAvailable MetricConfig `mapstructure:"system.linux.memory.available"`
+	SystemMemoryLimit          MetricConfig `mapstructure:"system.memory.limit"`
 	SystemMemoryUsage          MetricConfig `mapstructure:"system.memory.usage"`
 	SystemMemoryUtilization    MetricConfig `mapstructure:"system.memory.utilization"`
 }
@@ -33,6 +34,9 @@ type MetricsConfig struct {
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
 		SystemLinuxMemoryAvailable: MetricConfig{
+			Enabled: false,
+		},
+		SystemMemoryLimit: MetricConfig{
 			Enabled: false,
 		},
 		SystemMemoryUsage: MetricConfig{

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_config_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_config_test.go
@@ -27,6 +27,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
 					SystemLinuxMemoryAvailable: MetricConfig{Enabled: true},
+					SystemMemoryLimit:          MetricConfig{Enabled: true},
 					SystemMemoryUsage:          MetricConfig{Enabled: true},
 					SystemMemoryUtilization:    MetricConfig{Enabled: true},
 				},
@@ -37,6 +38,7 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
 					SystemLinuxMemoryAvailable: MetricConfig{Enabled: false},
+					SystemMemoryLimit:          MetricConfig{Enabled: false},
 					SystemMemoryUsage:          MetricConfig{Enabled: false},
 					SystemMemoryUtilization:    MetricConfig{Enabled: false},
 				},

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
@@ -109,6 +109,57 @@ func newMetricSystemLinuxMemoryAvailable(cfg MetricConfig) metricSystemLinuxMemo
 	return m
 }
 
+type metricSystemMemoryLimit struct {
+	data     pmetric.Metric // data buffer for generated metric.
+	config   MetricConfig   // metric config provided by user.
+	capacity int            // max observed number of data points added to the metric.
+}
+
+// init fills system.memory.limit metric with initial data.
+func (m *metricSystemMemoryLimit) init() {
+	m.data.SetName("system.memory.limit")
+	m.data.SetDescription("Total bytes of memory available.")
+	m.data.SetUnit("By")
+	m.data.SetEmptySum()
+	m.data.Sum().SetIsMonotonic(false)
+	m.data.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+}
+
+func (m *metricSystemMemoryLimit) recordDataPoint(start pcommon.Timestamp, ts pcommon.Timestamp, val int64) {
+	if !m.config.Enabled {
+		return
+	}
+	dp := m.data.Sum().DataPoints().AppendEmpty()
+	dp.SetStartTimestamp(start)
+	dp.SetTimestamp(ts)
+	dp.SetIntValue(val)
+}
+
+// updateCapacity saves max length of data point slices that will be used for the slice capacity.
+func (m *metricSystemMemoryLimit) updateCapacity() {
+	if m.data.Sum().DataPoints().Len() > m.capacity {
+		m.capacity = m.data.Sum().DataPoints().Len()
+	}
+}
+
+// emit appends recorded metric data to a metrics slice and prepares it for recording another set of data points.
+func (m *metricSystemMemoryLimit) emit(metrics pmetric.MetricSlice) {
+	if m.config.Enabled && m.data.Sum().DataPoints().Len() > 0 {
+		m.updateCapacity()
+		m.data.MoveTo(metrics.AppendEmpty())
+		m.init()
+	}
+}
+
+func newMetricSystemMemoryLimit(cfg MetricConfig) metricSystemMemoryLimit {
+	m := metricSystemMemoryLimit{config: cfg}
+	if cfg.Enabled {
+		m.data = pmetric.NewMetric()
+		m.init()
+	}
+	return m
+}
+
 type metricSystemMemoryUsage struct {
 	data     pmetric.Metric // data buffer for generated metric.
 	config   MetricConfig   // metric config provided by user.
@@ -222,6 +273,7 @@ type MetricsBuilder struct {
 	metricsBuffer                    pmetric.Metrics      // accumulates metrics data before emitting.
 	buildInfo                        component.BuildInfo  // contains version information.
 	metricSystemLinuxMemoryAvailable metricSystemLinuxMemoryAvailable
+	metricSystemMemoryLimit          metricSystemMemoryLimit
 	metricSystemMemoryUsage          metricSystemMemoryUsage
 	metricSystemMemoryUtilization    metricSystemMemoryUtilization
 }
@@ -243,6 +295,7 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.CreateSetting
 		metricsBuffer:                    pmetric.NewMetrics(),
 		buildInfo:                        settings.BuildInfo,
 		metricSystemLinuxMemoryAvailable: newMetricSystemLinuxMemoryAvailable(mbc.Metrics.SystemLinuxMemoryAvailable),
+		metricSystemMemoryLimit:          newMetricSystemMemoryLimit(mbc.Metrics.SystemMemoryLimit),
 		metricSystemMemoryUsage:          newMetricSystemMemoryUsage(mbc.Metrics.SystemMemoryUsage),
 		metricSystemMemoryUtilization:    newMetricSystemMemoryUtilization(mbc.Metrics.SystemMemoryUtilization),
 	}
@@ -303,6 +356,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSystemLinuxMemoryAvailable.emit(ils.Metrics())
+	mb.metricSystemMemoryLimit.emit(ils.Metrics())
 	mb.metricSystemMemoryUsage.emit(ils.Metrics())
 	mb.metricSystemMemoryUtilization.emit(ils.Metrics())
 
@@ -328,6 +382,11 @@ func (mb *MetricsBuilder) Emit(rmo ...ResourceMetricsOption) pmetric.Metrics {
 // RecordSystemLinuxMemoryAvailableDataPoint adds a data point to system.linux.memory.available metric.
 func (mb *MetricsBuilder) RecordSystemLinuxMemoryAvailableDataPoint(ts pcommon.Timestamp, val int64) {
 	mb.metricSystemLinuxMemoryAvailable.recordDataPoint(mb.startTime, ts, val)
+}
+
+// RecordSystemMemoryLimitDataPoint adds a data point to system.memory.limit metric.
+func (mb *MetricsBuilder) RecordSystemMemoryLimitDataPoint(ts pcommon.Timestamp, val int64) {
+	mb.metricSystemMemoryLimit.recordDataPoint(mb.startTime, ts, val)
 }
 
 // RecordSystemMemoryUsageDataPoint adds a data point to system.memory.usage metric.

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics_test.go
@@ -58,6 +58,9 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordSystemLinuxMemoryAvailableDataPoint(ts, 1)
 
+			allMetricsCount++
+			mb.RecordSystemMemoryLimitDataPoint(ts, 1)
+
 			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordSystemMemoryUsageDataPoint(ts, 1, AttributeStateBuffered)
@@ -93,6 +96,20 @@ func TestMetricsBuilder(t *testing.T) {
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
 					assert.Equal(t, "An estimate of how much memory is available for starting new applications, without swapping. This is a more accurate alternative than system.memory.usage with state=free. (Linux only)", ms.At(i).Description())
+					assert.Equal(t, "By", ms.At(i).Unit())
+					assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
+					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
+					dp := ms.At(i).Sum().DataPoints().At(0)
+					assert.Equal(t, start, dp.StartTimestamp())
+					assert.Equal(t, ts, dp.Timestamp())
+					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
+					assert.Equal(t, int64(1), dp.IntValue())
+				case "system.memory.limit":
+					assert.False(t, validatedMetrics["system.memory.limit"], "Found a duplicate in the metrics slice: system.memory.limit")
+					validatedMetrics["system.memory.limit"] = true
+					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
+					assert.Equal(t, "Total bytes of memory available.", ms.At(i).Description())
 					assert.Equal(t, "By", ms.At(i).Unit())
 					assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/testdata/config.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/testdata/config.yaml
@@ -3,6 +3,8 @@ all_set:
   metrics:
     system.linux.memory.available:
       enabled: true
+    system.memory.limit:
+      enabled: true
     system.memory.usage:
       enabled: true
     system.memory.utilization:
@@ -10,6 +12,8 @@ all_set:
 none_set:
   metrics:
     system.linux.memory.available:
+      enabled: false
+    system.memory.limit:
       enabled: false
     system.memory.usage:
       enabled: false

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper.go
@@ -53,6 +53,10 @@ func (s *scraper) start(ctx context.Context, _ component.Host) error {
 	return nil
 }
 
+func (s *scraper) recordMemoryLimitMetric(now pcommon.Timestamp, memInfo *mem.VirtualMemoryStat) {
+	s.mb.RecordSystemMemoryLimitDataPoint(now, int64(memInfo.Total))
+}
+
 func (s *scraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	ctx = context.WithValue(ctx, common.EnvKey, s.envMap)
 
@@ -69,6 +73,7 @@ func (s *scraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 				memInfo.Total), metricsLen)
 		}
 		s.recordMemoryUtilizationMetric(now, memInfo)
+		s.recordMemoryLimitMetric(now, memInfo)
 		s.recordSystemSpecificMetrics(now, memInfo)
 	}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -11,6 +11,15 @@ attributes:
     enum: [buffered, cached, inactive, free, slab_reclaimable, slab_unreclaimable, used]
 
 metrics:
+  system.memory.limit:
+    enabled: false
+    description: Total bytes of memory available.
+    unit: By
+    sum:
+      value_type: int
+      aggregation_temporality: cumulative
+      monotonic: false
+
   system.memory.usage:
     enabled: true
     description: Bytes of memory in use.


### PR DESCRIPTION
**Description:** 

Adds opt-in support for `system.memory.limit`, standardized on open-telemetry/semantic-conventions/pull/409.

**Testing:** Tested locally on my Linux machine
