### PR TITLE
prometheusremotewriteexporter: extract RemoteWriteQueue validation

### DIFF
--- a/.chloggen/rwqvalidate.yaml
+++ b/.chloggen/rwqvalidate.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Avoid dropping data when num_consumers is 0.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30633]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -83,11 +83,11 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			id:           component.NewIDWithName(metadata.Type, "negative_queue_size"),
-			errorMessage: "remote write queue size can't be negative",
+			errorMessage: "'queue_size' must be positive",
 		},
 		{
 			id:           component.NewIDWithName(metadata.Type, "negative_num_consumers"),
-			errorMessage: "remote write consumer number can't be negative",
+			errorMessage: "'num_consumers' must be positive",
 		},
 	}
 

--- a/exporter/prometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/prometheusremotewriteexporter/testdata/config.yaml
@@ -29,12 +29,14 @@ prometheusremotewrite/2:
 prometheusremotewrite/negative_queue_size:
   endpoint: "localhost:8888"
   remote_write_queue:
+    enabled: true
     queue_size: -1
     num_consumers: 10
 
 prometheusremotewrite/negative_num_consumers:
   endpoint: "localhost:8888"
   remote_write_queue:
+    enabled: true
     queue_size: 5
     num_consumers: -1
 


### PR DESCRIPTION
* Standardize with queue config from exporterhelper, and avoid checking configuration if the queue is disabled (like queue_size and num_consumers).
* Merge `queue_size` errors into one, not sure if it is important for the user as long as we fail to start anyway.
* Fix a bug where validation allowed `num_consumers` to be 0 where we silently drop all requests. I think this is a bug, but some my disagree that it may be a feature then this becomes a breaking change, happy to add a changelog for that if we want this way.