### PR TITLE
[chore][receiver/hostmetrics, exporter/awsxray] Fix some more empty IDs

### DIFF
--- a/exporter/awsxrayexporter/awsxray_test.go
+++ b/exporter/awsxrayexporter/awsxray_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -70,7 +69,7 @@ func TestTelemetryEnabled(t *testing.T) {
 	registry := telemetry.NewRegistry()
 	sink := telemetrytest.NewSenderSink()
 	// preload the sender that the exporter will use
-	sender, loaded := registry.LoadOrStore(component.NewID(""), sink)
+	sender, loaded := registry.LoadOrStore(exportertest.NewNopCreateSettings().ID, sink)
 	require.False(t, loaded)
 	require.NotNil(t, sender)
 	require.Equal(t, sink, sender)

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -227,7 +227,7 @@ func (m *mockFactory) CreateMetricsScraper(context.Context, receiver.CreateSetti
 	return args.Get(0).(scraperhelper.Scraper), args.Error(1)
 }
 
-func (m *mockScraper) ID() component.ID                            { return component.NewID("") }
+func (m *mockScraper) ID() component.ID                            { return component.NewID("mock_scraper") }
 func (m *mockScraper) Start(context.Context, component.Host) error { return nil }
 func (m *mockScraper) Shutdown(context.Context) error              { return nil }
 func (m *mockScraper) Scrape(context.Context) (pmetric.Metrics, error) {


### PR DESCRIPTION
**Description:** 

- Makes the test on awsxray exporter use the `exportertest.NewNopCreateSettings().ID`. This is because this is the ID passed to `newTracesExporter`: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/2f5b0bc52cd160886b4e1ee03461704d6c440a8d/exporter/awsxrayexporter/awsxray_test.go#L109 Currently, this makes no difference, but it will once the ID on NewNopCreateSettings is fixed.
- Also fixes the hostmetrics receiver ID, just for fun :)


**Link to tracking Issue:** Needed for open-telemetry/opentelemetry-collector/pull/9414
