### PR TITLE
[processor/remotetap] remotetapprocessor adopts `component.UseLocalHostAsDefaultHost` feature gate

### DIFF
--- a/.chloggen/mx-psi_internal-localhostgate.yaml
+++ b/.chloggen/mx-psi_internal-localhostgate.yaml
@@ -21,6 +21,7 @@ subtext: |
     - receiver/opencensus
     - receiver/zipkin
     - receiver/awsfirehose
+    - processor/remotetap
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/processor/remotetapprocessor/README.md
+++ b/processor/remotetapprocessor/README.md
@@ -25,6 +25,8 @@ The WebSocket processor has two configurable fields: `port` and `limit`:
 
 - `port`: The port on which the WebSocket processor listens. Optional. Defaults
   to `12001`.
+  The `component.UseLocalHostAsDefaultHost` feature gate changes this to localhost:12001. This will become the default in a future release.
+
 - `limit`: The rate limit over the WebSocket in messages per second. Can be a
   float or an integer. Optional. Defaults to `1`.
 

--- a/processor/remotetapprocessor/config.go
+++ b/processor/remotetapprocessor/config.go
@@ -7,9 +7,11 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"golang.org/x/time/rate"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/localhostgate"
 )
 
-const defaultEndpoint = ":12001"
+const defaultPort = 12001
 
 type Config struct {
 	confighttp.HTTPServerConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
@@ -22,7 +24,7 @@ type Config struct {
 func createDefaultConfig() component.Config {
 	return &Config{
 		HTTPServerConfig: confighttp.HTTPServerConfig{
-			Endpoint: defaultEndpoint,
+			Endpoint: localhostgate.EndpointForPort(defaultPort),
 		},
 		Limit: 1,
 	}

--- a/processor/remotetapprocessor/config_test.go
+++ b/processor/remotetapprocessor/config_test.go
@@ -11,6 +11,6 @@ import (
 
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	assert.Equal(t, ":12001", cfg.Endpoint)
+	assert.Equal(t, "0.0.0.0:12001", cfg.Endpoint)
 	assert.EqualValues(t, 1, cfg.Limit)
 }

--- a/processor/remotetapprocessor/go.mod
+++ b/processor/remotetapprocessor/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/remot
 go 1.20
 
 require (
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.93.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.93.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.93.0
 	github.com/stretchr/testify v1.8.4
@@ -80,3 +81,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common


### PR DESCRIPTION

**Description:**
remotetapprocessor adopts `component.UseLocalHostAsDefaultHost` feature gate

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30702

**Documentation:**
Updated docs.