### PR TITLE
[chore]ReportComponentStatus -> ReportStatus

### DIFF
--- a/extension/healthcheckextension/healthcheckextension.go
+++ b/extension/healthcheckextension/healthcheckextension.go
@@ -54,7 +54,7 @@ func (hc *healthCheckExtension) Start(_ context.Context, host component.Host) er
 
 			// The listener ownership goes to the server.
 			if err = hc.server.Serve(ln); !errors.Is(err, http.ErrServerClosed) && err != nil {
-				_ = hc.settings.ReportComponentStatus(component.NewFatalErrorEvent(err))
+				hc.settings.ReportStatus(component.NewFatalErrorEvent(err))
 			}
 		}()
 	} else {

--- a/extension/jaegerremotesampling/internal/http.go
+++ b/extension/jaegerremotesampling/internal/http.go
@@ -72,7 +72,7 @@ func (h *SamplingHTTPServer) Start(_ context.Context, host component.Host) error
 		defer h.shutdownWG.Done()
 
 		if err := h.srv.Serve(hln); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			_ = h.telemetry.ReportComponentStatus(component.NewFatalErrorEvent(err))
+			h.telemetry.ReportStatus(component.NewFatalErrorEvent(err))
 		}
 	}()
 

--- a/extension/observer/ecsobserver/extension.go
+++ b/extension/observer/ecsobserver/extension.go
@@ -32,7 +32,7 @@ func (e *ecsObserver) Start(_ context.Context, _ component.Host) error {
 		if err := e.sd.runAndWriteFile(ctx); err != nil {
 			e.telemetrySettings.Logger.Error("ECSDiscovery stopped by error", zap.Error(err))
 			// Stop the collector
-			_ = e.telemetrySettings.ReportComponentStatus(component.NewFatalErrorEvent(err))
+			e.telemetrySettings.ReportStatus(component.NewFatalErrorEvent(err))
 		}
 	}()
 	return nil

--- a/extension/observer/ecsobserver/extension_test.go
+++ b/extension/observer/ecsobserver/extension_test.go
@@ -104,9 +104,8 @@ func TestExtensionStartStop(t *testing.T) {
 		sdCfg.ResultFile = "testdata/ut_ext_critical_error.actual.yaml"
 		cs := extensiontest.NewNopCreateSettings()
 		statusEventChan := make(chan *component.StatusEvent)
-		cs.TelemetrySettings.ReportComponentStatus = func(e *component.StatusEvent) error {
+		cs.TelemetrySettings.ReportStatus = func(e *component.StatusEvent) {
 			statusEventChan <- e
-			return nil
 		}
 		ext, err := createExtensionWithFetcher(cs, sdCfg, f)
 		require.NoError(t, err)

--- a/extension/remotetapextension/extension.go
+++ b/extension/remotetapextension/extension.go
@@ -39,7 +39,7 @@ func (s *remoteObserverExtension) Start(_ context.Context, host component.Host) 
 	go func() {
 		err := s.server.ListenAndServe()
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			_ = s.settings.TelemetrySettings.ReportComponentStatus(component.NewFatalErrorEvent(err))
+			s.settings.TelemetrySettings.ReportStatus(component.NewFatalErrorEvent(err))
 		}
 	}()
 	return nil

--- a/receiver/cloudflarereceiver/logs.go
+++ b/receiver/cloudflarereceiver/logs.go
@@ -110,7 +110,7 @@ func (l *logsReceiver) startListening(ctx context.Context, _ component.Host) err
 
 			if !errors.Is(err, http.ErrServerClosed) {
 				l.logger.Error("ServeTLS failed", zap.Error(err))
-				_ = l.telemetrySettings.ReportComponentStatus(component.NewFatalErrorEvent(err))
+				l.telemetrySettings.ReportStatus(component.NewFatalErrorEvent(err))
 			}
 
 		} else {
@@ -123,7 +123,7 @@ func (l *logsReceiver) startListening(ctx context.Context, _ component.Host) err
 
 			if !errors.Is(err, http.ErrServerClosed) {
 				l.logger.Error("Serve failed", zap.Error(err))
-				_ = l.telemetrySettings.ReportComponentStatus(component.NewFatalErrorEvent(err))
+				l.telemetrySettings.ReportStatus(component.NewFatalErrorEvent(err))
 			}
 
 		}

--- a/receiver/collectdreceiver/receiver.go
+++ b/receiver/collectdreceiver/receiver.go
@@ -78,7 +78,7 @@ func (cdr *collectdReceiver) Start(_ context.Context, host component.Host) error
 	}
 	go func() {
 		if err := cdr.server.Serve(l); !errors.Is(err, http.ErrServerClosed) && err != nil {
-			_ = cdr.createSettings.TelemetrySettings.ReportComponentStatus(component.NewFatalErrorEvent(err))
+			cdr.createSettings.TelemetrySettings.ReportStatus(component.NewFatalErrorEvent(err))
 		}
 	}()
 	return nil


### PR DESCRIPTION
Move off deprecated `ReportComponentStatus` to `ReportStatus`. See https://github.com/open-telemetry/opentelemetry-collector/issues/9148 for rationale.