### PR TITLE
[chore] use [No]Error instead of [Not]Nil for checking errors

### DIFF
--- a/connector/exceptionsconnector/factory_test.go
+++ b/connector/exceptionsconnector/factory_test.go
@@ -48,7 +48,7 @@ func TestNewConnector(t *testing.T) {
 			traceMetricsConnector, err := factory.CreateTracesToMetrics(context.Background(), creationParams, cfg, consumertest.NewNop())
 			smc := traceMetricsConnector.(*metricsConnector)
 
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, smc)
 			assert.Equal(t, tc.wantDimensions, smc.dimensions)
 
@@ -56,7 +56,7 @@ func TestNewConnector(t *testing.T) {
 			traceLogsConnector, err := factory.CreateTracesToLogs(context.Background(), creationParams, cfg, consumertest.NewNop())
 			slc := traceLogsConnector.(*logsConnector)
 
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, slc)
 			assert.Equal(t, tc.wantDimensions, smc.dimensions)
 		})

--- a/connector/spanmetricsconnector/factory_test.go
+++ b/connector/spanmetricsconnector/factory_test.go
@@ -56,7 +56,7 @@ func TestNewConnector(t *testing.T) {
 			smc := traceConnector.(*connectorImp)
 
 			// Verify
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, smc)
 
 			assert.Equal(t, tc.wantDimensions, smc.dimensions)

--- a/exporter/awscloudwatchlogsexporter/exporter_test.go
+++ b/exporter/awscloudwatchlogsexporter/exporter_test.go
@@ -380,7 +380,7 @@ func TestConsumeLogs(t *testing.T) {
 		t.Run(testcase.id, func(t *testing.T) {
 			logPusher := new(mockPusher)
 			exp.pusherFactory = &mockFactory{logPusher}
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, exp)
 			ld := plog.NewLogs()
 			r := ld.ResourceLogs().AppendEmpty()
@@ -419,5 +419,5 @@ func TestNewExporterWithoutRegionErr(t *testing.T) {
 	expCfg.MaxRetries = 0
 	exp, err := newCwLogsExporter(expCfg, exportertest.NewNopCreateSettings())
 	assert.Nil(t, exp)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -54,7 +54,7 @@ func TestConsumeMetrics(t *testing.T) {
 	expCfg.Region = "us-west-2"
 	expCfg.MaxRetries = 0
 	exp, err := newEmfExporter(expCfg, exportertest.NewNopCreateSettings())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 
 	md := generateTestMetrics(testMetric{
@@ -95,7 +95,7 @@ func TestConsumeMetricsWithNaNValues(t *testing.T) {
 			expCfg.MaxRetries = 0
 			expCfg.OutputDestination = "stdout"
 			exp, err := newEmfExporter(expCfg, exportertest.NewNopCreateSettings())
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, exp)
 			md := tc.generateFunc(tc.testName)
 			require.NoError(t, exp.pushMetricsData(ctx, md))
@@ -135,7 +135,7 @@ func TestConsumeMetricsWithInfValues(t *testing.T) {
 			expCfg.MaxRetries = 0
 			expCfg.OutputDestination = "stdout"
 			exp, err := newEmfExporter(expCfg, exportertest.NewNopCreateSettings())
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, exp)
 			md := tc.generateFunc(tc.testName)
 			require.NoError(t, exp.pushMetricsData(ctx, md))
@@ -154,7 +154,7 @@ func TestConsumeMetricsWithOutputDestination(t *testing.T) {
 	expCfg.MaxRetries = 0
 	expCfg.OutputDestination = "stdout"
 	exp, err := newEmfExporter(expCfg, exportertest.NewNopCreateSettings())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 
 	md := generateTestMetrics(testMetric{
@@ -175,7 +175,7 @@ func TestConsumeMetricsWithLogGroupStreamConfig(t *testing.T) {
 	expCfg.LogGroupName = "test-logGroupName"
 	expCfg.LogStreamName = "test-logStreamName"
 	exp, err := newEmfExporter(expCfg, exportertest.NewNopCreateSettings())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 
 	md := generateTestMetrics(testMetric{
@@ -202,7 +202,7 @@ func TestConsumeMetricsWithLogGroupStreamValidPlaceholder(t *testing.T) {
 	expCfg.LogGroupName = "/aws/ecs/containerinsights/{ClusterName}/performance"
 	expCfg.LogStreamName = "{TaskId}"
 	exp, err := newEmfExporter(expCfg, exportertest.NewNopCreateSettings())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 
 	md := generateTestMetrics(testMetric{
@@ -233,7 +233,7 @@ func TestConsumeMetricsWithOnlyLogStreamPlaceholder(t *testing.T) {
 	expCfg.LogGroupName = "test-logGroupName"
 	expCfg.LogStreamName = "{TaskId}"
 	exp, err := newEmfExporter(expCfg, exportertest.NewNopCreateSettings())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 
 	md := generateTestMetrics(testMetric{
@@ -264,7 +264,7 @@ func TestConsumeMetricsWithWrongPlaceholder(t *testing.T) {
 	expCfg.LogGroupName = "test-logGroupName"
 	expCfg.LogStreamName = "{WrongKey}"
 	exp, err := newEmfExporter(expCfg, exportertest.NewNopCreateSettings())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 
 	md := generateTestMetrics(testMetric{
@@ -295,7 +295,7 @@ func TestPushMetricsDataWithErr(t *testing.T) {
 	expCfg.LogGroupName = "test-logGroupName"
 	expCfg.LogStreamName = "test-logStreamName"
 	exp, err := newEmfExporter(expCfg, exportertest.NewNopCreateSettings())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 
 	logPusher := new(mockPusher)
@@ -327,7 +327,7 @@ func TestNewExporterWithoutConfig(t *testing.T) {
 	t.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 
 	exp, err := newEmfExporter(expCfg, settings)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, exp)
 	assert.Equal(t, settings.Logger, expCfg.logger)
 }
@@ -364,10 +364,10 @@ func TestNewExporterWithMetricDeclarations(t *testing.T) {
 	params.Logger = zap.New(obs)
 
 	exp, err := newEmfExporter(expCfg, params)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 	err = expCfg.Validate()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Invalid metric declaration should be filtered out
 	assert.Equal(t, 3, len(exp.config.MetricDeclarations))
@@ -397,7 +397,7 @@ func TestNewExporterWithMetricDeclarations(t *testing.T) {
 
 func TestNewExporterWithoutSession(t *testing.T) {
 	exp, err := newEmfExporter(nil, exportertest.NewNopCreateSettings())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, exp)
 }
 
@@ -419,7 +419,7 @@ func TestNewEmfExporterWithoutConfig(t *testing.T) {
 	t.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 
 	exp, err := newEmfExporter(expCfg, settings)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, exp)
 	assert.Equal(t, settings.Logger, expCfg.logger)
 }

--- a/exporter/awsemfexporter/factory_test.go
+++ b/exporter/awsemfexporter/factory_test.go
@@ -38,7 +38,7 @@ func TestCreateTracesExporter(t *testing.T) {
 
 	ctx := context.Background()
 	exporter, err := factory.CreateTracesExporter(ctx, exportertest.NewNopCreateSettings(), cfg)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, exporter)
 }
 
@@ -54,6 +54,6 @@ func TestCreateMetricsExporter(t *testing.T) {
 
 	ctx := context.Background()
 	exporter, err := factory.CreateMetricsExporter(ctx, exportertest.NewNopCreateSettings(), cfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exporter)
 }

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -114,7 +114,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 					nil,
 					testCfg,
 					emfCalcs)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 
 			assert.Equal(t, 1, len(groupedMetrics))
@@ -157,7 +157,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 				nil,
 				testCfg,
 				emfCalcs)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 
 		assert.Equal(t, 4, len(groupedMetrics))
@@ -230,7 +230,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 				nil,
 				testCfg,
 				emfCalcs)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 
 		assert.Equal(t, 4, len(groupedMetrics))
@@ -281,7 +281,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			nil,
 			testCfg,
 			emfCalcs)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		metricMetadata2 := generateTestMetricMetadata(namespace,
 			timestamp,
@@ -291,7 +291,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			metric.Type(),
 		)
 		err = addToGroupedMetric(metric, groupedMetrics, metricMetadata2, true, logger, nil, testCfg, emfCalcs)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		assert.Len(t, groupedMetrics, 2)
 		seenLogGroup1 := false
@@ -349,7 +349,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 				testCfg,
 				emfCalcs,
 			)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 		assert.Equal(t, 1, len(groupedMetrics))
 
@@ -392,7 +392,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			testCfg,
 			emfCalcs,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 0, len(groupedMetrics))
 
 		// Test output warning logs

--- a/exporter/awsemfexporter/metric_declaration_test.go
+++ b/exporter/awsemfexporter/metric_declaration_test.go
@@ -19,37 +19,37 @@ func TestLabelMatcherInit(t *testing.T) {
 		Regex:      ".+",
 	}
 	err := lm.init()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, ";", lm.Separator)
 	assert.Equal(t, ".+", lm.Regex)
 	assert.NotNil(t, lm.compiledRegex)
 
 	lm.Separator = ""
 	err = lm.init()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, ";", lm.Separator)
 
 	lm.Separator = ","
 	err = lm.init()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, ",", lm.Separator)
 
 	lm.Regex = "a*"
 	err = lm.init()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "a*", lm.Regex)
 	assert.NotNil(t, lm.compiledRegex)
 
 	// Test error
 	lm.Regex = ""
 	err = lm.init()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.EqualError(t, err, "regex not specified for label matcher")
 
 	lm.LabelNames = []string{}
 	lm.Regex = ".+"
 	err = lm.init()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.EqualError(t, err, "label matcher must have at least one label name specified")
 }
 
@@ -104,7 +104,7 @@ func TestGetConcatenatedLabels(t *testing.T) {
 			Regex:      ".+",
 		}
 		err := lm.init()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		t.Run(tc.testName, func(t *testing.T) {
 			concatenatedLabels := lm.getConcatenatedLabels(labels)
 			assert.Equal(t, tc.expected, concatenatedLabels)
@@ -210,7 +210,7 @@ func TestLabelMatcherMatches(t *testing.T) {
 
 	for _, tc := range testCases {
 		err := tc.labelMatcher.init()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		t.Run(tc.testName, func(t *testing.T) {
 			matches := tc.labelMatcher.Matches(tc.labels)
 			assert.Equal(t, tc.expected, matches)
@@ -225,7 +225,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 			MetricNameSelectors: []string{"a", "b", "aa"},
 		}
 		err := m.init(logger)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 3, len(m.metricRegexList))
 	})
 
@@ -238,7 +238,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 			MetricNameSelectors: []string{"a.*", "b$", "aa+"},
 		}
 		err := m.init(logger)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 3, len(m.metricRegexList))
 		assert.Equal(t, 2, len(m.Dimensions))
 	})
@@ -255,7 +255,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 		obs, logs := observer.New(zap.WarnLevel)
 		obsLogger := zap.New(obs)
 		err := m.init(obsLogger)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 3, len(m.metricRegexList))
 		assert.Equal(t, 1, len(m.Dimensions))
 		// Check logged warning message
@@ -280,7 +280,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 		obs, logs := observer.New(zap.DebugLevel)
 		obsLogger := zap.New(obs)
 		err := m.init(obsLogger)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 1, len(m.Dimensions))
 		assert.Equal(t, []string{"a", "b", "c"}, m.Dimensions[0])
 		// Check logged warning message
@@ -302,7 +302,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 	t.Run("invalid metric declaration", func(t *testing.T) {
 		m := &MetricDeclaration{}
 		err := m.init(logger)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.EqualError(t, err, "invalid metric declaration: no metric name selectors defined")
 	})
 
@@ -323,7 +323,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 			},
 		}
 		err := m.init(logger)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 2, len(m.LabelMatchers))
 		assert.Equal(t, ";", m.LabelMatchers[0].Separator)
 		assert.Equal(t, ".+", m.LabelMatchers[0].Regex)
@@ -349,7 +349,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 			},
 		}
 		err := m.init(logger)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.EqualError(t, err, "label matcher must have at least one label name specified")
 
 		m = &MetricDeclaration{
@@ -361,7 +361,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 			},
 		}
 		err = m.init(logger)
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		assert.EqualError(t, err, "regex not specified for label matcher")
 	})
 }
@@ -372,7 +372,7 @@ func TestMetricDeclarationMatchesName(t *testing.T) {
 	}
 	logger := zap.NewNop()
 	err := m.init(logger)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.True(t, m.MatchesName("a"))
 	assert.True(t, m.MatchesName("aa"))
@@ -497,7 +497,7 @@ func TestMetricDeclarationMatchesLabels(t *testing.T) {
 		}
 		t.Run(tc.testName, func(t *testing.T) {
 			err := m.init(logger)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			matches := m.MatchesLabels(labels)
 			assert.Equal(t, tc.expected, matches)
 		})
@@ -580,7 +580,7 @@ func TestExtractDimensions(t *testing.T) {
 		}
 		t.Run(tc.testName, func(t *testing.T) {
 			err := m.init(logger)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			dimensions := m.ExtractDimensions(tc.labels)
 			assert.Equal(t, tc.extractedDimensions, dimensions)
 		})

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -350,7 +350,7 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 
 			groupedMetrics := make(map[any]*groupedMetric)
 			err := translator.translateOTelToGroupedMetric(tc.metric, groupedMetrics, config)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, groupedMetrics)
 			assert.Equal(t, 3, len(groupedMetrics))
 
@@ -382,7 +382,7 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 		rm.Resource().Attributes().PutStr(occonventions.AttributeExporterVersion, "SomeVersion")
 		groupedMetrics := make(map[any]*groupedMetric)
 		err := translator.translateOTelToGroupedMetric(rm, groupedMetrics, config)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, 0, len(groupedMetrics))
 	})
 }
@@ -778,7 +778,7 @@ func TestTranslateGroupedMetricToCWMetric(t *testing.T) {
 			}
 			for _, decl := range tc.metricDeclarations {
 				err := decl.init(logger)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 			cWMetric := translateGroupedMetricToCWMetric(tc.groupedMetric, config)
 			assert.NotNil(t, cWMetric)
@@ -1422,7 +1422,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 			}
 			for _, decl := range tc.metricDeclarations {
 				err := decl.init(logger)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 
 			cWMeasurements := groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
@@ -1467,7 +1467,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 		}
 		for _, decl := range metricDeclarations {
 			err := decl.init(zap.NewNop())
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 		obs, logs := observer.New(zap.DebugLevel)
 		logger := zap.New(obs)
@@ -1532,7 +1532,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 		}
 		for _, decl := range metricDeclarations {
 			err := decl.init(zap.NewNop())
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 		}
 		obs, logs := observer.New(zap.DebugLevel)
 		logger := zap.New(obs)
