### PR TITLE
[chore] Remove `ReportFatalError` use in host mock

### DIFF
--- a/receiver/purefbreceiver/internal/baerertoken_test.go
+++ b/receiver/purefbreceiver/internal/baerertoken_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configauth"
 	"go.opentelemetry.io/collector/extension/extensiontest"
 
@@ -29,6 +30,7 @@ func TestBearerToken(t *testing.T) {
 	baComponentName := component.NewIDWithName("bearertokenauth", "fb02")
 
 	host := &mockHost{
+		Host: componenttest.NewNopHost(),
 		extensions: map[component.ID]component.Component{
 			baComponentName: baExt,
 		},
@@ -47,19 +49,10 @@ func TestBearerToken(t *testing.T) {
 }
 
 type mockHost struct {
+	component.Host
 	extensions map[component.ID]component.Component
-}
-
-func (h *mockHost) ReportFatalError(_ error) {}
-
-func (h *mockHost) GetFactory(_ component.Kind, _ component.Type) component.Factory {
-	return nil
 }
 
 func (h *mockHost) GetExtensions() map[component.ID]component.Component {
 	return h.extensions
-}
-
-func (h *mockHost) GetExporters() map[component.DataType]map[component.ID]component.Component {
-	return nil
 }


### PR DESCRIPTION
**Description:** 
Remove `ReportFatalError` use in host mock

Fixes #30599