### PR TITLE
fix(router): route correctly if two or more routing statements are the same string

### DIFF
--- a/connector/routingconnector/logs_test.go
+++ b/connector/routingconnector/logs_test.go
@@ -58,12 +58,11 @@ func TestLogsRegisterConsumersForValidRoute(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, &defaultSink, rtConn.router.defaultConsumer)
 
-	route, ok := rtConn.router.routes[rtConn.router.table[0].Statement]
-	assert.True(t, ok)
-	require.Same(t, &sink0, route.consumer)
+	route := routingItem[consumer.Logs]{}
 
-	route, ok = rtConn.router.routes[rtConn.router.table[1].Statement]
-	assert.True(t, ok)
+	assert.NotPanics(t, func() { route = rtConn.router.routeSlice[0] })
+	require.Same(t, &sink0, route.consumer)
+	assert.NotPanics(t, func() { route = rtConn.router.routeSlice[1] })
 
 	routeConsumer, err := router.Consumer(logs0, logs1)
 	require.NoError(t, err)
@@ -155,6 +154,145 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		assert.Len(t, defaultSink.AllLogs(), 0)
 		assert.Len(t, sink0.AllLogs(), 1)
+		assert.Len(t, sink1.AllLogs(), 0)
+	})
+
+	t.Run("logs matched by two expressions", func(t *testing.T) {
+		resetSinks()
+
+		l := plog.NewLogs()
+
+		rl := l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("X-Tenant", "x_acme")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		rl = l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("X-Tenant", "_acme")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
+
+		assert.Len(t, defaultSink.AllLogs(), 0)
+		assert.Len(t, sink0.AllLogs(), 1)
+		assert.Len(t, sink1.AllLogs(), 1)
+
+		assert.Equal(t, sink0.AllLogs()[0].LogRecordCount(), 2)
+		assert.Equal(t, sink1.AllLogs()[0].LogRecordCount(), 2)
+		assert.Equal(t, sink0.AllLogs(), sink1.AllLogs())
+	})
+
+	t.Run("one log matched by multiple expressions, other matched none", func(t *testing.T) {
+		resetSinks()
+
+		l := plog.NewLogs()
+
+		rl := l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("X-Tenant", "_acme")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		rl = l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("X-Tenant", "something-else")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
+
+		assert.Len(t, defaultSink.AllLogs(), 1)
+		assert.Len(t, sink0.AllLogs(), 1)
+		assert.Len(t, sink1.AllLogs(), 1)
+
+		assert.Equal(t, sink0.AllLogs(), sink1.AllLogs())
+
+		rlog := defaultSink.AllLogs()[0].ResourceLogs().At(0)
+		attr, ok := rlog.Resource().Attributes().Get("X-Tenant")
+		assert.True(t, ok, "routing attribute must exists")
+		assert.Equal(t, attr.AsString(), "something-else")
+	})
+
+	t.Run("logs matched by one expression, multiple pipelines", func(t *testing.T) {
+		resetSinks()
+
+		l := plog.NewLogs()
+
+		rl := l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("X-Tenant", "ecorp")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
+
+		assert.Len(t, defaultSink.AllLogs(), 1)
+		assert.Len(t, sink0.AllLogs(), 1)
+		assert.Len(t, sink1.AllLogs(), 0)
+
+		assert.Equal(t, defaultSink.AllLogs()[0].LogRecordCount(), 1)
+		assert.Equal(t, sink0.AllLogs()[0].LogRecordCount(), 1)
+		assert.Equal(t, defaultSink.AllLogs(), sink0.AllLogs())
+	})
+}
+
+func TestLogsAreCorrectlySplitIfRoutingStatementsAreSameString(t *testing.T) {
+	logsDefault := component.NewIDWithName(component.DataTypeLogs, "default")
+	logs0 := component.NewIDWithName(component.DataTypeLogs, "0")
+	logs1 := component.NewIDWithName(component.DataTypeLogs, "1")
+
+	cfg := &Config{
+		DefaultPipelines: []component.ID{logsDefault},
+		Table: []RoutingTableItem{
+			{
+				Statement: `route() where IsMatch(attributes["X-Tenant"], ".*acme") == true`,
+				Pipelines: []component.ID{logs0},
+			},
+			{
+				Statement: `route() where IsMatch(attributes["X-Tenant"], ".*acme") == true`,
+				Pipelines: []component.ID{logs1},
+			},
+			{
+				Statement: `route() where attributes["X-Tenant"] == "ecorp"`,
+				Pipelines: []component.ID{logsDefault, logs0},
+			},
+		},
+	}
+
+	var defaultSink, sink0, sink1 consumertest.LogsSink
+
+	router := connector.NewLogsRouter(map[component.ID]consumer.Logs{
+		logsDefault: &defaultSink,
+		logs0:       &sink0,
+		logs1:       &sink1,
+	})
+
+	resetSinks := func() {
+		defaultSink.Reset()
+		sink0.Reset()
+		sink1.Reset()
+	}
+
+	factory := NewFactory()
+	conn, err := factory.CreateLogsToLogs(
+		context.Background(),
+		connectortest.NewNopCreateSettings(),
+		cfg,
+		router.(consumer.Logs),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.NoError(t, conn.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		assert.NoError(t, conn.Shutdown(context.Background()))
+	}()
+
+	t.Run("logs matched by no expressions", func(t *testing.T) {
+		resetSinks()
+
+		l := plog.NewLogs()
+		rl := l.ResourceLogs().AppendEmpty()
+		rl.Resource().Attributes().PutStr("X-Tenant", "something-else")
+		rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+
+		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
+
+		assert.Len(t, defaultSink.AllLogs(), 1)
+		assert.Len(t, sink0.AllLogs(), 0)
 		assert.Len(t, sink1.AllLogs(), 0)
 	})
 

--- a/connector/routingconnector/metrics_test.go
+++ b/connector/routingconnector/metrics_test.go
@@ -58,12 +58,11 @@ func TestMetricsRegisterConsumersForValidRoute(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, &defaultSink, rtConn.router.defaultConsumer)
 
-	route, ok := rtConn.router.routes[rtConn.router.table[0].Statement]
-	assert.True(t, ok)
-	require.Same(t, &sink0, route.consumer)
+	route := routingItem[consumer.Metrics]{}
 
-	route, ok = rtConn.router.routes[rtConn.router.table[1].Statement]
-	assert.True(t, ok)
+	assert.NotPanics(t, func() { route = rtConn.router.routeSlice[0] })
+	require.Same(t, &sink0, route.consumer)
+	assert.NotPanics(t, func() { route = rtConn.router.routeSlice[1] })
 
 	routeConsumer, err := router.Consumer(metrics0, metrics1)
 	require.NoError(t, err)
@@ -160,6 +159,158 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		assert.Len(t, defaultSink.AllMetrics(), 0)
 		assert.Len(t, sink0.AllMetrics(), 1)
+		assert.Len(t, sink1.AllMetrics(), 0)
+	})
+
+	t.Run("metric matched by two expressions", func(t *testing.T) {
+		resetSinks()
+
+		m := pmetric.NewMetrics()
+
+		rm := m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", 5.0)
+		metric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu")
+
+		rm = m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", 3.1)
+		metric = rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu1")
+
+		require.NoError(t, conn.ConsumeMetrics(context.Background(), m))
+
+		assert.Len(t, defaultSink.AllMetrics(), 0)
+		assert.Len(t, sink0.AllMetrics(), 1)
+		assert.Len(t, sink1.AllMetrics(), 1)
+
+		assert.Equal(t, sink0.AllMetrics()[0].MetricCount(), 2)
+		assert.Equal(t, sink1.AllMetrics()[0].MetricCount(), 2)
+		assert.Equal(t, sink0.AllMetrics(), sink1.AllMetrics())
+	})
+
+	t.Run("one metric matched by 2 expressions, others matched by none", func(t *testing.T) {
+		resetSinks()
+
+		m := pmetric.NewMetrics()
+
+		rm := m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", 5.0)
+		metric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu")
+
+		rm = m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", -1.0)
+		metric = rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu1")
+
+		require.NoError(t, conn.ConsumeMetrics(context.Background(), m))
+
+		assert.Len(t, defaultSink.AllMetrics(), 1)
+		assert.Len(t, sink0.AllMetrics(), 1)
+		assert.Len(t, sink1.AllMetrics(), 1)
+
+		assert.Equal(t, sink0.AllMetrics(), sink1.AllMetrics())
+
+		rmetric := defaultSink.AllMetrics()[0].ResourceMetrics().At(0)
+		attr, ok := rmetric.Resource().Attributes().Get("value")
+		assert.True(t, ok, "routing attribute must exist")
+		assert.Equal(t, attr.Double(), float64(-1.0))
+	})
+
+	t.Run("metric matched by one expression, multiple pipelines", func(t *testing.T) {
+		resetSinks()
+
+		m := pmetric.NewMetrics()
+
+		rm := m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", 1.0)
+		metric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu")
+
+		require.NoError(t, conn.ConsumeMetrics(context.Background(), m))
+
+		assert.Len(t, defaultSink.AllMetrics(), 1)
+		assert.Len(t, sink0.AllMetrics(), 1)
+		assert.Len(t, sink1.AllMetrics(), 0)
+
+		assert.Equal(t, defaultSink.AllMetrics()[0].MetricCount(), 1)
+		assert.Equal(t, sink0.AllMetrics()[0].MetricCount(), 1)
+		assert.Equal(t, defaultSink.AllMetrics(), sink0.AllMetrics())
+	})
+}
+
+func TestMetricsAreCorrectlySplitIfRoutingStatementsAreSameString(t *testing.T) {
+	metricsDefault := component.NewIDWithName(component.DataTypeMetrics, "default")
+	metrics0 := component.NewIDWithName(component.DataTypeMetrics, "0")
+	metrics1 := component.NewIDWithName(component.DataTypeMetrics, "1")
+
+	cfg := &Config{
+		DefaultPipelines: []component.ID{metricsDefault},
+		Table: []RoutingTableItem{
+			{
+				Statement: `route() where attributes["value"] > 2.5`,
+				Pipelines: []component.ID{metrics0},
+			},
+			{
+				Statement: `route() where attributes["value"] > 2.5`,
+				Pipelines: []component.ID{metrics1},
+			},
+			{
+				Statement: `route() where attributes["value"] == 1.0`,
+				Pipelines: []component.ID{metricsDefault, metrics0},
+			},
+		},
+	}
+
+	var defaultSink, sink0, sink1 consumertest.MetricsSink
+
+	router := connector.NewMetricsRouter(map[component.ID]consumer.Metrics{
+		metricsDefault: &defaultSink,
+		metrics0:       &sink0,
+		metrics1:       &sink1,
+	})
+
+	resetSinks := func() {
+		defaultSink.Reset()
+		sink0.Reset()
+		sink1.Reset()
+	}
+
+	factory := NewFactory()
+	conn, err := factory.CreateMetricsToMetrics(
+		context.Background(),
+		connectortest.NewNopCreateSettings(),
+		cfg,
+		router.(consumer.Metrics),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.NoError(t, conn.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		assert.NoError(t, conn.Shutdown(context.Background()))
+	}()
+
+	t.Run("metric matched by no expressions", func(t *testing.T) {
+		resetSinks()
+
+		m := pmetric.NewMetrics()
+
+		rm := m.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutDouble("value", 0.0)
+		metric := rm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+		metric.SetEmptyGauge()
+		metric.SetName("cpu")
+
+		require.NoError(t, conn.ConsumeMetrics(context.Background(), m))
+
+		assert.Len(t, defaultSink.AllMetrics(), 1)
+		assert.Len(t, sink0.AllMetrics(), 0)
 		assert.Len(t, sink1.AllMetrics(), 0)
 	})
 


### PR DESCRIPTION
**Description:**
The route map is removed, and routeSlice is used for setting up consumers.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30663

**Testing:** Added unit tests for the case

**Documentation:** <Describe the documentation added.>