### PR TITLE
[chore][receiver/haproxy] Fix scraperhelper name

### DIFF
--- a/receiver/haproxyreceiver/factory.go
+++ b/receiver/haproxyreceiver/factory.go
@@ -37,7 +37,7 @@ func newReceiver(
 ) (receiver.Metrics, error) {
 	haProxyCfg := cfg.(*Config)
 	mp := newScraper(haProxyCfg, settings)
-	s, err := scraperhelper.NewScraper(settings.ID.Name(), mp.scrape, scraperhelper.WithStart(mp.start))
+	s, err := scraperhelper.NewScraper(metadata.Type, mp.scrape, scraperhelper.WithStart(mp.start))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Description:** 

Same as #30917, before this change an empty name could be passed to the scraperhelper.

I think this is the only other instance of this pattern

**Link to tracking Issue**: This is needed to make contrib tests pass on open-telemetry/opentelemetry-collector/pull/9414
