### PR TITLE
[exporter/awscloudwatchlogs] Feat: include scope in log record of cloudwatchlogs exporter

### DIFF
--- a/.chloggen/add_scope_awscloudwatchlogsexporter.yaml
+++ b/.chloggen/add_scope_awscloudwatchlogsexporter.yaml
@@ -10,7 +10,7 @@ component: awscloudwatchlogsexporter
 note: Add instrumentation scope in log records exported to CloudWatch logs
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [30316]
+issues: [30316, 29884]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/add_scope_awscloudwatchlogsexporter.yaml
+++ b/.chloggen/add_scope_awscloudwatchlogsexporter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awscloudwatchlogsexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add instrumentation scope in log records exported to CloudWatch logs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30316]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/awscloudwatchlogsexporter/exporter_test.go
+++ b/exporter/awscloudwatchlogsexporter/exporter_test.go
@@ -47,6 +47,7 @@ func TestLogToCWLog(t *testing.T) {
 	tests := []struct {
 		name     string
 		resource pcommon.Resource
+		scope    pcommon.InstrumentationScope
 		log      plog.LogRecord
 		config   *Config
 		want     cwlogs.Event
@@ -54,6 +55,42 @@ func TestLogToCWLog(t *testing.T) {
 	}{
 		{
 			name:     "basic",
+			resource: testResource(),
+			log:      testLogRecord(),
+			scope:    testScope(),
+			config:   &Config{},
+			want: cwlogs.Event{
+				GeneratedTime: time.Now(),
+				InputLogEvent: &cloudwatchlogs.InputLogEvent{
+					Timestamp: aws.Int64(1609719139),
+					Message:   aws.String(`{"body":"hello world","severity_number":5,"severity_text":"debug","dropped_attributes_count":4,"flags":1,"trace_id":"0102030405060708090a0b0c0d0e0f10","span_id":"0102030405060708","attributes":{"key1":1,"key2":"attr2"},"scope":{"name":"test-scope","version":"1.0.0","attributes":{"scope-attr":"value"}},"resource":{"host":"abc123","node":5}}`),
+				},
+				StreamKey: cwlogs.StreamKey{
+					LogGroupName:  "",
+					LogStreamName: "",
+				},
+			},
+		},
+		{
+			name:     "no resource",
+			resource: pcommon.NewResource(),
+			scope:    testScope(),
+			log:      testLogRecord(),
+			config:   &Config{},
+			want: cwlogs.Event{
+				GeneratedTime: time.Now(),
+				InputLogEvent: &cloudwatchlogs.InputLogEvent{
+					Timestamp: aws.Int64(1609719139),
+					Message:   aws.String(`{"body":"hello world","severity_number":5,"severity_text":"debug","dropped_attributes_count":4,"flags":1,"trace_id":"0102030405060708090a0b0c0d0e0f10","span_id":"0102030405060708","attributes":{"key1":1,"key2":"attr2"},"scope":{"name":"test-scope","version":"1.0.0","attributes":{"scope-attr":"value"}}}`),
+				},
+				StreamKey: cwlogs.StreamKey{
+					LogGroupName:  "",
+					LogStreamName: "",
+				},
+			},
+		},
+		{
+			name:     "no scope",
 			resource: testResource(),
 			log:      testLogRecord(),
 			config:   &Config{},
@@ -70,25 +107,9 @@ func TestLogToCWLog(t *testing.T) {
 			},
 		},
 		{
-			name:     "no resource",
-			resource: pcommon.NewResource(),
-			log:      testLogRecord(),
-			config:   &Config{},
-			want: cwlogs.Event{
-				GeneratedTime: time.Now(),
-				InputLogEvent: &cloudwatchlogs.InputLogEvent{
-					Timestamp: aws.Int64(1609719139),
-					Message:   aws.String(`{"body":"hello world","severity_number":5,"severity_text":"debug","dropped_attributes_count":4,"flags":1,"trace_id":"0102030405060708090a0b0c0d0e0f10","span_id":"0102030405060708","attributes":{"key1":1,"key2":"attr2"}}`),
-				},
-				StreamKey: cwlogs.StreamKey{
-					LogGroupName:  "",
-					LogStreamName: "",
-				},
-			},
-		},
-		{
 			name:     "no trace",
 			resource: testResource(),
+			scope:    testScope(),
 			log:      testLogRecordWithoutTrace(),
 			config: &Config{
 				LogGroupName:  "tLogGroup",
@@ -98,7 +119,7 @@ func TestLogToCWLog(t *testing.T) {
 				GeneratedTime: time.Now(),
 				InputLogEvent: &cloudwatchlogs.InputLogEvent{
 					Timestamp: aws.Int64(1609719139),
-					Message:   aws.String(`{"body":"hello world","severity_number":5,"severity_text":"debug","dropped_attributes_count":4,"attributes":{"key1":1,"key2":"attr2"},"resource":{"host":"abc123","node":5}}`),
+					Message:   aws.String(`{"body":"hello world","severity_number":5,"severity_text":"debug","dropped_attributes_count":4,"attributes":{"key1":1,"key2":"attr2"},"scope":{"name":"test-scope","version":"1.0.0","attributes":{"scope-attr":"value"}},"resource":{"host":"abc123","node":5}}`),
 				},
 				StreamKey: cwlogs.StreamKey{
 					LogGroupName:  "tLogGroup",
@@ -109,6 +130,7 @@ func TestLogToCWLog(t *testing.T) {
 		{
 			name:     "raw",
 			resource: testResource(),
+			scope:    testScope(),
 			log:      testLogRecordWithoutTrace(),
 			config: &Config{
 				LogGroupName:  "tLogGroup",
@@ -130,6 +152,7 @@ func TestLogToCWLog(t *testing.T) {
 		{
 			name:     "raw emf v1",
 			resource: testResource(),
+			scope:    testScope(),
 			log:      createPLog(`{"_aws":{"Timestamp":1574109732004,"LogGroupName":"Foo","CloudWatchMetrics":[{"Namespace":"MyApp","Dimensions":[["Operation"]],"Metrics":[{"Name":"ProcessingLatency","Unit":"Milliseconds","StorageResolution":60}]}]},"Operation":"Aggregator","ProcessingLatency":100}`),
 			config: &Config{
 				LogGroupName:  "tLogGroup",
@@ -151,6 +174,7 @@ func TestLogToCWLog(t *testing.T) {
 		{
 			name:     "raw emf v1 with log stream",
 			resource: testResource(),
+			scope:    testScope(),
 			log:      createPLog(`{"_aws":{"Timestamp":1574109732004,"LogGroupName":"Foo","LogStreamName":"Foo","CloudWatchMetrics":[{"Namespace":"MyApp","Dimensions":[["Operation"]],"Metrics":[{"Name":"ProcessingLatency","Unit":"Milliseconds","StorageResolution":60}]}]},"Operation":"Aggregator","ProcessingLatency":100}`),
 			config: &Config{
 				LogGroupName:  "tLogGroup",
@@ -172,6 +196,7 @@ func TestLogToCWLog(t *testing.T) {
 		{
 			name:     "raw emf v0",
 			resource: testResource(),
+			scope:    testScope(),
 			log:      createPLog(`{"Timestamp":1574109732004,"log_group_name":"Foo","CloudWatchMetrics":[{"Namespace":"MyApp","Dimensions":[["Operation"]],"Metrics":[{"Name":"ProcessingLatency","Unit":"Milliseconds","StorageResolution":60}]}],"Operation":"Aggregator","ProcessingLatency":100}`),
 			config: &Config{
 				LogGroupName:  "tLogGroup",
@@ -193,6 +218,7 @@ func TestLogToCWLog(t *testing.T) {
 		{
 			name:     "raw emf v0 with log stream",
 			resource: testResource(),
+			scope:    testScope(),
 			log:      createPLog(`{"Timestamp":1574109732004,"log_group_name":"Foo","log_stream_name":"Foo","CloudWatchMetrics":[{"Namespace":"MyApp","Dimensions":[["Operation"]],"Metrics":[{"Name":"ProcessingLatency","Unit":"Milliseconds","StorageResolution":60}]}],"Operation":"Aggregator","ProcessingLatency":100}`),
 			config: &Config{
 				LogGroupName:  "tLogGroup",
@@ -216,13 +242,13 @@ func TestLogToCWLog(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resourceAttrs := attrsValue(tt.resource.Attributes())
-			got, err := logToCWLog(resourceAttrs, tt.log, tt.config)
+			got, err := logToCWLog(resourceAttrs, tt.scope, tt.log, tt.config)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("logToCWLog() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			// Do not test generated time since it is time.Now()
-			assert.Equal(t, tt.want.InputLogEvent, got.InputLogEvent)
+			assert.Equal(t, *tt.want.InputLogEvent, *got.InputLogEvent)
 			assert.Equal(t, tt.want.LogStreamName, got.LogStreamName)
 			assert.Equal(t, tt.want.LogGroupName, got.LogGroupName)
 		})
@@ -234,8 +260,9 @@ func BenchmarkLogToCWLog(b *testing.B) {
 
 	resource := testResource()
 	log := testLogRecord()
+	scope := testScope()
 	for i := 0; i < b.N; i++ {
-		_, err := logToCWLog(attrsValue(resource.Attributes()), log, &Config{})
+		_, err := logToCWLog(attrsValue(resource.Attributes()), scope, log, &Config{})
 		if err != nil {
 			b.Errorf("logToCWLog() failed %v", err)
 			return
@@ -248,6 +275,14 @@ func testResource() pcommon.Resource {
 	resource.Attributes().PutStr("host", "abc123")
 	resource.Attributes().PutInt("node", 5)
 	return resource
+}
+
+func testScope() pcommon.InstrumentationScope {
+	scope := pcommon.NewInstrumentationScope()
+	scope.SetName("test-scope")
+	scope.SetVersion("1.0.0")
+	scope.Attributes().PutStr("scope-attr", "value")
+	return scope
 }
 
 func testLogRecord() plog.LogRecord {

--- a/exporter/awscloudwatchlogsexporter/exporter_test.go
+++ b/exporter/awscloudwatchlogsexporter/exporter_test.go
@@ -93,6 +93,7 @@ func TestLogToCWLog(t *testing.T) {
 			name:     "no scope",
 			resource: testResource(),
 			log:      testLogRecord(),
+			scope:    emptyScope(),
 			config:   &Config{},
 			want: cwlogs.Event{
 				GeneratedTime: time.Now(),
@@ -282,6 +283,11 @@ func testScope() pcommon.InstrumentationScope {
 	scope.SetName("test-scope")
 	scope.SetVersion("1.0.0")
 	scope.Attributes().PutStr("scope-attr", "value")
+	return scope
+}
+
+func emptyScope() pcommon.InstrumentationScope {
+	scope := pcommon.NewInstrumentationScope()
 	return scope
 }
 


### PR DESCRIPTION

**Description:** Include the instrumentation scope in the log records exported by the cloudwatchlogs expoter

**Link to tracking Issue:** #29884

**Testing:** Unit tests were added.

