### PR TITLE
Added akats7 as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,7 +28,7 @@ confmap/provider/s3provider/                             @open-telemetry/collect
 connector/countconnector/                                @open-telemetry/collector-contrib-approvers @djaglowski @jpkrohling
 connector/datadogconnector/                              @open-telemetry/collector-contrib-approvers @mx-psi @dineshg13
 connector/exceptionsconnector/                           @open-telemetry/collector-contrib-approvers @jpkrohling @marctc
-connector/failoverconnector/                             @open-telemetry/collector-contrib-approvers @djaglowski @fatsheep9146
+connector/failoverconnector/                             @open-telemetry/collector-contrib-approvers @akats7 @djaglowski @fatsheep9146
 connector/routingconnector/                              @open-telemetry/collector-contrib-approvers @jpkrohling @mwear
 connector/servicegraphconnector/                         @open-telemetry/collector-contrib-approvers @jpkrohling @mapno
 connector/spanmetricsconnector/                          @open-telemetry/collector-contrib-approvers @portertech

--- a/connector/failoverconnector/README.md
+++ b/connector/failoverconnector/README.md
@@ -5,7 +5,7 @@
 | ------------- |-----------|
 | Distributions | [] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aconnector%2Ffailover%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aconnector%2Ffailover) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aconnector%2Ffailover%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aconnector%2Ffailover) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@djaglowski](https://www.github.com/djaglowski), [@fatsheep9146](https://www.github.com/fatsheep9146) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@akats7](https://www.github.com/akats7), [@djaglowski](https://www.github.com/djaglowski), [@fatsheep9146](https://www.github.com/fatsheep9146) |
 
 [development]: https://github.com/open-telemetry/opentelemetry-collector#development
 

--- a/connector/failoverconnector/metadata.yaml
+++ b/connector/failoverconnector/metadata.yaml
@@ -6,4 +6,4 @@ status:
     development: [metrics_to_metrics, traces_to_traces, logs_to_logs]
   distributions: []
   codeowners:
-    active: [akats7,djaglowski, fatsheep9146]
+    active: [akats7, djaglowski, fatsheep9146]

--- a/connector/failoverconnector/metadata.yaml
+++ b/connector/failoverconnector/metadata.yaml
@@ -6,4 +6,4 @@ status:
     development: [metrics_to_metrics, traces_to_traces, logs_to_logs]
   distributions: []
   codeowners:
-    active: [djaglowski, fatsheep9146]
+    active: [akats7,djaglowski, fatsheep9146]


### PR DESCRIPTION
**Description:** 
Hey @crobert-1, got the codeowners are not members error when running `make update-codeowners`. Is that still the correct way to add myself to the codeowners file, should I add my id manually?