### PR TITLE
[chore] use require.Eventually instead of time.Sleep to retry checks

### DIFF
--- a/connector/failoverconnector/traces_test.go
+++ b/connector/failoverconnector/traces_test.go
@@ -182,12 +182,11 @@ func TestTracesWithFailoverRecovery(t *testing.T) {
 	// Simulate recovery of exporter
 	failoverConnector.failover.ModifyConsumerAtIndex(0, consumertest.NewNop())
 
-	time.Sleep(100 * time.Millisecond)
-
-	_, ch, ok = failoverConnector.failover.getCurrentConsumer()
-	idx = failoverConnector.failover.pS.ChannelIndex(ch)
-	assert.True(t, ok)
-	require.Equal(t, idx, 0)
+	require.Eventually(t, func() bool {
+		_, ch, ok = failoverConnector.failover.getCurrentConsumer()
+		idx = failoverConnector.failover.pS.ChannelIndex(ch)
+		return ok && idx == 0
+	}, 3*time.Second, 100*time.Millisecond)
 }
 
 func sampleTrace() ptrace.Traces {


### PR DESCRIPTION
Do not use time.Sleep in tests. Use require.Eventually instead or channels.