### PR TITLE
Nil check named pipe shutdowns

### DIFF
--- a/.chloggen/sinkingpoint_named-pipe-sigsev.yaml
+++ b/.chloggen/sinkingpoint_named-pipe-sigsev.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: namedpipereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix SIGSEGV when named pipe creation fails
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31088]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/input/namedpipe/namedpipe.go
+++ b/pkg/stanza/operator/input/namedpipe/namedpipe.go
@@ -134,8 +134,14 @@ func (n *Input) Start(_ operator.Persister) error {
 }
 
 func (n *Input) Stop() error {
-	n.pipe.Close()
-	n.cancel()
+	if n.pipe != nil {
+		n.pipe.Close()
+	}
+
+	if n.cancel != nil {
+		n.cancel()
+	}
+
 	n.wg.Wait()
 	return nil
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>

When the `Start` method of the named pipe is called, it will create a new named pipe and start listening for connections. If that Start method _fails_ for any reason, some parts of the named pipe will not be initialized. This means that when the `Stop` method is called (as the collector does when `Start` fails), it will panic with a nil pointer dereference.

This change adds a couple of nil checks to the `Stop` method to prevent this panic, because otherwise we just get the SIGSEGV signal, and we never get any error logs.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Running this in prod @ Cloudflare

**Documentation:** <Describe the documentation added.>