### PR TITLE
[chore] remove deprecated calls with `confmap.WithErrorUnused`, now enabled by default

### DIFF
--- a/cmd/mdatagen/loader.go
+++ b/cmd/mdatagen/loader.go
@@ -253,7 +253,7 @@ func loadMetadata(filePath string) (metadata, error) {
 	}
 
 	md := metadata{ScopeName: scopeName(filePath), ShortFolderName: shortFolderName(filePath)}
-	if err := conf.Unmarshal(&md, confmap.WithErrorUnused()); err != nil {
+	if err := conf.Unmarshal(&md); err != nil {
 		return md, err
 	}
 

--- a/cmd/mdatagen/metricdata.go
+++ b/cmd/mdatagen/metricdata.go
@@ -155,7 +155,7 @@ func (d *sum) Unmarshal(parser *confmap.Conf) error {
 	if err := d.MetricValueType.Unmarshal(parser); err != nil {
 		return err
 	}
-	return parser.Unmarshal(d, confmap.WithErrorUnused())
+	return parser.Unmarshal(d)
 }
 
 // TODO: Currently, this func will not be called because of https://github.com/open-telemetry/opentelemetry-collector/issues/6671. Uncomment function and
@@ -166,7 +166,7 @@ func (d *sum) Unmarshal(parser *confmap.Conf) error {
 // 	if !parser.IsSet("monotonic") {
 // 		return errors.New("missing required field: `monotonic`")
 // 	}
-// 	return parser.Unmarshal(m, confmap.WithErrorUnused())
+// 	return parser.Unmarshal(m)
 // }
 
 func (d sum) Type() string {

--- a/exporter/signalfxexporter/config.go
+++ b/exporter/signalfxexporter/config.go
@@ -242,7 +242,7 @@ func loadConfig(bytes []byte) (Config, error) {
 		return cfg, err
 	}
 
-	if err := confmap.NewFromStringMap(data).Unmarshal(&cfg, confmap.WithErrorUnused()); err != nil {
+	if err := confmap.NewFromStringMap(data).Unmarshal(&cfg); err != nil {
 		return cfg, fmt.Errorf("failed to load default exclude metrics: %w", err)
 	}
 

--- a/exporter/signalfxexporter/internal/translation/dpfilters/propertyfilter_test.go
+++ b/exporter/signalfxexporter/internal/translation/dpfilters/propertyfilter_test.go
@@ -72,7 +72,7 @@ property_value: '!/property.value/'`,
 
 			cm := confmap.NewFromStringMap(conf)
 			pf := &PropertyFilter{}
-			err = cm.Unmarshal(pf, confmap.WithErrorUnused())
+			err = cm.Unmarshal(pf)
 			if test.expectedError != "" {
 				require.EqualError(t, err, test.expectedError)
 			} else {

--- a/internal/filter/filtermetric/config_test.go
+++ b/internal/filter/filtermetric/config_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterconfig"
@@ -42,7 +41,7 @@ func TestConfig(t *testing.T) {
 	v, err := confmaptest.LoadConf(testFile)
 	require.NoError(t, err)
 	testYamls := map[string]filterconfig.MetricMatchProperties{}
-	require.NoErrorf(t, v.Unmarshal(&testYamls, confmap.WithErrorUnused()), "unable to unmarshal yaml from file %v", testFile)
+	require.NoErrorf(t, v.Unmarshal(&testYamls), "unable to unmarshal yaml from file %v", testFile)
 
 	tests := []struct {
 		name   string

--- a/internal/filter/filterset/config_test.go
+++ b/internal/filter/filterset/config_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset/regexp"
@@ -21,7 +20,7 @@ func readTestdataConfigYamls(t *testing.T, filename string) map[string]*Config {
 	require.NoError(t, err)
 
 	cfgs := map[string]*Config{}
-	require.NoErrorf(t, v.Unmarshal(&cfgs, confmap.WithErrorUnused()), "unable to unmarshal yaml from file %v", testFile)
+	require.NoErrorf(t, v.Unmarshal(&cfgs), "unable to unmarshal yaml from file %v", testFile)
 	return cfgs
 }
 

--- a/internal/filter/filterset/regexp/config_test.go
+++ b/internal/filter/filterset/regexp/config_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 )
 
@@ -19,7 +18,7 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	actualConfigs := map[string]*Config{}
-	require.NoErrorf(t, v.Unmarshal(&actualConfigs, confmap.WithErrorUnused()),
+	require.NoErrorf(t, v.Unmarshal(&actualConfigs),
 		"unable to unmarshal yaml from file %v", testFile)
 
 	expectedConfigs := map[string]*Config{

--- a/receiver/azuremonitorreceiver/internal/metadata/metrics.go
+++ b/receiver/azuremonitorreceiver/internal/metadata/metrics.go
@@ -30,7 +30,7 @@ func (ras *ResourceAttributeSettings) Unmarshal(parser *confmap.Conf) error {
 	if parser == nil {
 		return nil
 	}
-	err := parser.Unmarshal(ras, confmap.WithErrorUnused())
+	err := parser.Unmarshal(ras)
 	if err != nil {
 		return err
 	}

--- a/receiver/receivercreator/runner.go
+++ b/receiver/receivercreator/runner.go
@@ -152,7 +152,7 @@ func mergeTemplatedAndDiscoveredConfigs(factory rcvr.Factory, templated, discove
 		endpointConfig := confmap.NewFromStringMap(map[string]any{
 			endpointConfigKey: targetEndpoint,
 		})
-		if err := endpointConfig.Unmarshal(factory.CreateDefaultConfig(), confmap.WithErrorUnused()); err != nil {
+		if err := endpointConfig.Unmarshal(factory.CreateDefaultConfig()); err != nil {
 			// rather than attach to error content that can change over time,
 			// confirm the error only arises w/ ErrorUnused mapstructure setting ("invalid keys")
 			if err = endpointConfig.Unmarshal(factory.CreateDefaultConfig(), confmap.WithIgnoreUnused()); err == nil {


### PR DESCRIPTION
**Description:**
Remove all calls to `confmap.WithErrorUnused` ahead of its removal.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/9484