### PR TITLE
[receiver/splunkhec] splunkhecreiver adopts ``component.UseLocalHostAsDefaultHost` feature gate`

### DIFF
--- a/.chloggen/mx-psi_internal-localhostgate.yaml
+++ b/.chloggen/mx-psi_internal-localhostgate.yaml
@@ -21,6 +21,7 @@ subtext: |
     - receiver/opencensus
     - receiver/zipkin
     - receiver/awsfirehose
+    - receiver/splunk_hec
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/splunkhecreceiver/README.md
+++ b/receiver/splunkhecreceiver/README.md
@@ -30,6 +30,8 @@ The following settings are required:
 * `endpoint` (default = `0.0.0.0:8088`): Address and port that the Splunk HEC
   receiver should bind to.
 
+The `component.UseLocalHostAsDefaultHost` feature gate changes this to localhost:8088. This will become the default in a future release.
+
 The following settings are optional:
 
 * `access_token_passthrough` (default = `false`): Whether to preserve incoming

--- a/receiver/splunkhecreceiver/config_test.go
+++ b/receiver/splunkhecreceiver/config_test.go
@@ -56,7 +56,7 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "tls"),
 			expected: &Config{
 				HTTPServerConfig: confighttp.HTTPServerConfig{
-					Endpoint: ":8088",
+					Endpoint: "0.0.0.0:8088",
 					TLSSetting: &configtls.TLSServerSetting{
 						TLSSetting: configtls.TLSSetting{
 							CertFile: "/test.crt",

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/localhostgate"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver/internal/metadata"
@@ -21,7 +22,7 @@ import (
 
 const (
 	// Default endpoints to bind to.
-	defaultEndpoint = ":8088"
+	defaultPort = 8088
 )
 
 // NewFactory creates a factory for Splunk HEC receiver.
@@ -37,7 +38,7 @@ func NewFactory() receiver.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		HTTPServerConfig: confighttp.HTTPServerConfig{
-			Endpoint: defaultEndpoint,
+			Endpoint: localhostgate.EndpointForPort(defaultPort),
 		},
 		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{},
 		HecToOtelAttrs: splunk.HecToOtelAttrs{


### PR DESCRIPTION
**Description:**
Add `component.UseLocalHostAsDefaultHost` feature gate that changes default endpoints from 0.0.0.0 to localhost

**Link to tracking Issue:**
#30702

**Documentation:**
Updated docs.