### PR TITLE
[chore] influxdb receiver ReportFatalError -> ReportStatus

### DIFF
--- a/receiver/influxdbreceiver/receiver.go
+++ b/receiver/influxdbreceiver/receiver.go
@@ -83,7 +83,7 @@ func (r *metricsReceiver) Start(_ context.Context, host component.Host) error {
 	go func() {
 		defer r.wg.Done()
 		if errHTTP := r.server.Serve(ln); !errors.Is(errHTTP, http.ErrServerClosed) && errHTTP != nil {
-			host.ReportFatalError(errHTTP)
+			r.settings.ReportStatus(component.NewFatalErrorEvent(errHTTP))
 		}
 	}()
 


### PR DESCRIPTION
Remove use of deprecated host.ReportFatalError

Linked to #30501
