### PR TITLE
[receiver/skywalking] adopt the `component.UseLocalHostAsDefaultHost` feature gate

### DIFF
--- a/.chloggen/mx-psi_internal-localhostgate.yaml
+++ b/.chloggen/mx-psi_internal-localhostgate.yaml
@@ -27,6 +27,7 @@ subtext: |
     - receiver/influxdb
     - receiver/zookeeper
     - receiver/signalfx
+    - receiver/skywalking
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/skywalkingreceiver/README.md
+++ b/receiver/skywalkingreceiver/README.md
@@ -29,6 +29,10 @@ object configuration parameter.
 - `grpc` (default `endpoint` = 0.0.0.0:11800)
 - `http` (default `endpoint` = 0.0.0.0:12800)
 
+The `component.UseLocalHostAsDefaultHost` feature gate changes endpoints to localhost:11800 and localhost:12800 respectively.
+This will become the default in a future release.
+
+
 Examples:
 
 ```yaml

--- a/receiver/skywalkingreceiver/config_test.go
+++ b/receiver/skywalkingreceiver/config_test.go
@@ -48,7 +48,7 @@ func TestLoadConfig(t *testing.T) {
 				Protocols: Protocols{
 					GRPC: &configgrpc.GRPCServerSettings{
 						NetAddr: confignet.NetAddr{
-							Endpoint:  defaultGRPCBindEndpoint,
+							Endpoint:  "0.0.0.0:11800",
 							Transport: "tcp",
 						},
 					},

--- a/receiver/skywalkingreceiver/factory.go
+++ b/receiver/skywalkingreceiver/factory.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/localhostgate"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver/internal/metadata"
 )
@@ -27,9 +28,9 @@ const (
 	protoGRPC = "grpc"
 	protoHTTP = "http"
 
-	// Default endpoints to bind to.
-	defaultGRPCBindEndpoint = "0.0.0.0:11800"
-	defaultHTTPBindEndpoint = "0.0.0.0:12800"
+	// Default ports to bind to.
+	defaultGRPCPort = 11800
+	defaultHTTPPort = 12800
 )
 
 // NewFactory creates a new Skywalking receiver factory.
@@ -47,12 +48,12 @@ func createDefaultConfig() component.Config {
 		Protocols: Protocols{
 			GRPC: &configgrpc.GRPCServerSettings{
 				NetAddr: confignet.NetAddr{
-					Endpoint:  defaultGRPCBindEndpoint,
+					Endpoint:  localhostgate.EndpointForPort(defaultGRPCPort),
 					Transport: "tcp",
 				},
 			},
 			HTTP: &confighttp.HTTPServerConfig{
-				Endpoint: defaultHTTPBindEndpoint,
+				Endpoint: localhostgate.EndpointForPort(defaultHTTPPort),
 			},
 		},
 	}

--- a/receiver/skywalkingreceiver/factory_test.go
+++ b/receiver/skywalkingreceiver/factory_test.go
@@ -43,7 +43,7 @@ func TestCreateReceiver(t *testing.T) {
 	// have to enable at least one protocol for the skywalking receiver to be created
 	cfg.(*Config).Protocols.GRPC = &configgrpc.GRPCServerSettings{
 		NetAddr: confignet.NetAddr{
-			Endpoint:  defaultGRPCBindEndpoint,
+			Endpoint:  "0.0.0.0:11800",
 			Transport: "tcp",
 		},
 	}
@@ -88,7 +88,7 @@ func TestCreateDefaultGRPCEndpoint(t *testing.T) {
 
 	cfg.(*Config).Protocols.GRPC = &configgrpc.GRPCServerSettings{
 		NetAddr: confignet.NetAddr{
-			Endpoint:  defaultGRPCBindEndpoint,
+			Endpoint:  "0.0.0.0:11800",
 			Transport: "tcp",
 		},
 	}
@@ -106,7 +106,7 @@ func TestCreateTLSGPRCEndpoint(t *testing.T) {
 
 	cfg.(*Config).Protocols.GRPC = &configgrpc.GRPCServerSettings{
 		NetAddr: confignet.NetAddr{
-			Endpoint:  defaultGRPCBindEndpoint,
+			Endpoint:  "0.0.0.0:11800",
 			Transport: "tcp",
 		},
 		TLSSetting: &configtls.TLSServerSetting{
@@ -127,7 +127,7 @@ func TestCreateTLSHTTPEndpoint(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	cfg.(*Config).Protocols.HTTP = &confighttp.HTTPServerConfig{
-		Endpoint: defaultHTTPBindEndpoint,
+		Endpoint: "0.0.0.0:12800",
 		TLSSetting: &configtls.TLSServerSetting{
 			TLSSetting: configtls.TLSSetting{
 				CertFile: "./testdata/server.crt",
@@ -147,7 +147,7 @@ func TestCreateInvalidHTTPEndpoint(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	cfg.(*Config).Protocols.HTTP = &confighttp.HTTPServerConfig{
-		Endpoint: defaultHTTPBindEndpoint,
+		Endpoint: "0.0.0.0:12800",
 	}
 	set := receivertest.NewNopCreateSettings()
 	traceSink := new(consumertest.TracesSink)

--- a/receiver/skywalkingreceiver/go.mod
+++ b/receiver/skywalkingreceiver/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/gorilla/mux v1.8.1
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.93.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.93.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/skywalking v0.93.0
 	github.com/stretchr/testify v1.8.4
@@ -89,3 +90,5 @@ retract (
 	v0.76.1
 	v0.65.0
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common


### PR DESCRIPTION
Description:
skywalkingreceiver adopts component.UseLocalHostAsDefaultHost feature gate

Link to tracking Issue:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30702

Fixes #30977 

Documentation:
Updated docs.