### PR TITLE
Remove the obsolete +build directive

### DIFF
--- a/.chloggen/remove-obsolete-build-directive.yaml
+++ b/.chloggen/remove-obsolete-build-directive.yaml
@@ -1,0 +1,20 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. otlpreceiver)
+component: all
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove obsolete "// +build" directive
+
+# One or more tracking issues or pull requests related to the change
+issues: [30651]
+
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e
-// +build e2e
 
 package main
 
@@ -31,12 +30,13 @@ import (
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/open-telemetry/opamp-go/server"
 	"github.com/open-telemetry/opamp-go/server/types"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	semconv "go.opentelemetry.io/collector/semconv/v1.21.0"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
 )
 
 type testLogger struct {

--- a/exporter/datadogexporter/internal/hostmetadata/internal/gohai/processes.go
+++ b/exporter/datadogexporter/internal/hostmetadata/internal/gohai/processes.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
+
 //go:build linux || darwin
-// +build linux darwin
 
 package gohai // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/hostmetadata/internal/gohai"
 

--- a/exporter/datadogexporter/internal/hostmetadata/internal/gohai/processes_other.go
+++ b/exporter/datadogexporter/internal/hostmetadata/internal/gohai/processes_other.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
+
 //go:build !linux && !darwin
-// +build !linux,!darwin
 
 package gohai // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/hostmetadata/internal/gohai"
 

--- a/exporter/datadogexporter/internal/hostmetadata/internal/system/host_unix.go
+++ b/exporter/datadogexporter/internal/hostmetadata/internal/system/host_unix.go
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 //go:build !windows
-// +build !windows
 
 package system // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/hostmetadata/internal/system"
 

--- a/exporter/datadogexporter/internal/hostmetadata/internal/system/host_unix_test.go
+++ b/exporter/datadogexporter/internal/hostmetadata/internal/system/host_unix_test.go
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 //go:build !windows
-// +build !windows
 
 package system
 

--- a/exporter/datadogexporter/internal/hostmetadata/internal/system/host_windows.go
+++ b/exporter/datadogexporter/internal/hostmetadata/internal/system/host_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package system // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/hostmetadata/internal/system"
 

--- a/exporter/datasetexporter/logs_exporter_stress_test.go
+++ b/exporter/datasetexporter/logs_exporter_stress_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package datasetexporter
 

--- a/exporter/signalfxexporter/internal/hostmetadata/host_linux.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/host_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 // Taken from https://github.com/signalfx/golib/blob/master/metadata/hostmetadata/host-linux.go
 // with minor modifications.

--- a/exporter/signalfxexporter/internal/hostmetadata/host_linux_test.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/host_linux_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 // Taken from https://github.com/signalfx/golib/blob/master/metadata/hostmetadata/host-linux_test.go as is.
 

--- a/exporter/signalfxexporter/internal/hostmetadata/host_others.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/host_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux
-// +build !linux
 
 // Taken from https://github.com/signalfx/golib/blob/master/metadata/hostmetadata/host-not-linux.go as is.
 

--- a/exporter/signalfxexporter/internal/hostmetadata/metadata_others_test.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/metadata_others_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux
-// +build !linux
 
 package hostmetadata
 

--- a/extension/observer/dockerobserver/integration_test.go
+++ b/extension/observer/dockerobserver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package dockerobserver
 

--- a/extension/storage/filestorage/default_others.go
+++ b/extension/storage/filestorage/default_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package filestorage // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
 

--- a/extension/storage/filestorage/default_windows.go
+++ b/extension/storage/filestorage/default_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package filestorage // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage"
 

--- a/internal/aws/proxy/server_test.go
+++ b/internal/aws/proxy/server_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 // TODO review if tests should succeed on Windows
 package proxy

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 // TODO review if tests should succeed on Windows
 

--- a/internal/kubelet/client_test.go
+++ b/internal/kubelet/client_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 // TODO review if tests should succeed on Windows
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build tools
-// +build tools
 
 package tools // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/tools"
 

--- a/pkg/stanza/fileconsumer/file_other.go
+++ b/pkg/stanza/fileconsumer/file_other.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
 

--- a/pkg/stanza/fileconsumer/file_windows.go
+++ b/pkg/stanza/fileconsumer/file_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package fileconsumer // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
 

--- a/pkg/stanza/operator/input/journald/journald.go
+++ b/pkg/stanza/operator/input/journald/journald.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package journald // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/journald"
 

--- a/pkg/stanza/operator/input/journald/journald_nonlinux.go
+++ b/pkg/stanza/operator/input/journald/journald_nonlinux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux
-// +build !linux
 
 package journald // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/journald"
 

--- a/pkg/stanza/operator/input/journald/journald_test.go
+++ b/pkg/stanza/operator/input/journald/journald_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package journald
 

--- a/pkg/stanza/operator/input/namedpipe/namedpipe.go
+++ b/pkg/stanza/operator/input/namedpipe/namedpipe.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package namedpipe // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/namedpipe"
 

--- a/pkg/stanza/operator/input/namedpipe/namedpipe_nonlinux.go
+++ b/pkg/stanza/operator/input/namedpipe/namedpipe_nonlinux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux
-// +build !linux
 
 package namedpipe // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/namedpipe"
 

--- a/pkg/stanza/operator/input/namedpipe/namedpipe_test.go
+++ b/pkg/stanza/operator/input/namedpipe/namedpipe_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package namedpipe
 

--- a/pkg/stanza/operator/input/namedpipe/watcher.go
+++ b/pkg/stanza/operator/input/namedpipe/watcher.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package namedpipe // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/namedpipe"
 

--- a/pkg/stanza/operator/input/windows/api.go
+++ b/pkg/stanza/operator/input/windows/api.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 

--- a/pkg/stanza/operator/input/windows/api_test.go
+++ b/pkg/stanza/operator/input/windows/api_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows
 

--- a/pkg/stanza/operator/input/windows/bookmark.go
+++ b/pkg/stanza/operator/input/windows/bookmark.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 

--- a/pkg/stanza/operator/input/windows/bookmark_test.go
+++ b/pkg/stanza/operator/input/windows/bookmark_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows
 

--- a/pkg/stanza/operator/input/windows/event.go
+++ b/pkg/stanza/operator/input/windows/event.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 

--- a/pkg/stanza/operator/input/windows/event_test.go
+++ b/pkg/stanza/operator/input/windows/event_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows
 

--- a/pkg/stanza/operator/input/windows/operator.go
+++ b/pkg/stanza/operator/input/windows/operator.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 

--- a/pkg/stanza/operator/input/windows/os_test.go
+++ b/pkg/stanza/operator/input/windows/os_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package windows
 

--- a/pkg/stanza/operator/input/windows/publisher.go
+++ b/pkg/stanza/operator/input/windows/publisher.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 

--- a/pkg/stanza/operator/input/windows/publisher_test.go
+++ b/pkg/stanza/operator/input/windows/publisher_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows
 

--- a/pkg/stanza/operator/input/windows/publishercache.go
+++ b/pkg/stanza/operator/input/windows/publishercache.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 

--- a/pkg/stanza/operator/input/windows/publishercache_test.go
+++ b/pkg/stanza/operator/input/windows/publishercache_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows
 

--- a/pkg/stanza/operator/input/windows/subscription.go
+++ b/pkg/stanza/operator/input/windows/subscription.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windows // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows"
 

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/kernel32.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/kernel32.go
@@ -29,7 +29,6 @@
 // Kevin Pors <krpors@gmail.com>
 
 //go:build windows
-// +build windows
 
 package win_perf_counters // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters"
 

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/pdh.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/pdh.go
@@ -29,7 +29,6 @@
 // Kevin Pors <krpors@gmail.com>
 
 //go:build windows
-// +build windows
 
 package win_perf_counters // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters"
 

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/pdh_386.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/pdh_386.go
@@ -29,7 +29,6 @@
 // Kevin Pors <krpors@gmail.com>
 
 //go:build windows
-// +build windows
 
 package win_perf_counters // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters"
 

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/pdh_amd64.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/pdh_amd64.go
@@ -29,7 +29,6 @@
 // Kevin Pors <krpors@gmail.com>
 
 //go:build windows
-// +build windows
 
 package win_perf_counters // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters"
 

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query.go
@@ -1,6 +1,5 @@
 // Go API over pdh syscalls
 //go:build windows
-// +build windows
 
 package win_perf_counters // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters"
 

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query_test.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/performance_query_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package win_perf_counters
 

--- a/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/win_perf_counters_notwindows.go
+++ b/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters/win_perf_counters_notwindows.go
@@ -1,4 +1,3 @@
 //go:build !windows
-// +build !windows
 
 package win_perf_counters // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters/internal/third_party/telegraf/win_perf_counters"

--- a/pkg/winperfcounters/watcher.go
+++ b/pkg/winperfcounters/watcher.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package winperfcounters // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters"
 

--- a/pkg/winperfcounters/watcher_test.go
+++ b/pkg/winperfcounters/watcher_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package winperfcounters // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters"
 

--- a/pkg/winperfcounters/win_perf_counters_notwindows.go
+++ b/pkg/winperfcounters/win_perf_counters_notwindows.go
@@ -2,6 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package winperfcounters // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters"

--- a/processor/k8sattributesprocessor/e2e_test.go
+++ b/processor/k8sattributesprocessor/e2e_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e
-// +build e2e
 
 package k8sattributesprocessor
 

--- a/processor/schemaprocessor/internal/race/disable.go
+++ b/processor/schemaprocessor/internal/race/disable.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !race
-// +build !race
 
 package race // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor/internal/race"
 

--- a/processor/schemaprocessor/internal/race/enable.go
+++ b/processor/schemaprocessor/internal/race/enable.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build race
-// +build race
 
 package race // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/schemaprocessor/internal/race"
 

--- a/receiver/activedirectorydsreceiver/counters.go
+++ b/receiver/activedirectorydsreceiver/counters.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package activedirectorydsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver"
 

--- a/receiver/activedirectorydsreceiver/counters_test.go
+++ b/receiver/activedirectorydsreceiver/counters_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package activedirectorydsreceiver
 

--- a/receiver/activedirectorydsreceiver/factory_others.go
+++ b/receiver/activedirectorydsreceiver/factory_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package activedirectorydsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver"
 

--- a/receiver/activedirectorydsreceiver/factory_others_test.go
+++ b/receiver/activedirectorydsreceiver/factory_others_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package activedirectorydsreceiver
 

--- a/receiver/activedirectorydsreceiver/factory_windows.go
+++ b/receiver/activedirectorydsreceiver/factory_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package activedirectorydsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver"
 

--- a/receiver/activedirectorydsreceiver/factory_windows_test.go
+++ b/receiver/activedirectorydsreceiver/factory_windows_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package activedirectorydsreceiver
 

--- a/receiver/activedirectorydsreceiver/scraper.go
+++ b/receiver/activedirectorydsreceiver/scraper.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package activedirectorydsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/activedirectorydsreceiver"
 

--- a/receiver/activedirectorydsreceiver/scraper_test.go
+++ b/receiver/activedirectorydsreceiver/scraper_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package activedirectorydsreceiver
 

--- a/receiver/aerospikereceiver/doc.go
+++ b/receiver/aerospikereceiver/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/aerospikereceiver/integration_test.go
+++ b/receiver/aerospikereceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package aerospikereceiver
 

--- a/receiver/apachereceiver/integration_test.go
+++ b/receiver/apachereceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package apachereceiver
 

--- a/receiver/apachesparkreceiver/integration_test.go
+++ b/receiver/apachesparkreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package apachesparkreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver"
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package cadvisor // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor"
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package cadvisor
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_nolinux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux
-// +build !linux
 
 package cadvisor // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor"
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package cadvisor // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor"
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package cadvisor
 

--- a/receiver/bigipreceiver/integration_test.go
+++ b/receiver/bigipreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package bigipreceiver
 

--- a/receiver/couchdbreceiver/doc.go
+++ b/receiver/couchdbreceiver/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/dockerstatsreceiver/integration_test.go
+++ b/receiver/dockerstatsreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package dockerstatsreceiver
 

--- a/receiver/dockerstatsreceiver/receiver_test.go
+++ b/receiver/dockerstatsreceiver/receiver_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 // TODO review if tests should succeed on Windows
 

--- a/receiver/elasticsearchreceiver/doc.go
+++ b/receiver/elasticsearchreceiver/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/elasticsearchreceiver/integration_test.go
+++ b/receiver/elasticsearchreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package elasticsearchreceiver
 

--- a/receiver/filestatsreceiver/filestats_darwin.go
+++ b/receiver/filestatsreceiver/filestats_darwin.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build darwin || freebsd || dragonfly || netbsd || openbsd
-// +build darwin freebsd dragonfly netbsd openbsd
 
 package filestatsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver"
 

--- a/receiver/filestatsreceiver/filestats_linux.go
+++ b/receiver/filestatsreceiver/filestats_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux || solaris
-// +build linux solaris
 
 package filestatsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver"
 

--- a/receiver/filestatsreceiver/filestats_other.go
+++ b/receiver/filestatsreceiver/filestats_other.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !darwin && !freebsd && !dragonfly && !netbsd && !openbsd && !linux && !solaris && !windows
-// +build !darwin,!freebsd,!dragonfly,!netbsd,!openbsd,!linux,!solaris,!windows
 
 package filestatsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver"
 

--- a/receiver/filestatsreceiver/filestats_windows.go
+++ b/receiver/filestatsreceiver/filestats_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package filestatsreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver"
 

--- a/receiver/filestatsreceiver/integration_test.go
+++ b/receiver/filestatsreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package filestatsreceiver
 

--- a/receiver/haproxyreceiver/integration_test.go
+++ b/receiver/haproxyreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package haproxyreceiver
 

--- a/receiver/hostmetricsreceiver/integration_test.go
+++ b/receiver/hostmetricsreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package hostmetricsreceiver
 

--- a/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package perfcounters // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/perfcounters"
 

--- a/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper_mock.go
+++ b/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper_mock.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package perfcounters // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/perfcounters"
 

--- a/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package perfcounters
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package cpuscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux
-// +build !linux
 
 package cpuscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package diskscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/diskscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_fallback.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_fallback.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package diskscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/diskscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package diskscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/diskscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package diskscraper
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_windows_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package diskscraper
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux && !darwin && !freebsd && !openbsd && !solaris
-// +build !linux,!darwin,!freebsd,!openbsd,!solaris
 
 package filesystemscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_unix.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux || darwin || freebsd || openbsd || solaris
-// +build linux darwin freebsd openbsd solaris
 
 package filesystemscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package loadscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/loadscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package loadscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/loadscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_windows_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package loadscraper
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package memoryscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/memoryscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux && !windows
-// +build !linux,!windows
 
 package memoryscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/memoryscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package memoryscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/memoryscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package networkscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/networkscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux
-// +build !linux
 
 package networkscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/networkscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package pagingscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/pagingscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_linux_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package pagingscraper
 

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows && !linux
-// +build !windows,!linux
 
 package pagingscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/pagingscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package pagingscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/pagingscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package pagingscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/pagingscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package pagingscraper
 

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package pagingscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/pagingscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package pagingscraper
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_fallback.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_fallback.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux && !darwin && !freebsd && !openbsd
-// +build !linux,!darwin,!freebsd,!openbsd
 
 package processesscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processesscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_unix.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux || darwin || freebsd || openbsd
-// +build linux darwin freebsd openbsd
 
 package processesscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processesscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/doc.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount/handles_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount/handles_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package handlecount // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount/handles_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount/handles_others_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package handlecount
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount/handles_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount/handles_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package handlecount // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount/handles_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount/handles_windows_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package handlecount
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_darwin.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_darwin.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build darwin
-// +build darwin
 
 package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_linux.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux && !windows && !darwin
-// +build !linux,!windows,!darwin
 
 package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_windows.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package processscraper // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
 

--- a/receiver/iisreceiver/factory_others.go
+++ b/receiver/iisreceiver/factory_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package iisreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver"
 

--- a/receiver/iisreceiver/factory_others_test.go
+++ b/receiver/iisreceiver/factory_others_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package iisreceiver
 

--- a/receiver/iisreceiver/factory_windows.go
+++ b/receiver/iisreceiver/factory_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package iisreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver"
 

--- a/receiver/iisreceiver/factory_windows_test.go
+++ b/receiver/iisreceiver/factory_windows_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package iisreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver"
 

--- a/receiver/iisreceiver/integration_test.go
+++ b/receiver/iisreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package iisreceiver
 

--- a/receiver/iisreceiver/recorder.go
+++ b/receiver/iisreceiver/recorder.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package iisreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver"
 

--- a/receiver/iisreceiver/scraper.go
+++ b/receiver/iisreceiver/scraper.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package iisreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver"
 

--- a/receiver/iisreceiver/scraper_test.go
+++ b/receiver/iisreceiver/scraper_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package iisreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver"
 

--- a/receiver/jmxreceiver/integration_test.go
+++ b/receiver/jmxreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package jmxreceiver
 

--- a/receiver/jmxreceiver/internal/subprocess/integration_test.go
+++ b/receiver/jmxreceiver/internal/subprocess/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration && !windows
-// +build integration,!windows
 
 package subprocess
 

--- a/receiver/jmxreceiver/internal/subprocess/subprocess_linux.go
+++ b/receiver/jmxreceiver/internal/subprocess/subprocess_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package subprocess // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver/internal/subprocess"
 

--- a/receiver/jmxreceiver/internal/subprocess/subprocess_others.go
+++ b/receiver/jmxreceiver/internal/subprocess/subprocess_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux
-// +build !linux
 
 package subprocess // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jmxreceiver/internal/subprocess"
 

--- a/receiver/journaldreceiver/journald.go
+++ b/receiver/journaldreceiver/journald.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package journaldreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
 

--- a/receiver/journaldreceiver/journald_nonlinux.go
+++ b/receiver/journaldreceiver/journald_nonlinux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !linux
-// +build !linux
 
 package journaldreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/journaldreceiver"
 

--- a/receiver/journaldreceiver/journald_test.go
+++ b/receiver/journaldreceiver/journald_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package journaldreceiver
 

--- a/receiver/k8sclusterreceiver/e2e_test.go
+++ b/receiver/k8sclusterreceiver/e2e_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e
-// +build e2e
 
 package k8sclusterreceiver
 

--- a/receiver/k8sobjectsreceiver/e2e_test.go
+++ b/receiver/k8sobjectsreceiver/e2e_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e
-// +build e2e
 
 package k8sobjectsreceiver
 

--- a/receiver/kafkametricsreceiver/doc.go
+++ b/receiver/kafkametricsreceiver/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/kubeletstatsreceiver/doc.go
+++ b/receiver/kubeletstatsreceiver/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/kubeletstatsreceiver/e2e_test.go
+++ b/receiver/kubeletstatsreceiver/e2e_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e
-// +build e2e
 
 package kubeletstatsreceiver
 

--- a/receiver/kubeletstatsreceiver/factory_test.go
+++ b/receiver/kubeletstatsreceiver/factory_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 // TODO review if tests should succeed on Windows
 

--- a/receiver/memcachedreceiver/integration_test.go
+++ b/receiver/memcachedreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package memcachedreceiver
 

--- a/receiver/mongodbatlasreceiver/doc.go
+++ b/receiver/mongodbatlasreceiver/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/mongodbreceiver/doc.go
+++ b/receiver/mongodbreceiver/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/mongodbreceiver/integration_test.go
+++ b/receiver/mongodbreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package mongodbreceiver
 

--- a/receiver/mysqlreceiver/integration_test.go
+++ b/receiver/mysqlreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package mysqlreceiver
 

--- a/receiver/namedpipereceiver/namedpipe_test.go
+++ b/receiver/namedpipereceiver/namedpipe_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build linux
-// +build linux
 
 package namedpipereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/namedpipereceiver"
 

--- a/receiver/nginxreceiver/doc.go
+++ b/receiver/nginxreceiver/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/nginxreceiver/integration_test.go
+++ b/receiver/nginxreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package nginxreceiver
 

--- a/receiver/podmanreceiver/factory_test.go
+++ b/receiver/podmanreceiver/factory_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver
 

--- a/receiver/podmanreceiver/libpod_client.go
+++ b/receiver/podmanreceiver/libpod_client.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver"
 

--- a/receiver/podmanreceiver/libpod_client_test.go
+++ b/receiver/podmanreceiver/libpod_client_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver
 

--- a/receiver/podmanreceiver/libpod_data.go
+++ b/receiver/podmanreceiver/libpod_data.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver"
 

--- a/receiver/podmanreceiver/metrics.go
+++ b/receiver/podmanreceiver/metrics.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver"
 

--- a/receiver/podmanreceiver/metrics_test.go
+++ b/receiver/podmanreceiver/metrics_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver
 

--- a/receiver/podmanreceiver/podman.go
+++ b/receiver/podmanreceiver/podman.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver"
 

--- a/receiver/podmanreceiver/podman_connection.go
+++ b/receiver/podmanreceiver/podman_connection.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver"
 

--- a/receiver/podmanreceiver/podman_connection_test.go
+++ b/receiver/podmanreceiver/podman_connection_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver
 

--- a/receiver/podmanreceiver/podman_test.go
+++ b/receiver/podmanreceiver/podman_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver
 

--- a/receiver/podmanreceiver/receiver.go
+++ b/receiver/podmanreceiver/receiver.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/podmanreceiver"
 

--- a/receiver/podmanreceiver/receiver_test.go
+++ b/receiver/podmanreceiver/receiver_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package podmanreceiver
 

--- a/receiver/postgresqlreceiver/integration_test.go
+++ b/receiver/postgresqlreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package postgresqlreceiver
 

--- a/receiver/redisreceiver/doc.go
+++ b/receiver/redisreceiver/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/redisreceiver/integration_test.go
+++ b/receiver/redisreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package redisreceiver
 

--- a/receiver/snmpreceiver/integration_test.go
+++ b/receiver/snmpreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package snmpreceiver
 

--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package sqlqueryreceiver
 

--- a/receiver/sqlserverreceiver/factory_others.go
+++ b/receiver/sqlserverreceiver/factory_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package sqlserverreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver"
 

--- a/receiver/sqlserverreceiver/factory_others_test.go
+++ b/receiver/sqlserverreceiver/factory_others_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package sqlserverreceiver
 

--- a/receiver/sqlserverreceiver/factory_windows.go
+++ b/receiver/sqlserverreceiver/factory_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package sqlserverreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver"
 

--- a/receiver/sqlserverreceiver/factory_windows_test.go
+++ b/receiver/sqlserverreceiver/factory_windows_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package sqlserverreceiver
 

--- a/receiver/sqlserverreceiver/recorders.go
+++ b/receiver/sqlserverreceiver/recorders.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package sqlserverreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver"
 

--- a/receiver/sqlserverreceiver/recorders_test.go
+++ b/receiver/sqlserverreceiver/recorders_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package sqlserverreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver"
 

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package sqlserverreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver"
 

--- a/receiver/sqlserverreceiver/scraper_test.go
+++ b/receiver/sqlserverreceiver/scraper_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package sqlserverreceiver
 

--- a/receiver/vcenterreceiver/integration_test.go
+++ b/receiver/vcenterreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package vcenterreceiver // import github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
 

--- a/receiver/windowseventlogreceiver/receiver_others.go
+++ b/receiver/windowseventlogreceiver/receiver_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package windowseventlogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
 

--- a/receiver/windowseventlogreceiver/receiver_others_test.go
+++ b/receiver/windowseventlogreceiver/receiver_others_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package windowseventlogreceiver
 

--- a/receiver/windowseventlogreceiver/receiver_windows.go
+++ b/receiver/windowseventlogreceiver/receiver_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windowseventlogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowseventlogreceiver"
 

--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windowseventlogreceiver
 

--- a/receiver/windowsperfcountersreceiver/factory_others.go
+++ b/receiver/windowsperfcountersreceiver/factory_others.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package windowsperfcountersreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver"
 

--- a/receiver/windowsperfcountersreceiver/factory_others_test.go
+++ b/receiver/windowsperfcountersreceiver/factory_others_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 package windowsperfcountersreceiver
 

--- a/receiver/windowsperfcountersreceiver/factory_windows.go
+++ b/receiver/windowsperfcountersreceiver/factory_windows.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windowsperfcountersreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver"
 

--- a/receiver/windowsperfcountersreceiver/factory_windows_test.go
+++ b/receiver/windowsperfcountersreceiver/factory_windows_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windowsperfcountersreceiver
 

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windowsperfcountersreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver"
 

--- a/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
+++ b/receiver/windowsperfcountersreceiver/windowsperfcounters_scraper_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build windows
-// +build windows
 
 package windowsperfcountersreceiver
 

--- a/receiver/zookeeperreceiver/doc.go
+++ b/receiver/zookeeperreceiver/doc.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build !windows
-// +build !windows
 
 //go:generate mdatagen metadata.yaml
 

--- a/receiver/zookeeperreceiver/integration_test.go
+++ b/receiver/zookeeperreceiver/integration_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build integration
-// +build integration
 
 package zookeeperreceiver
 


### PR DESCRIPTION
`// +build` was replaced with `//go:build` directive in Go 1.17. +build can be removed since we support only 1.20 and 1.21

Same as https://github.com/open-telemetry/opentelemetry-collector/pull/9304