### PR TITLE
[receiver/kafkareceiver] Add AVRO encoding support

### DIFF
--- a/.chloggen/kafkareceiver-avro.yaml
+++ b/.chloggen/kafkareceiver-avro.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add new encoding type 'avro' to support mapping of AVRO messages to logs.
+
+# One or more tracking issues related to the change
+issues: [21067]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -494,6 +494,8 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/awsproxy v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.97.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.97.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/jaegerremotesampling v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.97.0 // indirect
@@ -1159,3 +1161,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/enco
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding => ../../extension/encoding
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector => ../../connector/grafanacloudconnector
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension => ../../extension/encoding/avrologencodingextension

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -533,6 +533,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.0 // indirect
 	github.com/open-telemetry/opamp-go v0.14.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.97.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.97.0 // indirect
@@ -1184,6 +1185,8 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/enco
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/zipkinencodingextension => ../../extension/encoding/zipkinencodingextension
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/jsonlogencodingextension => ../../extension/encoding/jsonlogencodingextension
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension => ../../extension/encoding/avrologencodingextension
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension => ../../extension/encoding/textencodingextension
 

--- a/go.mod
+++ b/go.mod
@@ -497,6 +497,8 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/nginxinc/nginx-prometheus-exporter v0.11.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.97.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.97.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight v0.97.0 // indirect
@@ -1160,3 +1162,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/sqlqu
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding => ./extension/encoding
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension => ./extension/encoding/otlpencodingextension
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension => ./extension/encoding/avrologencodingextension

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -39,6 +39,7 @@ The following settings can be optionally configured:
   - `text`: (logs only) the payload are decoded as text and inserted as the body of a log record. By default, it uses UTF-8 to decode. You can use `text_<ENCODING>`, like `text_utf-8`, `text_shift_jis`, etc., to customize this behavior.
   - `json`: (logs only) the payload is decoded as JSON and inserted as the body of a log record.
   - `azure_resource_logs`: (logs only) the payload is converted from Azure Resource Logs format to OTel format.
+  - `avro`: (logs only) the payload is decoded as AVRO and inserted as the body of a log record.
 - `group_id` (default = otel-collector): The consumer group that receiver will be consuming messages from
 - `client_id` (default = otel-collector): The consumer client ID that receiver will use
 - `initial_offset` (default = latest): The initial offset to use if no offset was previously committed. Must be `latest` or `earliest`.
@@ -89,6 +90,9 @@ The following settings can be optionally configured:
   - `extract_headers` (default = false): Allows user to attach header fields to resource attributes in otel piepline
   - `headers` (default = []): List of headers they'd like to extract from kafka record. 
   **Note: Matching pattern will be `exact`. Regexes are not supported as of now.** 
