### PR TITLE
[chore][receiver/filestats] Fix scraperhelper name

### DIFF
--- a/receiver/filestatsreceiver/factory.go
+++ b/receiver/filestatsreceiver/factory.go
@@ -38,7 +38,7 @@ func newReceiver(
 	fileStatsConfig := cfg.(*Config)
 
 	mp := newScraper(fileStatsConfig, settings)
-	s, err := scraperhelper.NewScraper(settings.ID.Name(), mp.scrape)
+	s, err := scraperhelper.NewScraper(metadata.Type, mp.scrape)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description:** 

Before this change an empty name was passed to the scraperhelper.

**Link to tracking Issue:** This is needed to make contrib tests pass on open-telemetry/opentelemetry-collector/pull/9414
