### PR TITLE
Change default Docker client API version from 1.22 to 1.24

### DIFF
--- a/.chloggen/change-default-docker-client-api.yaml
+++ b/.chloggen/change-default-docker-client-api.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'dockerobserver'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Upgrading Docker API version default from 1.22 to 1.24"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30900]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: ['user']

--- a/extension/observer/dockerobserver/README.md
+++ b/extension/observer/dockerobserver/README.md
@@ -18,7 +18,7 @@ The Docker observer extension is a [Receiver Creator](../../../receiver/receiver
 container endpoints discovered through the Docker API. Only containers that are in the state of `Running` and not `Paused` will emit endpoints.
 This observer watches the Docker engine's stream of events to dynamically create, update, and remove endpoints as events are processed.
 
-Requires Docker API Version 1.22+.
+Requires Docker API Version 1.24+.
 
 The collector will need permissions to access the Docker Engine API, specifically it will need
 read access to the Docker socket (default `unix:///var/run/docker.sock`).
@@ -33,8 +33,8 @@ extensions:
     endpoint: my/path/to/docker.sock
     # list of container image names to exclude
     excluded_images: ['redis', 'another_image_name']
-    # client API version, default to 1.22
-    api_version: 1.24
+    # client API version, default to 1.24
+    api_version: 1.25
     # max amount of time to wait for a response from Docker API , default to 5s
     timeout: 15s
 
@@ -67,7 +67,7 @@ default: `5s`
 
 The client API version. If using one with a terminating zero, input as a string to prevent undesired truncation (e.g. `"1.40"` instead of `1.40`, which is parsed as `1.4`).
 
-default: `1.22`
+default: `1.24`
 
 ### `excluded_images`
 

--- a/extension/observer/dockerobserver/config_test.go
+++ b/extension/observer/dockerobserver/config_test.go
@@ -51,7 +51,7 @@ func TestLoadConfig(t *testing.T) {
 				Timeout:           5 * time.Second,
 				DockerAPIVersion:  "1.4",
 			},
-			expectedError: `"api_version" 1.4 must be at least 1.22`,
+			expectedError: `"api_version" 1.4 must be at least 1.24`,
 		},
 	}
 	for _, tt := range tests {
@@ -71,8 +71,8 @@ func TestValidateConfig(t *testing.T) {
 	cfg := &Config{}
 	assert.Equal(t, "endpoint must be specified", component.ValidateConfig(cfg).Error())
 
-	cfg = &Config{Endpoint: "someEndpoint", DockerAPIVersion: "1.21"}
-	assert.Equal(t, `"api_version" 1.21 must be at least 1.22`, component.ValidateConfig(cfg).Error())
+	cfg = &Config{Endpoint: "someEndpoint", DockerAPIVersion: "1.23"}
+	assert.Equal(t, `"api_version" 1.23 must be at least 1.24`, component.ValidateConfig(cfg).Error())
 
 	cfg = &Config{Endpoint: "someEndpoint", DockerAPIVersion: version}
 	assert.Equal(t, "timeout must be specified", component.ValidateConfig(cfg).Error())

--- a/extension/observer/dockerobserver/extension.go
+++ b/extension/observer/dockerobserver/extension.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	defaultDockerAPIVersion         = "1.22"
+	defaultDockerAPIVersion         = "1.24"
 	minimumRequiredDockerAPIVersion = docker.MustNewAPIVersion(defaultDockerAPIVersion)
 )
 


### PR DESCRIPTION
**Description:** Docker Client API default has been upgraded from 1.22 to 1.24. The details of the requirements to this change has been given in the accompanying issue with docker upstream PRs.
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** 
Fixes #30900
**Testing:** Updated unit tests accordingly and ran integration tests to make sure everything works as it  should.

**Documentation:** <Describe the documentation added.>