### PR TITLE
[chore] pprof extension ReportFatalError -> ReportStatus

### DIFF
--- a/extension/pprofextension/factory.go
+++ b/extension/pprofextension/factory.go
@@ -42,5 +42,5 @@ func createExtension(_ context.Context, set extension.CreateSettings, cfg compon
 		return nil, errors.New("\"endpoint\" is required when using the \"pprof\" extension")
 	}
 
-	return newServer(*config, set.Logger), nil
+	return newServer(*config, set.TelemetrySettings), nil
 }

--- a/extension/pprofextension/pprofextension_test.go
+++ b/extension/pprofextension/pprofextension_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 )
@@ -27,8 +27,10 @@ func TestPerformanceProfilerExtensionUsage(t *testing.T) {
 		BlockProfileFraction: 3,
 		MutexProfileFraction: 5,
 	}
+	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	require.NoError(t, err, "SetupTelemetry should succeed")
 
-	pprofExt := newServer(config, zap.NewNop())
+	pprofExt := newServer(config, tt.TelemetrySettings())
 	require.NotNil(t, pprofExt)
 
 	require.NoError(t, pprofExt.Start(context.Background(), componenttest.NewNopHost()))
@@ -59,7 +61,9 @@ func TestPerformanceProfilerExtensionPortAlreadyInUse(t *testing.T) {
 			Endpoint: endpoint,
 		},
 	}
-	pprofExt := newServer(config, zap.NewNop())
+	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	require.NoError(t, err, "SetupTelemetry should succeed")
+	pprofExt := newServer(config, tt.TelemetrySettings())
 	require.NotNil(t, pprofExt)
 
 	require.Error(t, pprofExt.Start(context.Background(), componenttest.NewNopHost()))
@@ -72,7 +76,9 @@ func TestPerformanceProfilerMultipleStarts(t *testing.T) {
 		},
 	}
 
-	pprofExt := newServer(config, zap.NewNop())
+	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	require.NoError(t, err, "SetupTelemetry should succeed")
+	pprofExt := newServer(config, tt.TelemetrySettings())
 	require.NotNil(t, pprofExt)
 
 	require.NoError(t, pprofExt.Start(context.Background(), componenttest.NewNopHost()))
@@ -89,7 +95,9 @@ func TestPerformanceProfilerMultipleShutdowns(t *testing.T) {
 		},
 	}
 
-	pprofExt := newServer(config, zap.NewNop())
+	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	require.NoError(t, err, "SetupTelemetry should succeed")
+	pprofExt := newServer(config, tt.TelemetrySettings())
 	require.NotNil(t, pprofExt)
 
 	require.NoError(t, pprofExt.Start(context.Background(), componenttest.NewNopHost()))
@@ -103,8 +111,9 @@ func TestPerformanceProfilerShutdownWithoutStart(t *testing.T) {
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
 	}
-
-	pprofExt := newServer(config, zap.NewNop())
+	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	require.NoError(t, err, "SetupTelemetry should succeed")
+	pprofExt := newServer(config, tt.TelemetrySettings())
 	require.NotNil(t, pprofExt)
 
 	require.NoError(t, pprofExt.Shutdown(context.Background()))
@@ -124,8 +133,9 @@ func TestPerformanceProfilerLifecycleWithFile(t *testing.T) {
 		},
 		SaveToFile: tmpFile.Name(),
 	}
-
-	pprofExt := newServer(config, zap.NewNop())
+	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	require.NoError(t, err, "SetupTelemetry should succeed")
+	pprofExt := newServer(config, tt.TelemetrySettings())
 	require.NotNil(t, pprofExt)
 
 	require.NoError(t, pprofExt.Start(context.Background(), componenttest.NewNopHost()))


### PR DESCRIPTION
Remove use of deprecated host.ReportFatalError

Linked to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30501

Fixes #30584
