### PR TITLE
[cmd/mdatagen] prepare deprecation

### DIFF
--- a/.chloggen/deprecate_mdatagen.yaml
+++ b/.chloggen/deprecate_mdatagen.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mdatagen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate mdatagen in preparation for its move to opentelemetry-collector
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30497]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/mdatagen/doc.go
+++ b/cmd/mdatagen/doc.go
@@ -4,4 +4,6 @@
 // Generate a test metrics builder from a sample metrics set covering all configuration options.
 //go:generate mdatagen metadata-sample.yaml
 
+// Deprecated: This package is moving to https://github.com/open-telemetry/opentelemetry-collector and will eventually be removed.
+// Please see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30497
 package main


### PR DESCRIPTION
See #30497

Note: the go.mod and README have deprecation marks already, this is just adding it to the go package.