### PR TITLE
[chore][receiver/cloudfoundry] Use ReportStatus instead of ReportFatalError

### DIFF
--- a/receiver/cloudfoundryreceiver/receiver.go
+++ b/receiver/cloudfoundryreceiver/receiver.go
@@ -92,13 +92,13 @@ func (cfr *cloudFoundryReceiver) Start(ctx context.Context, host component.Host)
 
 		_, tokenErr = tokenProvider.ProvideToken()
 		if tokenErr != nil {
-			host.ReportFatalError(fmt.Errorf("cloud foundry receiver failed to fetch initial token from UAA: %w", tokenErr))
+			cfr.settings.ReportStatus(component.NewFatalErrorEvent(fmt.Errorf("cloud foundry receiver failed to fetch initial token from UAA: %w", tokenErr)))
 			return
 		}
 
 		envelopeStream, err := streamFactory.CreateStream(innerCtx, cfr.config.RLPGateway.ShardID)
 		if err != nil {
-			host.ReportFatalError(fmt.Errorf("creating RLP gateway envelope stream: %w", err))
+			cfr.settings.ReportStatus(component.NewFatalErrorEvent(fmt.Errorf("creating RLP gateway envelope stream: %w", err)))
 			return
 		}
 
@@ -129,7 +129,7 @@ func (cfr *cloudFoundryReceiver) streamMetrics(
 		if envelopes == nil {
 			// If context has not been cancelled, then nil means the shutdown was due to an error within stream
 			if ctx.Err() == nil {
-				host.ReportFatalError(errors.New("RLP gateway streamer shut down due to an error"))
+				cfr.settings.ReportStatus(component.NewFatalErrorEvent(errors.New("RLP gateway streamer shut down due to an error")))
 			}
 
 			break

--- a/receiver/cloudfoundryreceiver/receiver.go
+++ b/receiver/cloudfoundryreceiver/receiver.go
@@ -102,7 +102,7 @@ func (cfr *cloudFoundryReceiver) Start(ctx context.Context, host component.Host)
 			return
 		}
 
-		cfr.streamMetrics(innerCtx, envelopeStream, host)
+		cfr.streamMetrics(innerCtx, envelopeStream)
 		cfr.settings.Logger.Debug("cloudfoundry metrics streamer stopped")
 	}()
 
@@ -120,8 +120,7 @@ func (cfr *cloudFoundryReceiver) Shutdown(_ context.Context) error {
 
 func (cfr *cloudFoundryReceiver) streamMetrics(
 	ctx context.Context,
-	stream loggregator.EnvelopeStream,
-	host component.Host) {
+	stream loggregator.EnvelopeStream) {
 
 	for {
 		// Blocks until non-empty result or context is cancelled (returns nil in that case)


### PR DESCRIPTION
**Description:**
Remove use of deprecated host.ReportFatalError

Link to **tracking** Issue:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30501
Resolves #30588