### PR TITLE
[chore] Move to non-deprecated symbols for configcompression

### DIFF
--- a/exporter/coralogixexporter/config_test.go
+++ b/exporter/coralogixexporter/config_test.go
@@ -46,20 +46,20 @@ func TestLoadConfig(t *testing.T) {
 				SubSystem:       "SUBSYSTEM_NAME",
 				TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
 				DomainSettings: configgrpc.ClientConfig{
-					Compression: configcompression.Gzip,
+					Compression: configcompression.TypeGzip,
 				},
 				Metrics: configgrpc.ClientConfig{
 					Endpoint:        "https://",
-					Compression:     configcompression.Gzip,
+					Compression:     configcompression.TypeGzip,
 					WriteBufferSize: 512 * 1024,
 				},
 				Logs: configgrpc.ClientConfig{
 					Endpoint:    "https://",
-					Compression: configcompression.Gzip,
+					Compression: configcompression.TypeGzip,
 				},
 				Traces: configgrpc.ClientConfig{
 					Endpoint:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					Compression: configcompression.Gzip,
+					Compression: configcompression.TypeGzip,
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting:         configtls.TLSSetting{},
 						Insecure:           false,
@@ -101,20 +101,20 @@ func TestLoadConfig(t *testing.T) {
 				SubSystem:       "SUBSYSTEM_NAME",
 				TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
 				DomainSettings: configgrpc.ClientConfig{
-					Compression: configcompression.Gzip,
+					Compression: configcompression.TypeGzip,
 				},
 				Metrics: configgrpc.ClientConfig{
 					Endpoint:        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					Compression:     configcompression.Gzip,
+					Compression:     configcompression.TypeGzip,
 					WriteBufferSize: 512 * 1024,
 				},
 				Logs: configgrpc.ClientConfig{
 					Endpoint:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					Compression: configcompression.Gzip,
+					Compression: configcompression.TypeGzip,
 				},
 				Traces: configgrpc.ClientConfig{
 					Endpoint:    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-					Compression: configcompression.Gzip,
+					Compression: configcompression.TypeGzip,
 					TLSSetting: configtls.TLSClientSetting{
 						TLSSetting:         configtls.TLSSetting{},
 						Insecure:           false,

--- a/exporter/coralogixexporter/factory.go
+++ b/exporter/coralogixexporter/factory.go
@@ -36,7 +36,7 @@ func createDefaultConfig() component.Config {
 		BackOffConfig:   configretry.NewDefaultBackOffConfig(),
 		TimeoutSettings: exporterhelper.NewDefaultTimeoutSettings(),
 		DomainSettings: configgrpc.ClientConfig{
-			Compression: configcompression.Gzip,
+			Compression: configcompression.TypeGzip,
 		},
 		ClientConfig: configgrpc.ClientConfig{
 			Endpoint: "https://",
@@ -44,17 +44,17 @@ func createDefaultConfig() component.Config {
 		// Traces GRPC client
 		Traces: configgrpc.ClientConfig{
 			Endpoint:    "https://",
-			Compression: configcompression.Gzip,
+			Compression: configcompression.TypeGzip,
 		},
 		Metrics: configgrpc.ClientConfig{
 			Endpoint: "https://",
 			// Default to gzip compression
-			Compression:     configcompression.Gzip,
+			Compression:     configcompression.TypeGzip,
 			WriteBufferSize: 512 * 1024,
 		},
 		Logs: configgrpc.ClientConfig{
 			Endpoint:    "https://",
-			Compression: configcompression.Gzip,
+			Compression: configcompression.TypeGzip,
 		},
 		PrivateKey: "",
 		AppName:    "",

--- a/exporter/coralogixexporter/factory_test.go
+++ b/exporter/coralogixexporter/factory_test.go
@@ -123,7 +123,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: &Config{
 				Traces: configgrpc.ClientConfig{
 					Endpoint:    endpoint,
-					Compression: configcompression.Gzip,
+					Compression: configcompression.TypeGzip,
 				},
 			},
 		},
@@ -132,7 +132,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: &Config{
 				Traces: configgrpc.ClientConfig{
 					Endpoint:    endpoint,
-					Compression: configcompression.Snappy,
+					Compression: configcompression.TypeSnappy,
 				},
 			},
 		},
@@ -141,7 +141,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: &Config{
 				Traces: configgrpc.ClientConfig{
 					Endpoint:    endpoint,
-					Compression: configcompression.Zstd,
+					Compression: configcompression.TypeZstd,
 				},
 			},
 		},

--- a/exporter/logzioexporter/config_test.go
+++ b/exporter/logzioexporter/config_test.go
@@ -45,7 +45,7 @@ func TestLoadConfig(t *testing.T) {
 		Timeout:  30 * time.Second,
 		Headers:  map[string]configopaque.String{},
 		// Default to gzip compression
-		Compression: configcompression.Gzip,
+		Compression: configcompression.TypeGzip,
 		// We almost read 0 bytes, so no need to tune ReadBufferSize.
 		WriteBufferSize: 512 * 1024,
 	}
@@ -72,7 +72,7 @@ func TestDefaultLoadConfig(t *testing.T) {
 		Timeout:  30 * time.Second,
 		Headers:  map[string]configopaque.String{},
 		// Default to gzip compression
-		Compression: configcompression.Gzip,
+		Compression: configcompression.TypeGzip,
 		// We almost read 0 bytes, so no need to tune ReadBufferSize.
 		WriteBufferSize: 512 * 1024,
 	}
@@ -93,7 +93,7 @@ func TestCheckAndWarnDeprecatedOptions(t *testing.T) {
 			Timeout:  10 * time.Second,
 			Headers:  map[string]configopaque.String{},
 			// Default to gzip compression
-			Compression: configcompression.Gzip,
+			Compression: configcompression.TypeGzip,
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.
 			WriteBufferSize: 512 * 1024,
 		},
@@ -117,7 +117,7 @@ func TestCheckAndWarnDeprecatedOptions(t *testing.T) {
 			Timeout:  10 * time.Second,
 			Headers:  map[string]configopaque.String{},
 			// Default to gzip compression
-			Compression: configcompression.Gzip,
+			Compression: configcompression.TypeGzip,
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.
 			WriteBufferSize: 512 * 1024,
 		},

--- a/exporter/logzioexporter/exporter_test.go
+++ b/exporter/logzioexporter/exporter_test.go
@@ -246,7 +246,7 @@ func TestPushTraceData(tester *testing.T) {
 		Region: "",
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint:    server.URL,
-			Compression: configcompression.Gzip,
+			Compression: configcompression.TypeGzip,
 		},
 	}
 	defer server.Close()
@@ -279,7 +279,7 @@ func TestPushLogsData(tester *testing.T) {
 		Region: "",
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint:    server.URL,
-			Compression: configcompression.Gzip,
+			Compression: configcompression.TypeGzip,
 		},
 	}
 	defer server.Close()

--- a/exporter/logzioexporter/factory.go
+++ b/exporter/logzioexporter/factory.go
@@ -44,7 +44,7 @@ func createDefaultConfig() component.Config {
 			Timeout:  30 * time.Second,
 			Headers:  map[string]configopaque.String{},
 			// Default to gzip compression
-			Compression: configcompression.Gzip,
+			Compression: configcompression.TypeGzip,
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.
 			WriteBufferSize: 512 * 1024,
 		},

--- a/exporter/logzioexporter/jsonlog_test.go
+++ b/exporter/logzioexporter/jsonlog_test.go
@@ -87,7 +87,7 @@ func TestSetTimeStamp(t *testing.T) {
 		Token:  "token",
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint:    server.URL,
-			Compression: configcompression.Gzip,
+			Compression: configcompression.TypeGzip,
 		},
 	}
 	var err error

--- a/exporter/otelarrowexporter/config.go
+++ b/exporter/otelarrowexporter/config.go
@@ -63,7 +63,7 @@ type ArrowSettings struct {
 	// gRPC-level compression is enabled by default.  This can be
 	// set to "zstd" to turn on Arrow-Zstd compression.
 	// Note that `Zstd` applies to gRPC, not Arrow compression.
-	PayloadCompression configcompression.CompressionType `mapstructure:"payload_compression"`
+	PayloadCompression configcompression.Type `mapstructure:"payload_compression"`
 
 	// Disabled prevents using OTel Arrow streams.  The exporter
 	// falls back to standard OTLP.
@@ -106,7 +106,7 @@ func (cfg *ArrowSettings) Validate() error {
 	// The cfg.PayloadCompression field is validated by the underlying library,
 	// but we only support Zstd or none.
 	switch cfg.PayloadCompression {
-	case "none", "", configcompression.Zstd:
+	case "none", "", configcompression.TypeZstd:
 	default:
 		return fmt.Errorf("unsupported payload compression: %s", cfg.PayloadCompression)
 	}
@@ -115,7 +115,7 @@ func (cfg *ArrowSettings) Validate() error {
 
 func (cfg *ArrowSettings) toArrowProducerOptions() (arrowOpts []config.Option) {
 	switch cfg.PayloadCompression {
-	case configcompression.Zstd:
+	case configcompression.TypeZstd:
 		arrowOpts = append(arrowOpts, config.WithZstd())
 	case "none", "":
 		arrowOpts = append(arrowOpts, config.WithNoZstd())

--- a/exporter/otelarrowexporter/config_test.go
+++ b/exporter/otelarrowexporter/config_test.go
@@ -84,7 +84,7 @@ func TestUnmarshalConfig(t *testing.T) {
 			Arrow: ArrowSettings{
 				NumStreams:         2,
 				MaxStreamLifetime:  2 * time.Hour,
-				PayloadCompression: configcompression.Zstd,
+				PayloadCompression: configcompression.TypeZstd,
 				Zstd:               zstd.DefaultEncoderConfig(),
 			},
 		}, cfg)
@@ -128,7 +128,7 @@ func TestDefaultSettingsValid(t *testing.T) {
 
 func TestArrowSettingsPayloadCompressionZstd(t *testing.T) {
 	settings := ArrowSettings{
-		PayloadCompression: configcompression.Zstd,
+		PayloadCompression: configcompression.TypeZstd,
 	}
 	var config config.Config
 	for _, opt := range settings.toArrowProducerOptions() {
@@ -140,7 +140,7 @@ func TestArrowSettingsPayloadCompressionZstd(t *testing.T) {
 func TestArrowSettingsPayloadCompressionNone(t *testing.T) {
 	for _, value := range []string{"", "none"} {
 		settings := ArrowSettings{
-			PayloadCompression: configcompression.CompressionType(value),
+			PayloadCompression: configcompression.Type(value),
 		}
 		var config config.Config
 		for _, opt := range settings.toArrowProducerOptions() {

--- a/exporter/otelarrowexporter/factory.go
+++ b/exporter/otelarrowexporter/factory.go
@@ -45,7 +45,7 @@ func createDefaultConfig() component.Config {
 		ClientConfig: configgrpc.ClientConfig{
 			Headers: map[string]configopaque.String{},
 			// Default to zstd compression
-			Compression: configcompression.Zstd,
+			Compression: configcompression.TypeZstd,
 			// We almost read 0 bytes, so no need to tune ReadBufferSize.
 			WriteBufferSize: 512 * 1024,
 			// The `configgrpc` default is pick_first,

--- a/exporter/otelarrowexporter/factory_test.go
+++ b/exporter/otelarrowexporter/factory_test.go
@@ -34,7 +34,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.Equal(t, ocfg.RetrySettings, configretry.NewDefaultBackOffConfig())
 	assert.Equal(t, ocfg.QueueSettings, exporterhelper.NewDefaultQueueSettings())
 	assert.Equal(t, ocfg.TimeoutSettings, exporterhelper.NewDefaultTimeoutSettings())
-	assert.Equal(t, ocfg.Compression, configcompression.Zstd)
+	assert.Equal(t, ocfg.Compression, configcompression.TypeZstd)
 	assert.Equal(t, ocfg.Arrow, ArrowSettings{
 		Disabled:           false,
 		NumStreams:         runtime.NumCPU(),
@@ -110,7 +110,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: Config{
 				ClientConfig: configgrpc.ClientConfig{
 					Endpoint:    endpoint,
-					Compression: configcompression.Gzip,
+					Compression: configcompression.TypeGzip,
 				},
 			},
 		},
@@ -119,7 +119,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: Config{
 				ClientConfig: configgrpc.ClientConfig{
 					Endpoint:    endpoint,
-					Compression: configcompression.Snappy,
+					Compression: configcompression.TypeSnappy,
 				},
 			},
 		},
@@ -128,7 +128,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			config: Config{
 				ClientConfig: configgrpc.ClientConfig{
 					Endpoint:    endpoint,
-					Compression: configcompression.Zstd,
+					Compression: configcompression.TypeZstd,
 				},
 			},
 		},

--- a/testbed/testbed/senders.go
+++ b/testbed/testbed/senders.go
@@ -78,7 +78,7 @@ func (dsb *DataSenderBase) Flush() {
 
 type otlpHTTPDataSender struct {
 	DataSenderBase
-	compression configcompression.CompressionType
+	compression configcompression.Type
 }
 
 func (ods *otlpHTTPDataSender) fillConfig(cfg *otlphttpexporter.Config) *otlphttpexporter.Config {
@@ -114,7 +114,7 @@ type otlpHTTPTraceDataSender struct {
 }
 
 // NewOTLPHTTPTraceDataSender creates a new TraceDataSender for OTLP/HTTP traces exporter.
-func NewOTLPHTTPTraceDataSender(host string, port int, compression configcompression.CompressionType) TraceDataSender {
+func NewOTLPHTTPTraceDataSender(host string, port int, compression configcompression.Type) TraceDataSender {
 	return &otlpHTTPTraceDataSender{
 		otlpHTTPDataSender: otlpHTTPDataSender{
 			DataSenderBase: DataSenderBase{


### PR DESCRIPTION
**Description:** Moves `configcompression` types to non-deprecated symbols.

**Link to tracking Issue:** Needed for open-telemetry/opentelemetry-collector/pull/9517
