### PR TITLE
[chore] Tune renovatebot

### DIFF
--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
   setup-environment:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'renovatebot') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency-major-update') && (github.actor == 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'renovatebot')) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,8 @@
       {
         "matchManagers": ["gomod"],
         "matchUpdateTypes": ["major"],
-        "prBodyNotes": [":warning: MAJOR VERSION UPDATE :warning: - please manually update this package"]
+        "prBodyNotes": [":warning: MAJOR VERSION UPDATE :warning: - please manually update this package"],
+        "labels": ["dependency-major-update"]
       },
       {
         "matchManagers": ["dockerfile"],

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,16 @@
     ],
     "packageRules": [
       {
+        "matchManagers": ["gomod"],
+        "matchUpdateTypes": ["pin", "pinDigest", "digest", "lockFileMaintenance", "rollback", "bump", "replacement"],
+        "enabled": false
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchUpdateTypes": ["major"],
+        "prBodyNotes": [":warning: MAJOR VERSION UPDATE :warning: - please manually update this package"]
+      },
+      {
         "matchManagers": ["dockerfile"],
         "groupName": "dockerfile deps"
       },
@@ -33,6 +43,36 @@
       },
       {
         "matchManagers": ["gomod"],
+        "matchSourceUrlPrefixes": ["https://github.com/aws"],
+        "groupName": "All github.com/aws packages"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchSourceUrlPrefixes": ["https://github.com/azure"],
+        "groupName": "All github.com/azure packages"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchSourceUrlPrefixes": ["https://github.com/datadog"],
+        "groupName": "All github.com/datadog packages"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchSourceUrlPrefixes": ["https://google.golang.org"],
+        "groupName": "All google.golang.org packages"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchSourceUrlPrefixes": ["https://golang.org"],
+        "groupName": "All golang.org packages"
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchSourceUrlPrefixes": ["https://github.com/googlecloudplatform"],
+        "groupName": "All github.com/googlecloudplatform packages"
+      },
+      {
+        "matchManagers": ["gomod"],
         "matchSourceUrlPrefixes": ["https://go.opentelemetry.io/collector"],
         "groupName": "All OpenTelemetry Collector dev packages",
         "matchUpdateTypes": ["digest"]
@@ -42,46 +82,6 @@
         "matchSourceUrlPrefixes": ["https://go.opentelemetry.io/collector"],
         "groupName": "All OpenTelemetry Collector packages",
         "matchUpdateTypes": ["major", "minor", "patch"]
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchSourceUrlPrefixes": ["https://github.com/aws"],
-        "groupName": "All github.com/aws packages",
-        "matchUpdateTypes": ["minor", "patch"]
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchSourceUrlPrefixes": ["https://github.com/azure"],
-        "groupName": "All github.com/azure packages",
-        "matchUpdateTypes": ["minor", "patch"]
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchSourceUrlPrefixes": ["https://github.com/datadog"],
-        "groupName": "All github.com/datadog packages",
-        "matchUpdateTypes": ["minor", "patch"]
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchSourceUrlPrefixes": ["https://google.golang.org"],
-        "groupName": "All google.golang.org packages",
-        "matchUpdateTypes": ["minor", "patch"]
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchSourceUrlPrefixes": ["https://golang.org"],
-        "groupName": "All golang.org packages",
-        "matchUpdateTypes": ["minor", "patch"]
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchSourceUrlPrefixes": ["https://github.com/googlecloudplatform"],
-        "groupName": "All github.com/googlecloudplatform packages",
-        "matchUpdateTypes": ["minor", "patch"]
-      },
-      {
-        "matchManagers": ["gomod"],
-        "matchUpdateTypes": ["minor", "patch"]
       }
     ],
     "ignoreDeps": [

--- a/renovate.json
+++ b/renovate.json
@@ -63,6 +63,18 @@
       },
       {
         "matchManagers": ["gomod"],
+        "matchSourceUrlPrefixes": ["https://google.golang.org"],
+        "groupName": "All google.golang.org packages",
+        "matchUpdateTypes": ["minor", "patch"]
+      },
+      {
+        "matchManagers": ["gomod"],
+        "matchSourceUrlPrefixes": ["https://golang.org"],
+        "groupName": "All golang.org packages",
+        "matchUpdateTypes": ["minor", "patch"]
+      },
+      {
+        "matchManagers": ["gomod"],
         "matchSourceUrlPrefixes": ["https://github.com/googlecloudplatform"],
         "groupName": "All github.com/googlecloudplatform packages",
         "matchUpdateTypes": ["minor", "patch"]
@@ -76,6 +88,6 @@
       "github.com/mattn/go-ieproxy",
       "github.com/DataDog/datadog-agent/pkg/trace/exportable"
     ],
-    "prConcurrentLimit": 50,
+    "prConcurrentLimit": 200,
     "suppressNotifications": ["prEditedNotification"]
   }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Tunes several renovatebot settings:
- We got rate limited again so I'm bumping our current limit. 
- Adds 2 more groupings. 
- [Actually disable unwanted update types.](https://github.com/renovatebot/renovate/discussions/13652)
- We've been seeing an issue with major updates where the `make gotidy` is undoing the changes.  This is happening because renovatebot isn't bumping the major versions correctly.  I still want renovatebot to create the PRs, but I don't expect us to merge them - they should be used to indicate that a major version needs to go be manually updated. I've updated the workflow to add some notes and a label so that `make gotidy` wont run.
- [Package rules are ordered least important to most important so I rearranged.](https://docs.renovatebot.com/configuration-options/#packagerules)