### PR TITLE
[receiver/vcenter] Remove vSphere version 7.5

### DIFF
--- a/receiver/vcenterreceiver/README.md
+++ b/receiver/vcenterreceiver/README.md
@@ -20,7 +20,6 @@ This receiver fetches metrics from a vCenter or ESXi host running VMware vSphere
 
 This receiver has been built to support ESXi and vCenter versions:
 
-- 7.5
 - 7.0
 - 6.7
 


### PR DESCRIPTION
**Description:**
Remove version 7.5 from the README as this version does not exist.

List of all versions of vSphere vCenter: https://kb.vmware.com/s/article/2143838
List of all versions of vSphere ESXi: https://kb.vmware.com/s/article/2143832

**Link to tracking Issue:**
N/A

**Testing:**
N/A

**Documentation:**
N/A