### PR TITLE
[chore] remove component.Host implementation from generated tests

### DIFF
--- a/cmd/mdatagen/templates/component_test.go.tmpl
+++ b/cmd/mdatagen/templates/component_test.go.tmpl
@@ -10,7 +10,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -49,19 +48,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
-
 
 {{ if isExporter }}
 func TestComponentLifecycle(t *testing.T) {
@@ -119,10 +105,10 @@ func TestComponentLifecycle(t *testing.T) {
 			{{ end }}
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -145,7 +131,7 @@ func TestComponentLifecycle(t *testing.T) {
 				}
 			})
 			{{ if not expectConsumerError }}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			{{ end }}
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
@@ -210,10 +196,10 @@ func TestComponentLifecycle(t *testing.T) {
 			{{ end }}
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -235,7 +221,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})
@@ -299,7 +285,7 @@ func TestComponentLifecycle(t *testing.T) {
 			{{ end }}
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))
@@ -337,12 +323,12 @@ func TestComponentLifecycle(t *testing.T) {
 		{{ end }}
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 		
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }
@@ -452,7 +438,7 @@ func TestComponentLifecycle(t *testing.T) {
 			{{ end }}
 			firstConnector, err := test.createFn(context.Background(), connectortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstConnector.Start(context.Background(), host))
 			require.NoError(t, firstConnector.Shutdown(context.Background()))

--- a/connector/countconnector/generated_component_test.go
+++ b/connector/countconnector/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -87,7 +74,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstConnector, err := test.createFn(context.Background(), connectortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstConnector.Start(context.Background(), host))
 			require.NoError(t, firstConnector.Shutdown(context.Background()))

--- a/connector/exceptionsconnector/generated_component_test.go
+++ b/connector/exceptionsconnector/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -80,7 +67,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstConnector, err := test.createFn(context.Background(), connectortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstConnector.Start(context.Background(), host))
 			require.NoError(t, firstConnector.Shutdown(context.Background()))

--- a/connector/servicegraphconnector/generated_component_test.go
+++ b/connector/servicegraphconnector/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstConnector, err := test.createFn(context.Background(), connectortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstConnector.Start(context.Background(), host))
 			require.NoError(t, firstConnector.Shutdown(context.Background()))

--- a/connector/spanmetricsconnector/generated_component_test.go
+++ b/connector/spanmetricsconnector/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstConnector, err := test.createFn(context.Background(), connectortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstConnector.Start(context.Background(), host))
 			require.NoError(t, firstConnector.Shutdown(context.Background()))

--- a/exporter/alertmanagerexporter/generated_component_test.go
+++ b/exporter/alertmanagerexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -74,10 +61,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/alibabacloudlogserviceexporter/generated_component_test.go
+++ b/exporter/alibabacloudlogserviceexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -88,10 +75,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 				}
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)

--- a/exporter/awscloudwatchlogsexporter/generated_component_test.go
+++ b/exporter/awscloudwatchlogsexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -74,10 +61,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/awss3exporter/generated_component_test.go
+++ b/exporter/awss3exporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -88,10 +75,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/awsxrayexporter/generated_component_test.go
+++ b/exporter/awsxrayexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -74,10 +61,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/azuremonitorexporter/generated_component_test.go
+++ b/exporter/azuremonitorexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -88,10 +75,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/clickhouseexporter/generated_component_test.go
+++ b/exporter/clickhouseexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -91,10 +78,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -117,7 +104,7 @@ func TestComponentLifecycle(t *testing.T) {
 				}
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)

--- a/exporter/datadogexporter/generated_component_test.go
+++ b/exporter/datadogexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -88,10 +75,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/datasetexporter/generated_component_test.go
+++ b/exporter/datasetexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -84,10 +71,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -110,7 +97,7 @@ func TestComponentLifecycle(t *testing.T) {
 				}
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)

--- a/exporter/dynatraceexporter/generated_component_test.go
+++ b/exporter/dynatraceexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -74,10 +61,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/honeycombmarkerexporter/generated_component_test.go
+++ b/exporter/honeycombmarkerexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -74,10 +61,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/kineticaexporter/generated_component_test.go
+++ b/exporter/kineticaexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -91,10 +78,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -117,7 +104,7 @@ func TestComponentLifecycle(t *testing.T) {
 				}
 			})
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)

