### PR TITLE
Fix jmxreceiver resource_attributes example

### DIFF
--- a/receiver/jmxreceiver/README.md
+++ b/receiver/jmxreceiver/README.md
@@ -48,7 +48,9 @@ receivers:
     username: my_jmx_username
     # determined by the environment variable value
     password: ${env:MY_JMX_PASSWORD}
-    resource_attributes: my.attr=my.value,my.other.attr=my.other.value
+    resource_attributes:
+      my.attr: my.value
+      my.other.attr: my.other.value
     log_level: info
     additional_jars:
       - /path/to/other.jar
@@ -186,7 +188,7 @@ Additional JARs to be included in the java command classpath. This is currently 
 
 ### resource_attributes
 
-List of resource attributes that will be applied to any metrics emitted from the metrics gatherer.
+Map of resource attributes that will be applied to any metrics emitted from the metrics gatherer.
 
 Corresponds to the `otel.resource.attributes` property.
 


### PR DESCRIPTION
**Description:**
Updating the jmxreceiver resource_attributes example in the readme. Faced an error when starting the collector telling us it should be a map, not a string.

**Testing:**
Changed to a map and it worked.