### PR TITLE
[chore][pkg/stanza/adapter] Enable goleak check

### DIFF
--- a/pkg/stanza/adapter/integration_test.go
+++ b/pkg/stanza/adapter/integration_test.go
@@ -110,6 +110,7 @@ func TestEmitterToConsumer(t *testing.T) {
 
 	err = logsReceiver.Start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
+	defer func() { require.NoError(t, logsReceiver.Shutdown(context.Background())) }()
 
 	go func() {
 		ctx := context.Background()

--- a/pkg/stanza/adapter/package_test.go
+++ b/pkg/stanza/adapter/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package adapter
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/pkg/stanza/adapter/storage_test.go
+++ b/pkg/stanza/adapter/storage_test.go
@@ -77,6 +77,7 @@ func TestFindCorrectStorageExtension(t *testing.T) {
 	err := r.Start(context.Background(), host)
 	require.NoError(t, err)
 	require.NotNil(t, r.storageClient)
+	defer func() { require.NoError(t, r.Shutdown(context.Background())) }()
 
 	clientCreatorID, err := storagetest.CreatorID(context.Background(), r.storageClient)
 	require.NoError(t, err)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Enable `goleak` check on tests in the pkg/stanza/adapter directory. This will help ensure no goroutines are being leaked. This is a test only change, a couple `Shutdown` calls were missing.

**Link to tracking Issue:** <Issue number if applicable>
#30438

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, added `goleak` check is also passing.