### PR TITLE
[chore] remove use of confmap.WithErrorUnused

### DIFF
--- a/receiver/receivercreator/runner.go
+++ b/receiver/receivercreator/runner.go
@@ -152,7 +152,7 @@ func mergeTemplatedAndDiscoveredConfigs(factory rcvr.Factory, templated, discove
 		endpointConfig := confmap.NewFromStringMap(map[string]any{
 			endpointConfigKey: targetEndpoint,
 		})
-		if err := endpointConfig.Unmarshal(factory.CreateDefaultConfig(), confmap.WithErrorUnused()); err != nil {
+		if err := endpointConfig.Unmarshal(factory.CreateDefaultConfig()); err != nil {
 			// rather than attach to error content that can change over time,
 			// confirm the error only arises w/ ErrorUnused mapstructure setting ("invalid keys")
 			if err = endpointConfig.Unmarshal(factory.CreateDefaultConfig(), confmap.WithIgnoreUnused()); err == nil {


### PR DESCRIPTION
**Description:** 
remove use of confmap.WithErrorUnused

See https://github.com/open-telemetry/opentelemetry-collector/issues/9484