### PR TITLE
[chore] kafka receiver ReportFatalError -> ReportStatus

### DIFF
--- a/receiver/kafkareceiver/kafka_receiver.go
+++ b/receiver/kafkareceiver/kafka_receiver.go
@@ -125,7 +125,7 @@ func createKafkaClient(config Config) (sarama.ConsumerGroup, error) {
 	return sarama.NewConsumerGroup(config.Brokers, config.GroupID, saramaConfig)
 }
 
-func (c *kafkaTracesConsumer) Start(_ context.Context, host component.Host) error {
+func (c *kafkaTracesConsumer) Start(_ context.Context, _ component.Host) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cancelConsumeLoop = cancel
 	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
@@ -160,7 +160,7 @@ func (c *kafkaTracesConsumer) Start(_ context.Context, host component.Host) erro
 	}
 	go func() {
 		if err := c.consumeLoop(ctx, consumerGroup); err != nil {
-			host.ReportFatalError(err)
+			c.settings.ReportStatus(component.NewFatalErrorEvent(err))
 		}
 	}()
 	<-consumerGroup.ready
@@ -209,7 +209,7 @@ func newMetricsReceiver(config Config, set receiver.CreateSettings, unmarshaler 
 	}, nil
 }
 
-func (c *kafkaMetricsConsumer) Start(_ context.Context, host component.Host) error {
+func (c *kafkaMetricsConsumer) Start(_ context.Context, _ component.Host) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cancelConsumeLoop = cancel
 	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
@@ -244,7 +244,7 @@ func (c *kafkaMetricsConsumer) Start(_ context.Context, host component.Host) err
 	}
 	go func() {
 		if err := c.consumeLoop(ctx, metricsConsumerGroup); err != nil {
-			host.ReportFatalError(err)
+			c.settings.ReportStatus(component.NewFatalErrorEvent(err))
 		}
 	}()
 	<-metricsConsumerGroup.ready
@@ -293,7 +293,7 @@ func newLogsReceiver(config Config, set receiver.CreateSettings, unmarshaler Log
 	}, nil
 }
 
-func (c *kafkaLogsConsumer) Start(_ context.Context, host component.Host) error {
+func (c *kafkaLogsConsumer) Start(_ context.Context, _ component.Host) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cancelConsumeLoop = cancel
 	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
@@ -328,7 +328,7 @@ func (c *kafkaLogsConsumer) Start(_ context.Context, host component.Host) error 
 	}
 	go func() {
 		if err := c.consumeLoop(ctx, logsConsumerGroup); err != nil {
-			host.ReportFatalError(err)
+			c.settings.ReportStatus(component.NewFatalErrorEvent(err))
 		}
 	}()
 	<-logsConsumerGroup.ready


### PR DESCRIPTION
Remove use of deprecated host.ReportFatalError

Linked to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30501
Fixes #30593
