### PR TITLE
[exporter/elasticsearch] Add support for OAuth2 client authentication

### DIFF
--- a/.chloggen/elasticsearchexporter_oauth2.yaml
+++ b/.chloggen/elasticsearchexporter_oauth2.yaml
@@ -1,0 +1,25 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added OAuth authentication support 
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29329]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -92,6 +92,7 @@ This exporter supports sending OpenTelemetry logs to [Elasticsearch](https://www
 - `user` (optional): Username used for HTTP Basic Authentication.
 - `password` (optional): Password used for HTTP Basic Authentication.
 - `api_key` (optional):  Authorization [API Key](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html).
+- `oauth` (optional): OAuth2 Client Authentication using [oauth2clientauthextension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/oauth2clientauthextension/README.md).
 
 ### TLS settings
 - `ca_file` (optional): Root Certificate Authority (CA) certificate, for

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/collector/config/configauth"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -105,6 +106,9 @@ type AuthenticationSettings struct {
 	//
 	// https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html
 	APIKey configopaque.String `mapstructure:"api_key"`
+
+	// OAuth is used for OAuth based client_credentials Authentication
+	OAuth *configauth.Authentication `mapstructure:"oauth"`
 }
 
 // DiscoverySettings defines Elasticsearch node discovery related settings.

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -90,6 +90,7 @@ func createLogsExporter(
 		set,
 		cfg,
 		logsExporter.pushLogsData,
+		exporterhelper.WithStart(logsExporter.start),
 		exporterhelper.WithShutdown(logsExporter.Shutdown),
 		exporterhelper.WithQueue(cf.QueueSettings),
 	)
@@ -112,6 +113,7 @@ func createTracesExporter(ctx context.Context,
 		set,
 		cfg,
 		tracesExporter.pushTraceData,
+		exporterhelper.WithStart(tracesExporter.start),
 		exporterhelper.WithShutdown(tracesExporter.Shutdown),
 		exporterhelper.WithQueue(cf.QueueSettings))
 }

