### PR TITLE
[chore] removed deprecated options gce, gke from the resourcedetection processor readme

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -547,7 +547,7 @@ See: [TLS Configuration Settings](https://github.com/open-telemetry/opentelemetr
 ## Configuration
 
 ```yaml
-# a list of resource detectors to run, valid options are: "env", "system", "gce", "gke", "ec2", "ecs", "elastic_beanstalk", "eks", "lambda", "azure", "heroku", "openshift"
+# a list of resource detectors to run, valid options are: "env", "system", "gcp", "ec2", "ecs", "elastic_beanstalk", "eks", "lambda", "azure", "heroku", "openshift"
 detectors: [ <string> ]
 # determines if existing resource attributes should be overridden or preserved, defaults to true
 override: <bool>
@@ -603,11 +603,6 @@ resourcedetection:
 ## Ordering
 
 Note that if multiple detectors are inserting the same attribute name, the first detector to insert wins. For example if you had `detectors: [eks, ec2]` then `cloud.platform` will be `aws_eks` instead of `ec2`. The below ordering is recommended.
-
-### GCP
-
-* gke
-* gce
 
 ### AWS
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Some time ago `gce` and `gke` detectors were [deprecated](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/10347) to use a single `gcp` detector.
This PR updates README to remove mentions of `gce` and `gke` detectors
