### PR TITLE
[chore] Run unit tests for 1.21

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -265,7 +265,7 @@ jobs:
           path: ~/.cache/go-build
           key: go-test-build-${{ runner.os }}-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
-        if: startsWith( matrix.go-version, '1.19' )
+        if: startsWith( matrix.go-version, '~1.21' )
         run: make gotest GROUP=${{ matrix.group }}
       - name: Run Unit Tests With Coverage
         if: startsWith( matrix.go-version, '~1.20' ) # only run coverage on one version


### PR DESCRIPTION
I think we weren't running unit tests for Go ~1.21. See https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/7441862453/job/20244563464?pr=30162 as an example.