### PR TITLE
[chore][pkg/stanza/operator/helper] Enable goleak check

### DIFF
--- a/pkg/stanza/operator/helper/ip_resolver_test.go
+++ b/pkg/stanza/operator/helper/ip_resolver_test.go
@@ -18,6 +18,7 @@ func TestIPResolverCacheLookup(t *testing.T) {
 	}
 
 	require.Equal(t, "definitely invalid hostname", resolver.GetHostFromIP("127.0.0.1"))
+	resolver.Stop()
 }
 
 func TestIPResolverCacheInvalidation(t *testing.T) {
@@ -45,6 +46,7 @@ func TestIPResolver100Hits(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		require.Equal(t, "definitely invalid hostname", resolver.GetHostFromIP("127.0.0.1"))
 	}
+	resolver.Stop()
 }
 
 func TestIPResolverWithMultipleStops(_ *testing.T) {

--- a/pkg/stanza/operator/helper/package_test.go
+++ b/pkg/stanza/operator/helper/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package helper
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This enables `goleak` in the `pkg/stanza/operator/helper` package to help ensure no goroutines are leaking. This is a test only change, some tests were simply missing `Stop` calls.

**Link to tracking Issue:** <Issue number if applicable>
#30438

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, as well as added `goleak` checks.