### PR TITLE
Add GOOS=windows to lint-matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -104,6 +104,8 @@ jobs:
           key: go-lint-build-${{ matrix.group }}-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Lint
         run: make -j2 golint GROUP=${{ matrix.group }}
+      - name: Lint with GOOS=windows
+        run: GOOS=windows make -j2 golint GROUP=${{ matrix.group }}
   lint:
     if: ${{ github.actor != 'dependabot[bot]' && always() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description:**

Add a lint step to CI with `GOOS=windows`. This will ensure that code for Windows keeps a clean lint pass.

Until the lint Go cache is invalidated the step with `GOOS=windows` will be a bit longer than the Linux step. I'm measuring in my fork to see what we should expect after the cache is updated. I had an alternative implementation using Windows runners instead, but, overall it required separated Go caches and many more runners, running on Linux also ensures that the step can also be run by contributors on their dev boxes.

**Link to tracking Issue:**
Related to #11557 and #27866, but, it doesn't fix any of the two.

**Testing:**
Validated that the step is passing for all components

**Documentation:**
N/A