### PR TITLE
[chore] awsproxy extension ReportFatalError -> ReportStatus

### DIFF
--- a/extension/awsproxy/extension.go
+++ b/extension/awsproxy/extension.go
@@ -16,17 +16,18 @@ import (
 )
 
 type xrayProxy struct {
-	logger *zap.Logger
-	config *Config
-	server proxy.Server
+	logger   *zap.Logger
+	config   *Config
+	server   proxy.Server
+	settings component.TelemetrySettings
 }
 
 var _ extension.Extension = (*xrayProxy)(nil)
 
-func (x xrayProxy) Start(_ context.Context, host component.Host) error {
+func (x xrayProxy) Start(_ context.Context, _ component.Host) error {
 	go func() {
 		if err := x.server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) && err != nil {
-			host.ReportFatalError(err)
+			x.settings.ReportStatus(component.NewFatalErrorEvent(err))
 		}
 	}()
 	x.logger.Info("X-Ray proxy server started on " + x.config.ProxyConfig.Endpoint)
@@ -37,17 +38,18 @@ func (x xrayProxy) Shutdown(ctx context.Context) error {
 	return x.server.Shutdown(ctx)
 }
 
-func newXrayProxy(config *Config, logger *zap.Logger) (extension.Extension, error) {
-	srv, err := proxy.NewServer(&config.ProxyConfig, logger)
+func newXrayProxy(config *Config, telemetrySettings component.TelemetrySettings) (extension.Extension, error) {
+	srv, err := proxy.NewServer(&config.ProxyConfig, telemetrySettings.Logger)
 
 	if err != nil {
 		return nil, err
 	}
 
 	p := &xrayProxy{
-		config: config,
-		logger: logger,
-		server: srv,
+		config:   config,
+		logger:   telemetrySettings.Logger,
+		server:   srv,
+		settings: telemetrySettings,
 	}
 
 	return p, nil

--- a/extension/awsproxy/extension_test.go
+++ b/extension/awsproxy/extension_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy"
 )
@@ -22,7 +22,7 @@ func TestInvalidEndpoint(t *testing.T) {
 				},
 			},
 		},
-		zap.NewNop(),
+		componenttest.NewNopTelemetrySettings(),
 	)
 	assert.Error(t, err)
 }

--- a/extension/awsproxy/factory.go
+++ b/extension/awsproxy/factory.go
@@ -43,5 +43,5 @@ func createDefaultConfig() component.Config {
 }
 
 func createExtension(_ context.Context, params extension.CreateSettings, cfg component.Config) (extension.Extension, error) {
-	return newXrayProxy(cfg.(*Config), params.Logger)
+	return newXrayProxy(cfg.(*Config), params.TelemetrySettings)
 }


### PR DESCRIPTION
Remove use of deprecated host.ReportFatalError

Linked to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30501