--- a/exporter/elasticsearchexporter/go.mod
+++ b/exporter/elasticsearchexporter/go.mod
@@ -7,14 +7,17 @@ require (
 	github.com/elastic/go-elasticsearch/v7 v7.17.10
 	github.com/elastic/go-structform v0.0.10
 	github.com/lestrrat-go/strftime v1.0.6
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension v0.92.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.92.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.92.0
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector/component v0.92.1-0.20240118172122-8131d31601b8
+	go.opentelemetry.io/collector/config/configauth v0.92.1-0.20240118172122-8131d31601b8
 	go.opentelemetry.io/collector/config/configopaque v0.92.1-0.20240118172122-8131d31601b8
 	go.opentelemetry.io/collector/config/configtls v0.92.1-0.20240118172122-8131d31601b8
 	go.opentelemetry.io/collector/confmap v0.92.1-0.20240118172122-8131d31601b8
 	go.opentelemetry.io/collector/exporter v0.92.1-0.20240118172122-8131d31601b8
+	go.opentelemetry.io/collector/extension v0.92.1-0.20240118172122-8131d31601b8
 	go.opentelemetry.io/collector/pdata v1.0.2-0.20240118172122-8131d31601b8
 	go.opentelemetry.io/collector/semconv v0.92.1-0.20240118172122-8131d31601b8
 	go.opentelemetry.io/otel/metric v1.22.0
@@ -24,6 +27,8 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute v1.23.0 // indirect
+	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -58,7 +63,7 @@ require (
 	go.opentelemetry.io/collector/config/configretry v0.92.1-0.20240118172122-8131d31601b8 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.92.1-0.20240118172122-8131d31601b8 // indirect
 	go.opentelemetry.io/collector/consumer v0.92.1-0.20240118172122-8131d31601b8 // indirect
-	go.opentelemetry.io/collector/extension v0.92.1-0.20240118172122-8131d31601b8 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.92.1-0.20240118172122-8131d31601b8 // indirect
 	go.opentelemetry.io/collector/featuregate v1.0.2-0.20240118172122-8131d31601b8 // indirect
 	go.opentelemetry.io/collector/receiver v0.92.1-0.20240118172122-8131d31601b8 // indirect
 	go.opentelemetry.io/otel v1.22.0 // indirect
@@ -67,8 +72,10 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.22.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.20.0 // indirect
+	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97 // indirect
 	google.golang.org/grpc v1.60.1 // indirect
 	google.golang.org/protobuf v1.32.0 // indirect
@@ -91,3 +98,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension => ../../extension/oauth2clientauthextension

--- a/exporter/elasticsearchexporter/go.sum
+++ b/exporter/elasticsearchexporter/go.sum
@@ -19,6 +19,10 @@ cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvf
 cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUMb4Nv6dBIg=
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
+cloud.google.com/go/compute v1.23.0 h1:tP41Zoavr8ptEqaW6j+LQOnyBBhO7OkOMAGrgLopTwY=
+cloud.google.com/go/compute v1.23.0/go.mod h1:4tCnrn48xsqlwSAiLf1HXMQk8CONslYbdiEZc9FEIbM=
+cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
+cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
@@ -68,6 +72,7 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -124,6 +129,7 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -169,6 +175,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=
 github.com/knadh/koanf/maps v0.1.1 h1:G5TjmUh2D7G2YWf5SQQqSiHRJEjaicvU0KpypqB3NIs=
 github.com/knadh/koanf/maps v0.1.1/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
 github.com/knadh/koanf/providers/confmap v0.1.0 h1:gOkxhHkemwG4LezxxN8DMOFopOPghxRVp7JbIvdvqzU=
@@ -244,6 +251,7 @@ github.com/prometheus/statsd_exporter v0.22.7 h1:7Pji/i2GuhK6Lu7DHrtTkFmNBCudCPT
 github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9dFqnUakOjnEuMPJJJnI=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
@@ -266,6 +274,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -278,6 +287,10 @@ go.opentelemetry.io/collector v0.92.1-0.20240118172122-8131d31601b8 h1:Nn2JQ6bwq
 go.opentelemetry.io/collector v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:rAYt6LjXy2CxnW+bHlsgOJuuSHVZqcNFTY6CiYWcDjA=
 go.opentelemetry.io/collector/component v0.92.1-0.20240118172122-8131d31601b8 h1:FYELfGMDrN3QlQi/umNNDFv+bBTcZ8H58MxDATWnDY0=
 go.opentelemetry.io/collector/component v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:Bwg4iVtuCHJmcvhQFQH/KI5dNYwHysTHDivxzVUmWgU=
+go.opentelemetry.io/collector/config/configauth v0.92.1-0.20240118172122-8131d31601b8 h1:tSCUQy87rpo+8d4pUvWbqcc9+8hCfU+aaTCI9xbtAOc=
+go.opentelemetry.io/collector/config/configauth v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:PCkupWQjjY1+0Ay7pv8CQQyF3WNyHZN4HaDHrcIghOI=
+go.opentelemetry.io/collector/config/configcompression v0.92.1-0.20240118172122-8131d31601b8 h1:QgiLlFy+51Z6E4GI1ptQXfaEtbJELsZGIi8lDOC7foQ=
+go.opentelemetry.io/collector/config/confighttp v0.92.1-0.20240118172122-8131d31601b8 h1:noMWgXJyUXvjtJpnB5jzJ9VQ+ajBC3tTXUs02ZDFKtk=
 go.opentelemetry.io/collector/config/configopaque v0.92.1-0.20240118172122-8131d31601b8 h1:SymD96TeYKaXiigWhdimNWZkbu8ixWKJ/iSeJENkgyk=
 go.opentelemetry.io/collector/config/configopaque v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:dQK8eUXjIGKaw1RB7UIg2nqx56AueNxeKFCdB0P1ypg=
 go.opentelemetry.io/collector/config/configretry v0.92.1-0.20240118172122-8131d31601b8 h1:/qbyGUTJjjuSn6tLAGSzE7VAjj54c/8imYKgovIML+E=
@@ -286,6 +299,7 @@ go.opentelemetry.io/collector/config/configtelemetry v0.92.1-0.20240118172122-81
 go.opentelemetry.io/collector/config/configtelemetry v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:2XLhyR/GVpWeZ2K044vCmrvH/d4Ewt0aD/y46avZyMU=
 go.opentelemetry.io/collector/config/configtls v0.92.1-0.20240118172122-8131d31601b8 h1:8L2sFdBx4AZKzGKF6WfumqH2xLwoC+BlHIR4waKF90Y=
 go.opentelemetry.io/collector/config/configtls v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:rL9BH5Hyrkni4t+QOx/opuwD0CHq/ZIFTsh6QLLsbmA=
+go.opentelemetry.io/collector/config/internal v0.92.1-0.20240118172122-8131d31601b8 h1:+TSSZgWdJPbc7cvgPbubruZShWN6QF4rs+qOc/eSRak=
 go.opentelemetry.io/collector/confmap v0.92.1-0.20240118172122-8131d31601b8 h1:TGBvac5l/nTDQB6u4Yasj3GINyupp2BptHHVZntlWy8=
 go.opentelemetry.io/collector/confmap v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:+QxYr8qSah4ffcVBUC2KJgwlMsrD2nK1CmcHkLB+D7A=
 go.opentelemetry.io/collector/consumer v0.92.1-0.20240118172122-8131d31601b8 h1:nHKcSsdhO/C2sTEil0cmY88MeLbW+B68bcBJ9j9Z0x8=
@@ -294,6 +308,8 @@ go.opentelemetry.io/collector/exporter v0.92.1-0.20240118172122-8131d31601b8 h1:
 go.opentelemetry.io/collector/exporter v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:80wcgdrM62OX2+6VidB1JbESpQKxArJApdrVe0gXUDw=
 go.opentelemetry.io/collector/extension v0.92.1-0.20240118172122-8131d31601b8 h1:sS33cmZpccGhTNLNXmb9IQU2il/anD7Iu7Nyyz9Lnt8=
 go.opentelemetry.io/collector/extension v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:4MG/LMqzVldOP4QZMzImRctujpWdzrd/+VZtZGAJZJU=
+go.opentelemetry.io/collector/extension/auth v0.92.1-0.20240118172122-8131d31601b8 h1:bunRKHJ1GcA/QXB7PFJDvA8q3G5GddOQouCzLvdNg5w=
+go.opentelemetry.io/collector/extension/auth v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:IRlhFZAFPkEhgJwuZfgVnm5rt1Sgu6ERGCFUMpBkOx4=
 go.opentelemetry.io/collector/featuregate v1.0.2-0.20240118172122-8131d31601b8 h1:CjfhuI22zntWF6c+PNhEMO3WNBh0OmKvv3e7tHcuIg4=
 go.opentelemetry.io/collector/featuregate v1.0.2-0.20240118172122-8131d31601b8/go.mod h1:QQXjP4etmJQhkQ20j4P/rapWuItYxoFozg/iIwuKnYg=
 go.opentelemetry.io/collector/pdata v1.0.2-0.20240118172122-8131d31601b8 h1:ygOOx2cN0zZHrPowRymfUgnRa6aEd5eE0xrv9VAQL9c=
@@ -302,6 +318,7 @@ go.opentelemetry.io/collector/receiver v0.92.1-0.20240118172122-8131d31601b8 h1:
 go.opentelemetry.io/collector/receiver v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:BOA4WlE4tBd4hPn3B85O6Gbj6hzyE8RsksK1GQgEWwM=
 go.opentelemetry.io/collector/semconv v0.92.1-0.20240118172122-8131d31601b8 h1:AIEKs1Nl302UUneHQGUL7fkJ1j7GTxRZ+bmc8iXe5Lw=
 go.opentelemetry.io/collector/semconv v0.92.1-0.20240118172122-8131d31601b8/go.mod h1:gZ0uzkXsN+J5NpiRcdp9xOhNGQDDui8Y62p15sKrlzo=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 h1:aFJWCqJMNjENlcleuuOkGAPH82y0yULBScfXcIEdS24=
 go.opentelemetry.io/otel v1.22.0 h1:xS7Ku+7yTFvDfDraDIJVpw7XPyuHlB9MCiqqX5mcJ6Y=
 go.opentelemetry.io/otel v1.22.0/go.mod h1:eoV4iAi3Ea8LkAEI9+GFT44O6T/D0GWAVFyZVCC6pMI=
 go.opentelemetry.io/otel/exporters/prometheus v0.44.1-0.20231201153405-6027c1ae76f2 h1:TnhkxGJ5qPHAMIMI4r+HPT/BbpoHxqn4xONJrok054o=
@@ -326,6 +343,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -356,6 +374,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -386,9 +405,11 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.20.0 h1:aCL9BSgETF1k+blQaYUBx9hJ9LOGP3gAVemcZlf1Kpo=
 golang.org/x/net v0.20.0/go.mod h1:z8BVo6PvndSri0LbOE3hAn0apkU+1YvI6E70E9jsnvY=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -398,6 +419,8 @@ golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
+golang.org/x/oauth2 v0.16.0 h1:aDkGMBSYxElaoP81NpoUoz2oo2R2wHdZpGToUxfyQrQ=
+golang.org/x/oauth2 v0.16.0/go.mod h1:hqZ+0LWXsiVoZpeld6jVt06P3adbS2Uu911W1SsJv2o=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -409,6 +432,7 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -450,6 +474,7 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -461,6 +486,7 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -508,6 +534,7 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -534,6 +561,8 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAsM=
+google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/exporter/elasticsearchexporter/logs_exporter_test.go
+++ b/exporter/elasticsearchexporter/logs_exporter_test.go
@@ -55,8 +55,10 @@ func TestExporter_New(t *testing.T) {
 
 	failWithMessage := func(msg string) validate {
 		return func(t *testing.T, exporter *elasticsearchLogsExporter, err error) {
-			require.Nil(t, exporter)
-			require.Error(t, err)
+			require.NotNil(t, exporter)
+			require.NoError(t, err)
+
+			err = exporter.start(context.Background(), nil)
 			require.Contains(t, err.Error(), msg)
 		}
 	}
@@ -143,7 +145,6 @@ func TestExporter_New(t *testing.T) {
 					require.NoError(t, exporter.Shutdown(context.TODO()))
 				}()
 			}
-
 			test.want(t, exporter, err)
 		})
 	}
