### PR TITLE
[chore]: disable sending_queue to reduce carbon load test flake

### DIFF
--- a/testbed/datareceivers/carbon.go
+++ b/testbed/datareceivers/carbon.go
@@ -57,6 +57,8 @@ func (cr *CarbonDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
 	return fmt.Sprintf(`
   carbon:
+    sending_queue:
+      enabled: false
     endpoint: "127.0.0.1:%d"`, cr.Port)
 }
 


### PR DESCRIPTION
**Description:**
Attempting to reduce carbon load test flake where sending queue limits ensure sent != received.

```
2024-01-11T08:06:36.342Z	error	exporterhelper/queue_sender.go:213	Dropping data because sending_queue is full. Try increasing queue_size.	{"kind": "exporter", "data_type": "metrics", "name": "carbon", "dropped_items": 1}
```

**Link to tracking Issue:**
#30478

**Testing:**
updating existing

**Documentation:**
none needed