### PR TITLE
[receiver/jaeger] jaegerreceiver adopts `component.UseLocalHostAsDefaultHost` feature gate

### DIFF
--- a/.chloggen/mx-psi_internal-localhostgate.yaml
+++ b/.chloggen/mx-psi_internal-localhostgate.yaml
@@ -27,6 +27,7 @@ subtext: |
     - receiver/influxdb
     - receiver/zookeeper
     - receiver/signalfx
+    - receiver/jaeger
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/jaegerreceiver/README.md
+++ b/receiver/jaegerreceiver/README.md
@@ -34,6 +34,9 @@ object configuration parameter.
 - `thrift_compact` (default `endpoint` = 0.0.0.0:6831)
 - `thrift_http` (default `endpoint` = 0.0.0.0:14268)
 
+The `component.UseLocalHostAsDefaultHost` feature gate changes these endpoints to localhost:14250, localhost:6832, 
+localhost:6831 and localhost:14268. This will become the default in a future release.
+
 Examples:
 
 ```yaml

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -69,19 +69,19 @@ func TestLoadConfig(t *testing.T) {
 				Protocols: Protocols{
 					GRPC: &configgrpc.GRPCServerSettings{
 						NetAddr: confignet.NetAddr{
-							Endpoint:  defaultGRPCBindEndpoint,
+							Endpoint:  "0.0.0.0:14250",
 							Transport: "tcp",
 						},
 					},
 					ThriftHTTP: &confighttp.HTTPServerConfig{
-						Endpoint: defaultHTTPBindEndpoint,
+						Endpoint: "0.0.0.0:14268",
 					},
 					ThriftCompact: &ProtocolUDP{
-						Endpoint:        defaultThriftCompactBindEndpoint,
+						Endpoint:        "0.0.0.0:6831",
 						ServerConfigUDP: defaultServerConfigUDP(),
 					},
 					ThriftBinary: &ProtocolUDP{
-						Endpoint:        defaultThriftBinaryBindEndpoint,
+						Endpoint:        "0.0.0.0:6832",
 						ServerConfigUDP: defaultServerConfigUDP(),
 					},
 				},
@@ -98,7 +98,7 @@ func TestLoadConfig(t *testing.T) {
 						},
 					},
 					ThriftCompact: &ProtocolUDP{
-						Endpoint:        defaultThriftCompactBindEndpoint,
+						Endpoint:        "0.0.0.0:6831",
 						ServerConfigUDP: defaultServerConfigUDP(),
 					},
 				},

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/localhostgate"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver/internal/metadata"
 )
 
@@ -28,11 +29,11 @@ const (
 	protoThriftBinary  = "thrift_binary"
 	protoThriftCompact = "thrift_compact"
 
-	// Default endpoints to bind to.
-	defaultGRPCBindEndpoint          = "0.0.0.0:14250"
-	defaultHTTPBindEndpoint          = "0.0.0.0:14268"
-	defaultThriftCompactBindEndpoint = "0.0.0.0:6831"
-	defaultThriftBinaryBindEndpoint  = "0.0.0.0:6832"
+	// Default ports to bind to.
+	defaultGRPCPort          = 14250
+	defaultHTTPPort          = 14268
+	defaultThriftCompactPort = 6831
+	defaultThriftBinaryPort  = 6832
 )
 
 var disableJaegerReceiverRemoteSampling = featuregate.GlobalRegistry().MustRegister(
@@ -74,19 +75,19 @@ func createDefaultConfig() component.Config {
 		Protocols: Protocols{
 			GRPC: &configgrpc.GRPCServerSettings{
 				NetAddr: confignet.NetAddr{
-					Endpoint:  defaultGRPCBindEndpoint,
+					Endpoint:  localhostgate.EndpointForPort(defaultGRPCPort),
 					Transport: "tcp",
 				},
 			},
 			ThriftHTTP: &confighttp.HTTPServerConfig{
-				Endpoint: defaultHTTPBindEndpoint,
+				Endpoint: localhostgate.EndpointForPort(defaultHTTPPort),
 			},
 			ThriftBinary: &ProtocolUDP{
-				Endpoint:        defaultThriftBinaryBindEndpoint,
+				Endpoint:        localhostgate.EndpointForPort(defaultThriftBinaryPort),
 				ServerConfigUDP: defaultServerConfigUDP(),
 			},
 			ThriftCompact: &ProtocolUDP{
-				Endpoint:        defaultThriftCompactBindEndpoint,
+				Endpoint:        localhostgate.EndpointForPort(defaultThriftCompactPort),
 				ServerConfigUDP: defaultServerConfigUDP(),
 			},
 		},

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -41,7 +41,7 @@ func TestCreateReceiver(t *testing.T) {
 	// have to enable at least one protocol for the jaeger receiver to be created
 	cfg.(*Config).Protocols.GRPC = &configgrpc.GRPCServerSettings{
 		NetAddr: confignet.NetAddr{
-			Endpoint:  defaultGRPCBindEndpoint,
+			Endpoint:  "0.0.0.0:14250",
 			Transport: "tcp",
 		},
 	}
@@ -82,7 +82,7 @@ func TestCreateDefaultGRPCEndpoint(t *testing.T) {
 
 	cfg.(*Config).Protocols.GRPC = &configgrpc.GRPCServerSettings{
 		NetAddr: confignet.NetAddr{
-			Endpoint:  defaultGRPCBindEndpoint,
+			Endpoint:  "0.0.0.0:14250",
 			Transport: "tcp",
 		},
 	}
@@ -90,7 +90,7 @@ func TestCreateDefaultGRPCEndpoint(t *testing.T) {
 	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
-	assert.Equal(t, defaultGRPCBindEndpoint, r.(*jReceiver).config.CollectorGRPCServerSettings.NetAddr.Endpoint, "grpc port should be default")
+	assert.Equal(t, "0.0.0.0:14250", r.(*jReceiver).config.CollectorGRPCServerSettings.NetAddr.Endpoint, "grpc port should be default")
 }
 
 func TestCreateTLSGPRCEndpoint(t *testing.T) {
@@ -99,7 +99,7 @@ func TestCreateTLSGPRCEndpoint(t *testing.T) {
 
 	cfg.(*Config).Protocols.GRPC = &configgrpc.GRPCServerSettings{
 		NetAddr: confignet.NetAddr{
-			Endpoint:  defaultGRPCBindEndpoint,
+			Endpoint:  "0.0.0.0:14250",
 			Transport: "tcp",
 		},
 		TLSSetting: &configtls.TLSServerSetting{
@@ -120,7 +120,7 @@ func TestCreateTLSThriftHTTPEndpoint(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	cfg.(*Config).Protocols.ThriftHTTP = &confighttp.HTTPServerConfig{
-		Endpoint: defaultHTTPBindEndpoint,
+		Endpoint: "0.0.0.0:14268",
 		TLSSetting: &configtls.TLSServerSetting{
 			TLSSetting: configtls.TLSSetting{
 				CertFile: "./testdata/server.crt",
@@ -143,7 +143,7 @@ func TestCreateInvalidHTTPEndpoint(t *testing.T) {
 	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
-	assert.Equal(t, defaultHTTPBindEndpoint, r.(*jReceiver).config.CollectorHTTPSettings.Endpoint, "http port should be default")
+	assert.Equal(t, "0.0.0.0:14268", r.(*jReceiver).config.CollectorHTTPSettings.Endpoint, "http port should be default")
 }
 
 func TestCreateInvalidThriftBinaryEndpoint(t *testing.T) {
@@ -151,13 +151,13 @@ func TestCreateInvalidThriftBinaryEndpoint(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	cfg.(*Config).Protocols.ThriftBinary = &ProtocolUDP{
-		Endpoint: defaultThriftBinaryBindEndpoint,
+		Endpoint: "0.0.0.0:6832",
 	}
 	set := receivertest.NewNopCreateSettings()
 	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
-	assert.Equal(t, defaultThriftBinaryBindEndpoint, r.(*jReceiver).config.AgentBinaryThrift.Endpoint, "thrift port should be default")
+	assert.Equal(t, "0.0.0.0:6832", r.(*jReceiver).config.AgentBinaryThrift.Endpoint, "thrift port should be default")
 }
 
 func TestCreateInvalidThriftCompactEndpoint(t *testing.T) {
@@ -165,11 +165,11 @@ func TestCreateInvalidThriftCompactEndpoint(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	cfg.(*Config).Protocols.ThriftCompact = &ProtocolUDP{
-		Endpoint: defaultThriftCompactBindEndpoint,
+		Endpoint: "0.0.0.0:6831",
 	}
 	set := receivertest.NewNopCreateSettings()
 	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
 	assert.NoError(t, err, "unexpected error creating receiver")
-	assert.Equal(t, defaultThriftCompactBindEndpoint, r.(*jReceiver).config.AgentCompactThrift.Endpoint, "thrift port should be default")
+	assert.Equal(t, "0.0.0.0:6831", r.(*jReceiver).config.AgentCompactThrift.Endpoint, "thrift port should be default")
 }


### PR DESCRIPTION
Description:
jaegerreceiver adopts component.UseLocalHostAsDefaultHost feature gate

Link to tracking Issue:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30702

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30979

Documentation:
Updated docs.