+- `avro`
+  - `schema`: Required if encoding set to `avro`, AVRO schema definition
+
 Example:
 
 ```yaml
@@ -133,3 +137,16 @@ we will get a log record in collector similar to:
 
 - Here you can see the kafka record header `header1` and `header2` being added to resource attribute.
 - Every **matching** kafka header key is prefixed with `kafka.header` string and attached to resource attributes.
+
+Example using Avro encoding:
+
+```yaml
+receivers:
+  kafka:
+    encoding: avro
+    avro:
+      schema: |
+        {"type":"record","name":"test","fields":[]}
+```
+
+> More information about Avro as a encoding format can be found here: [Apache Avro specification](https://avro.apache.org/docs/current/specification/).

--- a/receiver/kafkareceiver/avro_unmarshaler.go
+++ b/receiver/kafkareceiver/avro_unmarshaler.go
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkareceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver"
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding"
+	avroExt "github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension"
+	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+const (
+	avroEncoding = "avro"
+)
+
+var (
+	errFailedToReadAvroSchema      = errors.New("failed to read avro schema")
+	errAvroEncodingExtensionNotSet = errors.New("avro encoding extension not set")
+	errAvroEncodingExtension       = errors.New("failed to create avro encoding extension")
+)
+
+type avroLogsUnmarshaler struct {
+	encodingExtension encoding.LogsUnmarshalerExtension
+}
+
+func newAVROLogsUnmarshaler() *avroLogsUnmarshaler {
+	return &avroLogsUnmarshaler{}
+}
+
+func (a *avroLogsUnmarshaler) Encoding() string {
+	return avroEncoding
+}
+
+func (a *avroLogsUnmarshaler) WithSchema(schemaReader io.Reader) (*avroLogsUnmarshaler, error) {
+	schema, err := io.ReadAll(schemaReader)
+	if err != nil {
+		return nil, errFailedToReadAvroSchema
+	}
+
+	cfg := &avroExt.Config{
+		Schema: string(schema),
+	}
+
+	encodingExtension, err := avroExt.NewFactory().CreateExtension(
+		context.Background(),
+		extension.CreateSettings{},
+		cfg)
+	if err != nil {
+		return nil, errors.Join(errAvroEncodingExtension, err)
+	}
+
+	a.encodingExtension = encodingExtension.(encoding.LogsUnmarshalerExtension)
+
+	return a, err
+}
+
+func (a *avroLogsUnmarshaler) Unmarshal(data []byte) (plog.Logs, error) {
+	if a.encodingExtension == nil {
+		return plog.NewLogs(), errAvroEncodingExtensionNotSet
+	}
+
+	return a.encodingExtension.UnmarshalLogs(data)
+}

--- a/receiver/kafkareceiver/avro_unmarshaler_test.go
+++ b/receiver/kafkareceiver/avro_unmarshaler_test.go
@@ -1,0 +1,88 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kafkareceiver
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/linkedin/goavro/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAvroLogsUnmarshaler(t *testing.T) {
+	schema, err := loadAVROSchemaFromFile("testdata/avro/schema1.avro")
+	if err != nil {
+		t.Fatalf("Failed to read avro schema file: %q", err.Error())
+	}
+	codec, err := goavro.NewCodec(string(schema))
+	if err != nil {
+		t.Fatalf("Failed to create avro code from schema: %q", err.Error())
+	}
+
+	unmarshaler, err := newAVROLogsUnmarshaler().WithSchema(bytes.NewReader(schema))
+	if err != nil {
+		t.Errorf("Did not expect an error, got %q", err.Error())
+	}
+
+	binary := encodeAVROLogTestData(codec, `{
+		"timestamp": 1697187201488,
+		"hostname": "host1",
+		"message": "log message",
+		"count": 5,
+		"nestedRecord": {
+			"field1": 12
+		},
+		"properties": ["prop1", "prop2"],
+		"severity": 1
+	}`)
+
+	logs, err := unmarshaler.Unmarshal(binary)
+	if err != nil {
+		t.Fatalf("Did not expect an error, got %q", err.Error())
+	}
+
+	logRecord := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	assert.Equal(t, "{\"count\":5,\"hostname\":\"host1\",\"level\":\"warn\",\"levelEnum\":\"INFO\",\"mapField\":{},\"message\":\"log message\",\"nestedRecord\":{\"field1\":12,\"field2\":\"val2\"},\"properties\":[\"prop1\",\"prop2\"],\"severity\":1,\"timestamp\":1697187201488000000}", logRecord.Body().AsString())
+}
+
+func TestAvroLogsUnmarshalerInvalidSchema(t *testing.T) {
+	_, err := newAVROLogsUnmarshaler().WithSchema(bytes.NewReader([]byte("invalid schema")))
+	assert.Error(t, err)
+}
+
+func TestAvroLogsUnmarshalerNoDeserializer(t *testing.T) {
+	unmarshaler := newAVROLogsUnmarshaler()
+	_, err := unmarshaler.Unmarshal([]byte(""))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errAvroEncodingExtensionNotSet)
+}
+
+func encodeAVROLogTestData(codec *goavro.Codec, data string) []byte {
+	textual := []byte(data)
+	native, _, err := codec.NativeFromTextual(textual)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	binary, err := codec.BinaryFromNative(nil, native)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	return binary
+}
+
+func loadAVROSchemaFromFile(path string) ([]byte, error) {
+	cleanedPath := filepath.Clean(path)
+	schema, err := os.ReadFile(cleanedPath)
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to read schema from file: %w", err)
+	}
+
+	return schema, nil
+}

--- a/receiver/kafkareceiver/config.go
+++ b/receiver/kafkareceiver/config.go
@@ -37,6 +37,11 @@ type HeaderExtraction struct {
 	Headers        []string `mapstructure:"headers"`
 }
 
+type Avro struct {
+	// AVRO schema used to decode messages
+	Schema string `mapstructure:"schema"`
+}
+
 // Config defines configuration for Kafka receiver.
 type Config struct {
 	// The list of kafka brokers (default localhost:9092)
@@ -74,6 +79,9 @@ type Config struct {
 
 	// Extract headers from kafka records
 	HeaderExtraction HeaderExtraction `mapstructure:"header_extraction"`
+
+	// AVRO encoder config when "encoding: avro"
+	Avro Avro `mapstructure:"avro"`
 }
 
 const (

--- a/receiver/kafkareceiver/config_test.go
+++ b/receiver/kafkareceiver/config_test.go
@@ -94,6 +94,40 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "avroLogs"),
+			expected: &Config{
+				Topic:         "logs",
+				Encoding:      "direct",
+				Brokers:       []string{"coffee:123", "foobar:456"},
+				ClientID:      "otel-collector",
+				GroupID:       "otel-collector",
+				InitialOffset: "earliest",
+				Authentication: kafka.Authentication{
+					TLS: &configtls.ClientConfig{
+						Config: configtls.Config{
+							CAFile:   "ca.pem",
+							CertFile: "cert.pem",
+							KeyFile:  "key.pem",
+						},
+					},
+				},
+				Metadata: kafkaexporter.Metadata{
+					Full: true,
+					Retry: kafkaexporter.MetadataRetry{
+						Max:     10,
+						Backoff: time.Second * 5,
+					},
+				},
+				AutoCommit: AutoCommit{
+					Enable:   true,
+					Interval: 1 * time.Second,
+				},
+				Avro: Avro{
+					Schema: "{\"type\":\"record\",\"name\":\"test\",\"fields\":[]}",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -133,7 +133,7 @@ func TestGetLogsUnmarshaler_encoding_text_error(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := getLogsUnmarshaler(test.encoding, defaultLogsUnmarshalers("Test Version", zap.NewNop()))
+			_, err := getLogsUnmarshaler(Config{Encoding: test.encoding}, defaultLogsUnmarshalers("Test Version", zap.NewNop()))
 			assert.ErrorContains(t, err, fmt.Sprintf("unsupported encoding '%v'", test.encoding[5:]))
 		})
 	}

--- a/receiver/kafkareceiver/go.mod
+++ b/receiver/kafkareceiver/go.mod
@@ -8,7 +8,10 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/jaegertracing/jaeger v1.55.0
 	github.com/json-iterator/go v1.1.12
+	github.com/linkedin/goavro/v2 v2.9.8
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.97.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.97.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension v0.97.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.97.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.97.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure v0.97.0
@@ -21,6 +24,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.97.1-0.20240404121116-4f1a8936d26b
 	go.opentelemetry.io/collector/confmap v0.97.1-0.20240404121116-4f1a8936d26b
 	go.opentelemetry.io/collector/consumer v0.97.1-0.20240404121116-4f1a8936d26b
+	go.opentelemetry.io/collector/extension v0.97.1-0.20240404121116-4f1a8936d26b
 	go.opentelemetry.io/collector/pdata v1.4.1-0.20240404121116-4f1a8936d26b
 	go.opentelemetry.io/collector/receiver v0.97.1-0.20240404121116-4f1a8936d26b
 	go.opentelemetry.io/collector/semconv v0.97.1-0.20240404121116-4f1a8936d26b
@@ -80,7 +84,6 @@ require (
 	go.opentelemetry.io/collector/config/configretry v0.97.1-0.20240404121116-4f1a8936d26b // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.97.1-0.20240404121116-4f1a8936d26b // indirect
 	go.opentelemetry.io/collector/exporter v0.97.1-0.20240404121116-4f1a8936d26b // indirect
-	go.opentelemetry.io/collector/extension v0.97.1-0.20240404121116-4f1a8936d26b // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect
@@ -122,3 +125,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure => ../../pkg/translator/azure
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/avrologencodingextension => ../../extension/encoding/avrologencodingextension
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding => ../../extension/encoding

--- a/receiver/kafkareceiver/go.sum
+++ b/receiver/kafkareceiver/go.sum
@@ -59,6 +59,7 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -118,6 +119,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/linkedin/goavro/v2 v2.9.8 h1:jN50elxBsGBDGVDEKqUlDuU1cFwJ11K/yrJCBMe/7Wg=
+github.com/linkedin/goavro/v2 v2.9.8/go.mod h1:UgQUb2N/pmueQYH9bfqFioWxzYCZXSfF8Jw03O5sjqA=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -925,7 +925,7 @@ func TestGetLogsUnmarshaler_encoding_text(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := getLogsUnmarshaler(test.encoding, defaultLogsUnmarshalers("Test Version", zap.NewNop()))
+			_, err := getLogsUnmarshaler(Config{Encoding: test.encoding}, defaultLogsUnmarshalers("Test Version", zap.NewNop()))
 			assert.NoError(t, err)
 		})
 	}

--- a/receiver/kafkareceiver/testdata/avro/schema1.avro
+++ b/receiver/kafkareceiver/testdata/avro/schema1.avro
@@ -1,0 +1,53 @@
+{
+   "type" : "record",
+   "namespace" : "com.example",
+   "name" : "LogMsg",
+   "fields" : [
+      {
+         "name": "timestamp",
+         "type": "long",
+         "logicalType": "timestamp-millis"
+      },
+      { "name" : "message" , "type" : "string" },
+      { "name" : "hostname" , "type" : "string" },
+      { "name" : "count" , "type" : "int" },
+      {
+         "name": "levelEnum",
+         "type": {
+            "type": "enum",
+            "namespace": "com.example",
+            "name": "Level",
+            "symbols": [
+               "DEBUG",
+               "INFO",
+               "ERROR"
+            ]
+         },
+         "default": "INFO"
+      },
+      { "name" : "severity" , "type" : "int", "default": 0 },
+      { "name" : "level" , "type" : "string", "default": "warn" },
+      {
+         "name": "properties",
+         "type": { "type": "array", "items": "string" },
+         "default": []
+      },
+      {
+         "name": "nestedRecord",
+         "type": {
+            "type": "record",
+            "name": "NestedRecord",
+            "fields": [
+               { "name": "field1", "type": "long", "default": 0 },
+               { "name": "field2", "type": "string", "default": "val2" }
+            ]
+         },
+         "default": {}
+      },
+      {
+         "name": "mapField",
+         "type": { "type": "map", "values": "string" },
+         "default": {}
+      }
+   ]
+}

--- a/receiver/kafkareceiver/testdata/config.yaml
+++ b/receiver/kafkareceiver/testdata/config.yaml
@@ -33,3 +33,24 @@ kafka/logs:
     retry:
       max: 10
       backoff: 5s
+kafka/avroLogs:
+  topic: logs
+  encoding: direct
+  brokers:
+    - "coffee:123"
+    - "foobar:456"
+  client_id: otel-collector
+  group_id: otel-collector
+  initial_offset: earliest
+  auth:
+    tls:
+      ca_file: ca.pem
+      cert_file: cert.pem
+      key_file: key.pem
+  metadata:
+    retry:
+      max: 10
+      backoff: 5s
+  avro:
+    schema: |
+      {"type":"record","name":"test","fields":[]}

--- a/receiver/kafkareceiver/unmarshaler.go
+++ b/receiver/kafkareceiver/unmarshaler.go
@@ -78,11 +78,13 @@ func defaultLogsUnmarshalers(version string, logger *zap.Logger) map[string]Logs
 	raw := newRawLogsUnmarshaler()
 	text := newTextLogsUnmarshaler()
 	json := newJSONLogsUnmarshaler()
+	avro := newAVROLogsUnmarshaler()
 	return map[string]LogsUnmarshaler{
 		azureResourceLogs.Encoding(): azureResourceLogs,
 		otlpPb.Encoding():            otlpPb,
 		raw.Encoding():               raw,
 		text.Encoding():              text,
 		json.Encoding():              json,
+		avro.Encoding():              avro,
 	}
 }

--- a/receiver/kafkareceiver/unmarshaler_test.go
+++ b/receiver/kafkareceiver/unmarshaler_test.go
@@ -53,6 +53,7 @@ func TestDefaultLogsUnMarshaler(t *testing.T) {
 		"text",
 		"json",
 		"azure_resource_logs",
+		"avro",
 	}
 	marshalers := defaultLogsUnmarshalers("Test Version", zap.NewNop())
 	assert.Equal(t, len(expectedEncodings), len(marshalers))


### PR DESCRIPTION
**Description:** Support to read AVRO encoded structured logs from Kafka

This features allows to read Kafka messages and decode them with any provided AVRO schema. It works the same way as the JSON unmarshaler and puts the decoded messaged into the log record body. From there it can be further processed with e.g. a transform processor.

**Link to tracking Issue:** #21067 

**Testing:** 
- Unit tests
- Manual testing via local Kafka, custom build OTel collector, producer application

**Documentation:** Added how to configure avro encoder on the kafka receiver.