### PR TITLE
[processor/filter] mv from opencensus to otel

### DIFF
--- a/.chloggen/codeboten_rm-census-filter.yaml
+++ b/.chloggen/codeboten_rm-census-filter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filterprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: move metrics from OpenCensus to OpenTelemetry
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30736]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/filterprocessor/go.mod
+++ b/processor/filterprocessor/go.mod
@@ -3,15 +3,10 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/filte
 go 1.20
 
 require (
-	contrib.go.opencensus.io/exporter/prometheus v0.4.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.93.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.93.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.93.0
-	github.com/prometheus/client_golang v1.18.0
-	github.com/prometheus/client_model v0.5.0
-	github.com/prometheus/common v0.46.0
 	github.com/stretchr/testify v1.8.4
-	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector/component v0.93.0
 	go.opentelemetry.io/collector/confmap v0.93.0
 	go.opentelemetry.io/collector/consumer v0.93.0
@@ -26,6 +21,7 @@ require (
 )
 
 require (
+	contrib.go.opencensus.io/exporter/prometheus v0.4.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -54,8 +50,12 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.93.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.18.0 // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.46.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/prometheus/statsd_exporter v0.22.7 // indirect
+	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.93.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.93.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.0.1 // indirect

--- a/processor/filterprocessor/logs_test.go
+++ b/processor/filterprocessor/logs_test.go
@@ -765,7 +765,7 @@ func TestFilterLogProcessorWithOTTL(t *testing.T) {
 
 func TestFilterLogProcessorTelemetry(t *testing.T) {
 	telemetryTest(t, "FilterLogProcessorTelemetry", func(t *testing.T, tel testTelemetry) {
-		processor, err := newFilterLogsProcessor(processortest.NewNopCreateSettings(), &Config{
+		processor, err := newFilterLogsProcessor(tel.NewProcessorCreateSettings(), &Config{
 			Logs: LogFilters{LogConditions: []string{`IsMatch(body, "operationA")`}},
 		})
 		assert.NoError(t, err)

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -378,7 +378,7 @@ func TestFilterMetricProcessorTelemetry(t *testing.T) {
 		factory := NewFactory()
 		fmp, err := factory.CreateMetricsProcessor(
 			context.Background(),
-			processortest.NewNopCreateSettings(),
+			tel.NewProcessorCreateSettings(),
 			cfg,
 			next,
 		)
@@ -401,7 +401,7 @@ func TestFilterMetricProcessorTelemetry(t *testing.T) {
 		assert.NoError(t, err)
 
 		tel.assertMetrics(t, expectedMetrics{
-			metricDataPointsFiltered: float64(0),
+			metricDataPointsFiltered: 0,
 		})
 
 		err = fmp.ConsumeMetrics(context.Background(), testResourceMetrics([]metricWithResource{
@@ -415,7 +415,7 @@ func TestFilterMetricProcessorTelemetry(t *testing.T) {
 		assert.NoError(t, err)
 
 		tel.assertMetrics(t, expectedMetrics{
-			metricDataPointsFiltered: float64(1),
+			metricDataPointsFiltered: 1,
 		})
 
 		err = fmp.ConsumeMetrics(context.Background(), testResourceMetrics([]metricWithResource{
@@ -429,7 +429,7 @@ func TestFilterMetricProcessorTelemetry(t *testing.T) {
 		assert.NoError(t, err)
 
 		tel.assertMetrics(t, expectedMetrics{
-			metricDataPointsFiltered: float64(2),
+			metricDataPointsFiltered: 2,
 		})
 
 		assert.NoError(t, fmp.Shutdown(ctx))

--- a/processor/filterprocessor/telemetry.go
+++ b/processor/filterprocessor/telemetry.go
@@ -84,5 +84,5 @@ func (fpt *filterProcessorTelemetry) record(trigger trigger, dropped int64) {
 		triggerMeasure = fpt.spansFiltered
 	}
 
-	triggerMeasure.Add(fpt.exportCtx, dropped)
+	triggerMeasure.Add(fpt.exportCtx, dropped, metric.WithAttributes(fpt.processorAttr...))
 }

--- a/processor/filterprocessor/telemetry.go
+++ b/processor/filterprocessor/telemetry.go
@@ -6,12 +6,10 @@ package filterprocessor // import "github.com/open-telemetry/opentelemetry-colle
 import (
 	"context"
 
-	"go.opencensus.io/stats"
-	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor/internal/metadata"
 )
@@ -24,78 +22,67 @@ const (
 	triggerSpansDropped
 )
 
-var (
-	typeStr                      = metadata.Type
-	processorTagKey              = tag.MustNewKey(typeStr)
-	statMetricDataPointsFiltered = stats.Int64("datapoints.filtered", "Number of metric data points dropped by the filter processor", stats.UnitDimensionless)
-	statLogsFiltered             = stats.Int64("logs.filtered", "Number of logs dropped by the filter processor", stats.UnitDimensionless)
-	statSpansFiltered            = stats.Int64("spans.filtered", "Number of spans dropped by the filter processor", stats.UnitDimensionless)
-)
-
-func init() {
-	// TODO: Find a way to handle the error.
-	_ = view.Register(metricViews()...)
-}
-
-func metricViews() []*view.View {
-	processorTagKeys := []tag.Key{processorTagKey}
-
-	return []*view.View{
-		{
-			Name:        processorhelper.BuildCustomMetricName(typeStr, statMetricDataPointsFiltered.Name()),
-			Measure:     statMetricDataPointsFiltered,
-			Description: statMetricDataPointsFiltered.Description(),
-			Aggregation: view.Sum(),
-			TagKeys:     processorTagKeys,
-		},
-		{
-			Name:        processorhelper.BuildCustomMetricName(typeStr, statLogsFiltered.Name()),
-			Measure:     statLogsFiltered,
-			Description: statLogsFiltered.Description(),
-			Aggregation: view.Sum(),
-			TagKeys:     processorTagKeys,
-		},
-		{
-			Name:        processorhelper.BuildCustomMetricName(typeStr, statSpansFiltered.Name()),
-			Measure:     statSpansFiltered,
-			Description: statSpansFiltered.Description(),
-			Aggregation: view.Sum(),
-			TagKeys:     processorTagKeys,
-		},
-	}
-}
-
 type filterProcessorTelemetry struct {
 	exportCtx context.Context
 
 	processorAttr []attribute.KeyValue
+
+	datapointsFiltered metric.Int64Counter
+	logsFiltered       metric.Int64Counter
+	spansFiltered      metric.Int64Counter
 }
 
 func newfilterProcessorTelemetry(set processor.CreateSettings) (*filterProcessorTelemetry, error) {
 	processorID := set.ID.String()
 
-	exportCtx, err := tag.New(context.Background(), tag.Insert(processorTagKey, processorID))
+	fpt := &filterProcessorTelemetry{
+		processorAttr: []attribute.KeyValue{attribute.String(metadata.Type, processorID)},
+		exportCtx:     context.Background(),
+	}
+
+	counter, err := metadata.Meter(set.TelemetrySettings).Int64Counter(
+		processorhelper.BuildCustomMetricName(metadata.Type, "datapoints.filtered"),
+		metric.WithDescription("Number of metric data points dropped by the filter processor"),
+		metric.WithUnit("1"),
+	)
 	if err != nil {
 		return nil, err
 	}
-	fpt := &filterProcessorTelemetry{
-		processorAttr: []attribute.KeyValue{attribute.String(typeStr, processorID)},
-		exportCtx:     exportCtx,
+	fpt.datapointsFiltered = counter
+
+	counter, err = metadata.Meter(set.TelemetrySettings).Int64Counter(
+		processorhelper.BuildCustomMetricName(metadata.Type, "logs.filtered"),
+		metric.WithDescription("Number of logs dropped by the filter processor"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return nil, err
 	}
+	fpt.logsFiltered = counter
+
+	counter, err = metadata.Meter(set.TelemetrySettings).Int64Counter(
+		processorhelper.BuildCustomMetricName(metadata.Type, "spans.filtered"),
+		metric.WithDescription("Number of spans dropped by the filter processor"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	fpt.spansFiltered = counter
 
 	return fpt, nil
 }
 
 func (fpt *filterProcessorTelemetry) record(trigger trigger, dropped int64) {
-	var triggerMeasure *stats.Int64Measure
+	var triggerMeasure metric.Int64Counter
 	switch trigger {
 	case triggerMetricDataPointsDropped:
-		triggerMeasure = statMetricDataPointsFiltered
+		triggerMeasure = fpt.datapointsFiltered
 	case triggerLogsDropped:
-		triggerMeasure = statLogsFiltered
+		triggerMeasure = fpt.logsFiltered
 	case triggerSpansDropped:
-		triggerMeasure = statSpansFiltered
+		triggerMeasure = fpt.spansFiltered
 	}
 
-	stats.Record(fpt.exportCtx, triggerMeasure.M(dropped))
+	triggerMeasure.Add(fpt.exportCtx, dropped)
 }

--- a/processor/filterprocessor/telemetry_test.go
+++ b/processor/filterprocessor/telemetry_test.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
@@ -69,7 +70,10 @@ func (tt *testTelemetry) assertMetrics(t *testing.T, expected expectedMetrics) {
 				Temporality: metricdata.CumulativeTemporality,
 				IsMonotonic: true,
 				DataPoints: []metricdata.DataPoint[int64]{
-					{Value: expected.metricDataPointsFiltered},
+					{
+						Value:      expected.metricDataPointsFiltered,
+						Attributes: attribute.NewSet(attribute.String("filter", "filter")),
+					},
 				},
 			},
 		}
@@ -86,7 +90,10 @@ func (tt *testTelemetry) assertMetrics(t *testing.T, expected expectedMetrics) {
 				Temporality: metricdata.CumulativeTemporality,
 				IsMonotonic: true,
 				DataPoints: []metricdata.DataPoint[int64]{
-					{Value: expected.logsFiltered},
+					{
+						Value:      expected.logsFiltered,
+						Attributes: attribute.NewSet(attribute.String("filter", "filter")),
+					},
 				},
 			},
 		}
@@ -103,7 +110,10 @@ func (tt *testTelemetry) assertMetrics(t *testing.T, expected expectedMetrics) {
 				Temporality: metricdata.CumulativeTemporality,
 				IsMonotonic: true,
 				DataPoints: []metricdata.DataPoint[int64]{
-					{Value: expected.spansFiltered},
+					{
+						Value:      expected.spansFiltered,
+						Attributes: attribute.NewSet(attribute.String("filter", "filter")),
+					},
 				},
 			},
 		}

--- a/processor/filterprocessor/telemetry_test.go
+++ b/processor/filterprocessor/telemetry_test.go
@@ -35,11 +35,11 @@ type expectedMetrics struct {
 
 func telemetryTest(t *testing.T, name string, testFunc func(t *testing.T, tel testTelemetry)) {
 	t.Run(name, func(t *testing.T) {
-		testFunc(t, setupTelemetry(t))
+		testFunc(t, setupTelemetry())
 	})
 }
 
-func setupTelemetry(t *testing.T) testTelemetry {
+func setupTelemetry() testTelemetry {
 	reader := sdkmetric.NewManualReader()
 	return testTelemetry{
 		reader:        reader,
@@ -61,7 +61,7 @@ func (tt *testTelemetry) assertMetrics(t *testing.T, expected expectedMetrics) {
 
 	if expected.metricDataPointsFiltered > 0 {
 		name := "processor/filter/datapoints.filtered"
-		got := tt.getMetric(t, name, md)
+		got := tt.getMetric(name, md)
 		want := metricdata.Metrics{
 			Name:        name,
 			Description: "Number of metric data points dropped by the filter processor",
@@ -81,7 +81,7 @@ func (tt *testTelemetry) assertMetrics(t *testing.T, expected expectedMetrics) {
 	}
 	if expected.logsFiltered > 0 {
 		name := "processor/filter/logs.filtered"
-		got := tt.getMetric(t, name, md)
+		got := tt.getMetric(name, md)
 		want := metricdata.Metrics{
 			Name:        name,
 			Description: "Number of logs dropped by the filter processor",
@@ -101,7 +101,7 @@ func (tt *testTelemetry) assertMetrics(t *testing.T, expected expectedMetrics) {
 	}
 	if expected.spansFiltered > 0 {
 		name := "processor/filter/spans.filtered"
-		got := tt.getMetric(t, name, md)
+		got := tt.getMetric(name, md)
 		want := metricdata.Metrics{
 			Name:        name,
 			Description: "Number of spans dropped by the filter processor",
@@ -121,7 +121,7 @@ func (tt *testTelemetry) assertMetrics(t *testing.T, expected expectedMetrics) {
 	}
 }
 
-func (tt *testTelemetry) getMetric(t *testing.T, name string, got metricdata.ResourceMetrics) metricdata.Metrics {
+func (tt *testTelemetry) getMetric(name string, got metricdata.ResourceMetrics) metricdata.Metrics {
 	for _, sm := range got.ScopeMetrics {
 		for _, m := range sm.Metrics {
 			if m.Name == name {

--- a/processor/filterprocessor/telemetry_test.go
+++ b/processor/filterprocessor/telemetry_test.go
@@ -4,81 +4,46 @@
 package filterprocessor
 
 import (
-	"fmt"
-	"math"
-	"net/http"
-	"net/http/httptest"
+	"context"
 	"testing"
 
-	ocprom "contrib.go.opencensus.io/exporter/prometheus"
-	"github.com/prometheus/client_golang/prometheus"
-	io_prometheus_client "github.com/prometheus/client_model/go"
-	"github.com/prometheus/common/expfmt"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opencensus.io/stats/view"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor/internal/metadata"
 )
 
-func TestFilterProcessorMetrics(t *testing.T) {
-	viewNames := []string{
-		"datapoints.filtered",
-		"logs.filtered",
-		"spans.filtered",
-	}
-	views := metricViews()
-	for i, viewName := range viewNames {
-		assert.Equal(t, "processor/filter/"+viewName, views[i].Name)
-	}
-}
-
 type testTelemetry struct {
-	meter         view.Meter
-	promHandler   http.Handler
+	reader        *sdkmetric.ManualReader
 	meterProvider *sdkmetric.MeterProvider
 }
 
 type expectedMetrics struct {
 	// processor_filter_metrics_filtered
-	metricDataPointsFiltered float64
+	metricDataPointsFiltered int64
 	// processor_filter_logs_filtered
-	logsFiltered float64
+	logsFiltered int64
 	// processor_filter_spans_filtered
-	spansFiltered float64
+	spansFiltered int64
 }
 
 func telemetryTest(t *testing.T, name string, testFunc func(t *testing.T, tel testTelemetry)) {
-	t.Run(name+"WithOC", func(t *testing.T) {
+	t.Run(name, func(t *testing.T) {
 		testFunc(t, setupTelemetry(t))
 	})
 }
 
 func setupTelemetry(t *testing.T) testTelemetry {
-	// Unregister the views first since they are registered by the init, this way we reset them.
-	views := metricViews()
-	view.Unregister(views...)
-	require.NoError(t, view.Register(views...))
-
-	telemetry := testTelemetry{
-		meter: view.NewMeter(),
+	reader := sdkmetric.NewManualReader()
+	return testTelemetry{
+		reader:        reader,
+		meterProvider: sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)),
 	}
-
-	promReg := prometheus.NewRegistry()
-
-	ocExporter, err := ocprom.NewExporter(ocprom.Options{Registry: promReg})
-	require.NoError(t, err)
-
-	telemetry.promHandler = ocExporter
-
-	view.RegisterExporter(ocExporter)
-	t.Cleanup(func() { view.UnregisterExporter(ocExporter) })
-
-	return telemetry
 }
 
 func (tt *testTelemetry) NewProcessorCreateSettings() processor.CreateSettings {
@@ -90,67 +55,70 @@ func (tt *testTelemetry) NewProcessorCreateSettings() processor.CreateSettings {
 }
 
 func (tt *testTelemetry) assertMetrics(t *testing.T, expected expectedMetrics) {
-	for _, v := range metricViews() {
-		// Forces a flush for the opencensus view data.
-		_, _ = view.RetrieveData(v.Name)
-	}
-
-	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
-	require.NoError(t, err)
-
-	rr := httptest.NewRecorder()
-	tt.promHandler.ServeHTTP(rr, req)
-
-	var parser expfmt.TextParser
-	metrics, err := parser.TextToMetricFamilies(rr.Body)
-	require.NoError(t, err)
+	var md metricdata.ResourceMetrics
+	require.NoError(t, tt.reader.Collect(context.Background(), &md))
 
 	if expected.metricDataPointsFiltered > 0 {
-		name := "processor_filter_datapoints_filtered"
-		metric := tt.getMetric(t, name, io_prometheus_client.MetricType_COUNTER, metrics)
-
-		assertFloat(t, expected.metricDataPointsFiltered, metric.GetCounter().GetValue(), name)
+		name := "processor/filter/datapoints.filtered"
+		got := tt.getMetric(t, name, md)
+		want := metricdata.Metrics{
+			Name:        name,
+			Description: "Number of metric data points dropped by the filter processor",
+			Unit:        "1",
+			Data: metricdata.Sum[int64]{
+				Temporality: metricdata.CumulativeTemporality,
+				IsMonotonic: true,
+				DataPoints: []metricdata.DataPoint[int64]{
+					{Value: expected.metricDataPointsFiltered},
+				},
+			},
+		}
+		metricdatatest.AssertEqual(t, want, got, metricdatatest.IgnoreTimestamp())
 	}
 	if expected.logsFiltered > 0 {
-		name := "processor_filter_logs_filtered"
-		metric := tt.getMetric(t, name, io_prometheus_client.MetricType_COUNTER, metrics)
-
-		assertFloat(t, expected.logsFiltered, metric.GetCounter().GetValue(), name)
+		name := "processor/filter/logs.filtered"
+		got := tt.getMetric(t, name, md)
+		want := metricdata.Metrics{
+			Name:        name,
+			Description: "Number of logs dropped by the filter processor",
+			Unit:        "1",
+			Data: metricdata.Sum[int64]{
+				Temporality: metricdata.CumulativeTemporality,
+				IsMonotonic: true,
+				DataPoints: []metricdata.DataPoint[int64]{
+					{Value: expected.logsFiltered},
+				},
+			},
+		}
+		metricdatatest.AssertEqual(t, want, got, metricdatatest.IgnoreTimestamp())
 	}
 	if expected.spansFiltered > 0 {
-		name := "processor_filter_spans_filtered"
-		metric := tt.getMetric(t, name, io_prometheus_client.MetricType_COUNTER, metrics)
-
-		assertFloat(t, expected.spansFiltered, metric.GetCounter().GetValue(), name)
+		name := "processor/filter/spans.filtered"
+		got := tt.getMetric(t, name, md)
+		want := metricdata.Metrics{
+			Name:        name,
+			Description: "Number of spans dropped by the filter processor",
+			Unit:        "1",
+			Data: metricdata.Sum[int64]{
+				Temporality: metricdata.CumulativeTemporality,
+				IsMonotonic: true,
+				DataPoints: []metricdata.DataPoint[int64]{
+					{Value: expected.spansFiltered},
+				},
+			},
+		}
+		metricdatatest.AssertEqual(t, want, got, metricdatatest.IgnoreTimestamp())
 	}
 }
 
-func (tt *testTelemetry) getMetric(t *testing.T, name string, mtype io_prometheus_client.MetricType, got map[string]*io_prometheus_client.MetricFamily) *io_prometheus_client.Metric {
-	metricFamily, ok := got[name]
-	require.True(t, ok, "expected metric '%s' not found", name)
-	require.Equal(t, mtype, metricFamily.GetType())
-
-	metric, err := getSingleMetric(metricFamily)
-	require.NoError(t, err)
-
-	return metric
-}
-
-func getSingleMetric(metric *io_prometheus_client.MetricFamily) (*io_prometheus_client.Metric, error) {
-	if l := len(metric.Metric); l != 1 {
-		return nil, fmt.Errorf("expected metric '%s' with one set of attributes, but found %d", metric.GetName(), l)
-	}
-	first := metric.Metric[0]
-
-	if len(first.Label) != 1 || "filter" != first.Label[0].GetName() {
-		return nil, fmt.Errorf("expected metric '%s' with a single `filter=\"\"` attribute but got '%s'", metric.GetName(), first.GetLabel())
+func (tt *testTelemetry) getMetric(t *testing.T, name string, got metricdata.ResourceMetrics) metricdata.Metrics {
+	for _, sm := range got.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m
+			}
+		}
 	}
 
-	return first, nil
-}
-
-func assertFloat(t *testing.T, expected, got float64, metric string) {
-	if math.Abs(expected-got) > 0.00001 {
-		assert.Failf(t, "unexpected metric value", "value for metric '%s' did not match, expected '%f' got '%f'", metric, expected, got)
-	}
+	return metricdata.Metrics{}
 }

--- a/processor/filterprocessor/traces_test.go
+++ b/processor/filterprocessor/traces_test.go
@@ -282,7 +282,7 @@ func TestFilterTraceProcessorWithOTTL(t *testing.T) {
 
 func TestFilterTraceProcessorTelemetry(t *testing.T) {
 	telemetryTest(t, "FilterTraceProcessorTelemetry", func(t *testing.T, tel testTelemetry) {
-		processor, err := newFilterSpansProcessor(processortest.NewNopCreateSettings(), &Config{
+		processor, err := newFilterSpansProcessor(tel.NewProcessorCreateSettings(), &Config{
 			Traces: TraceFilters{
 				SpanConditions: []string{
 					`name == "operationA"`,


### PR DESCRIPTION
This moves the telemetry generated by the processor from using opencensus to using otel. Note that the test checks the name of the metric in the format that it is generated using the meter provider, hence the change from `processor_filter_datapoints_filtered` to `processor/filter/datapoints.filtered`. When using the prometheus exporter, the output name will be the same as before.

Fixes #30734
