### PR TITLE
[extension/filestorage] enable feature gate `extension.filestorage.replaceUnsafeCharacters`

### DIFF
--- a/.chloggen/file-storage-feature-beta.yaml
+++ b/.chloggen/file-storage-feature-beta.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: extension/filestorage
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Replace path-unsafe characters in component names
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [3148]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The feature gate `extension.filestorage.replaceUnsafeCharacters` is now enabled by default.
+  See the File Storage extension's README for details.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/storage/filestorage/README.md
+++ b/extension/storage/filestorage/README.md
@@ -131,7 +131,7 @@ For more details, see the following issues:
 The schedule for this feature gate is:
 
 - Introduced in v0.87.0 (October 2023) as `alpha` - disabled by default.
-- Moved to `beta` in January 2024 - enabled by default.
+- Moved to `beta` in v0.92.0 (January 2024) - enabled by default.
 - Moved to `stable` in April 2024 - cannot be disabled.
 - Removed three releases after `stable`.
 

--- a/extension/storage/filestorage/extension.go
+++ b/extension/storage/filestorage/extension.go
@@ -18,7 +18,7 @@ import (
 
 var replaceUnsafeCharactersFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"extension.filestorage.replaceUnsafeCharacters",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, characters that are not safe in file paths are replaced in component name using the extension. For example, the data for component `filelog/logs/json` will be stored in file `receiver_filelog_logs~007Ejson` and not in `receiver_filelog_logs/json`."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3148"),
 	featuregate.WithRegisterFromVersion("v0.87.0"),

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -16,7 +16,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.opentelemetry.io/collector/extension/extensiontest"
-	"go.opentelemetry.io/collector/featuregate"
 )
 
 func TestExtensionIntegrity(t *testing.T) {
@@ -223,9 +222,6 @@ func TestSanitize(t *testing.T) {
 }
 
 func TestComponentNameWithUnsafeCharacters(t *testing.T) {
-	err := featuregate.GlobalRegistry().Set("extension.filestorage.replaceUnsafeCharacters", true)
-	require.NoError(t, err)
-
 	tempDir := t.TempDir()
 
 	f := NewFactory()


### PR DESCRIPTION
**Description:**

Moves the feature gate `extension.filestorage.replaceUnsafeCharacters` to Beta stage, which means it is now enabled by default. This is according to the schedule for this feature gate described in the File Storage extension's [README](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.92.0/extension/storage/filestorage/README.md#extensionfilestoragereplaceunsafecharacters).

**Link to tracking Issue:**

- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/3148

**Testing:**

Updated tests to not require enabling of the feature gate.

**Documentation:**

Updated version in which feature gate was moved to Beta.