### PR TITLE
[chore] Do more steps in parallel in build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -395,7 +395,7 @@ jobs:
 
   cross-compile:
     runs-on: ubuntu-latest
-    needs: [unittest, integration-tests, lint]
+#    needs: [unittest, lint]
     strategy:
       matrix:
         os:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -543,7 +543,7 @@ jobs:
 
   publish-check:
     runs-on: ubuntu-latest
-    needs: [build-package]
+    needs: [lint, unittest, integration-tests, build-package]
     steps:
       - uses: actions/checkout@v4
       - name: Download Binaries

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -395,7 +395,7 @@ jobs:
 
   cross-compile:
     runs-on: ubuntu-latest
-#    needs: [unittest, lint]
+    needs: [setup-environment]
     strategy:
       matrix:
         os:


### PR DESCRIPTION
**Description:**
The build-and-test workflow takes a long time.  Part of the issue is that we spend a lot of time waiting for long jobs, such as integration tests, to finish before moving onto more long jobs.

This PR attempts to parallelize more steps by removing some existing ordering we've restricted ourselves to.  Specifically this moves the cross-compile chain to start in parallel with the unit tests, lint, and integration tests.  My reasoning is that if a unit tests or lint is bad it will still get caught and we don't need unit tests to pass to attempt to compile the code. I have update the publish-check step to still depend on all these steps. 

**Link to tracking Issue:** <Issue number if applicable>

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30880
