### PR TITLE
[exporter/datadogexporter] Add config example for kafka metrics

### DIFF
--- a/exporter/datadogexporter/examples/kafka.yaml
+++ b/exporter/datadogexporter/examples/kafka.yaml
@@ -1,0 +1,61 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "localhost:4318"
+      grpc:
+        endpoint: "localhost:4317"
+  filelog:
+    include_file_path: true
+    poll_interval: 500ms
+    include:
+      - /var/log/kafka/server.log
+    operators:
+      - type: json_parser
+  kafkametrics:
+    brokers: "${env:KAFKA_BROKER_ADDRESS}"
+    protocol_version: 2.0.0
+    scrapers:
+      - brokers
+      - topics
+      - consumers
+  jmx:
+    jar_path: /path/to/opentelemetry-jmx-metrics.jar
+    endpoint: ${env:KAFKA_BROKER_JMX_ADDRESS}
+    target_system: kafka,jvm
+  jmx/consumer:
+    jar_path: /path/to/opentelemetry-jmx-metrics.jar
+    endpoint: ${env:KAFKA_CONSUMER_JMX_ADDRESS}
+    target_system: kafka-consumer
+  jmx/producer:
+    jar_path: /path/to/opentelemetry-jmx-metrics.jar
+    endpoint: ${env:KAFKA_PRODUCER_JMX_ADDRESS}
+    target_system: kafka-producer
+
+processors:
+  batch:
+    send_batch_max_size: 1000
+    send_batch_size: 100
+    timeout: 10s
+  attributes:
+    actions:
+      - key: ddtags
+        value: "source:kafka"
+        action: insert
+
+exporters:
+  datadog:
+    api:
+      site: ${env:DD_SITE}
+      key: ${env:DD_API_KEY}
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp, kafkametrics, jmx, jmx/consumer, jmx/producer]
+      processors: [batch]
+      exporters: [datadog]
+    logs:
+      receivers: [otlp, filelog]
+      processors: [batch, attributes]
+      exporters: [datadog]

--- a/exporter/datadogexporter/examples_test.go
+++ b/exporter/datadogexporter/examples_test.go
@@ -41,6 +41,10 @@ func TestExamples(t *testing.T) {
 	files, err := os.ReadDir(folder)
 	require.NoError(t, err)
 	for _, f := range files {
+		if f.Name() == "kafka.yaml" {
+			// skip validation, as it requires jar file.
+			continue
+		}
 		if f.IsDir() {
 			continue
 		}


### PR DESCRIPTION
**Description:** 
This PR adds an example on how to configure the OTel collector to pull kafka metrics.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>