### PR TITLE
[chore] prometheusremotewrite: simplify wal initialization

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -80,14 +80,8 @@ func newPRWExporter(cfg *Config, set exporter.CreateSettings) (*prwExporter, err
 			SendMetadata:        cfg.SendMetadata,
 		},
 	}
-	if cfg.WAL == nil {
-		return prwe, nil
-	}
 
-	prwe.wal, err = newWAL(cfg.WAL, prwe.export)
-	if err != nil {
-		return nil, err
-	}
+	prwe.wal = newWAL(cfg.WAL, prwe.export)
 	return prwe, nil
 }
 

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -59,11 +59,11 @@ func (wc *WALConfig) truncateFrequency() time.Duration {
 	return defaultWALTruncateFrequency
 }
 
-func newWAL(walConfig *WALConfig, exportSink func(context.Context, []*prompb.WriteRequest) error) (*prweWAL, error) {
+func newWAL(walConfig *WALConfig, exportSink func(context.Context, []*prompb.WriteRequest) error) *prweWAL {
 	if walConfig == nil {
 		// There are cases for which the WAL can be disabled.
 		// TODO: Perhaps log that the WAL wasn't enabled.
-		return nil, errNilConfig
+		return nil
 	}
 
 	return &prweWAL{
@@ -72,7 +72,7 @@ func newWAL(walConfig *WALConfig, exportSink func(context.Context, []*prompb.Wri
 		stopChan:   make(chan struct{}),
 		rWALIndex:  &atomic.Uint64{},
 		wWALIndex:  &atomic.Uint64{},
-	}, nil
+	}
 }
 
 func (wc *WALConfig) createWAL() (*wal.Log, string, error) {
@@ -90,7 +90,6 @@ func (wc *WALConfig) createWAL() (*wal.Log, string, error) {
 var (
 	errAlreadyClosed = errors.New("already closed")
 	errNilWAL        = errors.New("wal is nil")
-	errNilConfig     = errors.New("expecting a non-nil configuration")
 )
 
 // retrieveWALIndices queries the WriteAheadLog for its current first and last indices.

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -21,16 +21,14 @@ func doNothingExportSink(_ context.Context, reqL []*prompb.WriteRequest) error {
 
 func TestWALCreation_nilConfig(t *testing.T) {
 	config := (*WALConfig)(nil)
-	pwal, err := newWAL(config, doNothingExportSink)
-	require.Equal(t, err, errNilConfig)
+	pwal := newWAL(config, doNothingExportSink)
 	require.Nil(t, pwal)
 }
 
 func TestWALCreation_nonNilConfig(t *testing.T) {
 	config := &WALConfig{Directory: t.TempDir()}
-	pwal, err := newWAL(config, doNothingExportSink)
+	pwal := newWAL(config, doNothingExportSink)
 	require.NotNil(t, pwal)
-	assert.Nil(t, err)
 	assert.NoError(t, pwal.stop())
 }
 
@@ -80,18 +78,15 @@ func TestWALStopManyTimes(t *testing.T) {
 		TruncateFrequency: 60 * time.Microsecond,
 		BufferSize:        1,
 	}
-	pwal, err := newWAL(config, doNothingExportSink)
-	require.Nil(t, err)
+	pwal := newWAL(config, doNothingExportSink)
 	require.NotNil(t, pwal)
 
 	// Ensure that invoking .stop() multiple times doesn't cause a panic, but actually
 	// First close should NOT return an error.
-	err = pwal.stop()
-	require.Nil(t, err)
+	require.NoError(t, pwal.stop())
 	for i := 0; i < 4; i++ {
 		// Every invocation to .stop() should return an errAlreadyClosed.
-		err = pwal.stop()
-		require.Equal(t, err, errAlreadyClosed)
+		require.ErrorIs(t, pwal.stop(), errAlreadyClosed)
 	}
 }
 
@@ -99,8 +94,8 @@ func TestWAL_persist(t *testing.T) {
 	// Unit tests that requests written to the WAL persist.
 	config := &WALConfig{Directory: t.TempDir()}
 
-	pwal, err := newWAL(config, doNothingExportSink)
-	require.Nil(t, err)
+	pwal := newWAL(config, doNothingExportSink)
+	require.NotNil(t, pwal)
 
 	// 1. Write out all the entries.
 	reqL := []*prompb.WriteRequest{
@@ -127,27 +122,25 @@ func TestWAL_persist(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	err = pwal.retrieveWALIndices()
-	require.Nil(t, err)
+	require.NoError(t, pwal.retrieveWALIndices())
 	t.Cleanup(func() {
 		assert.NoError(t, pwal.stop())
 	})
 
-	err = pwal.persistToWAL(reqL)
-	require.Nil(t, err)
+	require.NoError(t, pwal.persistToWAL(reqL))
 
 	// 2. Read all the entries from the WAL itself, guided by the indices available,
 	// and ensure that they are exactly in order as we'd expect them.
 	wal := pwal.wal
 	start, err := wal.FirstIndex()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	end, err := wal.LastIndex()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var reqLFromWAL []*prompb.WriteRequest
 	for i := start; i <= end; i++ {
 		req, err := pwal.readPrompbFromWAL(ctx, i)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		reqLFromWAL = append(reqLFromWAL, req)
 	}
 


### PR DESCRIPTION
In the only production code that calls the `newWal` we first verify that the config is not nil then call into the `newWal` that returns error if config is nil which means that code never runs in production, so better to simplify the newWal and return nil if error is nil.

Alternative we can just remove the nil check in `newWal` and rely on the caller to check for the nil config.