### PR TITLE
[testbed] fix panic test in windows env

### DIFF
--- a/testbed/testbed/child_process_collector_test.go
+++ b/testbed/testbed/child_process_collector_test.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build !windows
+
 package testbed // import "github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 
 import (


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The test `TestAgentEnvVarOption` panics in windows environment, which you can see in
https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/7553756890/job/20566742790

The error is 
```
--- FAIL: TestAgentEnvVarOption (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x1b917d0]

goroutine 51 [running]:
testing.tRunner.func1.2({0x1ccfa20, 0x2ce3300})
	C:/hostedtoolcache/windows/go/1.20.12/x64/src/testing/testing.go:1526 +0x372
testing.tRunner.func1()
	C:/hostedtoolcache/windows/go/1.20.12/x64/src/testing/testing.go:1529 +0x650
panic({0x1ccfa20, 0x2ce3300})
	C:/hostedtoolcache/windows/go/1.20.12/x64/src/runtime/panic.go:890 +0x263
github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed.TestAgentEnvVarOption(0x0?)
	D:/a/opentelemetry-collector-contrib/opentelemetry-collector-contrib/testbed/testbed/child_process_collector_test.go:48 +0x6f0
testing.tRunner(0xc00008d1e0, 0x1f307d0)
	C:/hostedtoolcache/windows/go/1.20.12/x64/src/testing/testing.go:1576 +0x217
created by testing.(*T).Run
	C:/hostedtoolcache/windows/go/1.20.12/x64/src/testing/testing.go:1629 +0x806
```

So I think this panic is due to following lines 

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/0f92b2195cfe7708c08f10096553270a3a533b9f/testbed/testbed/child_process_collector.go#L195-L200

These lines maybe failed on windows which results the `cp.cmd` is not set correctly, so the 

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/0f92b2195cfe7708c08f10096553270a3a533b9f/testbed/testbed/child_process_collector_test.go#L48

throws a panic.

I do not have a windows environment to dig this problem, so I try to reorder the code to escape the panic

**Link to tracking Issue:** 

**Testing:**

**Documentation:** 