--- a/exporter/logzioexporter/generated_component_test.go
+++ b/exporter/logzioexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -81,10 +68,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/opensearchexporter/generated_component_test.go
+++ b/exporter/opensearchexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -81,10 +68,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/sapmexporter/generated_component_test.go
+++ b/exporter/sapmexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -74,10 +61,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/sentryexporter/generated_component_test.go
+++ b/exporter/sentryexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -74,10 +61,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/signalfxexporter/generated_component_test.go
+++ b/exporter/signalfxexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -88,10 +75,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/exporter/splunkhecexporter/generated_component_test.go
+++ b/exporter/splunkhecexporter/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -26,18 +25,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -88,10 +75,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), exportertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case exporter.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)

--- a/extension/bearertokenauthextension/generated_component_test.go
+++ b/extension/bearertokenauthextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/encoding/jaegerencodingextension/generated_component_test.go
+++ b/extension/encoding/jaegerencodingextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/encoding/jsonlogencodingextension/generated_component_test.go
+++ b/extension/encoding/jsonlogencodingextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/encoding/otlpencodingextension/generated_component_test.go
+++ b/extension/encoding/otlpencodingextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/encoding/textencodingextension/generated_component_test.go
+++ b/extension/encoding/textencodingextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/headerssetterextension/generated_component_test.go
+++ b/extension/headerssetterextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/healthcheckextension/generated_component_test.go
+++ b/extension/healthcheckextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/healthcheckextension/healthcheckextension_test.go
+++ b/extension/healthcheckextension/healthcheckextension_test.go
@@ -361,8 +361,7 @@ func TestHealthCheckExtensionPortAlreadyInUse(t *testing.T) {
 	hcExt := newServer(config, componenttest.NewNopTelemetrySettings())
 	require.NotNil(t, hcExt)
 
-	mh := newAssertNoErrorHost(t)
-	require.Error(t, hcExt.Start(context.Background(), mh))
+	require.Error(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
 }
 
 func TestHealthCheckMultipleStarts(t *testing.T) {
@@ -377,11 +376,10 @@ func TestHealthCheckMultipleStarts(t *testing.T) {
 	hcExt := newServer(config, componenttest.NewNopTelemetrySettings())
 	require.NotNil(t, hcExt)
 
-	mh := newAssertNoErrorHost(t)
-	require.NoError(t, hcExt.Start(context.Background(), mh))
+	require.NoError(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, hcExt.Shutdown(context.Background())) })
 
-	require.Error(t, hcExt.Start(context.Background(), mh))
+	require.Error(t, hcExt.Start(context.Background(), componenttest.NewNopHost()))
 }
 
 func TestHealthCheckMultipleShutdowns(t *testing.T) {

--- a/extension/oauth2clientauthextension/generated_component_test.go
+++ b/extension/oauth2clientauthextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/oidcauthextension/generated_component_test.go
+++ b/extension/oidcauthextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -60,12 +47,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/opampextension/generated_component_test.go
+++ b/extension/opampextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/pprofextension/generated_component_test.go
+++ b/extension/pprofextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/remotetapextension/generated_component_test.go
+++ b/extension/remotetapextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/extension/sigv4authextension/generated_component_test.go
+++ b/extension/sigv4authextension/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -23,18 +22,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -57,12 +44,12 @@ func TestComponentLifecycle(t *testing.T) {
 
 		firstExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, firstExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, firstExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, firstExt.Shutdown(context.Background()))
 
 		secondExt, err := factory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), cfg)
 		require.NoError(t, err)
-		require.NoError(t, secondExt.Start(context.Background(), newAssertNoErrorHost(t)))
+		require.NoError(t, secondExt.Start(context.Background(), componenttest.NewNopHost()))
 		require.NoError(t, secondExt.Shutdown(context.Background()))
 	})
 }

