### PR TITLE
[chore] enable gci on generated code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,8 @@ linters-settings:
       - standard
       - default
       - prefix(github.com/open-telemetry/opentelemetry-collector-contrib)
+    # this defaults to true
+    skip-generated: false
 
   govet:
     # report about shadowed variables


### PR DESCRIPTION
This prevents us from having a bunch of code in the repo that isn't compliant w/ the import rules we have enabled.

Fixes #30439
