### PR TITLE
[chore][exporter/f5cloud] Fix TestLoadConfig w/ using factory default configs

### DIFF
--- a/exporter/f5cloudexporter/config_test.go
+++ b/exporter/f5cloudexporter/config_test.go
@@ -33,32 +33,32 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	actualCfg := cfg.(*Config)
-	expectedCfg := &Config{
-		Config: otlphttp.Config{
-			RetryConfig: configretry.BackOffConfig{
-				Enabled:             true,
-				InitialInterval:     10 * time.Second,
-				MaxInterval:         1 * time.Minute,
-				MaxElapsedTime:      10 * time.Minute,
-				RandomizationFactor: backoff.DefaultRandomizationFactor,
-				Multiplier:          backoff.DefaultMultiplier,
-			},
-			QueueConfig: exporterhelper.QueueSettings{
-				Enabled:      true,
-				NumConsumers: 2,
-				QueueSize:    10,
-			},
-			HTTPClientSettings: confighttp.HTTPClientSettings{
-				Endpoint:        "https://f5cloud",
-				ReadBufferSize:  123,
-				WriteBufferSize: 345,
-				Timeout:         time.Second * 10,
-				Headers: map[string]configopaque.String{
-					"User-Agent": "opentelemetry-collector-contrib {{version}}",
-				},
-				Compression: "gzip",
-			},
+	otlphttpCfg := otlphttp.NewFactory().CreateDefaultConfig().(*otlphttp.Config)
+	otlphttpCfg.RetryConfig = configretry.BackOffConfig{
+		Enabled:             true,
+		InitialInterval:     10 * time.Second,
+		MaxInterval:         1 * time.Minute,
+		MaxElapsedTime:      10 * time.Minute,
+		RandomizationFactor: backoff.DefaultRandomizationFactor,
+		Multiplier:          backoff.DefaultMultiplier,
+	}
+	otlphttpCfg.QueueConfig = exporterhelper.QueueSettings{
+		Enabled:      true,
+		NumConsumers: 2,
+		QueueSize:    10,
+	}
+	otlphttpCfg.HTTPClientSettings = confighttp.HTTPClientSettings{
+		Endpoint:        "https://f5cloud",
+		ReadBufferSize:  123,
+		WriteBufferSize: 345,
+		Timeout:         time.Second * 10,
+		Headers: map[string]configopaque.String{
+			"User-Agent": "opentelemetry-collector-contrib {{version}}",
 		},
+		Compression: "gzip",
+	}
+	expectedCfg := &Config{
+		Config: *otlphttpCfg,
 		Source: "dev",
 		AuthConfig: AuthConfig{
 			CredentialFile: "/etc/creds/key.json",


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30703.

This changes the test to create a otlphttpCfg from factory default, so that the test doesn't fail when new fields are introduced to otlphttp default config.