### PR TITLE
[extension/basicauth] Accept empty usernames ; remove extra validation code

### DIFF
--- a/.chloggen/basicauth_validation.yaml
+++ b/.chloggen/basicauth_validation.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: basicauthextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Accept empty usernames.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30470]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Per https://datatracker.ietf.org/doc/html/rfc2617#section-2, username and password may be empty strings ("").
+  The validation used to enforce that usernames cannot be empty.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/basicauthextension/extension.go
+++ b/extension/basicauthextension/extension.go
@@ -33,18 +33,14 @@ type basicAuth struct {
 	matchFunc  func(username, password string) bool
 }
 
-func newClientAuthExtension(cfg *Config) (auth.Client, error) {
-	if cfg.ClientAuth == nil || cfg.ClientAuth.Username == "" {
-		return nil, errNoCredentialSource
-	}
-
+func newClientAuthExtension(cfg *Config) auth.Client {
 	ba := basicAuth{
 		clientAuth: cfg.ClientAuth,
 	}
 	return auth.NewClient(
 		auth.WithClientRoundTripper(ba.roundTripper),
 		auth.WithClientPerRPCCredentials(ba.perRPCCredentials),
-	), nil
+	)
 }
 
 func newServerAuthExtension(cfg *Config) (auth.Server, error) {

--- a/extension/basicauthextension/extension_test.go
+++ b/extension/basicauthextension/extension_test.go
@@ -228,14 +228,13 @@ func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 }
 
 func TestBasicAuth_ClientValid(t *testing.T) {
-	ext, err := newClientAuthExtension(&Config{
+	ext := newClientAuthExtension(&Config{
 		ClientAuth: &ClientAuthSettings{
 			Username: "username",
 			Password: "password",
 		},
 	})
 	require.NotNil(t, ext)
-	require.NoError(t, err)
 
 	require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
 
@@ -274,29 +273,20 @@ func TestBasicAuth_ClientValid(t *testing.T) {
 }
 
 func TestBasicAuth_ClientInvalid(t *testing.T) {
-	t.Run("no username", func(t *testing.T) {
-		_, err := newClientAuthExtension(&Config{
-			ClientAuth: &ClientAuthSettings{
-				Username: "",
-			},
-		})
-		assert.Error(t, err)
-	})
 
 	t.Run("invalid username format", func(t *testing.T) {
-		ext, err := newClientAuthExtension(&Config{
+		ext := newClientAuthExtension(&Config{
 			ClientAuth: &ClientAuthSettings{
 				Username: "user:name",
 				Password: "password",
 			},
 		})
 		require.NotNil(t, ext)
-		require.NoError(t, err)
 
 		require.NoError(t, ext.Start(context.Background(), componenttest.NewNopHost()))
 
 		base := &mockRoundTripper{}
-		_, err = ext.RoundTripper(base)
+		_, err := ext.RoundTripper(base)
 		assert.Error(t, err)
 
 		_, err = ext.PerRPCCredentials()

--- a/extension/basicauthextension/factory.go
+++ b/extension/basicauthextension/factory.go
@@ -31,5 +31,5 @@ func createExtension(_ context.Context, _ extension.CreateSettings, cfg componen
 	if cfg.(*Config).Htpasswd != nil {
 		return newServerAuthExtension(cfg.(*Config))
 	}
-	return newClientAuthExtension(cfg.(*Config))
+	return newClientAuthExtension(cfg.(*Config)), nil
 }

--- a/extension/basicauthextension/factory_test.go
+++ b/extension/basicauthextension/factory_test.go
@@ -22,14 +22,6 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.NoError(t, componenttest.CheckConfigStruct(actual))
 }
 
-func TestCreateExtension_DefaultConfig(t *testing.T) {
-	cfg := createDefaultConfig()
-
-	ext, err := createExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
-	assert.Equal(t, err, errNoCredentialSource)
-	assert.Nil(t, ext)
-}
-
 func TestCreateExtension_ValidConfig(t *testing.T) {
 	cfg := &Config{
 		Htpasswd: &HtpasswdSettings{


### PR DESCRIPTION
**Description:**
Drop the validation that username is a required non-empty string.
Remove extraneous validation logic, use config.Validate
