### PR TITLE
[chore][receiver/sqlquery] Remove redundant validate function

### DIFF
--- a/receiver/sqlqueryreceiver/config.go
+++ b/receiver/sqlqueryreceiver/config.go
@@ -17,10 +17,6 @@ type Config struct {
 	sqlquery.Config `mapstructure:",squash"`
 }
 
-func (c Config) Validate() error {
-	return nil
-}
-
 func createDefaultConfig() component.Config {
 	cfg := scraperhelper.NewDefaultScraperControllerSettings(metadata.Type)
 	cfg.CollectionInterval = 10 * time.Second


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
[Requested change by Dmitrii](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30709#discussion_r1475381584), this function was redundant as the underlying config has a `Validate` function called automatically.