### PR TITLE
[cmd/opampsupervisor] fix failed test in windows

### DIFF
--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -4,6 +4,7 @@
 package supervisor
 
 import (
+	"bytes"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -52,6 +53,7 @@ func Test_composeEffectiveConfig(t *testing.T) {
 
 	expectedConfig, err := os.ReadFile("../testdata/collector/effective_config.yaml")
 	require.NoError(t, err)
+	expectedConfig = bytes.ReplaceAll(expectedConfig, []byte("\r\n"), []byte("\n"))
 
 	require.True(t, configChanged)
 	require.Equal(t, string(expectedConfig), s.effectiveConfig.Load().(string))


### PR DESCRIPTION
**Description:** 
fix opampsupervisor failed test in windows
https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/7535309382/job/20512459704
```
--- FAIL: Test_composeEffectiveConfig (0.00s)
    supervisor_test.go:57: 
        	Error Trace:	D:/a/opentelemetry-collector-contrib/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/supervisor_test.go:57
        	Error:      	Not equal: 
        	            	expected: "extensions:\r\n    health_check:\r\n        endpoint: localhost:8000\r\nservice:\r\n    extensions:\r\n        - health_check\r\n    telemetry:\r\n        logs:\r\n            encoding: json\r\n        resource:\r\n            service.name: otelcol\r\n"
        	            	actual  : "extensions:\n    health_check:\n        endpoint: localhost:8000\nservice:\n    extensions:\n        - health_check\n    telemetry:\n        logs:\n            encoding: json\n        resource:\n            service.name: otelcol\n"

```


**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>