### PR TITLE
[cmd/mdatagen] Add DefaultMetricsBuilderConfigAllDisabled

### DIFF
--- a/cmd/mdatagen/internal/metadata/generated_config.go
+++ b/cmd/mdatagen/internal/metadata/generated_config.go
@@ -120,3 +120,20 @@ func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 		ResourceAttributes: DefaultResourceAttributesConfig(),
 	}
 }
+
+func DefaultMetricsBuilderConfigAllDisabled() MetricsConfig {
+	return MetricsConfig{
+		DefaultMetric: MetricConfig{
+			Enabled: false,
+		},
+		DefaultMetricToBeRemoved: MetricConfig{
+			Enabled: false,
+		},
+		OptionalMetric: MetricConfig{
+			Enabled: false,
+		},
+		OptionalMetricEmptyUnit: MetricConfig{
+			Enabled: false,
+		},
+	}
+}

--- a/cmd/mdatagen/internal/metadata/generated_config_test.go
+++ b/cmd/mdatagen/internal/metadata/generated_config_test.go
@@ -142,3 +142,16 @@ func loadResourceAttributesConfig(t *testing.T, name string) ResourceAttributesC
 	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
 	return cfg
 }
+
+func TestDefaultMetricsBuilderConfigAllDisabled(t *testing.T) {
+	want := MetricsConfig{
+		DefaultMetric:            MetricConfig{Enabled: false},
+		DefaultMetricToBeRemoved: MetricConfig{Enabled: false},
+		OptionalMetric:           MetricConfig{Enabled: false},
+		OptionalMetricEmptyUnit:  MetricConfig{Enabled: false},
+	}
+	cfg := DefaultMetricsBuilderConfigAllDisabled()
+	if diff := cmp.Diff(want, cfg, cmpopts.IgnoreUnexported(MetricConfig{})); diff != "" {
+		t.Errorf("Config mismatch (-expected +actual):\n%s", diff)
+	}
+}

--- a/cmd/mdatagen/templates/config.go.tmpl
+++ b/cmd/mdatagen/templates/config.go.tmpl
@@ -100,4 +100,14 @@ func DefaultMetricsBuilderConfig() MetricsBuilderConfig {
 		{{- end }}
 	}
 }
+
+func DefaultMetricsBuilderConfigAllDisabled() MetricsConfig {
+	return MetricsConfig{
+		{{- range $name, $metric := .Metrics }}
+		{{ $name.Render }}: MetricConfig{
+			Enabled: false,
+		},
+		{{- end }}
+	}
+}
 {{- end }}

--- a/cmd/mdatagen/templates/config_test.go.tmpl
+++ b/cmd/mdatagen/templates/config_test.go.tmpl
@@ -128,4 +128,16 @@ func loadResourceAttributesConfig(t *testing.T, name string) ResourceAttributesC
 	require.NoError(t, component.UnmarshalConfig(sub, &cfg))
 	return cfg
 }
+
+func TestDefaultMetricsBuilderConfigAllDisabled(t *testing.T) {
+	want := MetricsConfig{
+		{{- range $name, $_ := .Metrics }}
+		{{ $name.Render }}: MetricConfig{Enabled: false},
+		{{- end }}
+	}
+	cfg := DefaultMetricsBuilderConfigAllDisabled()
+	if diff := cmp.Diff(want, cfg, cmpopts.IgnoreUnexported(MetricConfig{})); diff != "" {
+		t.Errorf("Config mismatch (-expected +actual):\n%s", diff)
+	}
+}
 {{- end }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Adds a new function to config.go.tmpl that will generate a new function to provide a MetricsBuilder config with all available metrics disabled.

**Link to tracking Issue:**
#30993

**Testing:**
Regenerated in this module to show an example of the generation. I also did this originally in #30894 and it worked well there, but I pulled it out in favour of opening it as a separate PR here.

**Documentation:** <Describe the documentation added.>
I'm not sure if there is any, but if there's something I missed I'm happy to add it.