### PR TITLE
[chore][exporter/splunk_hec] Explicit check for component.Type in test

### DIFF
--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -1394,8 +1394,10 @@ func TestHeartbeatStartupFailed(t *testing.T) {
 	params := exportertest.NewNopCreateSettings()
 	exporter, err := factory.CreateTracesExporter(context.Background(), params, cfg)
 	assert.NoError(t, err)
-	// The exporter's name is "" while generating default params
-	assert.EqualError(t, exporter.Start(context.Background(), componenttest.NewNopHost()), ": heartbeat on startup failed: HTTP 403 \"Forbidden\"")
+	assert.EqualError(t,
+		exporter.Start(context.Background(), componenttest.NewNopHost()),
+		fmt.Sprintf("%s: heartbeat on startup failed: HTTP 403 \"Forbidden\"", params.ID.Type()),
+	)
 }
 
 func TestHeartbeatStartupPass_Disabled(t *testing.T) {


### PR DESCRIPTION
**Description:** 

Explicit uses `component.Type` when building string to compare to in test.
Remove comment that will soon be outdated about the component.Type.

**Link to tracking Issue:** Needed for open-telemetry/opentelemetry-collector/pull/9414
