### PR TITLE
[chore][pkg/stanza] Flatten token processing

### DIFF
--- a/pkg/stanza/fileconsumer/internal/reader/factory.go
+++ b/pkg/stanza/fileconsumer/internal/reader/factory.go
@@ -70,9 +70,6 @@ func (f *Factory) NewReaderFromMetadata(file *os.File, m *Metadata) (r *Reader, 
 		deleteAtEOF:     f.DeleteAtEOF,
 	}
 
-	flushFunc := m.FlushState.Func(f.SplitFunc, f.FlushTimeout)
-	r.lineSplitFunc = trim.WithFunc(trim.ToLength(flushFunc, f.MaxLogSize), f.TrimFunc)
-
 	if !f.FromBeginning {
 		var info os.FileInfo
 		if info, err = r.file.Stat(); err != nil {
@@ -81,6 +78,8 @@ func (f *Factory) NewReaderFromMetadata(file *os.File, m *Metadata) (r *Reader, 
 		r.Offset = info.Size()
 	}
 
+	flushFunc := m.FlushState.Func(f.SplitFunc, f.FlushTimeout)
+	r.lineSplitFunc = trim.WithFunc(trim.ToLength(flushFunc, f.MaxLogSize), f.TrimFunc)
 	r.emitFunc = f.EmitFunc
 	if f.HeaderConfig == nil || m.HeaderFinalized {
 		r.splitFunc = r.lineSplitFunc


### PR DESCRIPTION
- Consolidate related reader setup code.
- Flatten the various cases for interpreting and processing tokens.

I think this PR effectively closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/23069, though I still plan to actually add more detailed tests now that the package is isolated and largely simplified.