@@ -449,6 +450,9 @@ func TestExporter_PushEvent(t *testing.T) {
 
 func newTestExporter(t *testing.T, url string, fns ...func(*Config)) *elasticsearchLogsExporter {
 	exporter, err := newLogsExporter(zaptest.NewLogger(t), withTestExporterConfig(fns...)(url))
+	require.NoError(t, err)
+
+	err = exporter.start(context.Background(), nil)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/exporter/elasticsearchexporter/oauth_test.go
+++ b/exporter/elasticsearchexporter/oauth_test.go
@@ -1,0 +1,161 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package elasticsearchexporter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configauth"
+	"go.opentelemetry.io/collector/extension"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension"
+)
+
+type mockComponentHost struct {
+	extensions map[component.ID]component.Component
+}
+
+func (mockcomponenthost *mockComponentHost) ReportFatalError(_ error) {
+}
+
+func (mockcomponenthost *mockComponentHost) GetFactory(_ component.Kind, _ component.Type) component.Factory {
+	return nil
+}
+
+func (mockcomponenthost *mockComponentHost) GetExtensions() map[component.ID]component.Component {
+	return mockcomponenthost.extensions
+}
+
+func (mockcomponenthost *mockComponentHost) GetExporters() map[component.DataType]map[component.ID]component.Component {
+	return nil
+}
+
+func TestExpoprtOAuth(t *testing.T) {
+	t.Run("auth success", func(t *testing.T) {
+		rec := newBulkRecorder()
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+			rec.Record(docs)
+			return itemsAllOK(docs)
+		})
+		tokenEndpoint := "/oauth2/token" //nolint:gosec
+		authServer := newOauthMockServer(t, tokenEndpoint, true)
+		id, host := createComponentHost(t, authServer.URL+tokenEndpoint)
+
+		exporter := newTestExporterWithHost(t, zaptest.NewLogger(t), server.URL, host, func(c *Config) {
+			c.Authentication = AuthenticationSettings{
+				OAuth: &configauth.Authentication{
+					AuthenticatorID: id,
+				},
+			}
+
+		})
+		mustSend(t, exporter, `{"message": "test1"}`)
+		mustSend(t, exporter, `{"message": "test2"}`)
+		rec.WaitItems(2)
+	})
+
+	t.Run("auth failure", func(t *testing.T) {
+		rec := newBulkRecorder()
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+			rec.Record(docs)
+			return itemsAllOK(docs)
+		})
+		tokenEndpoint := "/oauth2/token" //nolint:gosec
+		authServer := newOauthMockServer(t, tokenEndpoint, false)
+		id, host := createComponentHost(t, authServer.URL+tokenEndpoint)
+
+		observedZapCore, observedLogs := observer.New(zap.InfoLevel)
+		core := zapcore.NewTee(observedZapCore, zaptest.NewLogger(t).Core())
+		observedLogger := zap.New(core)
+		exporter := newTestExporterWithHost(t, observedLogger, server.URL, host, func(c *Config) {
+			c.Authentication = AuthenticationSettings{
+				OAuth: &configauth.Authentication{
+					AuthenticatorID: id,
+				},
+			}
+		})
+		mustSend(t, exporter, `{"message": "test1"}`)
+		time.Sleep(time.Millisecond * 100)
+		assert.Equal(t, 0, rec.NumItems())
+		filtered := observedLogs.FilterMessageSnippet("failed to get security token from token endpoin")
+		assert.NotEqual(t, 0, filtered.Len())
+	})
+}
+
+func createComponentHost(t *testing.T, tokenURL string) (component.ID, *mockComponentHost) {
+	factory := oauth2clientauthextension.NewFactory()
+
+	id := component.NewID(component.Type("oauth2client"))
+	config := factory.CreateDefaultConfig().(*oauth2clientauthextension.Config)
+	config.ClientID = "fakeclientid"
+	config.ClientSecret = "fakeclientsecret"
+	config.TokenURL = tokenURL
+	require.NoError(t, config.Validate())
+
+	extension, err := factory.CreateExtension(context.Background(), extension.CreateSettings{ID: id}, config)
+	require.NoError(t, err)
+
+	host := &mockComponentHost{
+		extensions: map[component.ID]component.Component{
+			id: extension,
+		},
+	}
+	return id, host
+}
+
+func newTestExporterWithHost(t *testing.T, logger *zap.Logger, url string, host component.Host, fns ...func(*Config)) *elasticsearchLogsExporter {
+
+	exporter, err := newLogsExporter(logger, withTestExporterConfig(fns...)(url))
+	require.NoError(t, err)
+
+	err = exporter.start(context.Background(), host)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, exporter.Shutdown(context.TODO()))
+	})
+	return exporter
+}
+
+func newOauthMockServer(t *testing.T, path string, authSuccess bool) *httptest.Server {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if authSuccess {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "MTQ0NjJkZmQ5OTM2NDE1ZTZjNGZmZjI3",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+				"refresh_token": "IwOGYzYTlmM2YxOTQ5MGE3YmNmMDFkNTVk",
+				"scope":         "create",
+			})
+		} else {
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error":             "some error",
+				"error_description": "error description",
+				"error_uri":         "error uri",
+			})
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}

