### PR TITLE
[exporter/awsemf] Drop redundant arg from addToGroupedMetric

### DIFF
--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -27,9 +27,17 @@ type metricInfo struct {
 }
 
 // addToGroupedMetric processes OT metrics and adds them into GroupedMetric buckets
-func addToGroupedMetric(pmd pmetric.Metric, groupedMetrics map[any]*groupedMetric, metadata cWMetricMetadata, patternReplaceSucceeded bool, logger *zap.Logger, descriptor map[string]MetricDescriptor, config *Config, calculators *emfCalculators) error {
+func addToGroupedMetric(
+	pmd pmetric.Metric,
+	groupedMetrics map[any]*groupedMetric,
+	metadata cWMetricMetadata,
+	patternReplaceSucceeded bool,
+	descriptor map[string]MetricDescriptor,
+	config *Config,
+	calculators *emfCalculators,
+) error {
 
-	dps := getDataPoints(pmd, metadata, logger)
+	dps := getDataPoints(pmd, metadata, config.logger)
 	if dps == nil || dps.Len() == 0 {
 		return nil
 	}
@@ -83,7 +91,7 @@ func addToGroupedMetric(pmd pmetric.Metric, groupedMetrics map[any]*groupedMetri
 			if _, ok := groupedMetrics[groupKey]; ok {
 				// if MetricName already exists in metrics map, print warning log
 				if _, ok := groupedMetrics[groupKey].metrics[dp.name]; ok {
-					logger.Warn(
+					config.logger.Warn(
 						"Duplicate metric found",
 						zap.String("Name", dp.name),
 						zap.Any("Labels", labels),

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -145,7 +145,7 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm pmetric.ResourceMetri
 				instrumentationScopeName: instrumentationScopeName,
 				receiver:                 metricReceiver,
 			}
-			err := addToGroupedMetric(metric, groupedMetrics, metadata, patternReplaceSucceeded, config.logger, mt.metricDescriptor, config, mt.calculators)
+			err := addToGroupedMetric(metric, groupedMetrics, metadata, patternReplaceSucceeded, mt.metricDescriptor, config, mt.calculators)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION

**Description:** <Describe what has changed.>
The `addToGroupedMetric` previously took the logger as well as the config as arguments. However, the logger is already available as a field in the config so it is redundant to pass it separately. 

This commit removes the logger argument.

**Testing:** 
The affected unit tests were updated