### PR TITLE
[connector/servicegraph] rename metrics

### DIFF
--- a/.chloggen/codeboten_rename-metrics-servicegraph.yaml
+++ b/.chloggen/codeboten_rename-metrics-servicegraph.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: servicegraphconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: update prefix to match the component type
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31023]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/servicegraphconnector/connector.go
+++ b/connector/servicegraphconnector/connector.go
@@ -19,7 +19,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
-	"go.opentelemetry.io/collector/processor/processorhelper"
 	semconv "go.opentelemetry.io/collector/semconv/v1.13.0"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
@@ -84,6 +83,10 @@ type serviceGraphConnector struct {
 	shutdownCh chan any
 }
 
+func customMetricName(name string) string {
+	return "connector/" + metadata.Type + "/" + name
+}
+
 func newConnector(set component.TelemetrySettings, config component.Config) *serviceGraphConnector {
 	pConfig := config.(*Config)
 
@@ -110,17 +113,17 @@ func newConnector(set component.TelemetrySettings, config component.Config) *ser
 	meter := metadata.Meter(set)
 
 	droppedSpan, _ := meter.Int64Counter(
-		processorhelper.BuildCustomMetricName(metadata.Type, "dropped_spans"),
+		customMetricName("dropped_spans"),
 		metric.WithDescription("Number of spans dropped when trying to add edges"),
 		metric.WithUnit("1"),
 	)
 	totalEdges, _ := meter.Int64Counter(
-		processorhelper.BuildCustomMetricName(metadata.Type, "total_edges"),
+		customMetricName("total_edges"),
 		metric.WithDescription("Total number of unique edges"),
 		metric.WithUnit("1"),
 	)
 	expiredEdges, _ := meter.Int64Counter(
-		processorhelper.BuildCustomMetricName(metadata.Type, "expired_edges"),
+		customMetricName("expired_edges"),
 		metric.WithDescription("Number of edges that expired before finding its matching span"),
 		metric.WithUnit("1"),
 	)

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -30,16 +30,16 @@ import (
 )
 
 func TestConnectorStart(t *testing.T) {
-	// Create servicegraph processor
+	// Create servicegraph connector
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig().(*Config)
 
 	procCreationParams := connectortest.NewNopCreateSettings()
-	traceProcessor, err := factory.CreateTracesToMetrics(context.Background(), procCreationParams, cfg, consumertest.NewNop())
+	traceConnector, err := factory.CreateTracesToMetrics(context.Background(), procCreationParams, cfg, consumertest.NewNop())
 	require.NoError(t, err)
 
 	// Test
-	smp := traceProcessor.(*serviceGraphConnector)
+	smp := traceConnector.(*serviceGraphConnector)
 	err = smp.Start(context.Background(), componenttest.NewNopHost())
 	defer require.NoError(t, smp.Shutdown(context.Background()))
 
@@ -335,7 +335,7 @@ func TestStaleSeriesCleanup(t *testing.T) {
 	td = buildSampleTrace(t, "second")
 	assert.NoError(t, p.ConsumeTraces(context.Background(), td))
 
-	// Shutdown the processor
+	// Shutdown the connector
 	assert.NoError(t, p.Shutdown(context.Background()))
 }
 
@@ -387,7 +387,7 @@ func TestValidateOwnTelemetry(t *testing.T) {
 	td = buildSampleTrace(t, "second")
 	assert.NoError(t, p.ConsumeTraces(context.Background(), td))
 
-	// Shutdown the processor
+	// Shutdown the connector
 	assert.NoError(t, p.Shutdown(context.Background()))
 
 	rm := metricdata.ResourceMetrics{}
@@ -397,7 +397,7 @@ func TestValidateOwnTelemetry(t *testing.T) {
 	require.Len(t, sm.Metrics, 1)
 	got := sm.Metrics[0]
 	want := metricdata.Metrics{
-		Name:        "processor/servicegraph/total_edges",
+		Name:        "connector/servicegraph/total_edges",
 		Description: "Total number of unique edges",
 		Unit:        "1",
 		Data: metricdata.Sum[int64]{


### PR DESCRIPTION
This follows the comment from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30149#discussion_r1452803677