--- a/exporter/elasticsearchexporter/testdata/config.yaml
+++ b/exporter/elasticsearchexporter/testdata/config.yaml
@@ -44,3 +44,9 @@ elasticsearch/logstash_format:
   endpoints: [http://localhost:9200]
   logstash_format:
     enabled: true
+elasticsearch/oauth:
+  endpoints: [http://localhost:9200]
+  oauth:
+    authenticator: oauth2client
+
+

--- a/exporter/elasticsearchexporter/traces_exporter_test.go
+++ b/exporter/elasticsearchexporter/traces_exporter_test.go
@@ -48,8 +48,10 @@ func TestTracesExporter_New(t *testing.T) {
 
 	failWithMessage := func(msg string) validate {
 		return func(t *testing.T, exporter *elasticsearchTracesExporter, err error) {
-			require.Nil(t, exporter)
-			require.Error(t, err)
+			require.NotNil(t, exporter)
+			require.NoError(t, err)
+
+			err = exporter.start(context.Background(), nil)
 			require.Contains(t, err.Error(), msg)
 		}
 	}
@@ -431,6 +433,9 @@ func newTestLogsExporter(t *testing.T, url string, fns ...func(*Config)) *elasti
 	exporter, err := newLogsExporter(zaptest.NewLogger(t), withTestTracesExporterConfig(fns...)(url))
 	require.NoError(t, err)
 
+	err = exporter.start(context.Background(), nil)
+	require.NoError(t, err)
+
 	t.Cleanup(func() {
 		require.NoError(t, exporter.Shutdown(context.TODO()))
 	})
@@ -439,6 +444,9 @@ func newTestLogsExporter(t *testing.T, url string, fns ...func(*Config)) *elasti
 
 func newTestTracesExporter(t *testing.T, url string, fns ...func(*Config)) *elasticsearchTracesExporter {
 	exporter, err := newTracesExporter(zaptest.NewLogger(t), withTestTracesExporterConfig(fns...)(url))
+	require.NoError(t, err)
+
+	err = exporter.start(context.Background(), nil)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
**Description:** 
Add support for OAuth2 client authentication 

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29329

**Testing:**
- Added unit testing
- Tested against a [reverse proxy](https://github.com/hvaghani221/elasticproxy) that authenticates requests incoming from the agent using oauth2 and redirects the request to elasticsearch if authenticated.

**Documentation:**
- Added required configuration in the README. 

**Sample config to enable oauth**
```yaml
receivers:
  filelog:
    include: [ ./sample.log ]

exporters:
  elasticsearch/log:
    oauth:
      authenticator: oauth2client
    endpoints: [ "http://localhost:9200/" ]

extensions:
  oauth2client:
    client_id: <client_id>
    client_secret: <client_secret>
    token_url: https://<host>/oauth2/token

service:
  extensions: [oauth2client]
  pipelines:
    logs:
      receivers: [filelog]
      processors: []
      exporters: [elasticsearch/log]
```
