### PR TITLE
[chore][Makefile] Fix make otel-from-tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ otel-from-tree:
 	# 2. Run `make otel-from-tree` (only need to run it once to remap go modules)
 	# 3. You can now build contrib and it will use your local otel core changes.
 	# 4. Before committing/pushing your contrib changes, undo by running `make otel-from-lib`.
-	$(MAKE) for-all CMD="$(GOCMD) mod edit -replace go.opentelemetry.io/collector=$(SRC_ROOT)/../opentelemetry-collector"
+	$(MAKE) for-all CMD="$(GOCMD) mod edit -replace go.opentelemetry.io/collector=$(SRC_PARENT_DIR)/opentelemetry-collector"
 
 .PHONY: otel-from-lib
 otel-from-lib:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -20,6 +20,8 @@ endif
 
 # SRC_ROOT is the top of the source tree.
 SRC_ROOT := $(shell git rev-parse --show-toplevel)
+# SRC_PARENT_DIR is the absolute path of source tree's parent directory
+SRC_PARENT_DIR :=  $(shell dirname $(SRC_ROOT))
 
 # build tags required by any component should be defined as an independent variables and later added to GO_BUILD_TAGS below
 GO_BUILD_TAGS=""


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
From testing I found out that golang's `replace` directive didn't work properly when using an absolute path with the `../` included. Using a relative path or an absolute path (without `../` in the middle) resolves the issue. The simple and most clear solution is to use a true absolute path, so I've used `dirname` with the repo's root dir to determine the parent dir.

**Link to tracking Issue:** <Issue number if applicable>
Fixes #30330

**Testing:** <Describe what testing was performed and which tests were added.>
Commands in bug description are all working.