### PR TITLE
Updates documentation on how to send a test metric to the statsd receiver

### DIFF
--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -166,4 +166,9 @@ service:
 
 A simple way to send a metric to `localhost:8125`:
 
-`echo "test.metric:42|c|#myKey:myVal" | nc -w 1 -u localhost 8125`
+```shell
+echo "test.metric:42|c|#myKey:myVal" | nc -w 1 -u -4 localhost 8125;
+echo "test.metric:42|c|#myKey:myVal" | nc -w 1 -u -6 localhost 8125;
+```
+
+Which sends a UDP packet using both IPV4 and IPV6, which is needed because the receiver's UDP server only accepts one or the other.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Updates the documentation on how to send a test metric to the statsd receiver, since the current command doesn't work on all machines.
    
The issue is that the component lets the `net` package decide whether to listen for either IPV6 or IPV4 UDP packets. That decision seems dependent on the OS. If the server picks IPV4, and localhost resolves to an IPV6 address, then the packet is not received. 

This [stackoverflow](https://superuser.com/questions/1238038/trouble-with-netcat-over-udp) question helped me figure out the problem

**Testing:** <Describe what testing was performed and which tests were added.>
In my case, using macOS, the net library decides to use IPV4:

```
workspace/opentelemetry-collector-contrib - (improve_statsd_test_command_documentation) > lsof -i | grep 8125
___go_bui 42575 sswartz   10u  IPv4 0xa2b466eb54dcda69      0t0  UDP localhost:8125
```

So only sending a IPV4 packet (using `-4`) works:
```
echo "test.metric:42|c|#myKey:myVal" | nc -w 1 -u -4 localhost 8125;
```