@@ -1947,7 +1947,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 			}
 			for _, decl := range tc.metricDeclarations {
 				err := decl.init(zap.NewNop())
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 			config := &Config{
 				DimensionRollupOption: tc.dimensionRollupOption,
@@ -2332,7 +2332,7 @@ func TestTranslateOtToGroupedMetricForLogGroupAndStream(t *testing.T) {
 
 			rm := test.inputMetrics.ResourceMetrics().At(0)
 			err := translator.translateOTelToGroupedMetric(rm, groupedMetrics, config)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			assert.NotNil(t, groupedMetrics)
 			assert.Equal(t, 1, len(groupedMetrics))
@@ -2363,7 +2363,7 @@ func TestTranslateOtToGroupedMetricForInitialDeltaValue(t *testing.T) {
 
 			rm := test.inputMetrics.ResourceMetrics().At(0)
 			err := translator.translateOTelToGroupedMetric(rm, groupedMetrics, config)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			assert.NotNil(t, groupedMetrics)
 			assert.Equal(t, 1, len(groupedMetrics))

--- a/exporter/awss3exporter/config_test.go
+++ b/exporter/awss3exporter/config_test.go
@@ -41,7 +41,7 @@ func TestLoadConfig(t *testing.T) {
 
 func TestConfig(t *testing.T) {
 	factories, err := otelcoltest.NopFactories()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	factory := NewFactory()
 	factories.Exporters[factory.Type()] = factory
@@ -69,7 +69,7 @@ func TestConfig(t *testing.T) {
 
 func TestConfigForS3CompatibleSystems(t *testing.T) {
 	factories, err := otelcoltest.NopFactories()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	factory := NewFactory()
 	factories.Exporters[factory.Type()] = factory
@@ -157,7 +157,7 @@ func TestConfig_Validate(t *testing.T) {
 
 func TestMarshallerName(t *testing.T) {
 	factories, err := otelcoltest.NopFactories()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	factory := NewFactory()
 	factories.Exporters[factory.Type()] = factory

--- a/exporter/awsxrayexporter/awsxray_test.go
+++ b/exporter/awsxrayexporter/awsxray_test.go
@@ -32,9 +32,9 @@ func TestTraceExport(t *testing.T) {
 	ctx := context.Background()
 	td := constructSpanData()
 	err := traceExporter.ConsumeTraces(ctx, td)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	err = traceExporter.Shutdown(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestXraySpanTraceResourceExtraction(t *testing.T) {
@@ -48,9 +48,9 @@ func TestXrayAndW3CSpanTraceExport(t *testing.T) {
 	ctx := context.Background()
 	td := constructXrayAndW3CSpanData()
 	err := traceExporter.ConsumeTraces(ctx, td)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	err = traceExporter.Shutdown(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestXrayAndW3CSpanTraceResourceExtraction(t *testing.T) {
@@ -81,9 +81,9 @@ func TestTelemetryEnabled(t *testing.T) {
 	assert.NoError(t, traceExporter.Start(ctx, componenttest.NewNopHost()))
 	td := constructSpanData()
 	err := traceExporter.ConsumeTraces(ctx, td)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	err = traceExporter.Shutdown(ctx)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.EqualValues(t, 1, sink.StartCount.Load())
 	assert.EqualValues(t, 1, sink.StopCount.Load())
 	assert.True(t, sink.HasRecording())

--- a/exporter/awsxrayexporter/factory_test.go
+++ b/exporter/awsxrayexporter/factory_test.go
@@ -81,7 +81,7 @@ func TestCreateTracesExporter(t *testing.T) {
 
 	ctx := context.Background()
 	exporter, err := factory.CreateTracesExporter(ctx, exportertest.NewNopCreateSettings(), cfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exporter)
 }
 
@@ -97,6 +97,6 @@ func TestCreateMetricsExporter(t *testing.T) {
 
 	ctx := context.Background()
 	exporter, err := factory.CreateMetricsExporter(ctx, exportertest.NewNopCreateSettings(), cfg)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, exporter)
 }

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -59,7 +59,7 @@ func TestClientSpanWithRpcAwsSdkClientAttributes(t *testing.T) {
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, jsonStr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, strings.Contains(jsonStr, "DynamoDB"))
 	assert.True(t, strings.Contains(jsonStr, "GetItem"))
 	assert.False(t, strings.Contains(jsonStr, user))
@@ -92,7 +92,7 @@ func TestClientSpanWithLegacyAwsSdkClientAttributes(t *testing.T) {
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, jsonStr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, strings.Contains(jsonStr, "DynamoDB"))
 	assert.True(t, strings.Contains(jsonStr, "GetItem"))
 	assert.False(t, strings.Contains(jsonStr, user))
@@ -333,7 +333,7 @@ func TestSpanWithInvalidTraceId(t *testing.T) {
 
 	_, err := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestSpanWithExpiredTraceId(t *testing.T) {
@@ -345,7 +345,7 @@ func TestSpanWithExpiredTraceId(t *testing.T) {
 	binary.BigEndian.PutUint32(tempTraceID[0:4], uint32(ExpiredEpoch))
 
 	_, err := convertToAmazonTraceID(tempTraceID, false)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestSpanWithInvalidTraceIdWithoutTimestampValidation(t *testing.T) {
@@ -367,13 +367,13 @@ func TestSpanWithInvalidTraceIdWithoutTimestampValidation(t *testing.T) {
 	span.SetTraceID(traceID)
 
 	segment, err := MakeSegment(span, resource, nil, false, nil, true)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "ProducerService", *segment.Name)
 	assert.Equal(t, "subsegment", *segment.Type)
 
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false, nil, true)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, jsonStr)
 	assert.True(t, strings.Contains(jsonStr, "ProducerService"))
 	assert.False(t, strings.Contains(jsonStr, user))
@@ -389,7 +389,7 @@ func TestSpanWithExpiredTraceIdWithoutTimestampValidation(t *testing.T) {
 	binary.BigEndian.PutUint32(tempTraceID[0:4], uint32(ExpiredEpoch))
 
 	amazonTraceID, err := convertToAmazonTraceID(tempTraceID, true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	expectedTraceID := "1-" + fmt.Sprintf("%x", tempTraceID[0:4]) + "-" + fmt.Sprintf("%x", tempTraceID[4:16])
 	assert.Equal(t, expectedTraceID, amazonTraceID)
 }
@@ -986,7 +986,7 @@ func TestClientSpanWithAwsRemoteServiceName(t *testing.T) {
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, jsonStr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, strings.Contains(jsonStr, "PaymentService"))
 	assert.False(t, strings.Contains(jsonStr, user))
 	assert.False(t, strings.Contains(jsonStr, "user"))
@@ -1013,7 +1013,7 @@ func TestAwsSdkSpanWithAwsRemoteServiceName(t *testing.T) {
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, jsonStr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, strings.Contains(jsonStr, "DynamoDb"))
 	assert.False(t, strings.Contains(jsonStr, "DynamoDb.PutItem"))
 	assert.False(t, strings.Contains(jsonStr, user))
@@ -1042,7 +1042,7 @@ func TestProducerSpanWithAwsRemoteServiceName(t *testing.T) {
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, jsonStr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, strings.Contains(jsonStr, "ProducerService"))
 	assert.False(t, strings.Contains(jsonStr, user))
 	assert.False(t, strings.Contains(jsonStr, "user"))
@@ -1069,7 +1069,7 @@ func TestConsumerSpanWithAwsRemoteServiceName(t *testing.T) {
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, jsonStr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, strings.Contains(jsonStr, "ConsumerService"))
 	assert.False(t, strings.Contains(jsonStr, user))
 	assert.False(t, strings.Contains(jsonStr, "user"))
@@ -1097,7 +1097,7 @@ func TestServerSpanWithAwsLocalServiceName(t *testing.T) {
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, jsonStr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, strings.Contains(jsonStr, "PaymentLocalService"))
 	assert.False(t, strings.Contains(jsonStr, user))
 	assert.False(t, strings.Contains(jsonStr, "user"))

--- a/exporter/azuredataexplorerexporter/adx_exporter_test.go
+++ b/exporter/azuredataexplorerexporter/adx_exporter_test.go
@@ -66,7 +66,7 @@ func TestMetricsDataPusherStreaming(t *testing.T) {
 	}
 	assert.NotNil(t, adxDataProducer)
 	err := adxDataProducer.metricsDataPusher(context.Background(), createMetricsData(10))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestMetricsDataPusherQueued(t *testing.T) {
@@ -84,7 +84,7 @@ func TestMetricsDataPusherQueued(t *testing.T) {
 	}
 	assert.NotNil(t, adxDataProducer)
 	err := adxDataProducer.metricsDataPusher(context.Background(), createMetricsData(10))
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestLogsDataPusher(t *testing.T) {
@@ -102,7 +102,7 @@ func TestLogsDataPusher(t *testing.T) {
 	}
 	assert.NotNil(t, adxDataProducer)
 	err := adxDataProducer.logsDataPusher(context.Background(), createLogsData())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestTracesDataPusher(t *testing.T) {
@@ -120,7 +120,7 @@ func TestTracesDataPusher(t *testing.T) {
 	}
 	assert.NotNil(t, adxDataProducer)
 	err := adxDataProducer.tracesDataPusher(context.Background(), createTracesData())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestClose(t *testing.T) {
@@ -137,7 +137,7 @@ func TestClose(t *testing.T) {
 		logger:        logger,
 	}
 	err := adxDataProducer.Close(context.Background())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestIngestedDataRecordCount(t *testing.T) {
@@ -159,7 +159,7 @@ func TestIngestedDataRecordCount(t *testing.T) {
 	err := adxDataProducer.metricsDataPusher(context.Background(), createMetricsData(recordstoingest))
 	ingestedrecordsactual := ingestor.Records()
 	assert.Equal(t, recordstoingest, len(ingestedrecordsactual), "Number of metrics created should match number of records ingested")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCreateKcsb(t *testing.T) {

--- a/exporter/azuremonitorexporter/factory_test.go
+++ b/exporter/azuremonitorexporter/factory_test.go
@@ -24,7 +24,7 @@ func TestCreateTracesExporterUsingSpecificTransportChannel(t *testing.T) {
 	config.ConnectionString = "InstrumentationKey=test-key;IngestionEndpoint=https://test-endpoint/"
 	exporter, err := f.createTracesExporter(ctx, params, config)
 	assert.NotNil(t, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCreateTracesExporterUsingDefaultTransportChannel(t *testing.T) {
@@ -36,7 +36,7 @@ func TestCreateTracesExporterUsingDefaultTransportChannel(t *testing.T) {
 	config.ConnectionString = "InstrumentationKey=test-key;IngestionEndpoint=https://test-endpoint/"
 	exporter, err := f.createTracesExporter(ctx, exportertest.NewNopCreateSettings(), config)
 	assert.NotNil(t, exporter)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, f.tChannel)
 }
 
@@ -51,5 +51,5 @@ func TestCreateTracesExporterUsingBadConfig(t *testing.T) {
 
 	exporter, err := f.createTracesExporter(ctx, params, badConfig)
 	assert.Nil(t, exporter)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/exporter/clickhouseexporter/config_test.go
+++ b/exporter/clickhouseexporter/config_test.go
@@ -261,7 +261,7 @@ func TestConfig_buildDSN(t *testing.T) {
 			} else {
 				// Validate DSN
 				opts, err := clickhouse.ParseDSN(got)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equalf(t, tt.wantChOptions.Secure, opts.TLS != nil, "TLSConfig is not nil")
 				assert.Equalf(t, tt.wantChOptions.DialTimeout, opts.DialTimeout, "DialTimeout is not nil")
 				if tt.wantChOptions.Compress != 0 {

--- a/exporter/clickhouseexporter/exporter_logs_test.go
+++ b/exporter/clickhouseexporter/exporter_logs_test.go
@@ -24,14 +24,14 @@ func TestLogsExporter_New(t *testing.T) {
 	type validate func(*testing.T, *logsExporter, error)
 
 	_ = func(t *testing.T, exporter *logsExporter, err error) {
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, exporter)
 	}
 
 	_ = func(want error) validate {
 		return func(t *testing.T, exporter *logsExporter, err error) {
 			require.Nil(t, exporter)
-			require.NotNil(t, err)
+			require.Error(t, err)
 			if !errors.Is(err, want) {
 				t.Fatalf("Expected error '%v', but got '%v'", want, err)
 			}
@@ -40,7 +40,7 @@ func TestLogsExporter_New(t *testing.T) {
 
 	failWithMsg := func(msg string) validate {
 		return func(t *testing.T, exporter *logsExporter, err error) {
-			require.NotNil(t, err)
+			require.Error(t, err)
 			require.Contains(t, err.Error(), msg)
 		}
 	}

--- a/exporter/coralogixexporter/factory_test.go
+++ b/exporter/coralogixexporter/factory_test.go
@@ -41,7 +41,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, oexp)
 }
 
@@ -52,7 +52,7 @@ func TestCreateMetricsExporterWithDomain(t *testing.T) {
 
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, oexp)
 }
 
@@ -63,7 +63,7 @@ func TestCreateLogsExporter(t *testing.T) {
 
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, oexp)
 }
 
@@ -73,7 +73,7 @@ func TestCreateLogsExporterWithDomain(t *testing.T) {
 	cfg.Domain = "localhost"
 	set := exportertest.NewNopCreateSettings()
 	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, oexp)
 }
 
@@ -198,7 +198,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			set := exportertest.NewNopCreateSettings()
 			consumer, err := factory.CreateTracesExporter(context.Background(), set, tt.config)
 			if tt.mustFailOnCreate {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
@@ -228,7 +228,7 @@ func TestCreateLogsExporterWithDomainAndEndpoint(t *testing.T) {
 
 	set := exportertest.NewNopCreateSettings()
 	consumer, err := factory.CreateLogsExporter(context.Background(), set, cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, consumer)
 
 	err = consumer.Start(context.Background(), componenttest.NewNopHost())

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -484,7 +484,7 @@ func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
 			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, exp)
 
 		texp, err := factory.CreateTracesExporter(
@@ -492,7 +492,7 @@ func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
 			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, texp)
 
 		lexp, err := factory.CreateLogsExporter(
@@ -500,7 +500,7 @@ func TestCreateAPIExporterFailOnInvalidKey_Zorkian(t *testing.T) {
 			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, lexp)
 	})
 }
@@ -564,7 +564,7 @@ func TestCreateAPIExporterFailOnInvalidKey(t *testing.T) {
 			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, exp)
 
 		texp, err := factory.CreateTracesExporter(
@@ -572,7 +572,7 @@ func TestCreateAPIExporterFailOnInvalidKey(t *testing.T) {
 			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, texp)
 
 		lexp, err := factory.CreateLogsExporter(
@@ -580,7 +580,7 @@ func TestCreateAPIExporterFailOnInvalidKey(t *testing.T) {
 			exportertest.NewNopCreateSettings(),
 			cfg,
 		)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotNil(t, lexp)
 	})
 }

--- a/exporter/datasetexporter/config_test.go
+++ b/exporter/datasetexporter/config_test.go
@@ -38,7 +38,7 @@ func TestConfigUseDefaults(t *testing.T) {
 		"api_key":     "secret",
 	})
 	err := config.Unmarshal(configMap)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "https://example.com", config.DatasetURL)
 	assert.Equal(t, "secret", string(config.APIKey))
@@ -158,7 +158,7 @@ func TestConfigUseProvidedExportResourceInfoValue(t *testing.T) {
 		},
 	})
 	err := config.Unmarshal(configMap)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, true, config.LogsSettings.ExportResourceInfo)
 }
 
@@ -173,6 +173,6 @@ func TestConfigUseProvidedExportScopeInfoValue(t *testing.T) {
 		},
 	})
 	err := config.Unmarshal(configMap)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, false, config.LogsSettings.ExportScopeInfo)
 }

--- a/exporter/datasetexporter/factory_test.go
+++ b/exporter/datasetexporter/factory_test.go
@@ -39,7 +39,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tests := []struct {
 		id       component.ID
@@ -142,7 +142,7 @@ func TestLoadConfig(t *testing.T) {
 			cfg := factory.CreateDefaultConfig()
 
 			sub, err := cm.Sub(tt.id.String())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Nil(t, component.UnmarshalConfig(sub, cfg))
 			if assert.Nil(t, component.ValidateConfig(cfg)) {
 				assert.Equal(t, tt.expected, cfg)

--- a/exporter/datasetexporter/logs_exporter_stress_test.go
+++ b/exporter/datasetexporter/logs_exporter_stress_test.go
@@ -108,7 +108,7 @@ func TestConsumeLogsManyLogsShouldSucceed(t *testing.T) {
 				expectedKeys[key] = 1
 			}
 			err = logs.ConsumeLogs(context.Background(), batch)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			time.Sleep(time.Duration(float64(maxDelay.Nanoseconds()) * 0.7))
 		}
 
@@ -116,7 +116,7 @@ func TestConsumeLogsManyLogsShouldSucceed(t *testing.T) {
 
 		time.Sleep(time.Second)
 		err = logs.Shutdown(context.Background())
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		lastProcessed := uint64(0)
 		sameNumber := 0
 		for {

--- a/exporter/datasetexporter/logs_exporter_test.go
+++ b/exporter/datasetexporter/logs_exporter_test.go
@@ -881,10 +881,10 @@ func TestConsumeLogsShouldSucceed(t *testing.T) {
 
 		assert.NotNil(t, logs)
 		err = logs.ConsumeLogs(context.Background(), ld)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		time.Sleep(time.Second)
 		err = logs.Shutdown(context.Background())
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	}
 
 	assert.True(t, wasSuccessful.Load())

--- a/exporter/elasticsearchexporter/logs_exporter_test.go
+++ b/exporter/elasticsearchexporter/logs_exporter_test.go
@@ -26,18 +26,18 @@ func TestExporter_New(t *testing.T) {
 	type validate func(*testing.T, *elasticsearchLogsExporter, error)
 
 	success := func(t *testing.T, exporter *elasticsearchLogsExporter, err error) {
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, exporter)
 	}
 	successWithInternalModel := func(expectedModel *encodeModel) validate {
 		return func(t *testing.T, exporter *elasticsearchLogsExporter, err error) {
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.EqualValues(t, expectedModel, exporter.model)
 		}
 	}
 	successWithDeprecatedIndexOption := func(index string) validate {
 		return func(t *testing.T, exporter *elasticsearchLogsExporter, err error) {
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, exporter)
 			require.EqualValues(t, index, exporter.index)
 		}
@@ -46,7 +46,7 @@ func TestExporter_New(t *testing.T) {
 	failWith := func(want error) validate {
 		return func(t *testing.T, exporter *elasticsearchLogsExporter, err error) {
 			require.Nil(t, exporter)
-			require.NotNil(t, err)
+			require.Error(t, err)
 			if !errors.Is(err, want) {
 				t.Fatalf("Expected error '%v', but got '%v'", want, err)
 			}
@@ -56,7 +56,7 @@ func TestExporter_New(t *testing.T) {
 	failWithMessage := func(msg string) validate {
 		return func(t *testing.T, exporter *elasticsearchLogsExporter, err error) {
 			require.Nil(t, exporter)
-			require.NotNil(t, err)
+			require.Error(t, err)
 			require.Contains(t, err.Error(), msg)
 		}
 	}
@@ -180,11 +180,11 @@ func TestExporter_PushEvent(t *testing.T) {
 			rec.Record(docs)
 
 			data, err := docs[0].Action.MarshalJSON()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			jsonVal := map[string]any{}
 			err = json.Unmarshal(data, &jsonVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			create := jsonVal["create"].(map[string]any)
 			expected := fmt.Sprintf("%s%s%s", prefix, index, suffix)
@@ -218,11 +218,11 @@ func TestExporter_PushEvent(t *testing.T) {
 			rec.Record(docs)
 
 			data, err := docs[0].Action.MarshalJSON()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			jsonVal := map[string]any{}
 			err = json.Unmarshal(data, &jsonVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			create := jsonVal["create"].(map[string]any)
 
@@ -253,11 +253,11 @@ func TestExporter_PushEvent(t *testing.T) {
 			rec.Record(docs)
 
 			data, err := docs[0].Action.MarshalJSON()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			jsonVal := map[string]any{}
 			err = json.Unmarshal(data, &jsonVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			create := jsonVal["create"].(map[string]any)
 			expected := fmt.Sprintf("%s%s%s", prefix, index, suffix)

--- a/exporter/elasticsearchexporter/traces_exporter_test.go
+++ b/exporter/elasticsearchexporter/traces_exporter_test.go
@@ -26,12 +26,12 @@ func TestTracesExporter_New(t *testing.T) {
 	type validate func(*testing.T, *elasticsearchTracesExporter, error)
 
 	success := func(t *testing.T, exporter *elasticsearchTracesExporter, err error) {
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, exporter)
 	}
 	successWithInternalModel := func(expectedModel *encodeModel) validate {
 		return func(t *testing.T, exporter *elasticsearchTracesExporter, err error) {
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.EqualValues(t, expectedModel, exporter.model)
 		}
 	}
@@ -39,7 +39,7 @@ func TestTracesExporter_New(t *testing.T) {
 	failWith := func(want error) validate {
 		return func(t *testing.T, exporter *elasticsearchTracesExporter, err error) {
 			require.Nil(t, exporter)
-			require.NotNil(t, err)
+			require.Error(t, err)
 			if !errors.Is(err, want) {
 				t.Fatalf("Expected error '%v', but got '%v'", want, err)
 			}
@@ -49,7 +49,7 @@ func TestTracesExporter_New(t *testing.T) {
 	failWithMessage := func(msg string) validate {
 		return func(t *testing.T, exporter *elasticsearchTracesExporter, err error) {
 			require.Nil(t, exporter)
-			require.NotNil(t, err)
+			require.Error(t, err)
 			require.Contains(t, err.Error(), msg)
 		}
 	}
@@ -158,11 +158,11 @@ func TestExporter_PushTraceRecord(t *testing.T) {
 			rec.Record(docs)
 
 			data, err := docs[0].Action.MarshalJSON()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			jsonVal := map[string]any{}
 			err = json.Unmarshal(data, &jsonVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			create := jsonVal["create"].(map[string]any)
 
@@ -198,11 +198,11 @@ func TestExporter_PushTraceRecord(t *testing.T) {
 			rec.Record(docs)
 
 			data, err := docs[0].Action.MarshalJSON()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			jsonVal := map[string]any{}
 			err = json.Unmarshal(data, &jsonVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			create := jsonVal["create"].(map[string]any)
 
@@ -234,11 +234,11 @@ func TestExporter_PushTraceRecord(t *testing.T) {
 			rec.Record(docs)
 
 			data, err := docs[0].Action.MarshalJSON()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			jsonVal := map[string]any{}
 			err = json.Unmarshal(data, &jsonVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			create := jsonVal["create"].(map[string]any)
 			expected := fmt.Sprintf("%s%s%s", prefix, index, suffix)

--- a/exporter/elasticsearchexporter/utils_test.go
+++ b/exporter/elasticsearchexporter/utils_test.go
@@ -258,22 +258,22 @@ func TestGetSuffixTime(t *testing.T) {
 	defaultCfg.LogstashFormat.Enabled = true
 	testTime := time.Date(2023, 12, 2, 10, 10, 10, 1, time.UTC)
 	index, err := generateIndexWithLogstashFormat(defaultCfg.LogsIndex, &defaultCfg.LogstashFormat, testTime)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, index, "logs-generic-default-2023.12.02")
 
 	defaultCfg.LogsIndex = "logstash"
 	defaultCfg.LogstashFormat.PrefixSeparator = "."
 	otelLogsIndex, err := generateIndexWithLogstashFormat(defaultCfg.LogsIndex, &defaultCfg.LogstashFormat, testTime)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, otelLogsIndex, "logstash.2023.12.02")
 
 	defaultCfg.LogstashFormat.DateFormat = "%Y-%m-%d"
 	newOtelLogsIndex, err := generateIndexWithLogstashFormat(defaultCfg.LogsIndex, &defaultCfg.LogstashFormat, testTime)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, newOtelLogsIndex, "logstash.2023-12-02")
 
 	defaultCfg.LogstashFormat.DateFormat = "%d/%m/%Y"
 	newOtelLogsIndexWithSpecDataFormat, err := generateIndexWithLogstashFormat(defaultCfg.LogsIndex, &defaultCfg.LogstashFormat, testTime)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, newOtelLogsIndexWithSpecDataFormat, "logstash.02/12/2023")
 }

--- a/exporter/f5cloudexporter/factory_test.go
+++ b/exporter/f5cloudexporter/factory_test.go
@@ -56,7 +56,7 @@ func TestFactory_CreateMetricsExporter(t *testing.T) {
 		Version: "0.0.0",
 	}
 	oexp, err := factory.CreateMetricsExporter(context.Background(), creationParams, cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, oexp)
 
 	require.Equal(t, configopaque.String("opentelemetry-collector-contrib 0.0.0"), cfg.Headers["User-Agent"])
@@ -87,7 +87,7 @@ func TestFactory_CreateTracesExporter(t *testing.T) {
 		Version: "0.0.0",
 	}
 	oexp, err := factory.CreateTracesExporter(context.Background(), creationParams, cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, oexp)
 
 	require.Equal(t, configopaque.String("opentelemetry-collector-contrib 0.0.0"), cfg.Headers["User-Agent"])
@@ -118,7 +118,7 @@ func TestFactory_CreateLogsExporter(t *testing.T) {
 		Version: "0.0.0",
 	}
 	oexp, err := factory.CreateLogsExporter(context.Background(), creationParams, cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, oexp)
 
 	require.Equal(t, configopaque.String("opentelemetry-collector-contrib 0.0.0"), cfg.Headers["User-Agent"])

--- a/exporter/googlemanagedprometheusexporter/config_test.go
+++ b/exporter/googlemanagedprometheusexporter/config_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	factories, err := otelcoltest.NopFactories()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	factory := NewFactory()
 	factories.Exporters[metadata.Type] = factory

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -25,7 +25,7 @@ func TestTracesExporterGetsCreatedWithValidConfiguration(t *testing.T) {
 	exp, err := factory.CreateTracesExporter(context.Background(), creationParams, cfg)
 
 	// verify
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 }
 
@@ -43,6 +43,6 @@ func TestLogExporterGetsCreatedWithValidConfiguration(t *testing.T) {
 	exp, err := factory.CreateLogsExporter(context.Background(), creationParams, cfg)
 
 	// verify
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 }

--- a/exporter/logzioexporter/factory_test.go
+++ b/exporter/logzioexporter/factory_test.go
@@ -38,7 +38,7 @@ func TestCreateTracesExporter(t *testing.T) {
 
 	params := exportertest.NewNopCreateSettings()
 	exporter, err := factory.CreateTracesExporter(context.Background(), params, cfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, exporter)
 }
 

--- a/exporter/opencensusexporter/factory_test.go
+++ b/exporter/opencensusexporter/factory_test.go
@@ -163,7 +163,7 @@ func TestCreateTracesExporter(t *testing.T) {
 
 func checkErrorsAndStartAndShutdown(t *testing.T, exporter component.Component, err error, mustFailOnCreate, mustFailOnStart bool) {
 	if mustFailOnCreate {
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		return
 	}
 	assert.NoError(t, err)

--- a/exporter/pulsarexporter/pulsar_exporter_test.go
+++ b/exporter/pulsarexporter/pulsar_exporter_test.go
@@ -59,7 +59,7 @@ func Test_tracerPublisher_marshaler_err(t *testing.T) {
 	producer := PulsarTracesProducer{client: nil, producer: mProducer, marshaler: &customTraceMarshaler{encoding: "unknown"}}
 	err := producer.tracesPusher(context.Background(), testdata.GenerateTracesManySpansSameResource(10))
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.True(t, consumererror.IsPermanent(err))
 }
 

--- a/exporter/sapmexporter/exporter_test.go
+++ b/exporter/sapmexporter/exporter_test.go
@@ -39,7 +39,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	params := exportertest.NewNopCreateSettings()
 
 	te, err := newSAPMTracesExporter(cfg, params)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, te, "failed to create trace exporter")
 
 	assert.NoError(t, te.Shutdown(context.Background()), "trace exporter shutdown failed")
@@ -199,7 +199,7 @@ func TestSAPMClientTokenUsageAndErrorMarshalling(t *testing.T) {
 			params := exportertest.NewNopCreateSettings()
 
 			se, err := newSAPMExporter(cfg, params)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, se, "failed to create trace exporter")
 
 			trace, testTraceErr := buildTestTrace()
@@ -315,7 +315,7 @@ func TestCompression(t *testing.T) {
 				params := exportertest.NewNopCreateSettings()
 
 				se, err := newSAPMExporter(cfg, params)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.NotNil(t, se, "failed to create trace exporter")
 
 				trace, testTraceErr := buildTestTrace()

--- a/exporter/sapmexporter/factory_test.go
+++ b/exporter/sapmexporter/factory_test.go
@@ -29,7 +29,7 @@ func TestCreateExporter(t *testing.T) {
 	params := exportertest.NewNopCreateSettings()
 
 	te, err := factory.CreateTracesExporter(context.Background(), params, eCfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, te, "failed to create trace exporter")
 
 	me, err := factory.CreateMetricsExporter(context.Background(), params, eCfg)

--- a/exporter/sentryexporter/factory_test.go
+++ b/exporter/sentryexporter/factory_test.go
@@ -30,7 +30,7 @@ func TestCreateExporter(t *testing.T) {
 	params := exportertest.NewNopCreateSettings()
 
 	te, err := factory.CreateTracesExporter(context.Background(), params, eCfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, te, "failed to create trace exporter")
 
 	me, err := factory.CreateMetricsExporter(context.Background(), params, eCfg)

--- a/exporter/sentryexporter/sentry_exporter_test.go
+++ b/exporter/sentryexporter/sentry_exporter_test.go
@@ -724,7 +724,7 @@ func TestPushTraceData(t *testing.T) {
 			}
 
 			err := s.pushTraceData(context.Background(), test.td)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.called, transport.called)
 		})
 	}

--- a/exporter/signalfxexporter/internal/translation/dpfilters/dimensions_test.go
+++ b/exporter/signalfxexporter/internal/translation/dpfilters/dimensions_test.go
@@ -122,9 +122,9 @@ func TestDimensionsFilter(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			f, err := newDimensionsFilter(test.filter)
 			if test.shouldError {
-				require.NotNil(t, err)
+				require.Error(t, err)
 			} else {
-				require.Nil(t, err)
+				require.NoError(t, err)
 			}
 
 			require.Equal(t, test.shouldMatch, f.Matches(test.input))

--- a/exporter/signalfxexporter/internal/translation/dpfilters/string_test.go
+++ b/exporter/signalfxexporter/internal/translation/dpfilters/string_test.go
@@ -149,9 +149,9 @@ func TestStringFilter(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			f, err := NewStringFilter(test.filter)
 			if test.shouldError {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 			for i := range test.inputs {
 				assert.Equal(t, test.shouldMatch[i], f.Matches(test.inputs[i]))

--- a/exporter/skywalkingexporter/factory_test.go
+++ b/exporter/skywalkingexporter/factory_test.go
@@ -141,7 +141,7 @@ func TestCreateTracesExporter(t *testing.T) {
 
 func checkErrorsAndStartAndShutdown(t *testing.T, exporter component.Component, err error, mustFailOnCreate, mustFailOnStart bool) {
 	if mustFailOnCreate {
-		assert.NotNil(t, err)
+		assert.Error(t, err)
 		return
 	}
 	assert.NoError(t, err)

--- a/exporter/sumologicexporter/config_test.go
+++ b/exporter/sumologicexporter/config_test.go
@@ -109,7 +109,7 @@ func TestConfigValidation(t *testing.T) {
 			if tc.expectedErr == "" {
 				assert.NoError(t, err)
 			} else {
-				require.NotNil(t, err)
+				require.Error(t, err)
 				assert.EqualError(t, err, tc.expectedErr)
 			}
 		})

--- a/extension/asapauthextension/factory_test.go
+++ b/extension/asapauthextension/factory_test.go
@@ -76,7 +76,7 @@ func TestCreateExtension(t *testing.T) {
 			if testcase.shouldError {
 				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.NotNil(t, ext)
 			}
 		})

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -83,7 +83,7 @@ func TestOAuthClientSettings(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			rc, err := newClientAuthenticator(test.settings, zap.NewNop())
 			if test.shouldError {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.Contains(t, err.Error(), test.expectedError)
 				return
 			}
@@ -99,7 +99,7 @@ func TestOAuthClientSettings(t *testing.T) {
 			transport := rc.client.Transport.(*http.Transport)
 			tlsClientConfig := transport.TLSClientConfig
 			tlsTestSettingConfig, err := test.settings.TLSSetting.LoadTLSConfig()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tlsClientConfig.Certificates, tlsTestSettingConfig.Certificates)
 		})
 	}
@@ -179,7 +179,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			rc, _ := newClientAuthenticator(test.settings, zap.NewNop())
 			cfg, err := rc.clientCredentials.createConfig()
 			if test.shouldError {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				assert.ErrorAs(t, err, test.expectedError)
 				return
 			}
@@ -191,7 +191,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			transport := rc.client.Transport.(*http.Transport)
 			tlsClientConfig := transport.TLSClientConfig
 			tlsTestSettingConfig, err := test.settings.TLSSetting.LoadTLSConfig()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tlsClientConfig.Certificates, tlsTestSettingConfig.Certificates)
 		})
 	}
@@ -237,7 +237,7 @@ func TestRoundTripper(t *testing.T) {
 
 			assert.NotNil(t, oauth2Authenticator)
 			roundTripper, err := oauth2Authenticator.roundTripper(baseRoundTripper)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			// test roundTripper is an OAuth RoundTripper
 			oAuth2Transport, ok := roundTripper.(*oauth2.Transport)
@@ -281,7 +281,7 @@ func TestOAuth2PerRPCCredentials(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			perRPCCredentials, err := oauth2Authenticator.perRPCCredentials()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			// test perRPCCredentials is an grpc OAuthTokenSource
 			_, ok := perRPCCredentials.(grpcOAuth.TokenSource)
 			assert.True(t, ok)
@@ -305,11 +305,11 @@ func TestFailContactingOAuth(t *testing.T) {
 		ClientSecret: "ABC",
 		TokenURL:     serverURL.String(),
 	}, zap.NewNop())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Test for gRPC connections
 	credential, err := oauth2Authenticator.perRPCCredentials()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = credential.GetRequestMetadata(context.Background())
 	assert.ErrorIs(t, err, errFailedToGetSecurityToken)

--- a/extension/oauth2clientauthextension/factory_test.go
+++ b/extension/oauth2clientauthextension/factory_test.go
@@ -56,7 +56,7 @@ func TestCreateExtension(t *testing.T) {
 				assert.Error(t, err)
 				assert.Nil(t, ext)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.NotNil(t, ext)
 			}
 		})

--- a/extension/observer/dockerobserver/integration_test.go
+++ b/extension/observer/dockerobserver/integration_test.go
@@ -50,10 +50,10 @@ func TestObserverEmitsEndpointsIntegration(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer func() {
 		err := container.Terminate(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}()
 	require.NotNil(t, container)
 
@@ -95,10 +95,10 @@ func TestObserverUpdatesEndpointsIntegration(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer func() {
 		err = container.Terminate(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}()
 	require.NotNil(t, container)
 
@@ -119,7 +119,7 @@ func TestObserverUpdatesEndpointsIntegration(t *testing.T) {
 	require.True(t, found, "No nginx container found")
 
 	tcDockerClient, err := testcontainers.NewDockerClientWithOpts(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.NoError(t, tcDockerClient.ContainerRename(context.Background(), container.GetContainerID(), "nginx-updated"))
 
@@ -155,7 +155,7 @@ func TestObserverRemovesEndpointsIntegration(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, container)
 
 	mn := &mockNotifier{endpointsMap: map[observer.EndpointID]observer.Endpoint{}}
@@ -175,7 +175,7 @@ func TestObserverRemovesEndpointsIntegration(t *testing.T) {
 	require.True(t, found, "No nginx container found")
 
 	err = container.Terminate(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Eventually(t, func() bool { return mn.RemoveCount() == 1 }, 3*time.Second, 10*time.Millisecond)
 }
@@ -192,10 +192,10 @@ func TestObserverExcludesImagesIntegration(t *testing.T) {
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer func() {
 		err := container.Terminate(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}()
 	require.NotNil(t, container)
 

--- a/extension/observer/ecsobserver/task_test.go
+++ b/extension/observer/ecsobserver/task_test.go
@@ -118,10 +118,10 @@ func TestTask_MappedPort(t *testing.T) {
 			EC2:        &ec2.Instance{PrivateIpAddress: aws.String("172.168.1.1")},
 		}
 		ip, err := task.PrivateIP()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "172.168.1.1", ip)
 		p, err := task.MappedPort(&ecs.ContainerDefinition{Name: aws.String("c1")}, 2112)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, int64(2345), p)
 	})
 
@@ -132,7 +132,7 @@ func TestTask_MappedPort(t *testing.T) {
 			EC2:        &ec2.Instance{PrivateIpAddress: aws.String("172.168.1.1")},
 		}
 		p, err := task.MappedPort(&ecs.ContainerDefinition{Name: aws.String("c1")}, 2112)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, int64(2345), p)
 	})
 
@@ -156,7 +156,7 @@ func TestTask_MappedPort(t *testing.T) {
 			Definition: vpcTaskDef,
 		}
 		p, err := task.MappedPort(vpcTaskDef.ContainerDefinitions[0], 2112)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, int64(2345), p)
 	})
 
@@ -168,7 +168,7 @@ func TestTask_MappedPort(t *testing.T) {
 			Definition: def,
 		}
 		p, err := task.MappedPort(def.ContainerDefinitions[0], 2112)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, int64(2345), p)
 	})
 

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -36,7 +36,7 @@ func TestRoundTripper(t *testing.T) {
 	assert.NotNil(t, sa)
 
 	rt, err := sa.RoundTripper(base)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	si := rt.(*signingRoundTripper)
 	assert.Equal(t, base, si.transport)

--- a/extension/sigv4authextension/factory_test.go
+++ b/extension/sigv4authextension/factory_test.go
@@ -34,7 +34,7 @@ func TestCreateExtension(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 
 	ext, err := createExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, ext)
 
 }

--- a/extension/sigv4authextension/signingroundtripper_test.go
+++ b/extension/sigv4authextension/signingroundtripper_test.go
@@ -161,7 +161,7 @@ func TestInferServiceAndRegion(t *testing.T) {
 			assert.NotNil(t, sa)
 
 			rt, err := sa.RoundTripper((http.RoundTripper)(http.DefaultTransport.(*http.Transport).Clone()))
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			si := rt.(*signingRoundTripper)
 
 			service, region := si.inferServiceAndRegion(testcase.request)

--- a/internal/aws/awsutil/conn_test.go
+++ b/internal/aws/awsutil/conn_test.go
@@ -48,7 +48,7 @@ func TestEC2Session(t *testing.T) {
 	cfg, s, err := GetAWSConfigSession(logger, m, &sessionCfg)
 	assert.Equal(t, s, expectedSession, "Expect the session object is not overridden")
 	assert.Equal(t, *cfg.Region, ec2Region, "Region value fetched from ec2-metadata service")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 // fetch region value from environment variable
@@ -65,7 +65,7 @@ func TestRegionEnv(t *testing.T) {
 	cfg, s, err := GetAWSConfigSession(logger, m, &sessionCfg)
 	assert.Equal(t, s, expectedSession, "Expect the session object is not overridden")
 	assert.Equal(t, *cfg.Region, region, "Region value fetched from environment")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestGetAWSConfigSessionWithSessionErr(t *testing.T) {
@@ -82,7 +82,7 @@ func TestGetAWSConfigSessionWithSessionErr(t *testing.T) {
 	cfg, s, err := GetAWSConfigSession(logger, m, &sessionCfg)
 	assert.Nil(t, cfg)
 	assert.Nil(t, s)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestGetAWSConfigSessionWithEC2RegionErr(t *testing.T) {
@@ -98,7 +98,7 @@ func TestGetAWSConfigSessionWithEC2RegionErr(t *testing.T) {
 	cfg, s, err := GetAWSConfigSession(logger, m, &sessionCfg)
 	assert.Nil(t, cfg)
 	assert.Nil(t, s)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestNewAWSSessionWithErr(t *testing.T) {
@@ -109,11 +109,11 @@ func TestNewAWSSessionWithErr(t *testing.T) {
 	t.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 	conn := &Conn{}
 	se, err := conn.newAWSSession(logger, roleArn, region)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, se)
 	roleArn = ""
 	se, err = conn.newAWSSession(logger, roleArn, region)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, se)
 	t.Setenv("AWS_SDK_LOAD_CONFIG", "true")
 	t.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "regional")
@@ -122,7 +122,7 @@ func TestNewAWSSessionWithErr(t *testing.T) {
 	})
 	assert.NotNil(t, se)
 	_, err = conn.getEC2Region(se)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestGetSTSCredsFromPrimaryRegionEndpoint(t *testing.T) {
@@ -143,7 +143,7 @@ func TestGetDefaultSession(t *testing.T) {
 	logger := zap.NewNop()
 	t.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 	_, err := GetDefaultSession(logger)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestGetSTSCreds(t *testing.T) {
@@ -151,8 +151,8 @@ func TestGetSTSCreds(t *testing.T) {
 	region := "fake_region"
 	roleArn := ""
 	_, err := getSTSCreds(logger, region, roleArn)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	t.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 	_, err = getSTSCreds(logger, region, roleArn)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/internal/aws/cwlogs/pusher_test.go
+++ b/internal/aws/cwlogs/pusher_test.go
@@ -30,7 +30,7 @@ func TestValidateLogEventWithMutating(t *testing.T) {
 	logEvent := NewEvent(0, "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789")
 	logEvent.GeneratedTime = time.Now()
 	err := logEvent.Validate(zap.NewNop())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, *logEvent.InputLogEvent.Timestamp > int64(0))
 	assert.Equal(t, 64-perEventHeaderBytes, len(*logEvent.InputLogEvent.Message))
 
@@ -41,13 +41,13 @@ func TestValidateLogEventFailed(t *testing.T) {
 	logger := zap.NewNop()
 	logEvent := NewEvent(0, "")
 	err := logEvent.Validate(logger)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "empty log event message", err.Error())
 
 	invalidTimestamp := time.Now().AddDate(0, -1, 0)
 	logEvent = NewEvent(invalidTimestamp.Unix()*1e3, "test")
 	err = logEvent.Validate(logger)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "the log entry's timestamp is older than 14 days or more than 2 hours in the future", err.Error())
 }
 

--- a/internal/aws/ecsutil/metadata_provider_test.go
+++ b/internal/aws/ecsutil/metadata_provider_test.go
@@ -49,7 +49,7 @@ func Test_ecsMetadata_fetchContainer(t *testing.T) {
 	md := ecsMetadataProviderImpl{logger: zap.NewNop(), client: mockRestClient}
 	fetchResp, err := md.FetchContainerMetadata()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, fetchResp)
 	assert.Equal(t, "325c979aea914acd93be2fdd2429e1d9-3811061257", fetchResp.DockerID)
 	assert.Equal(t, "arn:aws:ecs:us-east-1:123456789123:an-image/123", fetchResp.ContainerARN)

--- a/internal/aws/ecsutil/rest_client_test.go
+++ b/internal/aws/ecsutil/rest_client_test.go
@@ -32,7 +32,7 @@ func TestRestClientFromClient(t *testing.T) {
 	rest := NewRestClientFromClient(&fakeClient{})
 	metadata, err := rest.GetResponse(endpoints.TaskMetadataPath)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, endpoints.TaskMetadataPath, string(metadata))
 }
 

--- a/internal/aws/k8s/k8sclient/endpoint_test.go
+++ b/internal/aws/k8s/k8sclient/endpoint_test.go
@@ -406,7 +406,7 @@ func TestEpClient_ServiceNameToPodNum(t *testing.T) {
 func TestTransformFuncEndpoint(t *testing.T) {
 	info, err := transformFuncEndpoint(nil)
 	assert.Nil(t, info)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestNewEndpointClient(t *testing.T) {

--- a/internal/aws/k8s/k8sclient/job_test.go
+++ b/internal/aws/k8s/k8sclient/job_test.go
@@ -65,5 +65,5 @@ func TestJobClient_JobToCronJob(t *testing.T) {
 func TestTransformFuncJob(t *testing.T) {
 	info, err := transformFuncJob(nil)
 	assert.Nil(t, info)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/internal/aws/k8s/k8sclient/node_test.go
+++ b/internal/aws/k8s/k8sclient/node_test.go
@@ -311,5 +311,5 @@ func TestNodeClient(t *testing.T) {
 func TestTransformFuncNode(t *testing.T) {
 	info, err := transformFuncNode(nil)
 	assert.Nil(t, info)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/internal/aws/k8s/k8sclient/obj_store_test.go
+++ b/internal/aws/k8s/k8sclient/obj_store_test.go
@@ -33,7 +33,7 @@ func TestGet(t *testing.T) {
 	item, exists, err := o.Get("a")
 	assert.Nil(t, item)
 	assert.False(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestGetByKey(t *testing.T) {
@@ -41,7 +41,7 @@ func TestGetByKey(t *testing.T) {
 	item, exists, err := o.GetByKey("a")
 	assert.Nil(t, item)
 	assert.False(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestGetListKeys(t *testing.T) {
@@ -76,7 +76,7 @@ func TestGetList(t *testing.T) {
 func TestDelete(t *testing.T) {
 	o := NewObjStore(transformFunc, zap.NewNop())
 	err := o.Delete(nil)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	o.objs = map[types.UID]any{
 		"bc5f5839-f62e-44b9-a79e-af250d92dcb1": &v1.Pod{
@@ -115,7 +115,7 @@ func TestDelete(t *testing.T) {
 		},
 	}
 	err = o.Delete(obj)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, o.refreshed)
 
 	keys := o.ListKeys()
@@ -126,7 +126,7 @@ func TestDelete(t *testing.T) {
 func TestAdd(t *testing.T) {
 	o := NewObjStore(transformFunc, zap.NewNop())
 	err := o.Add(nil)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	o = NewObjStore(transformFuncWithError, zap.NewNop())
 	obj := &v1.Pod{
@@ -141,7 +141,7 @@ func TestAdd(t *testing.T) {
 		},
 	}
 	err = o.Add(obj)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestUpdate(t *testing.T) {
@@ -171,7 +171,7 @@ func TestUpdate(t *testing.T) {
 		},
 	}
 	err := o.Update(updatedObj)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	keys := o.ListKeys()
 	assert.Equal(t, 1, len(keys))
@@ -209,5 +209,5 @@ func TestReplace(t *testing.T) {
 		},
 	}
 	err := o.Replace(objArray, "")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/internal/aws/k8s/k8sclient/pod_test.go
+++ b/internal/aws/k8s/k8sclient/pod_test.go
@@ -189,5 +189,5 @@ func TestPodClient_NamespaceToRunningPodNum(t *testing.T) {
 func TestTransformFuncPod(t *testing.T) {
 	info, err := transformFuncPod(nil)
 	assert.Nil(t, info)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/internal/aws/k8s/k8sclient/replicaset_test.go
+++ b/internal/aws/k8s/k8sclient/replicaset_test.go
@@ -74,5 +74,5 @@ func TestReplicaSetClient_ReplicaSetToDeployment(t *testing.T) {
 func TestTransformFuncReplicaSet(t *testing.T) {
 	info, err := transformFuncReplicaSet(nil)
 	assert.Nil(t, info)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }

--- a/internal/coreinternal/attraction/attraction_test.go
+++ b/internal/coreinternal/attraction/attraction_test.go
@@ -77,7 +77,7 @@ func TestAttributes_InsertValue(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	for _, tt := range testCases {
@@ -135,7 +135,7 @@ func TestAttributes_InsertFromAttribute(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	for _, tt := range testCases {
@@ -181,7 +181,7 @@ func TestAttributes_UpdateValue(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	for _, tt := range testCases {
@@ -239,7 +239,7 @@ func TestAttributes_UpdateFromAttribute(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	for _, tt := range testCases {
@@ -289,7 +289,7 @@ func TestAttributes_UpsertValue(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	for _, tt := range testCases {
@@ -409,7 +409,7 @@ func TestAttributes_Extract(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	for _, tt := range testCases {
@@ -472,7 +472,7 @@ func TestAttributes_UpsertFromAttribute(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	for _, tt := range testCases {
@@ -533,7 +533,7 @@ func TestAttributes_Delete(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	for _, tt := range testCases {
@@ -579,7 +579,7 @@ func TestAttributes_Delete_Regexp(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	for _, tt := range testCases {
@@ -684,7 +684,7 @@ func TestAttributes_HashValue(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	for _, tt := range testCases {
@@ -712,7 +712,7 @@ func TestAttributes_FromAttributeNoChange(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	runIndividualTestCase(t, tc, ap)
@@ -793,7 +793,7 @@ func TestAttributes_Ordering(t *testing.T) {
 	}
 
 	ap, err := NewAttrProc(cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, ap)
 
 	for _, tt := range testCases {
@@ -1030,7 +1030,7 @@ func TestFromContext(t *testing.T) {
 			ap, err := NewAttrProc(&Settings{
 				Actions: []ActionKeyValue{*tc.action},
 			})
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, ap)
 			attrMap := pcommon.NewMap()
 			ap.Process(tc.ctx, nil, attrMap)

--- a/internal/coreinternal/goldendataset/traces_generator_test.go
+++ b/internal/coreinternal/goldendataset/traces_generator_test.go
@@ -12,6 +12,6 @@ import (
 func TestGenerateTraces(t *testing.T) {
 	rscSpans, err := GenerateTraces("testdata/generated_pict_pairs_traces.txt",
 		"testdata/generated_pict_pairs_spans.txt")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 32, len(rscSpans))
 }

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -81,7 +81,7 @@ func TestWatchingTimeouts(t *testing.T) {
 
 	cli, err := NewDockerClient(config, zap.NewNop())
 	assert.NotNil(t, cli)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expectedError := "context deadline exceeded"
 
@@ -93,7 +93,7 @@ func TestWatchingTimeouts(t *testing.T) {
 	observed, logs := observer.New(zapcore.WarnLevel)
 	cli, err = NewDockerClient(config, zap.New(observed))
 	assert.NotNil(t, cli)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	cnt, ofInterest := cli.inspectedContainerIsOfInterest(context.Background(), "SomeContainerId")
 	assert.False(t, ofInterest)
@@ -126,7 +126,7 @@ func TestFetchingTimeouts(t *testing.T) {
 
 	cli, err := NewDockerClient(config, zap.NewNop())
 	assert.NotNil(t, cli)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expectedError := "context deadline exceeded"
 
@@ -135,7 +135,7 @@ func TestFetchingTimeouts(t *testing.T) {
 	observed, logs := observer.New(zapcore.WarnLevel)
 	cli, err = NewDockerClient(config, zap.New(observed))
 	assert.NotNil(t, cli)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	statsJSON, err := cli.FetchContainerStatsAsJSON(
 		context.Background(),
@@ -182,7 +182,7 @@ func TestToStatsJSONErrorHandling(t *testing.T) {
 
 	cli, err := NewDockerClient(config, zap.NewNop())
 	assert.NotNil(t, cli)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	dc := &Container{
 		ContainerJSON: &dtypes.ContainerJSON{
@@ -229,7 +229,7 @@ func TestEventLoopHandlesError(t *testing.T) {
 
 	cli, err := NewDockerClient(config, zap.New(observed))
 	assert.NotNil(t, cli)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	go cli.ContainerEventLoop(context.Background())
 

--- a/internal/docker/matcher_test.go
+++ b/internal/docker/matcher_test.go
@@ -137,7 +137,7 @@ func TestStringMatcher(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, err := newStringMatcher(tc.items)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.shouldMatch, f.matches(tc.input))
 		})
 	}

--- a/internal/filter/filterlog/filterlog_test.go
+++ b/internal/filter/filterlog/filterlog_test.go
@@ -81,7 +81,7 @@ func TestLogRecord_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			expr, err := newExpr(tc.property)
 			assert.Nil(t, expr)
-			require.NotNil(t, err)
+			require.Error(t, err)
 			println(tc.name)
 			assert.Equal(t, tc.errorString, err.Error())
 		})
@@ -148,7 +148,7 @@ func TestLogRecord_Matching_False(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			expr, err := newExpr(tc.properties)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			require.NotNil(t, expr)
 
 			val, err := expr.Eval(context.Background(), ottllog.NewTransformContext(lr, pcommon.NewInstrumentationScope(), pcommon.NewResource()))

--- a/internal/filter/filtermatcher/filtermatcher_test.go
+++ b/internal/filter/filtermatcher/filtermatcher_test.go
@@ -226,7 +226,7 @@ func Test_MatchingCornerCases(t *testing.T) {
 	}
 
 	mp, err := NewMatcher(cfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, mp)
 
 	assert.False(t, mp.Match(pcommon.NewMap(), resource("svcA"), pcommon.NewInstrumentationScope()))

--- a/internal/filter/filterset/config_test.go
+++ b/internal/filter/filterset/config_test.go
@@ -74,7 +74,7 @@ func TestConfigInvalid(t *testing.T) {
 			assert.Equal(t, expCfg, actualCfg)
 
 			fs, err := CreateFilterSet([]string{}, actualCfg)
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 			assert.Nil(t, fs)
 		})
 	}

--- a/internal/filter/filterspan/filterspan_test.go
+++ b/internal/filter/filterspan/filterspan_test.go
@@ -193,7 +193,7 @@ func TestSpan_MissingServiceName(t *testing.T) {
 	}
 
 	mp, err := newExpr(cfg)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, mp)
 
 	emptySpan := ptrace.NewSpan()

--- a/pkg/ottl/contexts/internal/map_test.go
+++ b/pkg/ottl/contexts/internal/map_test.go
@@ -119,7 +119,7 @@ func Test_GetMapValue_MissingKey(t *testing.T) {
 		},
 	}
 	result, err := GetMapValue[any](context.Background(), nil, m, keys)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Nil(t, result)
 }
 
@@ -235,7 +235,7 @@ func Test_SetMapValue_AddingNewSubMap(t *testing.T) {
 		},
 	}
 	err := SetMapValue[any](context.Background(), nil, m, keys, "bar")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expected := pcommon.NewMap()
 	sub := expected.PutEmptyMap("map1")
@@ -259,7 +259,7 @@ func Test_SetMapValue_EmptyMap(t *testing.T) {
 		},
 	}
 	err := SetMapValue[any](context.Background(), nil, m, keys, "bar")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expected := pcommon.NewMap()
 	expected.PutEmptyMap("map1").PutEmptyMap("map2").PutStr("foo", "bar")

--- a/pkg/ottl/contexts/internal/metric_test.go
+++ b/pkg/ottl/contexts/internal/metric_test.go
@@ -116,11 +116,11 @@ func Test_MetricPathGetSetter(t *testing.T) {
 			metric := createMetricTelemetry()
 
 			got, err := accessor.Get(context.Background(), newMetricContext(metric))
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), newMetricContext(metric), tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expectedMetric := createMetricTelemetry()
 			tt.modified(expectedMetric)

--- a/pkg/ottl/contexts/internal/resource_test.go
+++ b/pkg/ottl/contexts/internal/resource_test.go
@@ -314,11 +314,11 @@ func TestResourcePathGetSetter(t *testing.T) {
 			resource := createResource()
 
 			got, err := accessor.Get(context.Background(), newResourceContext(resource))
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), newResourceContext(resource), tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expectedResource := createResource()
 			tt.modified(expectedResource)

--- a/pkg/ottl/contexts/internal/scope_test.go
+++ b/pkg/ottl/contexts/internal/scope_test.go
@@ -340,11 +340,11 @@ func TestScopePathGetSetter(t *testing.T) {
 			is := createInstrumentationScope()
 
 			got, err := accessor.Get(context.Background(), newInstrumentationScopeContext(is))
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), newInstrumentationScopeContext(is), tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expectedIS := createInstrumentationScope()
 			tt.modified(expectedIS)

--- a/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
@@ -68,11 +68,11 @@ func Test_newPathGetSetter_Cache(t *testing.T) {
 			ctx := NewTransformContext(numberDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
 			got, err := accessor.Get(context.Background(), ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), ctx, tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			exCache := pcommon.NewMap()
 			tt.modified(exCache)
@@ -486,11 +486,11 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			ctx := NewTransformContext(numberDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
 			got, err := accessor.Get(context.Background(), ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), ctx, tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			exNumberDataPoint := createNumberDataPointTelemetry(tt.valueType)
 			tt.modified(exNumberDataPoint)
@@ -921,11 +921,11 @@ func Test_newPathGetSetter_HistogramDataPoint(t *testing.T) {
 			ctx := NewTransformContext(histogramDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
 			got, err := accessor.Get(context.Background(), ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), ctx, tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			exNumberDataPoint := createHistogramDataPointTelemetry()
 			tt.modified(exNumberDataPoint)
@@ -1439,11 +1439,11 @@ func Test_newPathGetSetter_ExpoHistogramDataPoint(t *testing.T) {
 			ctx := NewTransformContext(expoHistogramDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
 			got, err := accessor.Get(context.Background(), ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), ctx, tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			exNumberDataPoint := createExpoHistogramDataPointTelemetry()
 			tt.modified(exNumberDataPoint)
@@ -1858,11 +1858,11 @@ func Test_newPathGetSetter_SummaryDataPoint(t *testing.T) {
 			ctx := NewTransformContext(summaryDataPoint, pmetric.NewMetric(), pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
 			got, err := accessor.Get(context.Background(), ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), ctx, tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			exNumberDataPoint := createSummaryDataPointTelemetry()
 			tt.modified(exNumberDataPoint)
@@ -2042,11 +2042,11 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 			ctx := NewTransformContext(pmetric.NewNumberDataPoint(), metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
 			got, err := accessor.Get(context.Background(), ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), ctx, tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			exMetric := createMetricTelemetry()
 			tt.modified(exMetric)

--- a/pkg/ottl/contexts/ottllog/log_test.go
+++ b/pkg/ottl/contexts/ottllog/log_test.go
@@ -630,12 +630,12 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			tCtx := NewTransformContext(log, il, resource)
 			got, err := accessor.Get(context.Background(), tCtx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			tCtx = NewTransformContext(log, il, resource)
 			err = accessor.Set(context.Background(), tCtx, tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			exLog, exIl, exRes := createTelemetry(tt.bodyType)
 			exCache := pcommon.NewMap()

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -152,11 +152,11 @@ func Test_newPathGetSetter(t *testing.T) {
 			ctx := NewTransformContext(metric, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource())
 
 			got, err := accessor.Get(context.Background(), ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), ctx, tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			exMetric := createMetricTelemetry()
 			exCache := pcommon.NewMap()

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -370,11 +370,11 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			tCtx := NewTransformContext(resource)
 			got, err := accessor.Get(context.Background(), tCtx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), tCtx, tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			exRes := createTelemetry()
 			exCache := pcommon.NewMap()

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -403,11 +403,11 @@ func Test_newPathGetSetter(t *testing.T) {
 
 			tCtx := NewTransformContext(il, resource)
 			got, err := accessor.Get(context.Background(), tCtx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), tCtx, tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			exIl, exRes := createTelemetry()
 			exCache := pcommon.NewMap()

--- a/pkg/ottl/contexts/ottlspan/span_test.go
+++ b/pkg/ottl/contexts/ottlspan/span_test.go
@@ -702,11 +702,11 @@ func Test_newPathGetSetter(t *testing.T) {
 			tCtx := NewTransformContext(span, il, resource)
 
 			got, err := accessor.Get(context.Background(), tCtx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.orig, got)
 
 			err = accessor.Set(context.Background(), tCtx, tt.newVal)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			exSpan, exIl, exRes := createTelemetry()
 			exCache := pcommon.NewMap()

--- a/pkg/ottl/ottlfuncs/func_delete_key_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key_test.go
@@ -68,7 +68,7 @@ func Test_deleteKey(t *testing.T) {
 			exprFunc := deleteKey(tt.target, tt.key)
 
 			_, err := exprFunc(nil, scenarioMap)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
@@ -68,7 +68,7 @@ func Test_deleteMatchingKeys(t *testing.T) {
 			assert.NoError(t, err)
 
 			_, err = exprFunc(nil, scenarioMap)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -69,7 +69,7 @@ func Test_keepKeys(t *testing.T) {
 			exprFunc := keepKeys(tt.target, tt.keys)
 
 			_, err := exprFunc(nil, scenarioMap)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -422,7 +422,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 			assert.NoError(t, err)
 
 			_, err = exprFunc(nil, scenarioMap)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expected := pcommon.NewMap()
 			tt.want(expected)
@@ -447,7 +447,7 @@ func Test_replaceAllPatterns_bad_input(t *testing.T) {
 	function := ottl.Optional[ottl.FunctionGetter[any]]{}
 
 	exprFunc, err := replaceAllPatterns[any](target, modeValue, "regexpattern", replacement, function)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = exprFunc(nil, input)
 	assert.Error(t, err)

--- a/processor/attributesprocessor/attributes_log_test.go
+++ b/processor/attributesprocessor/attributes_log_test.go
@@ -82,7 +82,7 @@ func TestLogProcessor_NilEmptyData(t *testing.T) {
 
 	tp, err := factory.CreateLogsProcessor(
 		context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 	for i := range testCases {
 		tt := testCases[i]
@@ -209,7 +209,7 @@ func TestAttributes_FilterLogsByNameStrict(t *testing.T) {
 		Config:    *createConfig(filterset.Strict),
 	}
 	tp, err := factory.CreateLogsProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tt := range testCases {
@@ -272,7 +272,7 @@ func TestAttributes_FilterLogsByNameRegexp(t *testing.T) {
 		Config:    *createConfig(filterset.Regexp),
 	}
 	tp, err := factory.CreateLogsProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tt := range testCases {
@@ -331,7 +331,7 @@ func TestLogAttributes_Hash(t *testing.T) {
 	}
 
 	tp, err := factory.CreateLogsProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tt := range testCases {
@@ -407,7 +407,7 @@ func TestLogAttributes_Convert(t *testing.T) {
 	}
 
 	tp, err := factory.CreateLogsProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tt := range testCases {

--- a/processor/attributesprocessor/attributes_metric_test.go
+++ b/processor/attributesprocessor/attributes_metric_test.go
@@ -89,7 +89,7 @@ func TestMetricProcessor_NilEmptyData(t *testing.T) {
 	}
 
 	mp, err := factory.CreateMetricsProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, mp)
 	for i := range metricTestCases {
 		tc := metricTestCases[i]
@@ -217,7 +217,7 @@ func TestAttributes_FilterMetricsByNameStrict(t *testing.T) {
 		Config:    *createConfig(filterset.Strict),
 	}
 	mp, err := factory.CreateMetricsProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, mp)
 
 	for _, tc := range testCases {
@@ -281,7 +281,7 @@ func TestAttributes_FilterMetricsByNameRegexp(t *testing.T) {
 		Config:    *createConfig(filterset.Regexp),
 	}
 	mp, err := factory.CreateMetricsProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, mp)
 
 	for _, tc := range testCases {
@@ -340,7 +340,7 @@ func TestMetricAttributes_Hash(t *testing.T) {
 	}
 
 	mp, err := factory.CreateMetricsProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, mp)
 
 	for _, tc := range testCases {
@@ -397,7 +397,7 @@ func TestMetricAttributes_Convert(t *testing.T) {
 	}
 
 	tp, err := factory.CreateMetricsProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tt := range testCases {

--- a/processor/attributesprocessor/attributes_trace_test.go
+++ b/processor/attributesprocessor/attributes_trace_test.go
@@ -91,7 +91,7 @@ func TestSpanProcessor_NilEmptyData(t *testing.T) {
 	}
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 	for i := range testCases {
 		tt := testCases[i]
@@ -158,7 +158,7 @@ func TestAttributes_FilterSpans(t *testing.T) {
 		Config: *createConfig(filterset.Strict),
 	}
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tt := range testCases {
@@ -226,7 +226,7 @@ func TestAttributes_FilterSpansByNameStrict(t *testing.T) {
 		Config:    *createConfig(filterset.Strict),
 	}
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tt := range testCases {
@@ -294,7 +294,7 @@ func TestAttributes_FilterSpansByNameRegexp(t *testing.T) {
 		Config:    *createConfig(filterset.Regexp),
 	}
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tt := range testCases {
@@ -353,7 +353,7 @@ func TestAttributes_Hash(t *testing.T) {
 	}
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tt := range testCases {
@@ -456,7 +456,7 @@ func TestAttributes_Convert(t *testing.T) {
 	}
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tt := range testCases {

--- a/processor/cumulativetodeltaprocessor/processor_test.go
+++ b/processor/cumulativetodeltaprocessor/processor_test.go
@@ -454,7 +454,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 				next,
 			)
 			assert.NotNil(t, mgp)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			caps := mgp.Capabilities()
 			assert.True(t, caps.MutatesData)

--- a/processor/deltatorateprocessor/processor_test.go
+++ b/processor/deltatorateprocessor/processor_test.go
@@ -126,7 +126,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 				next,
 			)
 			assert.NotNil(t, mgp)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			caps := mgp.Capabilities()
 			assert.True(t, caps.MutatesData)

--- a/processor/filterprocessor/logs_test.go
+++ b/processor/filterprocessor/logs_test.go
@@ -585,7 +585,7 @@ func TestFilterLogProcessor(t *testing.T) {
 				next,
 			)
 			assert.NotNil(t, flp)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			caps := flp.Capabilities()
 			assert.True(t, caps.MutatesData)

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -335,7 +335,7 @@ func TestFilterMetricProcessor(t *testing.T) {
 				next,
 			)
 			assert.NotNil(t, fmp)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			caps := fmp.Capabilities()
 			assert.True(t, caps.MutatesData)
@@ -383,7 +383,7 @@ func TestFilterMetricProcessorTelemetry(t *testing.T) {
 			next,
 		)
 		assert.NotNil(t, fmp)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		caps := fmp.Capabilities()
 		assert.True(t, caps.MutatesData)
@@ -398,7 +398,7 @@ func TestFilterMetricProcessorTelemetry(t *testing.T) {
 				},
 			},
 		}))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		tel.assertMetrics(t, expectedMetrics{
 			metricDataPointsFiltered: float64(0),
@@ -412,7 +412,7 @@ func TestFilterMetricProcessorTelemetry(t *testing.T) {
 				},
 			},
 		}))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		tel.assertMetrics(t, expectedMetrics{
 			metricDataPointsFiltered: float64(1),
@@ -426,7 +426,7 @@ func TestFilterMetricProcessorTelemetry(t *testing.T) {
 				},
 			},
 		}))
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 
 		tel.assertMetrics(t, expectedMetrics{
 			metricDataPointsFiltered: float64(2),

--- a/processor/filterprocessor/traces_test.go
+++ b/processor/filterprocessor/traces_test.go
@@ -135,7 +135,7 @@ func TestFilterTraceProcessor(t *testing.T) {
 				next,
 			)
 			require.NotNil(t, fmp)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			caps := fmp.Capabilities()
 			require.True(t, caps.MutatesData)

--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -281,7 +281,7 @@ func TestMetricsGenerationProcessor(t *testing.T) {
 				next,
 			)
 			assert.NotNil(t, mgp)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			caps := mgp.Capabilities()
 			assert.True(t, caps.MutatesData)

--- a/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ecs/ecs_test.go
@@ -72,7 +72,7 @@ func Test_detectorReturnsIfNoEnvVars(t *testing.T) {
 	d, _ := NewDetector(processortest.NewNopCreateSettings(), CreateDefaultConfig())
 	res, _, err := d.Detect(context.TODO())
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, res.Attributes().Len())
 }
 
@@ -138,7 +138,7 @@ func Test_ecsDetectV4(t *testing.T) {
 	d := Detector{provider: &mockMetaDataProvider{isV4: true, taskArnVersion: 1}, rb: metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())}
 	got, _, err := d.Detect(context.TODO())
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, got)
 	assert.Equal(t, want.Attributes().AsRaw(), got.Attributes().AsRaw())
 }
@@ -167,7 +167,7 @@ func Test_ecsDetectV4WithTaskArnVersion2(t *testing.T) {
 	d := Detector{provider: &mockMetaDataProvider{isV4: true, taskArnVersion: 2}, rb: metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())}
 	got, _, err := d.Detect(context.TODO())
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, got)
 	assert.Equal(t, want.Attributes().AsRaw(), got.Attributes().AsRaw())
 }
@@ -191,7 +191,7 @@ func Test_ecsDetectV3(t *testing.T) {
 	d := Detector{provider: &mockMetaDataProvider{isV4: false, taskArnVersion: 1}, rb: metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())}
 	got, _, err := d.Detect(context.TODO())
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, got)
 	assert.Equal(t, want.Attributes().AsRaw(), got.Attributes().AsRaw())
 }
@@ -215,7 +215,7 @@ func Test_ecsDetectV3WithTaskArnVersion2(t *testing.T) {
 	d := Detector{provider: &mockMetaDataProvider{isV4: false, taskArnVersion: 2}, rb: metadata.NewResourceBuilder(metadata.DefaultResourceAttributesConfig())}
 	got, _, err := d.Detect(context.TODO())
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, got)
 	assert.Equal(t, want.Attributes().AsRaw(), got.Attributes().AsRaw())
 }

--- a/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/elasticbeanstalk_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/elasticbeanstalk/elasticbeanstalk_test.go
@@ -46,7 +46,7 @@ func Test_windowsPath(t *testing.T) {
 
 	r, _, err := d.Detect(context.TODO())
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, windowsPath, mfs.path)
 }
@@ -57,7 +57,7 @@ func Test_fileNotExists(t *testing.T) {
 
 	r, _, err := d.Detect(context.TODO())
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, 0, r.Attributes().Len())
 }
@@ -68,7 +68,7 @@ func Test_fileMalformed(t *testing.T) {
 
 	r, _, err := d.Detect(context.TODO())
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, 0, r.Attributes().Len())
 }
@@ -88,7 +88,7 @@ func Test_AttributesDetectedSuccessfully(t *testing.T) {
 
 	r, _, err := d.Detect(context.TODO())
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Equal(t, want.Attributes().AsRaw(), r.Attributes().AsRaw())
 }

--- a/processor/routingprocessor/factory_test.go
+++ b/processor/routingprocessor/factory_test.go
@@ -198,7 +198,7 @@ func TestShutdown(t *testing.T) {
 	}
 
 	exp, err := factory.CreateTracesProcessor(context.Background(), creationParams, cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, exp)
 
 	// test

--- a/processor/spanmetricsprocessor/factory_test.go
+++ b/processor/spanmetricsprocessor/factory_test.go
@@ -57,7 +57,7 @@ func TestNewProcessor(t *testing.T) {
 			smp := traceProcessor.(*processorImp)
 
 			// Verify
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.NotNil(t, smp)
 
 			assert.Equal(t, tc.wantLatencyHistogramBuckets, smp.latencyBounds)

--- a/processor/spanprocessor/factory_test.go
+++ b/processor/spanprocessor/factory_test.go
@@ -41,7 +41,7 @@ func TestFactory_CreateTracesProcessor(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"test-key"}
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tp)
 }
 

--- a/processor/spanprocessor/span_test.go
+++ b/processor/spanprocessor/span_test.go
@@ -32,7 +32,7 @@ func TestNewTracesProcessor(t *testing.T) {
 	require.Nil(t, tp)
 
 	tp, err = factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 }
 
@@ -108,7 +108,7 @@ func TestSpanProcessor_NilEmptyData(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key"}
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 	for i := range testCases {
 		tt := testCases[i]
@@ -212,7 +212,7 @@ func TestSpanProcessor_Values(t *testing.T) {
 	oCfg.Rename.FromAttributes = []string{"key1"}
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 	for _, tc := range testCases {
 		runIndividualTestCase(t, tc, tp)
@@ -288,7 +288,7 @@ func TestSpanProcessor_MissingKeys(t *testing.T) {
 	oCfg.Rename.Separator = "::"
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 	for _, tc := range testCases {
 		runIndividualTestCase(t, tc, tp)
@@ -306,7 +306,7 @@ func TestSpanProcessor_Separator(t *testing.T) {
 	oCfg.Rename.Separator = "::"
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	traceData := generateTraceData(
@@ -335,7 +335,7 @@ func TestSpanProcessor_NoSeparatorMultipleKeys(t *testing.T) {
 	oCfg.Rename.Separator = ""
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	traceData := generateTraceData(
@@ -365,7 +365,7 @@ func TestSpanProcessor_SeparatorMultipleKeys(t *testing.T) {
 	oCfg.Rename.Separator = "::"
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	traceData := generateTraceData(
@@ -400,7 +400,7 @@ func TestSpanProcessor_NilName(t *testing.T) {
 	oCfg.Rename.Separator = "::"
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	traceData := generateTraceData(
@@ -497,7 +497,7 @@ func TestSpanProcessor_ToAttributes(t *testing.T) {
 		oCfg.Rename.ToAttributes.Rules = tc.rules
 		oCfg.Rename.ToAttributes.BreakAfterMatch = tc.breakAfterMatch
 		tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, tp)
 
 		runIndividualTestCase(t, tc.testCase, tp)
@@ -564,7 +564,7 @@ func TestSpanProcessor_skipSpan(t *testing.T) {
 		Rules: []string{`(?P<operation_website>.*?)$`},
 	}
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	for _, tc := range testCases {
@@ -592,7 +592,7 @@ func TestSpanProcessor_setStatusCode(t *testing.T) {
 		Description: "Set custom error message",
 	}
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	td := generateTraceDataSetStatus(ptrace.StatusCodeUnset, "foobar", nil)
@@ -620,7 +620,7 @@ func TestSpanProcessor_setStatusCodeConditionally(t *testing.T) {
 		},
 	}
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), oCfg, consumertest.NewNop())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, tp)
 
 	testCases := []struct {

--- a/processor/sumologicprocessor/config_test.go
+++ b/processor/sumologicprocessor/config_test.go
@@ -23,7 +23,7 @@ func TestLoadConfig(t *testing.T) {
 	factories.Processors[metadata.Type] = factory
 	cfg, err := otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config.yaml"), factories)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
 	p0 := cfg.Processors[component.NewID(metadata.Type)]

--- a/processor/tailsamplingprocessor/internal/sampling/always_sample_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/always_sample_test.go
@@ -16,6 +16,6 @@ func TestEvaluate_AlwaysSample(t *testing.T) {
 	filter := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	decision, err := filter.Evaluate(context.Background(), pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 		16}), newTraceStringAttrs(nil, "example", "value"))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, decision, Sampled)
 }

--- a/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/rate_limiting_test.go
@@ -23,7 +23,7 @@ func TestRateLimiter(t *testing.T) {
 	traceSpanCount.Store(10)
 	trace.SpanCount = traceSpanCount
 	decision, err := rateLimiter.Evaluate(context.Background(), traceID, trace)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, decision, NotSampled)
 
 	// Trace span count equal to spans per second
@@ -31,7 +31,7 @@ func TestRateLimiter(t *testing.T) {
 	traceSpanCount.Store(3)
 	trace.SpanCount = traceSpanCount
 	decision, err = rateLimiter.Evaluate(context.Background(), traceID, trace)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, decision, NotSampled)
 
 	// Trace span count less than spans per second
@@ -39,13 +39,13 @@ func TestRateLimiter(t *testing.T) {
 	traceSpanCount.Store(2)
 	trace.SpanCount = traceSpanCount
 	decision, err = rateLimiter.Evaluate(context.Background(), traceID, trace)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, decision, Sampled)
 
 	// Trace span count less than spans per second
 	traceSpanCount = &atomic.Int64{}
 	trace.SpanCount = traceSpanCount
 	decision, err = rateLimiter.Evaluate(context.Background(), traceID, trace)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, decision, Sampled)
 }

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_datapoint_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_datapoint_test.go
@@ -120,7 +120,7 @@ func Test_convertDatapointGaugeToSum(t *testing.T) {
 			exprFunc, _ := convertDatapointGaugeToSum(tt.stringAggTemp, tt.monotonic)
 
 			_, err := exprFunc(nil, ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_gauge_to_sum_test.go
@@ -120,7 +120,7 @@ func Test_convertGaugeToSum(t *testing.T) {
 			exprFunc, _ := convertGaugeToSum(tt.stringAggTemp, tt.monotonic)
 
 			_, err := exprFunc(nil, ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_datapoint_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_datapoint_test.go
@@ -88,7 +88,7 @@ func Test_convertDatapointSumToGauge(t *testing.T) {
 			exprFunc, _ := convertDatapointSumToGauge()
 
 			_, err := exprFunc(nil, ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_sum_to_gauge_test.go
@@ -88,7 +88,7 @@ func Test_convertSumToGauge(t *testing.T) {
 			exprFunc, _ := convertSumToGauge()
 
 			_, err := exprFunc(nil, ctx)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expected := pmetric.NewMetric()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_count_val_to_sum_test.go
@@ -98,7 +98,7 @@ func Test_ConvertSummaryCountValToSum(t *testing.T) {
 			assert.NoError(t, err)
 
 			_, err = evaluate(nil, ottldatapoint.NewTransformContext(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource()))
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expected := pmetric.NewMetricSlice()
 			tt.want(expected)

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
@@ -106,7 +106,7 @@ func Test_ConvertSummarySumValToSum(t *testing.T) {
 			assert.NoError(t, err)
 
 			_, err = evaluate(nil, ottldatapoint.NewTransformContext(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource()))
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			expected := pmetric.NewMetricSlice()
 			tt.want(expected)

--- a/receiver/apachesparkreceiver/client_test.go
+++ b/receiver/apachesparkreceiver/client_test.go
@@ -89,7 +89,7 @@ func TestClusterStats(t *testing.T) {
 				tc := createTestClient(t, testURL)
 
 				clusterStats, err := tc.ClusterStats()
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.Nil(t, clusterStats)
 			},
 		},
@@ -113,7 +113,7 @@ func TestClusterStats(t *testing.T) {
 
 				clusterStats, err := tc.ClusterStats()
 				require.Nil(t, clusterStats)
-				require.NotNil(t, err)
+				require.Error(t, err)
 			},
 		},
 		{
@@ -172,7 +172,7 @@ func TestApplications(t *testing.T) {
 				tc := createTestClient(t, testURL)
 
 				apps, err := tc.Applications()
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.Nil(t, apps)
 			},
 		},
@@ -196,7 +196,7 @@ func TestApplications(t *testing.T) {
 
 				apps, err := tc.Applications()
 				require.Nil(t, apps)
-				require.NotNil(t, err)
+				require.Error(t, err)
 			},
 		},
 		{
@@ -255,7 +255,7 @@ func TestStageStats(t *testing.T) {
 				tc := createTestClient(t, testURL)
 
 				stageStats, err := tc.StageStats("some_app_id")
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.Nil(t, stageStats)
 			},
 		},
@@ -279,7 +279,7 @@ func TestStageStats(t *testing.T) {
 
 				stageStats, err := tc.StageStats("some_app_id")
 				require.Nil(t, stageStats)
-				require.NotNil(t, err)
+				require.Error(t, err)
 			},
 		},
 		{
@@ -338,7 +338,7 @@ func TestExecutorStats(t *testing.T) {
 				tc := createTestClient(t, testURL)
 
 				executorStats, err := tc.ExecutorStats("some_app_id")
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.Nil(t, executorStats)
 			},
 		},
@@ -362,7 +362,7 @@ func TestExecutorStats(t *testing.T) {
 
 				executorStats, err := tc.ExecutorStats("some_app_id")
 				require.Nil(t, executorStats)
-				require.NotNil(t, err)
+				require.Error(t, err)
 			},
 		},
 		{
@@ -421,7 +421,7 @@ func TestJobStats(t *testing.T) {
 				tc := createTestClient(t, testURL)
 
 				jobStats, err := tc.JobStats("some_app_id")
-				require.NotNil(t, err)
+				require.Error(t, err)
 				require.Nil(t, jobStats)
 			},
 		},
@@ -445,7 +445,7 @@ func TestJobStats(t *testing.T) {
 
 				jobStats, err := tc.JobStats("some_app_id")
 				require.Nil(t, jobStats)
-				require.NotNil(t, err)
+				require.Error(t, err)
 			},
 		},
 		{

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup_test.go
@@ -49,7 +49,7 @@ func TestGetCGroupPathForTask(t *testing.T) {
 			got, err := getCGroupPathForTask(cgroupMount, controller, tt.input, clusterName)
 
 			if tt.err != nil {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.wantRes, got)
@@ -100,7 +100,7 @@ func TestGetCGroupPathFromARN(t *testing.T) {
 			got, err := getTaskCgroupPathFromARN(tt.input)
 
 			if tt.err != nil {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.wantRes, got)
@@ -153,7 +153,7 @@ func TestGetCGroupMountPoint(t *testing.T) {
 			got, err := getCGroupMountPoint(tt.input)
 
 			if tt.err != nil {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.wantRes, got)

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils_test.go
@@ -35,7 +35,7 @@ func TestGetContainerInstanceIDFromArn(t *testing.T) {
 
 	wrongFormatARN := "arn:aws:ecs:region:aws_account_id:task"
 	_, err := GetContainerInstanceIDFromArn(wrongFormatARN)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestIsClosed(t *testing.T) {
@@ -69,7 +69,7 @@ func TestRequestSuccessWithKnownLength(t *testing.T) {
 
 	body, err := request(ctx, "0.0.0.0", MockHTTPClient)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.NotNil(t, body)
 
@@ -94,7 +94,7 @@ func TestRequestSuccessWithUnknownLength(t *testing.T) {
 
 	body, err := request(ctx, "0.0.0.0", MockHTTPClient)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.NotNil(t, body)
 
@@ -122,7 +122,7 @@ func TestRequestWithFailedStatus(t *testing.T) {
 
 	assert.Nil(t, body)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 }
 
@@ -147,6 +147,6 @@ func TestRequestWithLargeContentLength(t *testing.T) {
 
 	assert.Nil(t, body)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 }

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
@@ -79,7 +79,7 @@ func TestInfo(t *testing.T) {
 	}
 	m, err := NewInfo(ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// test the case when aws session fails to initialize
 	nodeCapacityCreatorOpt = func(m *Info) {
@@ -94,7 +94,7 @@ func TestInfo(t *testing.T) {
 	}
 	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// test normal case where everything is working
 	awsSessionCreatorOpt = func(m *Info) {
@@ -122,7 +122,7 @@ func TestInfo(t *testing.T) {
 	}
 	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, m)
 
 	// befoe ebsVolume and ec2Tags are initialized
@@ -153,7 +153,7 @@ func TestInfoForECS(t *testing.T) {
 	}
 	m, err := NewInfo(ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// test the case when aws session fails to initialize
 	nodeCapacityCreatorOpt = func(m *Info) {
@@ -168,7 +168,7 @@ func TestInfoForECS(t *testing.T) {
 	}
 	m, err = NewInfo(ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// test normal case where everything is working
 	awsSessionCreatorOpt = func(m *Info) {
@@ -196,7 +196,7 @@ func TestInfoForECS(t *testing.T) {
 	}
 	m, err = NewInfo(ci.ECS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, m)
 
 	// befoe ebsVolume and ec2Tags are initialized

--- a/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
@@ -24,7 +24,7 @@ func TestNodeCapacity(t *testing.T) {
 	}
 	nc, err := newNodeCapacity(zap.NewNop(), lstatOption)
 	assert.Nil(t, nc)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	// can't set environment variables
 	lstatOption = func(nc *nodeCapacity) {
@@ -45,7 +45,7 @@ func TestNodeCapacity(t *testing.T) {
 	}
 	nc, err = newNodeCapacity(zap.NewNop(), lstatOption, virtualMemOption, cpuInfoOption)
 	assert.NotNil(t, nc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int64(0), nc.getMemoryCapacity())
 	assert.Equal(t, int64(0), nc.getNumCores())
 
@@ -67,7 +67,7 @@ func TestNodeCapacity(t *testing.T) {
 	}
 	nc, err = newNodeCapacity(zap.NewNop(), lstatOption, virtualMemOption, cpuInfoOption)
 	assert.NotNil(t, nc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, int64(1024), nc.getMemoryCapacity())
 	assert.Equal(t, int64(2), nc.getNumCores())
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -157,7 +157,7 @@ func TestK8sAPIServer_New(t *testing.T) {
 	}
 	k8sAPIServer, err := New(MockClusterNameProvicer{}, zap.NewNop(), k8sClientOption)
 	assert.Nil(t, k8sAPIServer)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestK8sAPIServer_GetMetrics(t *testing.T) {
@@ -182,7 +182,7 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 		leadingOption, broadcasterOption, isLeadingCOption)
 
 	assert.NotNil(t, k8sAPIServer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	mockClient.On("NamespaceToRunningPodNum").Return(map[string]int{"default": 2})
 	mockClient.On("ClusterFailedNodeCount").Return(1)
@@ -230,12 +230,12 @@ func TestK8sAPIServer_init(t *testing.T) {
 	k8sAPIServer := &K8sAPIServer{}
 
 	err := k8sAPIServer.init()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), "environment variable HOST_NAME is not set"))
 
 	t.Setenv("HOST_NAME", "hostname")
 
 	err = k8sAPIServer.init()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), "environment variable K8S_NAMESPACE is not set"))
 }

--- a/receiver/awscontainerinsightreceiver/receiver_test.go
+++ b/receiver/awscontainerinsightreceiver/receiver_test.go
@@ -71,7 +71,7 @@ func TestReceiverForNilConsumer(t *testing.T) {
 		nil,
 	)
 
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.Nil(t, metricsReceiver)
 }
 
@@ -92,13 +92,13 @@ func TestCollectData(t *testing.T) {
 	r.k8sapiserver = &mockK8sAPIServer{}
 	r.cadvisor = &mockCadvisor{}
 	err = r.collectData(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// test the case when cadvisor and k8sapiserver failed to initialize
 	r.cadvisor = nil
 	r.k8sapiserver = nil
 	err = r.collectData(ctx)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestCollectDataWithErrConsumer(t *testing.T) {
@@ -119,7 +119,7 @@ func TestCollectDataWithErrConsumer(t *testing.T) {
 	ctx := context.Background()
 
 	err = r.collectData(ctx)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestCollectDataWithECS(t *testing.T) {
@@ -140,10 +140,10 @@ func TestCollectDataWithECS(t *testing.T) {
 
 	r.cadvisor = &mockCadvisor{}
 	err = r.collectData(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// test the case when cadvisor and k8sapiserver failed to initialize
 	r.cadvisor = nil
 	err = r.collectData(ctx)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator_test.go
@@ -242,13 +242,13 @@ func TestCalculateDuration(t *testing.T) {
 	startTime = "2010-10-02 00:15:07"
 	endTime = "2020-10-03T15:14:06.620913372Z"
 	result, err = calculateDuration(startTime, endTime)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.EqualValues(t, 0, result)
 
 	startTime = "2010-10-02T00:15:07.620912337Z"
 	endTime = "2020-10-03 15:14:06 +800"
 	result, err = calculateDuration(startTime, endTime)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.EqualValues(t, 0, result)
 
 }

--- a/receiver/awsecscontainermetricsreceiver/receiver_test.go
+++ b/receiver/awsecscontainermetricsreceiver/receiver_test.go
@@ -62,7 +62,7 @@ func TestReceiverForNilConsumer(t *testing.T) {
 		&fakeRestClient{},
 	)
 
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.Nil(t, metricsReceiver)
 }
 

--- a/receiver/azureeventhubreceiver/config_test.go
+++ b/receiver/azureeventhubreceiver/config_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	factories, err := otelcoltest.NopFactories()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	factory := NewFactory()
 	factories.Receivers[metadata.Type] = factory

--- a/receiver/couchdbreceiver/client_test.go
+++ b/receiver/couchdbreceiver/client_test.go
@@ -24,7 +24,7 @@ func defaultClient(t *testing.T, endpoint string) client {
 		cfg,
 		componenttest.NewNopHost(),
 		componenttest.NewNopTelemetrySettings())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, couchdbClient)
 	return couchdbClient
 }
@@ -83,7 +83,7 @@ func TestGet(t *testing.T) {
 		couchdbClient := defaultClient(t, url)
 
 		result, err := couchdbClient.Get(url)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 		require.Contains(t, err.Error(), "invalid port ")
 	})
@@ -92,7 +92,7 @@ func TestGet(t *testing.T) {
 		couchdbClient := defaultClient(t, url)
 
 		result, err := couchdbClient.Get(url)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 		require.Contains(t, err.Error(), "404 Not Found")
 	})
@@ -101,7 +101,7 @@ func TestGet(t *testing.T) {
 		couchdbClient := defaultClient(t, url)
 
 		result, err := couchdbClient.Get(url)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, result)
 		require.Contains(t, err.Error(), "failed to read response body ")
 	})
@@ -117,12 +117,12 @@ func TestGet(t *testing.T) {
 			},
 			componenttest.NewNopHost(),
 			componenttest.NewNopTelemetrySettings())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, couchdbClient)
 
 		result, err := couchdbClient.Get(url)
 		require.Nil(t, result)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Contains(t, err.Error(), "401 Unauthorized")
 	})
 	t.Run("no error", func(t *testing.T) {
@@ -130,7 +130,7 @@ func TestGet(t *testing.T) {
 		couchdbClient := defaultClient(t, url)
 
 		result, err := couchdbClient.Get(url)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, result)
 	})
 }
@@ -158,14 +158,14 @@ func TestGetNodeStats(t *testing.T) {
 		couchdbClient := defaultClient(t, "invalid")
 
 		actualStats, err := couchdbClient.GetStats("_local")
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, actualStats)
 	})
 	t.Run("invalid json", func(t *testing.T) {
 		couchdbClient := defaultClient(t, ts.URL+"/invalid_json")
 
 		actualStats, err := couchdbClient.GetStats("_local")
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Nil(t, actualStats)
 	})
 	t.Run("no error", func(t *testing.T) {
@@ -173,7 +173,7 @@ func TestGetNodeStats(t *testing.T) {
 		couchdbClient := defaultClient(t, ts.URL)
 
 		actualStats, err := couchdbClient.GetStats("_local")
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.EqualValues(t, expectedStats, actualStats)
 	})
 }

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -89,7 +89,7 @@ func TestScrape(t *testing.T) {
 		scraper := newCouchdbScraper(receivertest.NewNopCreateSettings(), cfg)
 
 		_, err := scraper.scrape(context.Background())
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Equal(t, err, errors.New("no client available"))
 	})
 
@@ -103,7 +103,7 @@ func TestScrape(t *testing.T) {
 		scraper.client = mockClient
 
 		_, err := scraper.scrape(context.Background())
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Equal(t, 1, logs.Len())
 		require.Equal(t, []observer.LoggedEntry{
 			{
@@ -139,7 +139,7 @@ func TestStart(t *testing.T) {
 
 		scraper := newCouchdbScraper(receivertest.NewNopCreateSettings(), cfg)
 		err := scraper.start(context.Background(), componenttest.NewNopHost())
-		require.NotNil(t, err)
+		require.Error(t, err)
 	})
 }
 

--- a/receiver/dockerstatsreceiver/integration_test.go
+++ b/receiver/dockerstatsreceiver/integration_test.go
@@ -63,7 +63,7 @@ func createNginxContainer(ctx context.Context, t *testing.T) testcontainers.Cont
 		ContainerRequest: req,
 		Started:          true,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, container)
 
 	return container

--- a/receiver/expvarreceiver/scraper_test.go
+++ b/receiver/expvarreceiver/scraper_test.go
@@ -166,7 +166,7 @@ func TestJSONParseError(t *testing.T) {
 	err := scraper.start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
 	_, err = scraper.scrape(context.Background())
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestEmptyResponseBodyError(t *testing.T) {

--- a/receiver/flinkmetricsreceiver/client_test.go
+++ b/receiver/flinkmetricsreceiver/client_test.go
@@ -175,7 +175,7 @@ func TestGetJobmanagerMetrics(t *testing.T) {
 				require.Equal(t, expected, &actual.Metrics)
 
 				hostname, err := os.Hostname()
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.EqualValues(t, hostname, actual.Host)
 			},
 		},
@@ -378,7 +378,7 @@ func TestGetJobsMetrics(t *testing.T) {
 				require.EqualValues(t, "State machine job", actual[0].JobName)
 
 				hostname, err := os.Hostname()
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.EqualValues(t, hostname, actual[0].Host)
 			},
 		},

--- a/receiver/fluentforwardreceiver/ack_test.go
+++ b/receiver/fluentforwardreceiver/ack_test.go
@@ -30,13 +30,13 @@ func TestAckEncoding(t *testing.T) {
 	}
 
 	err := a.EncodeMsg(msgpWriterWithLimit(t, 1000))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = a.EncodeMsg(msgpWriterWithLimit(t, 4))
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 	err = a.EncodeMsg(msgpWriterWithLimit(t, 7))
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 // LimitedWriter is an io.Writer that will return an EOF error after MaxLen has

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -21,7 +21,7 @@ func TestMessageEventConversion(t *testing.T) {
 
 	var event MessageEventLogRecord
 	err := event.DecodeMsg(reader)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	expectedLog := logConstructor(
 		Log{
@@ -86,7 +86,7 @@ func TestAttributeTypeConversion(t *testing.T) {
 
 	var event MessageEventLogRecord
 	err = event.DecodeMsg(reader)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	le := event.LogRecords().At(0)
 
@@ -129,7 +129,7 @@ func TestEventMode(t *testing.T) {
 
 func TestTimeFromTimestampBadType(t *testing.T) {
 	_, err := timeFromTimestamp("bad")
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestMessageEventConversionWithErrors(t *testing.T) {
@@ -148,7 +148,7 @@ func TestMessageEventConversionWithErrors(t *testing.T) {
 
 			var event MessageEventLogRecord
 			err := event.DecodeMsg(reader)
-			require.NotNil(t, err)
+			require.Error(t, err)
 		})
 	}
 }
@@ -162,7 +162,7 @@ func TestForwardEventConversionWithErrors(t *testing.T) {
 
 			var event ForwardEventLogRecords
 			err := event.DecodeMsg(reader)
-			require.NotNil(t, err)
+			require.Error(t, err)
 		})
 	}
 }
@@ -176,7 +176,7 @@ func TestPackedForwardEventConversionWithErrors(t *testing.T) {
 
 			var event PackedForwardEventLogRecords
 			err := event.DecodeMsg(reader)
-			require.NotNil(t, err)
+			require.Error(t, err)
 		})
 	}
 
@@ -188,7 +188,7 @@ func TestPackedForwardEventConversionWithErrors(t *testing.T) {
 
 		var event PackedForwardEventLogRecords
 		err := event.DecodeMsg(reader)
-		require.NotNil(t, err)
+		require.Error(t, err)
 		require.Contains(t, err.Error(), "gzip")
 		fmt.Println(err.Error())
 	})
@@ -222,7 +222,7 @@ func TestBodyConversion(t *testing.T) {
 
 	var event MessageEventLogRecord
 	err = event.DecodeMsg(reader)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	le := event.LogRecords().At(0)
 

--- a/receiver/fluentforwardreceiver/heartbeat_test.go
+++ b/receiver/fluentforwardreceiver/heartbeat_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestUDPHeartbeat(t *testing.T) {
 	udpSock, err := net.ListenPacket("udp", "127.0.0.1:0")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -23,16 +23,16 @@ func TestUDPHeartbeat(t *testing.T) {
 	go respondToHeartbeats(ctx, udpSock, zap.NewNop())
 
 	conn, err := net.Dial("udp", udpSock.LocalAddr().String())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	n, err := conn.Write([]byte{0x00})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, n)
 
 	buf := make([]byte, 1)
 	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
 	n, err = conn.Read(buf)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, n)
 	require.Equal(t, uint8(0x00), buf[0])
 }

--- a/receiver/fluentforwardreceiver/receiver_test.go
+++ b/receiver/fluentforwardreceiver/receiver_test.go
@@ -45,7 +45,7 @@ func setupServer(t *testing.T) (func() net.Conn, *consumertest.LogsSink, *observ
 
 	connect := func() net.Conn {
 		conn, err := net.Dial("tcp", receiver.(*fluentReceiver).listener.Addr().String())
-		require.Nil(t, err)
+		require.NoError(t, err)
 		return conn
 	}
 

--- a/receiver/fluentforwardreceiver/timeext_test.go
+++ b/receiver/fluentforwardreceiver/timeext_test.go
@@ -18,13 +18,13 @@ func TestTimeEventExp(t *testing.T) {
 	var b [8]byte
 
 	err := e.MarshalBinaryTo(b[:])
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, []byte{0x00, 0x00, 0x01, 0xf4, 0x00, 0x00, 0x00, 0xfa}, b[:])
 
 	err = e.UnmarshalBinary(b[:])
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, tim, time.Time(e))
 
 	err = e.UnmarshalBinary(b[:5])
-	require.NotNil(t, err)
+	require.Error(t, err)
 }

--- a/receiver/googlecloudspannerreceiver/internal/datasource/database_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/datasource/database_test.go
@@ -28,7 +28,7 @@ func TestNewDatabase(t *testing.T) {
 
 	database, err := NewDatabase(ctx, databaseID, "../../testdata/serviceAccount.json")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, database.Client())
 	assert.Equal(t, databaseID, database.DatabaseID())
 }
@@ -39,7 +39,7 @@ func TestNewDatabaseWithError(t *testing.T) {
 
 	database, err := NewDatabase(ctx, databaseID, "does not exist")
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, database)
 }
 
@@ -51,7 +51,7 @@ func TestNewDatabaseWithNoCredentialsFilePath(t *testing.T) {
 
 	database, err := NewDatabase(ctx, databaseID, "")
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, database.Client())
 	assert.Equal(t, databaseID, database.DatabaseID())
 }

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
@@ -44,7 +44,7 @@ func TestNewDatabaseReader(t *testing.T) {
 
 	reader, err := NewDatabaseReader(ctx, parsedMetadata, databaseID, serviceAccountPath, readerConfig, logger)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	defer executeShutdown(reader)
 
@@ -66,7 +66,7 @@ func TestNewDatabaseReaderWithError(t *testing.T) {
 
 	reader, err := NewDatabaseReader(ctx, parsedMetadata, databaseID, serviceAccountPath, readerConfig, logger)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	// Do not call executeShutdown() here because reader hasn't been created
 	assert.Nil(t, reader)
 }

--- a/receiver/googlecloudspannerreceiver/receiver_test.go
+++ b/receiver/googlecloudspannerreceiver/receiver_test.go
@@ -313,9 +313,9 @@ func TestGoogleCloudSpannerReceiver_Shutdown(t *testing.T) {
 			err := receiver.Shutdown(ctx)
 
 			if testCase.expectError {
-				require.NotNil(t, err)
+				require.Error(t, err)
 			} else {
-				require.Nil(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
@@ -103,7 +103,7 @@ func TestScrape(t *testing.T) {
 
 			if test.bootTimeFunc != nil {
 				actualBootTime, err := scraper.bootTime(context.Background())
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, uint64(bootTime), actualBootTime)
 			}
 			// expect 3 metrics

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -1110,7 +1110,7 @@ func TestScrapeMetrics_MuteErrorFlags(t *testing.T) {
 			assert.Equal(t, test.expectedCount, md.MetricCount())
 
 			if config.MuteProcessNameError && config.MuteProcessExeError && config.MuteProcessUserError {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			} else {
 				assert.EqualError(t, err, test.expectedError)
 			}
@@ -1170,7 +1170,7 @@ func TestScrapeMetrics_DontCheckDisabledMetrics(t *testing.T) {
 		md, err := scraper.scrape(context.Background())
 
 		assert.Zero(t, md.MetricCount())
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 }
 
@@ -1239,11 +1239,11 @@ func TestScrapeMetrics_CpuUtilizationWhenCpuTimesIsDisabled(t *testing.T) {
 
 			// scrape the first time
 			_, err = scraper.scrape(context.Background())
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			// scrape second time to get utilization
 			md, err := scraper.scrape(context.Background())
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			for k := 0; k < md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len(); k++ {
 				fmt.Println(md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(k).Name())

--- a/receiver/k8sclusterreceiver/config_test.go
+++ b/receiver/k8sclusterreceiver/config_test.go
@@ -84,7 +84,7 @@ func TestInvalidConfig(t *testing.T) {
 		CollectionInterval: 30 * time.Second,
 	}
 	err := component.ValidateConfig(cfg)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "invalid authType for kubernetes: ", err.Error())
 
 	// Wrong distro
@@ -94,6 +94,6 @@ func TestInvalidConfig(t *testing.T) {
 		CollectionInterval: 30 * time.Second,
 	}
 	err = component.ValidateConfig(cfg)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "\"wrong\" is not a supported distribution. Must be one of: \"openshift\", \"kubernetes\"", err.Error())
 }

--- a/receiver/kafkametricsreceiver/factory_test.go
+++ b/receiver/kafkametricsreceiver/factory_test.go
@@ -44,5 +44,5 @@ func TestCreateMetricsReceiver(t *testing.T) {
 	cfg.Scrapers = []string{"topics"}
 	_, err := createMetricsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, nil)
 	newMetricsReceiver = prev
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/receiver/kafkametricsreceiver/receiver_test.go
+++ b/receiver/kafkametricsreceiver/receiver_test.go
@@ -68,7 +68,7 @@ func TestNewReceiver(t *testing.T) {
 	}
 	allScrapers["brokers"] = mockScraper
 	r, err := newMetricsReceiver(context.Background(), *c, receivertest.NewNopCreateSettings(), consumertest.NewNop())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, r)
 }
 
@@ -80,6 +80,6 @@ func TestNewReceiver_handles_scraper_error(t *testing.T) {
 	}
 	allScrapers["brokers"] = mockScraper
 	r, err := newMetricsReceiver(context.Background(), *c, receivertest.NewNopCreateSettings(), consumertest.NewNop())
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Nil(t, r)
 }

--- a/receiver/kafkametricsreceiver/topic_scraper_test.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_test.go
@@ -66,7 +66,7 @@ func TestTopicScraper_ScrapeHandlesError(t *testing.T) {
 	sc := sarama.NewConfig()
 	ms, err := createTopicsScraper(context.Background(), Config{}, sc, receivertest.NewNopCreateSettings())
 	assert.NotNil(t, ms)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	_, err = ms.Scrape(context.Background())
 	assert.Error(t, err)
 }
@@ -78,7 +78,7 @@ func TestTopicScraper_ShutdownHandlesNilClient(t *testing.T) {
 	sc := sarama.NewConfig()
 	ms, err := createTopicsScraper(context.Background(), Config{}, sc, receivertest.NewNopCreateSettings())
 	assert.NotNil(t, ms)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = ms.Shutdown(context.Background())
 	assert.NoError(t, err)
 }

--- a/receiver/kafkareceiver/json_unmarshaler_test.go
+++ b/receiver/kafkareceiver/json_unmarshaler_test.go
@@ -24,7 +24,7 @@ func TestPlogReturnType(t *testing.T) {
 	unmarshaledJSON, err := um.Unmarshal([]byte(json))
 
 	assert.NoError(t, err)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var expectedType plog.Logs
 	assert.IsType(t, expectedType, unmarshaledJSON)

--- a/receiver/mongodbreceiver/config_test.go
+++ b/receiver/mongodbreceiver/config_test.go
@@ -92,7 +92,7 @@ func TestValidate(t *testing.T) {
 			}
 			err := component.ValidateConfig(cfg)
 			if tc.expected == nil {
-				require.Nil(t, err)
+				require.NoError(t, err)
 			} else {
 				require.Contains(t, err.Error(), tc.expected.Error())
 			}

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -414,7 +414,7 @@ func TestOCReceiverTrace_HandleNextConsumerResponse(t *testing.T) {
 
 				var opts []ocOption
 				ocr, err := newOpenCensusReceiver("tcp", addr, nil, nil, receiver.CreateSettings{ID: exporter.receiverID, TelemetrySettings: testTel.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, opts...)
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.NotNil(t, ocr)
 
 				ocr.traceConsumer = sink
@@ -565,7 +565,7 @@ func TestOCReceiverMetrics_HandleNextConsumerResponse(t *testing.T) {
 
 				var opts []ocOption
 				ocr, err := newOpenCensusReceiver("tcp", addr, nil, nil, receiver.CreateSettings{ID: exporter.receiverID, TelemetrySettings: testTel.TelemetrySettings(), BuildInfo: component.NewDefaultBuildInfo()}, opts...)
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.NotNil(t, ocr)
 
 				ocr.metricsConsumer = sink

--- a/receiver/podmanreceiver/libpod_client_test.go
+++ b/receiver/podmanreceiver/libpod_client_test.go
@@ -66,7 +66,7 @@ func TestStats(t *testing.T) {
 
 	cli, err := newLibpodClient(zap.NewNop(), config)
 	assert.NotNil(t, cli)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expectedStats := containerStats{
 		AvgCPU:        42.04781177856639,
@@ -122,7 +122,7 @@ func TestStatsError(t *testing.T) {
 
 	cli, err := newLibpodClient(zap.NewNop(), config)
 	assert.NotNil(t, cli)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	stats, err := cli.stats(context.Background(), nil)
 	assert.Nil(t, stats)
@@ -156,7 +156,7 @@ func TestList(t *testing.T) {
 
 	cli, err := newLibpodClient(zap.NewNop(), config)
 	assert.NotNil(t, cli)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expectedContainer := container{
 
@@ -227,7 +227,7 @@ func TestEvents(t *testing.T) {
 
 	cli, err := newLibpodClient(zap.NewNop(), config)
 	assert.NotNil(t, cli)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	expectedEvents := []event{
 		{ID: "49a4c52afb06e6b36b2941422a0adf47421dbfbf40503dbe17bd56b4570b6681", Status: "start"},

--- a/receiver/podmanreceiver/podman_test.go
+++ b/receiver/podmanreceiver/podman_test.go
@@ -77,7 +77,7 @@ func TestWatchingTimeouts(t *testing.T) {
 	}
 
 	client, err := newLibpodClient(zap.NewNop(), config)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	cli := newContainerScraper(client, zap.NewNop(), config)
 	assert.NotNil(t, cli)
@@ -130,7 +130,7 @@ func TestEventLoopHandlesError(t *testing.T) {
 	}
 
 	client, err := newLibpodClient(zap.NewNop(), config)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	cli := newContainerScraper(client, zap.New(observed), config)
 	assert.NotNil(t, cli)

--- a/receiver/podmanreceiver/receiver_test.go
+++ b/receiver/podmanreceiver/receiver_test.go
@@ -36,7 +36,7 @@ func TestNewReceiver(t *testing.T) {
 	mr, err := newMetricsReceiver(context.Background(), receivertest.NewNopCreateSettings(), config, nextConsumer, nil)
 
 	assert.NotNil(t, mr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestNewReceiverErrors(t *testing.T) {

--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -128,17 +128,17 @@ service:
       exporters: [prometheusremotewrite]`, serverURL.Host, prweServer.URL)
 
 	confFile, err := os.CreateTemp(os.TempDir(), "conf-")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer os.Remove(confFile.Name())
 	_, err = confFile.Write([]byte(cfg))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	// 4. Run the OpenTelemetry Collector.
 	receivers, err := receiver.MakeFactoryMap(prometheusreceiver.NewFactory())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	exporters, err := exporter.MakeFactoryMap(prometheusremotewriteexporter.NewFactory())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	processors, err := processor.MakeFactoryMap(batchprocessor.NewFactory())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	factories := otelcol.Factories{
 		Receivers:  receivers,
@@ -173,7 +173,7 @@ service:
 	}
 
 	app, err := otelcol.NewCollector(appSettings)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	go func() {
 		assert.NoError(t, app.Run(context.Background()))

--- a/receiver/receivercreator/config_test.go
+++ b/receiver/receivercreator/config_test.go
@@ -137,7 +137,7 @@ func TestLoadConfig(t *testing.T) {
 
 func TestInvalidResourceAttributeEndpointType(t *testing.T) {
 	factories, err := otelcoltest.NopFactories()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	factories.Receivers[("nop")] = &nopWithEndpointFactory{Factory: receivertest.NewNopFactory()}
 
@@ -150,7 +150,7 @@ func TestInvalidResourceAttributeEndpointType(t *testing.T) {
 
 func TestInvalidReceiverResourceAttributeValueType(t *testing.T) {
 	factories, err := otelcoltest.NopFactories()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	factories.Receivers[("nop")] = &nopWithEndpointFactory{Factory: receivertest.NewNopFactory()}
 

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -449,7 +449,7 @@ type mockHost struct {
 
 func newMockHost(t *testing.T) *mockHost {
 	factories, err := otelcoltest.NopFactories()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	factories.Receivers["with.endpoint"] = &nopWithEndpointFactory{Factory: receivertest.NewNopFactory()}
 	factories.Receivers["without.endpoint"] = &nopWithoutEndpointFactory{Factory: receivertest.NewNopFactory()}
 	return &mockHost{t: t, factories: factories}

--- a/receiver/redisreceiver/client_test.go
+++ b/receiver/redisreceiver/client_test.go
@@ -48,6 +48,6 @@ func readFile(fname string) (string, error) {
 func TestRetrieveInfo(t *testing.T) {
 	g := fakeClient{}
 	res, err := g.retrieveInfo()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(res, "# Server"))
 }

--- a/receiver/redisreceiver/info_test.go
+++ b/receiver/redisreceiver/info_test.go
@@ -14,6 +14,6 @@ func TestGetUptime(t *testing.T) {
 	svc := newRedisSvc(newFakeClient())
 	info, _ := svc.info()
 	uptime, err := info.getUptimeInSeconds()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, time.Duration(104946000000000), uptime)
 }

--- a/receiver/redisreceiver/keyspace_test.go
+++ b/receiver/redisreceiver/keyspace_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestParseKeyspace(t *testing.T) {
 	ks, err := parseKeyspaceString(9, "keys=1,expires=2,avg_ttl=3")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "9", ks.db)
 	require.Equal(t, 1, ks.keys)
 	require.Equal(t, 2, ks.expires)
@@ -28,7 +28,7 @@ func TestParseMalformedKeyspace(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := parseKeyspaceString(0, test.keyspace)
-			require.NotNil(t, err)
+			require.Error(t, err)
 		})
 	}
 }

--- a/receiver/redisreceiver/latencystats_test.go
+++ b/receiver/redisreceiver/latencystats_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestParseLatencyStats(t *testing.T) {
 	ls, err := parseLatencyStats("p50=181.247,p55=182.271,p99=309.247,p99.9=1023.999")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, ls["p50"], 181.247)
 	require.Equal(t, ls["p55"], 182.271)
 	require.Equal(t, ls["p99"], 309.247)
@@ -28,7 +28,7 @@ func TestParseMalformedLatencyStats(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := parseLatencyStats(test.stats)
-			require.NotNil(t, err)
+			require.Error(t, err)
 		})
 	}
 }

--- a/receiver/redisreceiver/redis_svc_test.go
+++ b/receiver/redisreceiver/redis_svc_test.go
@@ -16,7 +16,7 @@ func newFakeAPIParser() *redisSvc {
 func TestParser(t *testing.T) {
 	s := newFakeAPIParser()
 	info, err := s.info()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 130, len(info))
 	require.Equal(t, "1.24", info["allocator_frag_ratio"]) // spot check
 }

--- a/receiver/solacereceiver/unmarshaller_receive_test.go
+++ b/receiver/solacereceiver/unmarshaller_receive_test.go
@@ -649,7 +649,7 @@ func TestReceiveUnmarshallerReceiveBaggageString(t *testing.T) {
 			u := newTestReceiveV1Unmarshaller(t)
 			err := u.unmarshalBaggage(actual, testCase.baggage)
 			if testCase.errStr == "" {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			} else {
 				assert.ErrorContains(t, err, testCase.errStr)
 			}

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -138,7 +138,7 @@ func TestStartTraceReception(t *testing.T) {
 				},
 			}
 			zr, err := newReceiver(cfg, sink, receivertest.NewNopCreateSettings())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, zr)
 
 			err = zr.Start(context.Background(), tt.host)


### PR DESCRIPTION
* It enforces type checking at compile time (e.g. changing return type error -> bool  will be caught).
* It is easier to read that you expect an error or not an error.
* Offers easier to read/improved error message when fails.

