### PR TITLE
[chore][extension/health_check] Use component.UseLocalHostAsDefaultHost feature gate

### DIFF
--- a/.chloggen/mx-psi_internal-localhostgate.yaml
+++ b/.chloggen/mx-psi_internal-localhostgate.yaml
@@ -17,21 +17,22 @@ issues: [30702]
 # Use pipe (|) for multiline entries.
 subtext: | 
   This change affects the following components:
-    - receiver/loki
-    - receiver/opencensus
-    - receiver/zipkin
-    - receiver/awsfirehose
+    - extension/awsproxy
+    - extension/health_check
+    - extension/jaegerremotesampling
     - processor/remotetap
-    - receiver/splunk_hec
+    - receiver/awsfirehose
     - receiver/awsxray
     - receiver/influxdb
-    - receiver/zookeeper
-    - receiver/signalfx
-    - extension/awsproxy
-    - receiver/sapm
-    - extension/jaegerremotesampling
     - receiver/jaeger
+    - receiver/loki
+    - receiver/opencensus
+    - receiver/sapm
+    - receiver/signalfx
     - receiver/skywalking
+    - receiver/splunk_hec
+    - receiver/zipkin
+    - receiver/zookeeper
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/extension/healthcheckextension/README.md
+++ b/extension/healthcheckextension/README.md
@@ -40,7 +40,7 @@ processors in the future.
 
 The following settings are required:
 
-- `endpoint` (default = 0.0.0.0:13133): Address to publish the health check status. For full list of `HTTPServerConfig` refer [here](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp).
+- `endpoint` (default = 0.0.0.0:13133): Address to publish the health check status. For full list of `HTTPServerConfig` refer [here](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp). The `component.UseLocalHostAsDefaultHost` feature gate changes this to localhost:13133. This will become the default in a future release.
 - `path` (default = "/"): Specifies the path to be configured for the health check server.
 - `response_body` (default = ""): Specifies a static body that overrides the default response returned by the health check service. 
 - `check_collector_pipeline:` (optional): Settings of collector pipeline health check

--- a/extension/healthcheckextension/factory.go
+++ b/extension/healthcheckextension/factory.go
@@ -11,13 +11,10 @@ import (
 	"go.opentelemetry.io/collector/extension"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/localhostgate"
 )
 
-const (
-	// Use 0.0.0.0 to make the health check endpoint accessible
-	// in container orchestration environments like Kubernetes.
-	defaultEndpoint = "0.0.0.0:13133"
-)
+const defaultPort = 13133
 
 // NewFactory creates a factory for HealthCheck extension.
 func NewFactory() extension.Factory {
@@ -32,7 +29,7 @@ func NewFactory() extension.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		HTTPServerConfig: confighttp.HTTPServerConfig{
-			Endpoint: defaultEndpoint,
+			Endpoint: localhostgate.EndpointForPort(defaultPort),
 		},
 		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 		Path:                   "/",

--- a/extension/healthcheckextension/factory_test.go
+++ b/extension/healthcheckextension/factory_test.go
@@ -20,7 +20,7 @@ func TestFactory_CreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig()
 	assert.Equal(t, &Config{
 		HTTPServerConfig: confighttp.HTTPServerConfig{
-			Endpoint: defaultEndpoint,
+			Endpoint: "0.0.0.0:13133",
 		},
 		CheckCollectorPipeline: defaultCheckCollectorPipelineSettings(),
 		Path:                   "/",


### PR DESCRIPTION
**Description:** Fixes #30818, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30818#issuecomment-1914354982 for historical context. I think we should still do it.

Also reorders the entries in the changelog to be in alphabetical order
