### PR TITLE
[chore] update codeowners to match metadata.yaml content

### DIFF
--- a/.github/ALLOWLIST
+++ b/.github/ALLOWLIST
@@ -22,6 +22,8 @@
 internal/common
 
 ## DEPRECATED components
+processor/spanmetricsprocessor/
 
 ## UNMAINTAINED components
 exporter/alibabacloudlogserviceexporter/
+exporter/skywalkingexporter/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,7 +28,7 @@ confmap/provider/s3provider/                             @open-telemetry/collect
 connector/countconnector/                                @open-telemetry/collector-contrib-approvers @djaglowski @jpkrohling
 connector/datadogconnector/                              @open-telemetry/collector-contrib-approvers @mx-psi @dineshg13
 connector/exceptionsconnector/                           @open-telemetry/collector-contrib-approvers @jpkrohling @marctc
-connector/failoverconnector/                             @open-telemetry/collector-contrib-approvers @akats7 @djaglowski @fatsheep9146
+connector/failoverconnector/                             @open-telemetry/collector-contrib-approvers @djaglowski @fatsheep9146
 connector/routingconnector/                              @open-telemetry/collector-contrib-approvers @jpkrohling @mwear
 connector/servicegraphconnector/                         @open-telemetry/collector-contrib-approvers @jpkrohling @mapno
 connector/spanmetricsconnector/                          @open-telemetry/collector-contrib-approvers @portertech
@@ -75,7 +75,6 @@ exporter/pulsarexporter/                                 @open-telemetry/collect
 exporter/sapmexporter/                                   @open-telemetry/collector-contrib-approvers @dmitryax @atoulme
 exporter/sentryexporter/                                 @open-telemetry/collector-contrib-approvers @AbhiPrasad
 exporter/signalfxexporter/                               @open-telemetry/collector-contrib-approvers @dmitryax @crobert-1
-exporter/skywalkingexporter/                             @open-telemetry/collector-contrib-approvers
 exporter/splunkhecexporter/                              @open-telemetry/collector-contrib-approvers @atoulme @dmitryax
 exporter/sumologicexporter/                              @open-telemetry/collector-contrib-approvers @sumo-drosiek
 exporter/syslogexporter/                                 @open-telemetry/collector-contrib-approvers @kkujawa-sumo @rnishtala-sumo @astencel-sumo
@@ -138,7 +137,7 @@ pkg/ottl/                                                @open-telemetry/collect
 pkg/pdatatest/                                           @open-telemetry/collector-contrib-approvers @djaglowski @fatsheep9146
 pkg/pdatautil/                                           @open-telemetry/collector-contrib-approvers @dmitryax
 pkg/resourcetotelemetry/                                 @open-telemetry/collector-contrib-approvers @mx-psi
-pkg/sampling/                                            @open-telemetry/collector-contrib-approvers @jmacd @kentquirk
+pkg/sampling/                                            @open-telemetry/collector-contrib-approvers @kentquirk @jmacd
 pkg/stanza/                                              @open-telemetry/collector-contrib-approvers @djaglowski
 pkg/translator/azure/                                    @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @atoulme @cparkins
 pkg/translator/jaeger/                                   @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @frzifus
@@ -165,7 +164,7 @@ processor/metricsgenerationprocessor/                    @open-telemetry/collect
 processor/metricstransformprocessor/                     @open-telemetry/collector-contrib-approvers @dmitryax
 processor/probabilisticsamplerprocessor/                 @open-telemetry/collector-contrib-approvers @jpkrohling
 processor/redactionprocessor/                            @open-telemetry/collector-contrib-approvers @dmitryax @mx-psi @TylerHelmuth
-processor/remotetapprocessor/                            @open-telemetry/collector-contrib-approvers @pmcollins
+processor/remotetapprocessor/                            @open-telemetry/collector-contrib-approvers @atoulme
 processor/resourcedetectionprocessor/                    @open-telemetry/collector-contrib-approvers @Aneurysm9 @dashpole
 processor/resourcedetectionprocessor/internal/azure/     @open-telemetry/collector-contrib-approvers @mx-psi
 processor/resourcedetectionprocessor/internal/heroku/    @open-telemetry/collector-contrib-approvers @atoulme
@@ -294,3 +293,4 @@ reports/distributions/liatrio.yaml  @open-telemetry/collector-contrib-approvers 
 ## UNMAINTAINED components
 
 exporter/alibabacloudlogserviceexporter/                 @open-telemetry/collector-contrib-approvers 
+exporter/skywalkingexporter/                             @open-telemetry/collector-contrib-approvers 

--- a/cmd/githubgen/allowlist.txt
+++ b/cmd/githubgen/allowlist.txt
@@ -3,12 +3,13 @@ MaxKsyunz
 MitchellGale
 YANG-DB
 asaharn
-billmeyer
 emreyalvac
 shaochengwang
 yiyang5055
 am-kinetica
 mcube8
 sokoide
-zdaratom
-braydonk
+RichieSams
+cheempz
+jerrytfleung
+sh0rez

--- a/processor/remotetapprocessor/README.md
+++ b/processor/remotetapprocessor/README.md
@@ -5,7 +5,8 @@
 | Stability     | [alpha]: logs, metrics, traces   |
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aprocessor%2Fremotetap%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aprocessor%2Fremotetap) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aprocessor%2Fremotetap%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aprocessor%2Fremotetap) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@pmcollins](https://www.github.com/pmcollins) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@atoulme](https://www.github.com/atoulme) |
+| Emeritus      | [@pmcollins](https://www.github.com/pmcollins) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/processor/remotetapprocessor/metadata.yaml
+++ b/processor/remotetapprocessor/metadata.yaml
@@ -6,7 +6,8 @@ status:
     alpha: [logs, metrics, traces]
   distributions: [contrib]
   codeowners:
-    active: [pmcollins]
+    active: [atoulme]
+    emeritus: [pmcollins]
 
 tests:
   config:


### PR DESCRIPTION
Update codeowners against the latest info from the opentelemetry membership list.
Update remotetap processor codeowners, removing @pmcollins and adding @atoulme