### PR TITLE
[exporter/signalfx] Use "unknown" env correlation value as fallback

### DIFF
--- a/.chloggen/signalfx-exp-env-correlation-fix.yaml
+++ b/.chloggen/signalfx-exp-env-correlation-fix.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/signalfx
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use "unknown" value for the environment correlation calls as fallback.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31052]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+  This fixed the APM/IM correlation in the Splunk Observability UI for the users that send traces with no
+  "deployment.environment" resource attribute value set.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
**Description:**

Use the same fallback value for the metrics/tracing environment correlation calls as being set by the backend on the traces. This fixed the APM/IM correlation in the Splunk Observability UI for the users that send traces with no "deployment.environment" resource attribute value set.

**Testing:** Updated unit test and validated the fix manually.
