### PR TITLE
[chore] address linting issues in generated tests

### DIFF
--- a/cmd/mdatagen/lint_test.go
+++ b/cmd/mdatagen/lint_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_formatIdentifier(t *testing.T) {
+func TestFormatIdentifier(t *testing.T) {
 	var tests = []struct {
 		input    string
 		want     string

--- a/cmd/mdatagen/loader_test.go
+++ b/cmd/mdatagen/loader_test.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-func Test_loadMetadata(t *testing.T) {
+func TestLoadMetadata(t *testing.T) {
 	tests := []struct {
 		name    string
 		want    metadata

--- a/cmd/mdatagen/main_test.go
+++ b/cmd/mdatagen/main_test.go
@@ -16,7 +16,7 @@ import (
 	md "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/mdatagen/internal/metadata"
 )
 
-func Test_runContents(t *testing.T) {
+func TestRunContents(t *testing.T) {
 	tests := []struct {
 		yml                  string
 		wantMetricsGenerated bool
@@ -96,7 +96,7 @@ foo
 	}
 }
 
-func Test_run(t *testing.T) {
+func TestRun(t *testing.T) {
 	type args struct {
 		ymlPath string
 	}
@@ -125,7 +125,7 @@ func Test_run(t *testing.T) {
 	}
 }
 
-func Test_inlineReplace(t *testing.T) {
+func TestInlineReplace(t *testing.T) {
 	tests := []struct {
 		name           string
 		markdown       string

--- a/cmd/mdatagen/templates/component_test.go.tmpl
+++ b/cmd/mdatagen/templates/component_test.go.tmpl
@@ -55,7 +55,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 
 
 {{ if isExporter }}
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct{
@@ -146,7 +146,7 @@ func Test_ComponentLifecycle(t *testing.T) {
 {{ end }}
 
 {{ if isProcessor }}
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct{
@@ -235,7 +235,7 @@ func Test_ComponentLifecycle(t *testing.T) {
 {{ end }}
 
 {{ if isReceiver }}
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct{
@@ -304,7 +304,7 @@ func Test_ComponentLifecycle(t *testing.T) {
 {{ end }}
 
 {{ if isExtension }}
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")

--- a/exporter/alertmanagerexporter/generated_component_test.go
+++ b/exporter/alertmanagerexporter/generated_component_test.go
@@ -39,7 +39,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/exporter/alibabacloudlogserviceexporter/generated_component_test.go
+++ b/exporter/alibabacloudlogserviceexporter/generated_component_test.go
@@ -39,7 +39,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/exporter/awss3exporter/generated_component_test.go
+++ b/exporter/awss3exporter/generated_component_test.go
@@ -39,7 +39,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/exporter/signalfxexporter/generated_component_test.go
+++ b/exporter/signalfxexporter/generated_component_test.go
@@ -39,7 +39,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/exporter/splunkhecexporter/generated_component_test.go
+++ b/exporter/splunkhecexporter/generated_component_test.go
@@ -39,7 +39,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/extension/bearertokenauthextension/generated_component_test.go
+++ b/extension/bearertokenauthextension/generated_component_test.go
@@ -36,7 +36,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")

--- a/extension/headerssetterextension/generated_component_test.go
+++ b/extension/headerssetterextension/generated_component_test.go
@@ -36,7 +36,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")

--- a/extension/healthcheckextension/generated_component_test.go
+++ b/extension/healthcheckextension/generated_component_test.go
@@ -36,7 +36,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")

--- a/extension/opampextension/generated_component_test.go
+++ b/extension/opampextension/generated_component_test.go
@@ -36,7 +36,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")

--- a/extension/pprofextension/generated_component_test.go
+++ b/extension/pprofextension/generated_component_test.go
@@ -36,7 +36,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")

--- a/extension/remotetapextension/generated_component_test.go
+++ b/extension/remotetapextension/generated_component_test.go
@@ -36,7 +36,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")

--- a/extension/sigv4authextension/generated_component_test.go
+++ b/extension/sigv4authextension/generated_component_test.go
@@ -36,7 +36,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	cm, err := confmaptest.LoadConf("metadata.yaml")

--- a/processor/attributesprocessor/generated_component_test.go
+++ b/processor/attributesprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/cumulativetodeltaprocessor/generated_component_test.go
+++ b/processor/cumulativetodeltaprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/datadogprocessor/generated_component_test.go
+++ b/processor/datadogprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/deltatorateprocessor/generated_component_test.go
+++ b/processor/deltatorateprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/filterprocessor/generated_component_test.go
+++ b/processor/filterprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/groupbyattrsprocessor/generated_component_test.go
+++ b/processor/groupbyattrsprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/groupbytraceprocessor/generated_component_test.go
+++ b/processor/groupbytraceprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/k8sattributesprocessor/generated_component_test.go
+++ b/processor/k8sattributesprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/logstransformprocessor/generated_component_test.go
+++ b/processor/logstransformprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/metricsgenerationprocessor/generated_component_test.go
+++ b/processor/metricsgenerationprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/metricstransformprocessor/generated_component_test.go
+++ b/processor/metricstransformprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/probabilisticsamplerprocessor/generated_component_test.go
+++ b/processor/probabilisticsamplerprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/redactionprocessor/generated_component_test.go
+++ b/processor/redactionprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/remotetapprocessor/generated_component_test.go
+++ b/processor/remotetapprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/resourcedetectionprocessor/generated_component_test.go
+++ b/processor/resourcedetectionprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/resourceprocessor/generated_component_test.go
+++ b/processor/resourceprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/routingprocessor/generated_component_test.go
+++ b/processor/routingprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/schemaprocessor/generated_component_test.go
+++ b/processor/schemaprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/servicegraphprocessor/generated_component_test.go
+++ b/processor/servicegraphprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/spanmetricsprocessor/generated_component_test.go
+++ b/processor/spanmetricsprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/spanprocessor/generated_component_test.go
+++ b/processor/spanprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/sumologicprocessor/generated_component_test.go
+++ b/processor/sumologicprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/tailsamplingprocessor/generated_component_test.go
+++ b/processor/tailsamplingprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/processor/transformprocessor/generated_component_test.go
+++ b/processor/transformprocessor/generated_component_test.go
@@ -40,7 +40,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/aerospikereceiver/generated_component_test.go
+++ b/receiver/aerospikereceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/apachereceiver/generated_component_test.go
+++ b/receiver/apachereceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/apachesparkreceiver/generated_component_test.go
+++ b/receiver/apachesparkreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/awscloudwatchmetricsreceiver/generated_component_test.go
+++ b/receiver/awscloudwatchmetricsreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/awscloudwatchreceiver/generated_component_test.go
+++ b/receiver/awscloudwatchreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/awscontainerinsightreceiver/generated_component_test.go
+++ b/receiver/awscontainerinsightreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/awsfirehosereceiver/generated_component_test.go
+++ b/receiver/awsfirehosereceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/azureblobreceiver/generated_component_test.go
+++ b/receiver/azureblobreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/azureeventhubreceiver/generated_component_test.go
+++ b/receiver/azureeventhubreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/azuremonitorreceiver/generated_component_test.go
+++ b/receiver/azuremonitorreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/bigipreceiver/generated_component_test.go
+++ b/receiver/bigipreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/carbonreceiver/generated_component_test.go
+++ b/receiver/carbonreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/cloudflarereceiver/generated_component_test.go
+++ b/receiver/cloudflarereceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/cloudfoundryreceiver/generated_component_test.go
+++ b/receiver/cloudfoundryreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/collectdreceiver/generated_component_test.go
+++ b/receiver/collectdreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/couchdbreceiver/generated_component_test.go
+++ b/receiver/couchdbreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/expvarreceiver/generated_component_test.go
+++ b/receiver/expvarreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/filestatsreceiver/generated_component_test.go
+++ b/receiver/filestatsreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/flinkmetricsreceiver/generated_component_test.go
+++ b/receiver/flinkmetricsreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/fluentforwardreceiver/generated_component_test.go
+++ b/receiver/fluentforwardreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/googlecloudpubsubreceiver/generated_component_test.go
+++ b/receiver/googlecloudpubsubreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/googlecloudspannerreceiver/generated_component_test.go
+++ b/receiver/googlecloudspannerreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/haproxyreceiver/generated_component_test.go
+++ b/receiver/haproxyreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/hostmetricsreceiver/generated_component_test.go
+++ b/receiver/hostmetricsreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/httpcheckreceiver/generated_component_test.go
+++ b/receiver/httpcheckreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/influxdbreceiver/generated_component_test.go
+++ b/receiver/influxdbreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/jaegerreceiver/generated_component_test.go
+++ b/receiver/jaegerreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/k8seventsreceiver/generated_component_test.go
+++ b/receiver/k8seventsreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/kafkametricsreceiver/generated_component_test.go
+++ b/receiver/kafkametricsreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/kafkareceiver/generated_component_test.go
+++ b/receiver/kafkareceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/mysqlreceiver/generated_component_test.go
+++ b/receiver/mysqlreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/nginxreceiver/generated_component_test.go
+++ b/receiver/nginxreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/nsxtreceiver/generated_component_test.go
+++ b/receiver/nsxtreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/opencensusreceiver/generated_component_test.go
+++ b/receiver/opencensusreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/oracledbreceiver/generated_component_test.go
+++ b/receiver/oracledbreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/otlpjsonfilereceiver/generated_component_test.go
+++ b/receiver/otlpjsonfilereceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/podmanreceiver/generated_component_test.go
+++ b/receiver/podmanreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/postgresqlreceiver/generated_component_test.go
+++ b/receiver/postgresqlreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/prometheusreceiver/generated_component_test.go
+++ b/receiver/prometheusreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/pulsarreceiver/generated_component_test.go
+++ b/receiver/pulsarreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/purefareceiver/generated_component_test.go
+++ b/receiver/purefareceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/purefbreceiver/generated_component_test.go
+++ b/receiver/purefbreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/rabbitmqreceiver/generated_component_test.go
+++ b/receiver/rabbitmqreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/redisreceiver/generated_component_test.go
+++ b/receiver/redisreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/riakreceiver/generated_component_test.go
+++ b/receiver/riakreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/sapmreceiver/generated_component_test.go
+++ b/receiver/sapmreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/signalfxreceiver/generated_component_test.go
+++ b/receiver/signalfxreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/simpleprometheusreceiver/generated_component_test.go
+++ b/receiver/simpleprometheusreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/skywalkingreceiver/generated_component_test.go
+++ b/receiver/skywalkingreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/snmpreceiver/generated_component_test.go
+++ b/receiver/snmpreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/snowflakereceiver/generated_component_test.go
+++ b/receiver/snowflakereceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/splunkenterprisereceiver/generated_component_test.go
+++ b/receiver/splunkenterprisereceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/splunkhecreceiver/generated_component_test.go
+++ b/receiver/splunkhecreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/sqlqueryreceiver/generated_component_test.go
+++ b/receiver/sqlqueryreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/sshcheckreceiver/generated_component_test.go
+++ b/receiver/sshcheckreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/statsdreceiver/generated_component_test.go
+++ b/receiver/statsdreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/syslogreceiver/generated_component_test.go
+++ b/receiver/syslogreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/tcplogreceiver/generated_component_test.go
+++ b/receiver/tcplogreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/udplogreceiver/generated_component_test.go
+++ b/receiver/udplogreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/vcenterreceiver/generated_component_test.go
+++ b/receiver/vcenterreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/wavefrontreceiver/generated_component_test.go
+++ b/receiver/wavefrontreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/webhookeventreceiver/generated_component_test.go
+++ b/receiver/webhookeventreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/zipkinreceiver/generated_component_test.go
+++ b/receiver/zipkinreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {

--- a/receiver/zookeeperreceiver/generated_component_test.go
+++ b/receiver/zookeeperreceiver/generated_component_test.go
@@ -38,7 +38,7 @@ func (aneh *assertNoErrorHost) ReportFatalError(err error) {
 	assert.NoError(aneh, err)
 }
 
-func Test_ComponentLifecycle(t *testing.T) {
+func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
 
 	tests := []struct {


### PR DESCRIPTION
This addresses the following lint failure:

```
var-naming: don't use underscores in Go names; func Test_ComponentLifecycle should be TestComponentLifecycle (revive)
func Test_ComponentLifecycle(t *testing.T) {
```
