### PR TITLE
[chore] update references to logging exporter 

### DIFF
--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -45,7 +45,6 @@ extensions:
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8
-  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240124123350-9047c0e373f9
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240124123350-9047c0e373f9
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240124123350-9047c0e373f9
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/alertmanagerexporter v0.93.0

--- a/cmd/otelcontribcol/components.go
+++ b/cmd/otelcontribcol/components.go
@@ -7,7 +7,6 @@ import (
 	forwardconnector "go.opentelemetry.io/collector/connector/forwardconnector"
 	"go.opentelemetry.io/collector/exporter"
 	debugexporter "go.opentelemetry.io/collector/exporter/debugexporter"
-	loggingexporter "go.opentelemetry.io/collector/exporter/loggingexporter"
 	otlpexporter "go.opentelemetry.io/collector/exporter/otlpexporter"
 	otlphttpexporter "go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/extension"
@@ -345,7 +344,6 @@ func components() (otelcol.Factories, error) {
 
 	factories.Exporters, err = exporter.MakeFactoryMap(
 		debugexporter.NewFactory(),
-		loggingexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),
 		alertmanagerexporter.NewFactory(),

--- a/cmd/otelcontribcol/exporters_test.go
+++ b/cmd/otelcontribcol/exporters_test.go
@@ -124,9 +124,6 @@ func TestDefaultExporters(t *testing.T) {
 			exporter: "debug",
 		},
 		{
-			exporter: "logging",
-		},
-		{
 			exporter: "opencensus",
 			getConfigFn: func() component.Config {
 				cfg := expFactories["opencensus"].CreateDefaultConfig().(*opencensusexporter.Config)

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -207,7 +207,6 @@ require (
 	go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8
-	go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/extension v0.93.1-0.20240125183026-3cacd40b27e8

--- a/cmd/otelcontribcol/go.sum
+++ b/cmd/otelcontribcol/go.sum
@@ -1619,8 +1619,6 @@ go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:
 go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:cufzF+FLxlTj4SeCjvyiPgR6MDhkKkcP7BAQgjoZH+4=
 go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:t9JrQmmki7Kj3p5l2/ndrqTfABVJn10st5a6rMAxL2k=
 go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:w1nlRsL2ljIwoZRvserVAgSDFRuDjVyuL/hcU7Hu8hY=
-go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:rDi6ieHDCa2whtB2/FPMlKMGhwqu2e0JDyZSP9wJGrg=
-go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:QfDSZQ4P5/8W/Ucv4ivSrTtgbOvZM7EhkjnuGkmW098=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:pCa9cldSbwZVOfJKBW/o2UD4dH6qmnFZ0/8sTWfg3pE=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:xhobg7vtcZhzNOFAr2Cm1ZPDS5MUcrTUJ+z+9pX6GzE=
 go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:FDdkWqnUezXZH5j+aEPXJAOdH1yQ8vajsEhsGLCBDjU=

--- a/cmd/oteltestbedcol/builder-config.yaml
+++ b/cmd/oteltestbedcol/builder-config.yaml
@@ -14,7 +14,6 @@ extensions:
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8
-  - gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8
   - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter v0.93.0

--- a/cmd/oteltestbedcol/components.go
+++ b/cmd/oteltestbedcol/components.go
@@ -6,7 +6,6 @@ import (
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/exporter"
 	debugexporter "go.opentelemetry.io/collector/exporter/debugexporter"
-	loggingexporter "go.opentelemetry.io/collector/exporter/loggingexporter"
 	otlpexporter "go.opentelemetry.io/collector/exporter/otlpexporter"
 	otlphttpexporter "go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/extension"
@@ -83,7 +82,6 @@ func components() (otelcol.Factories, error) {
 
 	factories.Exporters, err = exporter.MakeFactoryMap(
 		debugexporter.NewFactory(),
-		loggingexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),
 		carbonexporter.NewFactory(),

--- a/cmd/oteltestbedcol/go.mod
+++ b/cmd/oteltestbedcol/go.mod
@@ -36,7 +36,6 @@ require (
 	go.opentelemetry.io/collector/connector v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8
-	go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/extension v0.93.1-0.20240125183026-3cacd40b27e8

--- a/cmd/oteltestbedcol/go.sum
+++ b/cmd/oteltestbedcol/go.sum
@@ -678,8 +678,6 @@ go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:
 go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:cufzF+FLxlTj4SeCjvyiPgR6MDhkKkcP7BAQgjoZH+4=
 go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:t9JrQmmki7Kj3p5l2/ndrqTfABVJn10st5a6rMAxL2k=
 go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:w1nlRsL2ljIwoZRvserVAgSDFRuDjVyuL/hcU7Hu8hY=
-go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:rDi6ieHDCa2whtB2/FPMlKMGhwqu2e0JDyZSP9wJGrg=
-go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:QfDSZQ4P5/8W/Ucv4ivSrTtgbOvZM7EhkjnuGkmW098=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:pCa9cldSbwZVOfJKBW/o2UD4dH6qmnFZ0/8sTWfg3pE=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:xhobg7vtcZhzNOFAr2Cm1ZPDS5MUcrTUJ+z+9pX6GzE=
 go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:FDdkWqnUezXZH5j+aEPXJAOdH1yQ8vajsEhsGLCBDjU=

--- a/examples/secure-tracing/otel-collector-config.yaml
+++ b/examples/secure-tracing/otel-collector-config.yaml
@@ -11,7 +11,7 @@ processors:
   batch:
 
 exporters:
-  logging:
+  debug:
     verbosity: detailed
 
 service:
@@ -19,5 +19,5 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
 

--- a/extension/healthcheckextension/go.mod
+++ b/extension/healthcheckextension/go.mod
@@ -105,7 +105,7 @@ require (
 	go.opentelemetry.io/collector/connector v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
 	go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
 	go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
-	go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
+	go.opentelemetry.io/collector/exporter/debugexporter v0.93.0 // indirect
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.93.1-0.20240125183026-3cacd40b27e8 // indirect

--- a/extension/healthcheckextension/go.mod
+++ b/extension/healthcheckextension/go.mod
@@ -105,7 +105,7 @@ require (
 	go.opentelemetry.io/collector/connector v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
 	go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
 	go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
-	go.opentelemetry.io/collector/exporter/debugexporter v0.93.0 // indirect
+	go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.93.1-0.20240125183026-3cacd40b27e8 // indirect

--- a/extension/healthcheckextension/go.sum
+++ b/extension/healthcheckextension/go.sum
@@ -390,8 +390,8 @@ go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8 h1:
 go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:6BI1qsWw89DmTjoEu/acTcvTLISt3Y0lHioUfafpsAE=
 go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:HlcwkBkSBBLNu7hZeu+CN56HD4wc3hRhirtENoqzvyE=
 go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:cufzF+FLxlTj4SeCjvyiPgR6MDhkKkcP7BAQgjoZH+4=
-go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:rDi6ieHDCa2whtB2/FPMlKMGhwqu2e0JDyZSP9wJGrg=
-go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:QfDSZQ4P5/8W/Ucv4ivSrTtgbOvZM7EhkjnuGkmW098=
+go.opentelemetry.io/collector/exporter/debugexporter v0.93.0 h1:uT1AQBC54KlHrlrrDIvdEZPooCQDDsP23tqUAJxaXlQ=
+go.opentelemetry.io/collector/exporter/debugexporter v0.93.0/go.mod h1:LdaeHR1xfYGEKstw2TnurOrrhN96Qg6GELXSiO5Dkdo=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:pCa9cldSbwZVOfJKBW/o2UD4dH6qmnFZ0/8sTWfg3pE=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:xhobg7vtcZhzNOFAr2Cm1ZPDS5MUcrTUJ+z+9pX6GzE=
 go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:FDdkWqnUezXZH5j+aEPXJAOdH1yQ8vajsEhsGLCBDjU=

--- a/extension/healthcheckextension/go.sum
+++ b/extension/healthcheckextension/go.sum
@@ -390,8 +390,8 @@ go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8 h1:
 go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:6BI1qsWw89DmTjoEu/acTcvTLISt3Y0lHioUfafpsAE=
 go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:HlcwkBkSBBLNu7hZeu+CN56HD4wc3hRhirtENoqzvyE=
 go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:cufzF+FLxlTj4SeCjvyiPgR6MDhkKkcP7BAQgjoZH+4=
-go.opentelemetry.io/collector/exporter/debugexporter v0.93.0 h1:uT1AQBC54KlHrlrrDIvdEZPooCQDDsP23tqUAJxaXlQ=
-go.opentelemetry.io/collector/exporter/debugexporter v0.93.0/go.mod h1:LdaeHR1xfYGEKstw2TnurOrrhN96Qg6GELXSiO5Dkdo=
+go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:t9JrQmmki7Kj3p5l2/ndrqTfABVJn10st5a6rMAxL2k=
+go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:w1nlRsL2ljIwoZRvserVAgSDFRuDjVyuL/hcU7Hu8hY=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:pCa9cldSbwZVOfJKBW/o2UD4dH6qmnFZ0/8sTWfg3pE=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:xhobg7vtcZhzNOFAr2Cm1ZPDS5MUcrTUJ+z+9pX6GzE=
 go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:FDdkWqnUezXZH5j+aEPXJAOdH1yQ8vajsEhsGLCBDjU=

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -43,7 +43,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8
-	go.opentelemetry.io/collector/exporter/debugexporter v0.93.0
+	go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/extension v0.93.1-0.20240125183026-3cacd40b27e8

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -43,7 +43,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8
-	go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8
+	go.opentelemetry.io/collector/exporter/debugexporter v0.93.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8
 	go.opentelemetry.io/collector/extension v0.93.1-0.20240125183026-3cacd40b27e8

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -665,8 +665,8 @@ go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8 h1:
 go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:6BI1qsWw89DmTjoEu/acTcvTLISt3Y0lHioUfafpsAE=
 go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:HlcwkBkSBBLNu7hZeu+CN56HD4wc3hRhirtENoqzvyE=
 go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:cufzF+FLxlTj4SeCjvyiPgR6MDhkKkcP7BAQgjoZH+4=
-go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:rDi6ieHDCa2whtB2/FPMlKMGhwqu2e0JDyZSP9wJGrg=
-go.opentelemetry.io/collector/exporter/loggingexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:QfDSZQ4P5/8W/Ucv4ivSrTtgbOvZM7EhkjnuGkmW098=
+go.opentelemetry.io/collector/exporter/debugexporter v0.93.0 h1:uT1AQBC54KlHrlrrDIvdEZPooCQDDsP23tqUAJxaXlQ=
+go.opentelemetry.io/collector/exporter/debugexporter v0.93.0/go.mod h1:LdaeHR1xfYGEKstw2TnurOrrhN96Qg6GELXSiO5Dkdo=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:pCa9cldSbwZVOfJKBW/o2UD4dH6qmnFZ0/8sTWfg3pE=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:xhobg7vtcZhzNOFAr2Cm1ZPDS5MUcrTUJ+z+9pX6GzE=
 go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:FDdkWqnUezXZH5j+aEPXJAOdH1yQ8vajsEhsGLCBDjU=

--- a/testbed/go.sum
+++ b/testbed/go.sum
@@ -665,8 +665,8 @@ go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8 h1:
 go.opentelemetry.io/collector/consumer v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:6BI1qsWw89DmTjoEu/acTcvTLISt3Y0lHioUfafpsAE=
 go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:HlcwkBkSBBLNu7hZeu+CN56HD4wc3hRhirtENoqzvyE=
 go.opentelemetry.io/collector/exporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:cufzF+FLxlTj4SeCjvyiPgR6MDhkKkcP7BAQgjoZH+4=
-go.opentelemetry.io/collector/exporter/debugexporter v0.93.0 h1:uT1AQBC54KlHrlrrDIvdEZPooCQDDsP23tqUAJxaXlQ=
-go.opentelemetry.io/collector/exporter/debugexporter v0.93.0/go.mod h1:LdaeHR1xfYGEKstw2TnurOrrhN96Qg6GELXSiO5Dkdo=
+go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:t9JrQmmki7Kj3p5l2/ndrqTfABVJn10st5a6rMAxL2k=
+go.opentelemetry.io/collector/exporter/debugexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:w1nlRsL2ljIwoZRvserVAgSDFRuDjVyuL/hcU7Hu8hY=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:pCa9cldSbwZVOfJKBW/o2UD4dH6qmnFZ0/8sTWfg3pE=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.93.1-0.20240125183026-3cacd40b27e8/go.mod h1:xhobg7vtcZhzNOFAr2Cm1ZPDS5MUcrTUJ+z+9pX6GzE=
 go.opentelemetry.io/collector/exporter/otlphttpexporter v0.93.1-0.20240125183026-3cacd40b27e8 h1:FDdkWqnUezXZH5j+aEPXJAOdH1yQ8vajsEhsGLCBDjU=

--- a/testbed/testbed/components.go
+++ b/testbed/testbed/components.go
@@ -5,7 +5,7 @@ package testbed // import "github.com/open-telemetry/opentelemetry-collector-con
 
 import (
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/loggingexporter"
+	"go.opentelemetry.io/collector/exporter/debugexporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/exporter/otlphttpexporter"
 	"go.opentelemetry.io/collector/extension"
@@ -51,7 +51,7 @@ func Components() (
 	errs = multierr.Append(errs, err)
 
 	exporters, err := exporter.MakeFactoryMap(
-		loggingexporter.NewFactory(),
+		debugexporter.NewFactory(),
 		opencensusexporter.NewFactory(),
 		otlpexporter.NewFactory(),
 		otlphttpexporter.NewFactory(),


### PR DESCRIPTION
There are a few places where we probably don't need the logging exporter anymore. Updating the local builds to only include the debug exporter instead of both the logging and the debug exporter.