--- a/processor/attributesprocessor/generated_component_test.go
+++ b/processor/attributesprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -89,10 +76,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/cumulativetodeltaprocessor/generated_component_test.go
+++ b/processor/cumulativetodeltaprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -75,10 +62,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -100,7 +87,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/datadogprocessor/generated_component_test.go
+++ b/processor/datadogprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -78,10 +65,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -103,7 +90,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/deltatorateprocessor/generated_component_test.go
+++ b/processor/deltatorateprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -75,10 +62,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -100,7 +87,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/filterprocessor/generated_component_test.go
+++ b/processor/filterprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -89,10 +76,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/groupbyattrsprocessor/generated_component_test.go
+++ b/processor/groupbyattrsprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -89,10 +76,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/groupbytraceprocessor/generated_component_test.go
+++ b/processor/groupbytraceprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -75,10 +62,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -100,7 +87,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/intervalprocessor/generated_component_test.go
+++ b/processor/intervalprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -75,10 +62,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -100,7 +87,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/k8sattributesprocessor/generated_component_test.go
+++ b/processor/k8sattributesprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -89,10 +76,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/logstransformprocessor/generated_component_test.go
+++ b/processor/logstransformprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -75,10 +62,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -100,7 +87,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/metricsgenerationprocessor/generated_component_test.go
+++ b/processor/metricsgenerationprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -75,10 +62,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -100,7 +87,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/metricstransformprocessor/generated_component_test.go
+++ b/processor/metricstransformprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -75,10 +62,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -100,7 +87,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/probabilisticsamplerprocessor/generated_component_test.go
+++ b/processor/probabilisticsamplerprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -82,10 +69,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -107,7 +94,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/redactionprocessor/generated_component_test.go
+++ b/processor/redactionprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -75,10 +62,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -100,7 +87,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/remotetapprocessor/generated_component_test.go
+++ b/processor/remotetapprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -89,10 +76,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/resourcedetectionprocessor/generated_component_test.go
+++ b/processor/resourcedetectionprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -89,10 +76,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/resourceprocessor/generated_component_test.go
+++ b/processor/resourceprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -89,10 +76,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/routingprocessor/generated_component_test.go
+++ b/processor/routingprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -89,10 +76,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/schemaprocessor/generated_component_test.go
+++ b/processor/schemaprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -89,10 +76,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/servicegraphprocessor/generated_component_test.go
+++ b/processor/servicegraphprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -78,10 +65,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -103,7 +90,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/spanmetricsprocessor/generated_component_test.go
+++ b/processor/spanmetricsprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -78,10 +65,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -103,7 +90,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/spanprocessor/generated_component_test.go
+++ b/processor/spanprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -75,10 +62,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -100,7 +87,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/sumologicprocessor/generated_component_test.go
+++ b/processor/sumologicprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -89,10 +76,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/tailsamplingprocessor/generated_component_test.go
+++ b/processor/tailsamplingprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -75,10 +62,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -100,7 +87,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/processor/transformprocessor/generated_component_test.go
+++ b/processor/transformprocessor/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -89,10 +76,10 @@ func TestComponentLifecycle(t *testing.T) {
 
 			c, err := test.createFn(context.Background(), processortest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			err = c.Start(context.Background(), host)
 			require.NoError(t, err)
-			assert.NotPanics(t, func() {
+			require.NotPanics(t, func() {
 				switch e := c.(type) {
 				case processor.Logs:
 					logs := testdata.GenerateLogsManyLogRecordsSameResource(2)
@@ -114,7 +101,7 @@ func TestComponentLifecycle(t *testing.T) {
 					err = e.ConsumeTraces(context.Background(), traces)
 				}
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
 		})

--- a/receiver/aerospikereceiver/generated_component_test.go
+++ b/receiver/aerospikereceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/apachereceiver/generated_component_test.go
+++ b/receiver/apachereceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/apachesparkreceiver/generated_component_test.go
+++ b/receiver/apachesparkreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/awscloudwatchmetricsreceiver/generated_component_test.go
+++ b/receiver/awscloudwatchmetricsreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/awscloudwatchreceiver/generated_component_test.go
+++ b/receiver/awscloudwatchreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/awscontainerinsightreceiver/generated_component_test.go
+++ b/receiver/awscontainerinsightreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -76,7 +63,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/awsfirehosereceiver/generated_component_test.go
+++ b/receiver/awsfirehosereceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/azureblobreceiver/generated_component_test.go
+++ b/receiver/azureblobreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -83,7 +70,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/azureeventhubreceiver/generated_component_test.go
+++ b/receiver/azureeventhubreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -83,7 +70,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/azuremonitorreceiver/generated_component_test.go
+++ b/receiver/azuremonitorreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/bigipreceiver/generated_component_test.go
+++ b/receiver/bigipreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/carbonreceiver/generated_component_test.go
+++ b/receiver/carbonreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -76,7 +63,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/cloudflarereceiver/generated_component_test.go
+++ b/receiver/cloudflarereceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/cloudfoundryreceiver/generated_component_test.go
+++ b/receiver/cloudfoundryreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -76,7 +63,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/collectdreceiver/generated_component_test.go
+++ b/receiver/collectdreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/couchdbreceiver/generated_component_test.go
+++ b/receiver/couchdbreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/expvarreceiver/generated_component_test.go
+++ b/receiver/expvarreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/filestatsreceiver/generated_component_test.go
+++ b/receiver/filestatsreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/flinkmetricsreceiver/generated_component_test.go
+++ b/receiver/flinkmetricsreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/fluentforwardreceiver/generated_component_test.go
+++ b/receiver/fluentforwardreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/googlecloudpubsubreceiver/generated_component_test.go
+++ b/receiver/googlecloudpubsubreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -90,7 +77,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/googlecloudspannerreceiver/generated_component_test.go
+++ b/receiver/googlecloudspannerreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/haproxyreceiver/generated_component_test.go
+++ b/receiver/haproxyreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/hostmetricsreceiver/generated_component_test.go
+++ b/receiver/hostmetricsreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/httpcheckreceiver/generated_component_test.go
+++ b/receiver/httpcheckreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/influxdbreceiver/generated_component_test.go
+++ b/receiver/influxdbreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/jaegerreceiver/generated_component_test.go
+++ b/receiver/jaegerreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/k8seventsreceiver/generated_component_test.go
+++ b/receiver/k8seventsreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -76,7 +63,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/kafkametricsreceiver/generated_component_test.go
+++ b/receiver/kafkametricsreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/kafkareceiver/generated_component_test.go
+++ b/receiver/kafkareceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -90,7 +77,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/lokireceiver/generated_component_test.go
+++ b/receiver/lokireceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/memcachedreceiver/generated_component_test.go
+++ b/receiver/memcachedreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/mongodbreceiver/generated_component_test.go
+++ b/receiver/mongodbreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -76,7 +63,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/mysqlreceiver/generated_component_test.go
+++ b/receiver/mysqlreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/nginxreceiver/generated_component_test.go
+++ b/receiver/nginxreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/nsxtreceiver/generated_component_test.go
+++ b/receiver/nsxtreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/opencensusreceiver/generated_component_test.go
+++ b/receiver/opencensusreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -83,7 +70,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/oracledbreceiver/generated_component_test.go
+++ b/receiver/oracledbreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/otlpjsonfilereceiver/generated_component_test.go
+++ b/receiver/otlpjsonfilereceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -87,7 +74,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/podmanreceiver/generated_component_test.go
+++ b/receiver/podmanreceiver/generated_component_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -78,7 +65,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/postgresqlreceiver/generated_component_test.go
+++ b/receiver/postgresqlreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/prometheusreceiver/generated_component_test.go
+++ b/receiver/prometheusreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/pulsarreceiver/generated_component_test.go
+++ b/receiver/pulsarreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -90,7 +77,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/purefareceiver/generated_component_test.go
+++ b/receiver/purefareceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/purefbreceiver/generated_component_test.go
+++ b/receiver/purefbreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/rabbitmqreceiver/generated_component_test.go
+++ b/receiver/rabbitmqreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/redisreceiver/generated_component_test.go
+++ b/receiver/redisreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/riakreceiver/generated_component_test.go
+++ b/receiver/riakreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/saphanareceiver/generated_component_test.go
+++ b/receiver/saphanareceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/sapmreceiver/generated_component_test.go
+++ b/receiver/sapmreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/sapmreceiver/trace_receiver_test.go
+++ b/receiver/sapmreceiver/trace_receiver_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/signalfx/sapm-proto/sapmprotocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -246,9 +247,8 @@ func setupReceiver(t *testing.T, config *Config, sink *consumertest.TracesSink) 
 	assert.NoError(t, err, "should not have failed to create the SAPM receiver")
 	t.Log("Starting")
 
-	mh := newAssertNoErrorHost(t)
-	require.NoError(t, sr.Start(context.Background(), mh), "should not have failed to start trace reception")
-	require.NoError(t, sr.Start(context.Background(), mh), "should not fail to start log on second Start call")
+	require.NoError(t, sr.Start(context.Background(), componenttest.NewNopHost()), "should not have failed to start trace reception")
+	require.NoError(t, sr.Start(context.Background(), componenttest.NewNopHost()), "should not fail to start log on second Start call")
 
 	// If there are errors reported through host.ReportFatalError() this will retrieve it.
 	<-time.After(500 * time.Millisecond)

--- a/receiver/signalfxreceiver/generated_component_test.go
+++ b/receiver/signalfxreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -80,7 +67,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -550,7 +550,7 @@ func Test_sfxReceiver_TLS(t *testing.T) {
 		require.NoError(t, r.Shutdown(context.Background()))
 	}()
 
-	mh := newAssertNoErrorHost(t)
+	mh := componenttest.NewNopHost()
 	require.NoError(t, r.Start(context.Background(), mh), "should not have failed to start metric reception")
 
 	// If there are errors reported through host.ReportFatalError() this will retrieve it.

--- a/receiver/simpleprometheusreceiver/generated_component_test.go
+++ b/receiver/simpleprometheusreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/skywalkingreceiver/generated_component_test.go
+++ b/receiver/skywalkingreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -80,7 +67,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/snmpreceiver/generated_component_test.go
+++ b/receiver/snmpreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/snowflakereceiver/generated_component_test.go
+++ b/receiver/snowflakereceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/solacereceiver/generated_component_test.go
+++ b/receiver/solacereceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -76,7 +63,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/splunkenterprisereceiver/generated_component_test.go
+++ b/receiver/splunkenterprisereceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/splunkhecreceiver/generated_component_test.go
+++ b/receiver/splunkhecreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -80,7 +67,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/sqlqueryreceiver/generated_component_test.go
+++ b/receiver/sqlqueryreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -80,7 +67,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/sshcheckreceiver/generated_component_test.go
+++ b/receiver/sshcheckreceiver/generated_component_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -27,18 +26,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -75,7 +62,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/statsdreceiver/generated_component_test.go
+++ b/receiver/statsdreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/syslogreceiver/generated_component_test.go
+++ b/receiver/syslogreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/tcplogreceiver/generated_component_test.go
+++ b/receiver/tcplogreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/udplogreceiver/generated_component_test.go
+++ b/receiver/udplogreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/vcenterreceiver/generated_component_test.go
+++ b/receiver/vcenterreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/wavefrontreceiver/generated_component_test.go
+++ b/receiver/wavefrontreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -76,7 +63,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/webhookeventreceiver/generated_component_test.go
+++ b/receiver/webhookeventreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/zipkinreceiver/generated_component_test.go
+++ b/receiver/zipkinreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))

--- a/receiver/zookeeperreceiver/generated_component_test.go
+++ b/receiver/zookeeperreceiver/generated_component_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -25,18 +24,6 @@ type assertNoErrorHost struct {
 }
 
 var _ component.Host = (*assertNoErrorHost)(nil)
-
-// newAssertNoErrorHost returns a new instance of assertNoErrorHost.
-func newAssertNoErrorHost(t *testing.T) component.Host {
-	return &assertNoErrorHost{
-		componenttest.NewNopHost(),
-		t,
-	}
-}
-
-func (aneh *assertNoErrorHost) ReportFatalError(err error) {
-	assert.NoError(aneh, err)
-}
 
 func TestComponentLifecycle(t *testing.T) {
 	factory := NewFactory()
@@ -73,7 +60,7 @@ func TestComponentLifecycle(t *testing.T) {
 
 			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
 			require.NoError(t, err)
-			host := newAssertNoErrorHost(t)
+			host := componenttest.NewNopHost()
 			require.NoError(t, err)
 			require.NoError(t, firstRcvr.Start(context.Background(), host))
 			require.NoError(t, firstRcvr.Shutdown(context.Background()))


### PR DESCRIPTION
**Description:**
The `assertNoErrorHost` struct was used in tests to check that no error was thrown. However, it uses a deprecated function `ReportFatalError` we are trying to remove from our code.

**Link to tracking Issue:** 
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30579