### PR TITLE
[receiver/signalfx] signalfxreceiver adopts `component.UseLocalHostAsDefaultHost` feature gate

### DIFF
--- a/.chloggen/mx-psi_internal-localhostgate.yaml
+++ b/.chloggen/mx-psi_internal-localhostgate.yaml
@@ -26,6 +26,7 @@ subtext: |
     - receiver/awsxray
     - receiver/influxdb
     - receiver/zookeeper
+    - receiver/signalfx
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/signalfxreceiver/README.md
+++ b/receiver/signalfxreceiver/README.md
@@ -30,6 +30,7 @@ The following settings are required:
 
 - `endpoint` (default = `0.0.0.0:9943`): Address and port that the SignalFx
   receiver should bind to.
+  The `component.UseLocalHostAsDefaultHost` feature gate changes this to localhost:9943. This will become the default in a future release.
 
 The following settings are optional:
 

--- a/receiver/signalfxreceiver/config_test.go
+++ b/receiver/signalfxreceiver/config_test.go
@@ -47,7 +47,7 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "tls"),
 			expected: &Config{
 				HTTPServerConfig: confighttp.HTTPServerConfig{
-					Endpoint: ":9943",
+					Endpoint: "0.0.0.0:9943",
 					TLSSetting: &configtls.TLSServerSetting{
 						TLSSetting: configtls.TLSSetting{
 							CertFile: "/test.crt",

--- a/receiver/signalfxreceiver/factory.go
+++ b/receiver/signalfxreceiver/factory.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/localhostgate"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver/internal/metadata"
 )
 
@@ -22,8 +23,8 @@ import (
 
 const (
 
-	// Default endpoints to bind to.
-	defaultEndpoint = ":9943"
+	// Default port to bind to.
+	defaultPort = 9943
 )
 
 // NewFactory creates a factory for SignalFx receiver.
@@ -38,7 +39,7 @@ func NewFactory() receiver.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		HTTPServerConfig: confighttp.HTTPServerConfig{
-			Endpoint: defaultEndpoint,
+			Endpoint: localhostgate.EndpointForPort(defaultPort),
 		},
 	}
 }


### PR DESCRIPTION

**Description:**
signalfxreceiver adopts `component.UseLocalHostAsDefaultHost` feature gate

**Link to tracking Issue:**
#30702 

**Documentation:**
Updated docs.