### PR TITLE
[chore] [exporter/prometheus] Log when prometheus exporter drops metrics with incorrect temporality

### DIFF
--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -165,11 +165,13 @@ func (a *lastValueAccumulator) accumulateSum(metric pmetric.Metric, il pcommon.I
 
 	// Drop metrics with unspecified aggregations
 	if doubleSum.AggregationTemporality() == pmetric.AggregationTemporalityUnspecified {
+		a.logger.Debug(fmt.Sprintf("Dropping metric with unspecified aggregation: %s", metric.Name()))
 		return
 	}
 
 	// Drop non-monotonic and non-cumulative metrics
 	if doubleSum.AggregationTemporality() == pmetric.AggregationTemporalityDelta && !doubleSum.IsMonotonic() {
+		a.logger.Debug(fmt.Sprintf("Dropping non-monotonic and non-cumulative metric %s", metric.Name()))
 		return
 	}
 


### PR DESCRIPTION
The exporter only supports cumulative temporality

These debug logs will help people identify bad configurations, rather than silently dropping the metrics

I ran into this myself and had to step through the code to figure out the problem