### PR TITLE
[chore] Switch to `component.MustNewID` and `component.MustNewIDWithName` when passing literal strings

### DIFF
--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -313,7 +313,7 @@ func TestStaleSeriesCleanup(t *testing.T) {
 
 	mHost := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
-			component.NewID("mock"): mockMetricsExporter,
+			component.MustNewID("mock"): mockMetricsExporter,
 		},
 	})
 
@@ -365,7 +365,7 @@ func TestValidateOwnTelemetry(t *testing.T) {
 
 	mHost := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
-			component.NewID("mock"): mockMetricsExporter,
+			component.MustNewID("mock"): mockMetricsExporter,
 		},
 	})
 

--- a/exporter/awss3exporter/config_test.go
+++ b/exporter/awss3exporter/config_test.go
@@ -26,7 +26,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	e := cfg.Exporters[component.NewID("awss3")].(*Config)
+	e := cfg.Exporters[component.MustNewID("awss3")].(*Config)
 	assert.Equal(t, e,
 		&Config{
 			S3Uploader: S3UploaderConfig{
@@ -51,7 +51,7 @@ func TestConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	e := cfg.Exporters[component.NewID("awss3")].(*Config)
+	e := cfg.Exporters[component.MustNewID("awss3")].(*Config)
 
 	assert.Equal(t, e,
 		&Config{
@@ -79,7 +79,7 @@ func TestConfigForS3CompatibleSystems(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	e := cfg.Exporters[component.NewID("awss3")].(*Config)
+	e := cfg.Exporters[component.MustNewID("awss3")].(*Config)
 
 	assert.Equal(t, e,
 		&Config{
@@ -167,7 +167,7 @@ func TestMarshallerName(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	e := cfg.Exporters[component.NewID("awss3")].(*Config)
+	e := cfg.Exporters[component.MustNewID("awss3")].(*Config)
 
 	assert.Equal(t, e,
 		&Config{

--- a/exporter/awss3exporter/config_test.go
+++ b/exporter/awss3exporter/config_test.go
@@ -180,7 +180,7 @@ func TestMarshallerName(t *testing.T) {
 		},
 	)
 
-	e = cfg.Exporters[component.NewIDWithName("awss3", "proto")].(*Config)
+	e = cfg.Exporters[component.MustNewIDWithName("awss3", "proto")].(*Config)
 
 	assert.Equal(t, e,
 		&Config{

--- a/exporter/azuremonitorexporter/config_test.go
+++ b/exporter/azuremonitorexporter/config_test.go
@@ -23,7 +23,7 @@ func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
 
-	disk := component.NewIDWithName("disk", "")
+	disk := component.MustNewIDWithName("disk", "")
 
 	tests := []struct {
 		id       component.ID

--- a/exporter/kineticaexporter/config_test.go
+++ b/exporter/kineticaexporter/config_test.go
@@ -29,7 +29,7 @@ func TestLoadConfig(t *testing.T) {
 	}{
 
 		{
-			id:       component.NewIDWithName("kinetica", ""),
+			id:       component.MustNewIDWithName("kinetica", ""),
 			expected: defaultCfg,
 		},
 	}

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -243,7 +243,7 @@ func TestRemoveExtraExporters(t *testing.T) {
 func TestAddMissingExporters(t *testing.T) {
 	// prepare
 	cfg := simpleConfig()
-	exporterFactory := exporter.NewFactory("otlp", func() component.Config {
+	exporterFactory := exporter.NewFactory(component.MustNewType("otlp"), func() component.Config {
 		return &otlpexporter.Config{}
 	}, exporter.WithTraces(func(
 		_ context.Context,
@@ -277,7 +277,7 @@ func TestFailedToAddMissingExporters(t *testing.T) {
 	// prepare
 	cfg := simpleConfig()
 	expectedErr := errors.New("some expected error")
-	exporterFactory := exporter.NewFactory("otlp", func() component.Config {
+	exporterFactory := exporter.NewFactory(component.MustNewType("otlp"), func() component.Config {
 		return &otlpexporter.Config{}
 	}, exporter.WithTraces(func(
 		_ context.Context,

--- a/exporter/opensearchexporter/config_test.go
+++ b/exporter/opensearchexporter/config_test.go
@@ -57,7 +57,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 					MaxIdleConns:    &maxIdleConns,
 					IdleConnTimeout: &idleConnTimeout,
-					Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("sample_basic_auth")},
+					Auth:            &configauth.Authentication{AuthenticatorID: component.MustNewID("sample_basic_auth")},
 				},
 				BackOffConfig: configretry.BackOffConfig{
 					Enabled:             true,

--- a/exporter/otelarrowexporter/config_test.go
+++ b/exporter/otelarrowexporter/config_test.go
@@ -79,7 +79,7 @@ func TestUnmarshalConfig(t *testing.T) {
 				},
 				WriteBufferSize: 512 * 1024,
 				BalancerName:    "experimental",
-				Auth:            &configauth.Authentication{AuthenticatorID: component.NewID("nop")},
+				Auth:            &configauth.Authentication{AuthenticatorID: component.MustNewID("nop")},
 			},
 			Arrow: ArrowSettings{
 				NumStreams:         2,

--- a/extension/pprofextension/pprofextension_test.go
+++ b/extension/pprofextension/pprofextension_test.go
@@ -27,7 +27,7 @@ func TestPerformanceProfilerExtensionUsage(t *testing.T) {
 		BlockProfileFraction: 3,
 		MutexProfileFraction: 5,
 	}
-	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	tt, err := componenttest.SetupTelemetry(component.MustNewID("TestPprofExtension"))
 	require.NoError(t, err, "SetupTelemetry should succeed")
 
 	pprofExt := newServer(config, tt.TelemetrySettings())
@@ -61,7 +61,7 @@ func TestPerformanceProfilerExtensionPortAlreadyInUse(t *testing.T) {
 			Endpoint: endpoint,
 		},
 	}
-	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	tt, err := componenttest.SetupTelemetry(component.MustNewID("TestPprofExtension"))
 	require.NoError(t, err, "SetupTelemetry should succeed")
 	pprofExt := newServer(config, tt.TelemetrySettings())
 	require.NotNil(t, pprofExt)
@@ -76,7 +76,7 @@ func TestPerformanceProfilerMultipleStarts(t *testing.T) {
 		},
 	}
 
-	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	tt, err := componenttest.SetupTelemetry(component.MustNewID("TestPprofExtension"))
 	require.NoError(t, err, "SetupTelemetry should succeed")
 	pprofExt := newServer(config, tt.TelemetrySettings())
 	require.NotNil(t, pprofExt)
@@ -95,7 +95,7 @@ func TestPerformanceProfilerMultipleShutdowns(t *testing.T) {
 		},
 	}
 
-	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	tt, err := componenttest.SetupTelemetry(component.MustNewID("TestPprofExtension"))
 	require.NoError(t, err, "SetupTelemetry should succeed")
 	pprofExt := newServer(config, tt.TelemetrySettings())
 	require.NotNil(t, pprofExt)
@@ -111,7 +111,7 @@ func TestPerformanceProfilerShutdownWithoutStart(t *testing.T) {
 			Endpoint: testutil.GetAvailableLocalAddress(t),
 		},
 	}
-	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	tt, err := componenttest.SetupTelemetry(component.MustNewID("TestPprofExtension"))
 	require.NoError(t, err, "SetupTelemetry should succeed")
 	pprofExt := newServer(config, tt.TelemetrySettings())
 	require.NotNil(t, pprofExt)
@@ -133,7 +133,7 @@ func TestPerformanceProfilerLifecycleWithFile(t *testing.T) {
 		},
 		SaveToFile: tmpFile.Name(),
 	}
-	tt, err := componenttest.SetupTelemetry(component.NewID("TestPprofExtension"))
+	tt, err := componenttest.SetupTelemetry(component.MustNewID("TestPprofExtension"))
 	require.NoError(t, err, "SetupTelemetry should succeed")
 	pprofExt := newServer(config, tt.TelemetrySettings())
 	require.NotNil(t, pprofExt)

--- a/extension/storage/dbstorage/extension_test.go
+++ b/extension/storage/dbstorage/extension_test.go
@@ -113,5 +113,5 @@ func newTestExtension(t *testing.T) storage.Extension {
 }
 
 func newTestEntity(name string) component.ID {
-	return component.NewIDWithName("nop", name)
+	return component.MustNewIDWithName("nop", name)
 }

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -292,7 +292,7 @@ func newTestExtension(t *testing.T) storage.Extension {
 }
 
 func newTestEntity(name string) component.ID {
-	return component.NewIDWithName("nop", name)
+	return component.MustNewIDWithName("nop", name)
 }
 
 func TestCompaction(t *testing.T) {

--- a/extension/storage/storagetest/extension_test.go
+++ b/extension/storage/storagetest/extension_test.go
@@ -36,7 +36,7 @@ func runExtensionLifecycle(t *testing.T, ext *TestStorage, expectPersistence boo
 	ctx := context.Background()
 	require.NoError(t, ext.Start(ctx, componenttest.NewNopHost()))
 
-	clientOne, err := ext.GetClient(ctx, component.KindProcessor, component.NewID("foo"), "client_one")
+	clientOne, err := ext.GetClient(ctx, component.KindProcessor, component.MustNewID("foo"), "client_one")
 	require.NoError(t, err)
 
 	creatorID, err := CreatorID(ctx, clientOne)
@@ -65,7 +65,7 @@ func runExtensionLifecycle(t *testing.T, ext *TestStorage, expectPersistence boo
 	require.NoError(t, clientOne.Close(ctx))
 
 	// Create new client to test persistence
-	clientTwo, err := ext.GetClient(ctx, component.KindProcessor, component.NewID("foo"), "client_one")
+	clientTwo, err := ext.GetClient(ctx, component.KindProcessor, component.MustNewID("foo"), "client_one")
 	require.NoError(t, err)
 
 	creatorID, err = CreatorID(ctx, clientTwo)

--- a/internal/aws/xray/telemetry/registry_test.go
+++ b/internal/aws/xray/telemetry/registry_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestRegistry(t *testing.T) {
 	r := NewRegistry()
-	newID := component.NewID("new")
-	contribID := component.NewID("contrib")
-	notCreatedID := component.NewID("not-created")
+	newID := component.MustNewID("new")
+	contribID := component.MustNewID("contrib")
+	notCreatedID := component.MustNewID("not-created")
 	original := r.Register(
 		newID,
 		Config{

--- a/internal/aws/xray/telemetry/registry_test.go
+++ b/internal/aws/xray/telemetry/registry_test.go
@@ -14,7 +14,7 @@ func TestRegistry(t *testing.T) {
 	r := NewRegistry()
 	newID := component.MustNewID("new")
 	contribID := component.MustNewID("contrib")
-	notCreatedID := component.MustNewID("not-created")
+	notCreatedID := component.MustNewID("not_created")
 	original := r.Register(
 		newID,
 		Config{

--- a/internal/aws/xray/telemetry/telemetrytest/nop_registry_test.go
+++ b/internal/aws/xray/telemetry/telemetrytest/nop_registry_test.go
@@ -16,9 +16,9 @@ func TestNopRegistry(t *testing.T) {
 	assert.Same(t, nopRegistryInstance, NewNopRegistry())
 	r := NewNopRegistry()
 	assert.NotPanics(t, func() {
-		recorder := r.Register(component.NewID("a"), telemetry.Config{}, nil)
-		assert.Same(t, recorder, r.Load(component.NewID("b")))
-		r.LoadOrStore(component.NewID("c"), recorder)
-		r.LoadOrNop(component.NewID("d"))
+		recorder := r.Register(component.MustNewID("a"), telemetry.Config{}, nil)
+		assert.Same(t, recorder, r.Load(component.MustNewID("b")))
+		r.LoadOrStore(component.MustNewID("c"), recorder)
+		r.LoadOrNop(component.MustNewID("d"))
 	})
 }

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 )
 
-var id = component.NewID("test")
+var id = component.MustNewID("test")
 
 func TestNewSharedComponents(t *testing.T) {
 	comps := NewSharedComponents()

--- a/pkg/stanza/adapter/integration_test.go
+++ b/pkg/stanza/adapter/integration_test.go
@@ -36,7 +36,7 @@ func createNoopReceiver(nextConsumer consumer.Logs) (*receiver, error) {
 		return nil, err
 	}
 
-	receiverID := component.NewID("test")
+	receiverID := component.MustNewID("test")
 	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
 		ReceiverID:             receiverID,
 		ReceiverCreateSettings: receivertest.NewNopCreateSettings(),
@@ -46,7 +46,7 @@ func createNoopReceiver(nextConsumer consumer.Logs) (*receiver, error) {
 	}
 
 	return &receiver{
-		id:        component.NewID("testReceiver"),
+		id:        component.MustNewID("testReceiver"),
 		pipe:      pipe,
 		emitter:   emitter,
 		consumer:  nextConsumer,

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -151,7 +151,7 @@ func BenchmarkReadLine(b *testing.B) {
 
 	storageClient := storagetest.NewInMemoryClient(
 		component.KindReceiver,
-		component.NewID("foolog"),
+		component.MustNewID("foolog"),
 		"test",
 	)
 
@@ -216,7 +216,7 @@ func BenchmarkParseAndMap(b *testing.B) {
 
 	storageClient := storagetest.NewInMemoryClient(
 		component.KindReceiver,
-		component.NewID("foolog"),
+		component.MustNewID("foolog"),
 		"test",
 	)
 

--- a/pkg/stanza/adapter/storage_test.go
+++ b/pkg/stanza/adapter/storage_test.go
@@ -85,7 +85,7 @@ func TestFindCorrectStorageExtension(t *testing.T) {
 }
 
 func TestFailOnMissingStorageExtension(t *testing.T) {
-	id := component.NewIDWithName("test", "missing")
+	id := component.MustNewIDWithName("test", "missing")
 	r := createReceiver(t, id)
 	err := r.Start(context.Background(), storagetest.NewStorageHost())
 	require.Error(t, err)

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -40,7 +40,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 		expected *Config
 	}{
 		{
-			id: component.NewIDWithName("filter", "empty"),
+			id: component.MustNewIDWithName("filter", "empty"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -50,7 +50,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "include"),
+			id: component.MustNewIDWithName("filter", "include"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -58,7 +58,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "exclude"),
+			id: component.MustNewIDWithName("filter", "exclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -66,7 +66,7 @@ func TestLoadingConfigStrict(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "includeexclude"),
+			id: component.MustNewIDWithName("filter", "includeexclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -126,7 +126,7 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 		expected *Config
 	}{
 		{
-			id: component.NewIDWithName("filter", "empty"),
+			id: component.MustNewIDWithName("filter", "empty"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -136,7 +136,7 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "include"),
+			id: component.MustNewIDWithName("filter", "include"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -144,7 +144,7 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "exclude"),
+			id: component.MustNewIDWithName("filter", "exclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -152,7 +152,7 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "includeexclude"),
+			id: component.MustNewIDWithName("filter", "includeexclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -199,7 +199,7 @@ func TestLoadingConfigSeverityLogsStrict(t *testing.T) {
 		expected *Config
 	}{
 		{
-			id: component.NewIDWithName("filter", "include"),
+			id: component.MustNewIDWithName("filter", "include"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -207,7 +207,7 @@ func TestLoadingConfigSeverityLogsStrict(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "exclude"),
+			id: component.MustNewIDWithName("filter", "exclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -215,7 +215,7 @@ func TestLoadingConfigSeverityLogsStrict(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "includeexclude"),
+			id: component.MustNewIDWithName("filter", "includeexclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -261,7 +261,7 @@ func TestLoadingConfigSeverityLogsRegexp(t *testing.T) {
 		expected *Config
 	}{
 		{
-			id: component.NewIDWithName("filter", "include"),
+			id: component.MustNewIDWithName("filter", "include"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -269,7 +269,7 @@ func TestLoadingConfigSeverityLogsRegexp(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "exclude"),
+			id: component.MustNewIDWithName("filter", "exclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -277,7 +277,7 @@ func TestLoadingConfigSeverityLogsRegexp(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "includeexclude"),
+			id: component.MustNewIDWithName("filter", "includeexclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -324,7 +324,7 @@ func TestLoadingConfigBodyLogsStrict(t *testing.T) {
 		expected *Config
 	}{
 		{
-			id: component.NewIDWithName("filter", "include"),
+			id: component.MustNewIDWithName("filter", "include"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -332,7 +332,7 @@ func TestLoadingConfigBodyLogsStrict(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "exclude"),
+			id: component.MustNewIDWithName("filter", "exclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -340,7 +340,7 @@ func TestLoadingConfigBodyLogsStrict(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "includeexclude"),
+			id: component.MustNewIDWithName("filter", "includeexclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -387,7 +387,7 @@ func TestLoadingConfigBodyLogsRegexp(t *testing.T) {
 		expected *Config
 	}{
 		{
-			id: component.NewIDWithName("filter", "include"),
+			id: component.MustNewIDWithName("filter", "include"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -395,7 +395,7 @@ func TestLoadingConfigBodyLogsRegexp(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "exclude"),
+			id: component.MustNewIDWithName("filter", "exclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -403,7 +403,7 @@ func TestLoadingConfigBodyLogsRegexp(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "includeexclude"),
+			id: component.MustNewIDWithName("filter", "includeexclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -452,7 +452,7 @@ func TestLoadingConfigMinSeverityNumberLogs(t *testing.T) {
 		expected *Config
 	}{
 		{
-			id: component.NewIDWithName("filter", "include"),
+			id: component.MustNewIDWithName("filter", "include"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -460,7 +460,7 @@ func TestLoadingConfigMinSeverityNumberLogs(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "exclude"),
+			id: component.MustNewIDWithName("filter", "exclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -468,7 +468,7 @@ func TestLoadingConfigMinSeverityNumberLogs(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "includeexclude"),
+			id: component.MustNewIDWithName("filter", "includeexclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Logs: LogFilters{
@@ -521,7 +521,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 		expected component.Config
 	}{
 		{
-			id: component.NewIDWithName("filter", "include"),
+			id: component.MustNewIDWithName("filter", "include"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -529,7 +529,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "exclude"),
+			id: component.MustNewIDWithName("filter", "exclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -537,7 +537,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "unlimitedcache"),
+			id: component.MustNewIDWithName("filter", "unlimitedcache"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -551,7 +551,7 @@ func TestLoadingConfigRegexp(t *testing.T) {
 				},
 			},
 		}, {
-			id: component.NewIDWithName("filter", "limitedcache"),
+			id: component.MustNewIDWithName("filter", "limitedcache"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -592,7 +592,7 @@ func TestLoadingSpans(t *testing.T) {
 		expected component.Config
 	}{
 		{
-			id: component.NewIDWithName("filter", "spans"),
+			id: component.MustNewIDWithName("filter", "spans"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Spans: filterconfig.MatchConfig{
@@ -642,7 +642,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 		expected component.Config
 	}{
 		{
-			id: component.NewIDWithName("filter", "empty"),
+			id: component.MustNewIDWithName("filter", "empty"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -653,7 +653,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 			},
 		},
 		{
-			id: component.NewIDWithName("filter", "include"),
+			id: component.MustNewIDWithName("filter", "include"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -668,7 +668,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 			},
 		},
 		{
-			id: component.NewIDWithName("filter", "exclude"),
+			id: component.MustNewIDWithName("filter", "exclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -683,7 +683,7 @@ func TestLoadingConfigExpr(t *testing.T) {
 			},
 		},
 		{
-			id: component.NewIDWithName("filter", "includeexclude"),
+			id: component.MustNewIDWithName("filter", "includeexclude"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Metrics: MetricFilters{
@@ -842,7 +842,7 @@ func TestLoadingConfigOTTL(t *testing.T) {
 		errorMessage string
 	}{
 		{
-			id: component.NewIDWithName("filter", "ottl"),
+			id: component.MustNewIDWithName("filter", "ottl"),
 			expected: &Config{
 				ErrorMode: ottl.IgnoreError,
 				Traces: TraceFilters{
@@ -869,7 +869,7 @@ func TestLoadingConfigOTTL(t *testing.T) {
 			},
 		},
 		{
-			id: component.NewIDWithName("filter", "multiline"),
+			id: component.MustNewIDWithName("filter", "multiline"),
 			expected: &Config{
 				ErrorMode: ottl.PropagateError,
 				Traces: TraceFilters{

--- a/processor/routingprocessor/factory_test.go
+++ b/processor/routingprocessor/factory_test.go
@@ -152,10 +152,10 @@ func TestProcessorDoesNotFailToBuildExportersWithMultiplePipelines(t *testing.T)
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
-			component.NewID("otlp/traces"): otlpTracesExporter,
+			component.MustNewID("otlp/traces"): otlpTracesExporter,
 		},
 		component.DataTypeMetrics: {
-			component.NewID("otlp/metrics"): otlpMetricsExporter,
+			component.MustNewID("otlp/metrics"): otlpMetricsExporter,
 		},
 	})
 

--- a/processor/routingprocessor/factory_test.go
+++ b/processor/routingprocessor/factory_test.go
@@ -152,10 +152,10 @@ func TestProcessorDoesNotFailToBuildExportersWithMultiplePipelines(t *testing.T)
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
-			component.MustNewID("otlp/traces"): otlpTracesExporter,
+			component.MustNewIDWithName("otlp", "traces"): otlpTracesExporter,
 		},
 		component.DataTypeMetrics: {
-			component.MustNewID("otlp/metrics"): otlpMetricsExporter,
+			component.MustNewIDWithName("otlp", "metrics"): otlpMetricsExporter,
 		},
 	})
 

--- a/processor/routingprocessor/logs_test.go
+++ b/processor/routingprocessor/logs_test.go
@@ -41,7 +41,7 @@ func TestLogs_RoutingWorks_Context(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): lExp,
 		},
 	})
@@ -133,7 +133,7 @@ func TestLogs_RoutingWorks_ResourceAttribute(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): lExp,
 		},
 	})
@@ -188,7 +188,7 @@ func TestLogs_RoutingWorks_ResourceAttribute_DropsRoutingAttribute(t *testing.T)
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): lExp,
 		},
 	})
@@ -232,7 +232,7 @@ func TestLogs_AreCorrectlySplitPerResourceAttributeRouting(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): lExp,
 		},
 	})
@@ -286,7 +286,7 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "1"): firstExp,
 			component.NewIDWithName("otlp", "2"): secondExp,
 		},
@@ -408,7 +408,7 @@ func TestLogsAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "1"): firstExp,
 		},
 	})

--- a/processor/routingprocessor/logs_test.go
+++ b/processor/routingprocessor/logs_test.go
@@ -42,7 +42,7 @@ func TestLogs_RoutingWorks_Context(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): lExp,
+			component.MustNewIDWithName("otlp", "2"): lExp,
 		},
 	})
 
@@ -134,7 +134,7 @@ func TestLogs_RoutingWorks_ResourceAttribute(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): lExp,
+			component.MustNewIDWithName("otlp", "2"): lExp,
 		},
 	})
 
@@ -189,7 +189,7 @@ func TestLogs_RoutingWorks_ResourceAttribute_DropsRoutingAttribute(t *testing.T)
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): lExp,
+			component.MustNewIDWithName("otlp", "2"): lExp,
 		},
 	})
 
@@ -233,7 +233,7 @@ func TestLogs_AreCorrectlySplitPerResourceAttributeRouting(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): lExp,
+			component.MustNewIDWithName("otlp", "2"): lExp,
 		},
 	})
 
@@ -287,8 +287,8 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "1"): firstExp,
-			component.NewIDWithName("otlp", "2"): secondExp,
+			component.MustNewIDWithName("otlp", "1"): firstExp,
+			component.MustNewIDWithName("otlp", "2"): secondExp,
 		},
 	})
 
@@ -409,7 +409,7 @@ func TestLogsAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeLogs: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "1"): firstExp,
+			component.MustNewIDWithName("otlp", "1"): firstExp,
 		},
 	})
 

--- a/processor/routingprocessor/metrics_test.go
+++ b/processor/routingprocessor/metrics_test.go
@@ -42,7 +42,7 @@ func TestMetrics_AreCorrectlySplitPerResourceAttributeRouting(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): mExp,
 		},
 	})
@@ -101,7 +101,7 @@ func TestMetrics_RoutingWorks_Context(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): mExp,
 		},
 	})
@@ -195,7 +195,7 @@ func TestMetrics_RoutingWorks_ResourceAttribute(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): mExp,
 		},
 	})
@@ -250,7 +250,7 @@ func TestMetrics_RoutingWorks_ResourceAttribute_DropsRoutingAttribute(t *testing
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): mExp,
 		},
 	})
@@ -312,7 +312,7 @@ func Benchmark_MetricsRouting_ResourceAttribute(b *testing.B) {
 
 		host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 			component.DataTypeMetrics: {
-				component.NewID("otlp"):              defaultExp,
+				component.MustNewID("otlp"):              defaultExp,
 				component.NewIDWithName("otlp", "2"): mExp,
 			},
 		})
@@ -345,7 +345,7 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeRoutingWithOTTL(t *testing.
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "1"): firstExp,
 			component.NewIDWithName("otlp", "2"): secondExp,
 		},
@@ -480,7 +480,7 @@ func TestMetricsAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "1"): firstExp,
 		},
 	})

--- a/processor/routingprocessor/metrics_test.go
+++ b/processor/routingprocessor/metrics_test.go
@@ -43,7 +43,7 @@ func TestMetrics_AreCorrectlySplitPerResourceAttributeRouting(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): mExp,
+			component.MustNewIDWithName("otlp", "2"): mExp,
 		},
 	})
 
@@ -102,7 +102,7 @@ func TestMetrics_RoutingWorks_Context(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): mExp,
+			component.MustNewIDWithName("otlp", "2"): mExp,
 		},
 	})
 
@@ -196,7 +196,7 @@ func TestMetrics_RoutingWorks_ResourceAttribute(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): mExp,
+			component.MustNewIDWithName("otlp", "2"): mExp,
 		},
 	})
 
@@ -251,7 +251,7 @@ func TestMetrics_RoutingWorks_ResourceAttribute_DropsRoutingAttribute(t *testing
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): mExp,
+			component.MustNewIDWithName("otlp", "2"): mExp,
 		},
 	})
 
@@ -313,7 +313,7 @@ func Benchmark_MetricsRouting_ResourceAttribute(b *testing.B) {
 		host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 			component.DataTypeMetrics: {
 				component.MustNewID("otlp"):              defaultExp,
-				component.NewIDWithName("otlp", "2"): mExp,
+				component.MustNewIDWithName("otlp", "2"): mExp,
 			},
 		})
 
@@ -346,8 +346,8 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeRoutingWithOTTL(t *testing.
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "1"): firstExp,
-			component.NewIDWithName("otlp", "2"): secondExp,
+			component.MustNewIDWithName("otlp", "1"): firstExp,
+			component.MustNewIDWithName("otlp", "2"): secondExp,
 		},
 	})
 
@@ -481,7 +481,7 @@ func TestMetricsAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "1"): firstExp,
+			component.MustNewIDWithName("otlp", "1"): firstExp,
 		},
 	})
 

--- a/processor/routingprocessor/traces_test.go
+++ b/processor/routingprocessor/traces_test.go
@@ -34,7 +34,7 @@ func TestTraces_RegisterExportersForValidRoute(t *testing.T) {
 	require.NoError(t, err)
 
 	otlpExpFactory := otlpexporter.NewFactory()
-	otlpID := component.NewID("otlp")
+	otlpID := component.MustNewID("otlp")
 	otlpConfig := &otlpexporter.Config{
 		ClientConfig: configgrpc.ClientConfig{
 			Endpoint: "example.com:1234",
@@ -72,7 +72,7 @@ func TestTraces_InvalidExporter(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
-			component.NewID("otlp"): &mockComponent{},
+			component.MustNewID("otlp"): &mockComponent{},
 		},
 	})
 
@@ -89,7 +89,7 @@ func TestTraces_AreCorrectlySplitPerResourceAttributeRouting(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): tExp,
 		},
 	})
@@ -145,7 +145,7 @@ func TestTraces_RoutingWorks_Context(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): tExp,
 		},
 	})
@@ -238,7 +238,7 @@ func TestTraces_RoutingWorks_ResourceAttribute(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): tExp,
 		},
 	})
@@ -293,7 +293,7 @@ func TestTraces_RoutingWorks_ResourceAttribute_DropsRoutingAttribute(t *testing.
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "2"): tExp,
 		},
 	})
@@ -340,7 +340,7 @@ func TestTracesAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "1"): firstExp,
 			component.NewIDWithName("otlp", "2"): secondExp,
 		},
@@ -465,7 +465,7 @@ func TestTracesAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
 
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
-			component.NewID("otlp"):              defaultExp,
+			component.MustNewID("otlp"):              defaultExp,
 			component.NewIDWithName("otlp", "1"): firstExp,
 		},
 	})

--- a/processor/routingprocessor/traces_test.go
+++ b/processor/routingprocessor/traces_test.go
@@ -90,7 +90,7 @@ func TestTraces_AreCorrectlySplitPerResourceAttributeRouting(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): tExp,
+			component.MustNewIDWithName("otlp", "2"): tExp,
 		},
 	})
 
@@ -146,7 +146,7 @@ func TestTraces_RoutingWorks_Context(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): tExp,
+			component.MustNewIDWithName("otlp", "2"): tExp,
 		},
 	})
 
@@ -239,7 +239,7 @@ func TestTraces_RoutingWorks_ResourceAttribute(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): tExp,
+			component.MustNewIDWithName("otlp", "2"): tExp,
 		},
 	})
 
@@ -294,7 +294,7 @@ func TestTraces_RoutingWorks_ResourceAttribute_DropsRoutingAttribute(t *testing.
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "2"): tExp,
+			component.MustNewIDWithName("otlp", "2"): tExp,
 		},
 	})
 
@@ -341,8 +341,8 @@ func TestTracesAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "1"): firstExp,
-			component.NewIDWithName("otlp", "2"): secondExp,
+			component.MustNewIDWithName("otlp", "1"): firstExp,
+			component.MustNewIDWithName("otlp", "2"): secondExp,
 		},
 	})
 
@@ -466,7 +466,7 @@ func TestTracesAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
 	host := newMockHost(map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeTraces: {
 			component.MustNewID("otlp"):              defaultExp,
-			component.NewIDWithName("otlp", "1"): firstExp,
+			component.MustNewIDWithName("otlp", "1"): firstExp,
 		},
 	})
 

--- a/processor/spanmetricsprocessor/processor_test.go
+++ b/processor/spanmetricsprocessor/processor_test.go
@@ -721,7 +721,7 @@ func initSpan(span span, s ptrace.Span) {
 
 func newOTLPExporters(t *testing.T) (component.ID, exporter.Metrics, exporter.Traces) {
 	otlpExpFactory := otlpexporter.NewFactory()
-	otlpID := component.NewID("otlp")
+	otlpID := component.MustNewID("otlp")
 	otlpConfig := &otlpexporter.Config{
 		ClientConfig: configgrpc.ClientConfig{
 			Endpoint: "example.com:1234",

--- a/processor/spanprocessor/config_test.go
+++ b/processor/spanprocessor/config_test.go
@@ -24,7 +24,7 @@ func TestLoadingConfig(t *testing.T) {
 		expected component.Config
 	}{
 		{
-			id: component.NewIDWithName("span", "custom"),
+			id: component.MustNewIDWithName("span", "custom"),
 			expected: &Config{
 				Rename: Name{
 					FromAttributes: []string{"db.svc", "operation", "id"},
@@ -33,7 +33,7 @@ func TestLoadingConfig(t *testing.T) {
 			},
 		},
 		{
-			id: component.NewIDWithName("span", "no-separator"),
+			id: component.MustNewIDWithName("span", "no-separator"),
 			expected: &Config{
 				Rename: Name{
 					FromAttributes: []string{"db.svc", "operation", "id"},
@@ -42,7 +42,7 @@ func TestLoadingConfig(t *testing.T) {
 			},
 		},
 		{
-			id: component.NewIDWithName("span", "to_attributes"),
+			id: component.MustNewIDWithName("span", "to_attributes"),
 			expected: &Config{
 				Rename: Name{
 					ToAttributes: &ToAttributes{
@@ -52,7 +52,7 @@ func TestLoadingConfig(t *testing.T) {
 			},
 		},
 		{
-			id: component.NewIDWithName("span", "includeexclude"),
+			id: component.MustNewIDWithName("span", "includeexclude"),
 			expected: &Config{
 				MatchConfig: filterconfig.MatchConfig{
 					Include: &filterconfig.MatchProperties{
@@ -74,7 +74,7 @@ func TestLoadingConfig(t *testing.T) {
 		},
 		{
 			// Set name
-			id: component.NewIDWithName("span", "set_status_err"),
+			id: component.MustNewIDWithName("span", "set_status_err"),
 			expected: &Config{
 				SetStatus: &Status{
 					Code:        "Error",
@@ -83,7 +83,7 @@ func TestLoadingConfig(t *testing.T) {
 			},
 		},
 		{
-			id: component.NewIDWithName("span", "set_status_ok"),
+			id: component.MustNewIDWithName("span", "set_status_ok"),
 			expected: &Config{
 				MatchConfig: filterconfig.MatchConfig{
 					Include: &filterconfig.MatchProperties{

--- a/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
@@ -113,7 +113,7 @@ func TestCloseStopsPoller(t *testing.T) {
 }
 
 func TestSuccessfullyPollPacket(t *testing.T) {
-	receiverID := component.NewID("TestSuccessfullyPollPacket")
+	receiverID := component.MustNewID("TestSuccessfullyPollPacket")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -149,7 +149,7 @@ func TestSuccessfullyPollPacket(t *testing.T) {
 }
 
 func TestIncompletePacketNoSeparator(t *testing.T) {
-	receiverID := component.NewID("TestIncompletePacketNoSeparator")
+	receiverID := component.MustNewID("TestIncompletePacketNoSeparator")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -179,7 +179,7 @@ func TestIncompletePacketNoSeparator(t *testing.T) {
 }
 
 func TestIncompletePacketNoBody(t *testing.T) {
-	receiverID := component.NewID("TestIncompletePacketNoBody")
+	receiverID := component.MustNewID("TestIncompletePacketNoBody")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -204,7 +204,7 @@ func TestIncompletePacketNoBody(t *testing.T) {
 }
 
 func TestNonJsonHeader(t *testing.T) {
-	receiverID := component.NewID("TestNonJsonHeader")
+	receiverID := component.MustNewID("TestNonJsonHeader")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -234,7 +234,7 @@ func TestNonJsonHeader(t *testing.T) {
 }
 
 func TestJsonInvalidHeader(t *testing.T) {
-	receiverID := component.NewID("TestJsonInvalidHeader")
+	receiverID := component.MustNewID("TestJsonInvalidHeader")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -270,7 +270,7 @@ func TestJsonInvalidHeader(t *testing.T) {
 }
 
 func TestSocketReadIrrecoverableNetError(t *testing.T) {
-	receiverID := component.NewID("TestSocketReadIrrecoverableNetError")
+	receiverID := component.MustNewID("TestSocketReadIrrecoverableNetError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -306,7 +306,7 @@ func TestSocketReadIrrecoverableNetError(t *testing.T) {
 }
 
 func TestSocketReadTimeOutNetError(t *testing.T) {
-	receiverID := component.NewID("TestSocketReadTimeOutNetError")
+	receiverID := component.MustNewID("TestSocketReadTimeOutNetError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -343,7 +343,7 @@ func TestSocketReadTimeOutNetError(t *testing.T) {
 }
 
 func TestSocketGenericReadError(t *testing.T) {
-	receiverID := component.NewID("TestSocketGenericReadError")
+	receiverID := component.MustNewID("TestSocketGenericReadError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {

--- a/receiver/awsxrayreceiver/receiver_test.go
+++ b/receiver/awsxrayreceiver/receiver_test.go
@@ -106,7 +106,7 @@ func TestSegmentsPassedToConsumer(t *testing.T) {
 	}
 	t.Skip("Flaky Test - See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10596")
 
-	receiverID := component.NewID("TestSegmentsPassedToConsumer")
+	receiverID := component.MustNewID("TestSegmentsPassedToConsumer")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -137,7 +137,7 @@ func TestSegmentsPassedToConsumer(t *testing.T) {
 }
 
 func TestTranslatorErrorsOut(t *testing.T) {
-	receiverID := component.NewID("TestTranslatorErrorsOut")
+	receiverID := component.MustNewID("TestTranslatorErrorsOut")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -164,7 +164,7 @@ func TestTranslatorErrorsOut(t *testing.T) {
 }
 
 func TestSegmentsConsumerErrorsOut(t *testing.T) {
-	receiverID := component.NewID("TestSegmentsConsumerErrorsOut")
+	receiverID := component.MustNewID("TestSegmentsConsumerErrorsOut")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -194,7 +194,7 @@ func TestSegmentsConsumerErrorsOut(t *testing.T) {
 }
 
 func TestPollerCloseError(t *testing.T) {
-	receiverID := component.NewID("TestPollerCloseError")
+	receiverID := component.MustNewID("TestPollerCloseError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -212,7 +212,7 @@ func TestPollerCloseError(t *testing.T) {
 }
 
 func TestProxyCloseError(t *testing.T) {
-	receiverID := component.NewID("TestPollerCloseError")
+	receiverID := component.MustNewID("TestPollerCloseError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
@@ -230,7 +230,7 @@ func TestProxyCloseError(t *testing.T) {
 }
 
 func TestBothPollerAndProxyCloseError(t *testing.T) {
-	receiverID := component.NewID("TestBothPollerAndProxyCloseError")
+	receiverID := component.MustNewID("TestBothPollerAndProxyCloseError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
 	assert.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {

--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -50,7 +50,7 @@ func TestLoadConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewID("filelog").String())
+	sub, err := cm.Sub(component.MustNewID("filelog").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 

--- a/receiver/fluentforwardreceiver/config_test.go
+++ b/receiver/fluentforwardreceiver/config_test.go
@@ -20,7 +20,7 @@ func TestLoadConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewID("fluentforward").String())
+	sub, err := cm.Sub(component.MustNewID("fluentforward").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -227,7 +227,7 @@ func (m *mockFactory) CreateMetricsScraper(context.Context, receiver.CreateSetti
 	return args.Get(0).(scraperhelper.Scraper), args.Error(1)
 }
 
-func (m *mockScraper) ID() component.ID                            { return component.NewID("mock_scraper") }
+func (m *mockScraper) ID() component.ID                            { return component.MustNewID("mock_scraper") }
 func (m *mockScraper) Start(context.Context, component.Host) error { return nil }
 func (m *mockScraper) Shutdown(context.Context) error              { return nil }
 func (m *mockScraper) Scrape(context.Context) (pmetric.Metrics, error) {

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 )
 
-var jaegerReceiver = component.NewIDWithName("jaeger", "receiver_test")
+var jaegerReceiver = component.MustNewIDWithName("jaeger", "receiver_test")
 
 func TestTraceSource(t *testing.T) {
 	set := receivertest.NewNopCreateSettings()

--- a/receiver/k8sclusterreceiver/factory_test.go
+++ b/receiver/k8sclusterreceiver/factory_test.go
@@ -111,8 +111,8 @@ func newNopHostWithExporters() component.Host {
 func (n *nopHostWithExporters) GetExporters() map[component.DataType]map[component.ID]component.Component {
 	return map[component.DataType]map[component.ID]component.Component{
 		component.DataTypeMetrics: {
-			component.NewIDWithName("nop", "withoutmetadata"): MockExporter{},
-			component.NewIDWithName("nop", "withmetadata"):    mockExporterWithK8sMetadata{},
+			component.MustNewIDWithName("nop", "withoutmetadata"): MockExporter{},
+			component.MustNewIDWithName("nop", "withmetadata"):    mockExporterWithK8sMetadata{},
 		},
 	}
 }

--- a/receiver/k8sclusterreceiver/watcher_test.go
+++ b/receiver/k8sclusterreceiver/watcher_test.go
@@ -54,7 +54,7 @@ func TestSetupMetadataExporters(t *testing.T) {
 			fields{},
 			args{
 				exporters: map[component.ID]component.Component{
-					component.NewID("nop"): MockExporter{},
+					component.MustNewID("nop"): MockExporter{},
 				},
 				metadataExportersFromConfig: []string{"nop"},
 			},
@@ -66,7 +66,7 @@ func TestSetupMetadataExporters(t *testing.T) {
 				metadataConsumers: []metadataConsumer{(&mockExporterWithK8sMetadata{}).ConsumeMetadata},
 			},
 			args{exporters: map[component.ID]component.Component{
-				component.NewID("nop"): mockExporterWithK8sMetadata{},
+				component.MustNewID("nop"): mockExporterWithK8sMetadata{},
 			},
 				metadataExportersFromConfig: []string{"nop"},
 			},
@@ -78,7 +78,7 @@ func TestSetupMetadataExporters(t *testing.T) {
 				metadataConsumers: []metadataConsumer{},
 			},
 			args{exporters: map[component.ID]component.Component{
-				component.NewID("nop"): mockExporterWithK8sMetadata{},
+				component.MustNewID("nop"): mockExporterWithK8sMetadata{},
 			},
 				metadataExportersFromConfig: []string{"nop/1"},
 			},

--- a/receiver/namedpipereceiver/namedpipe_test.go
+++ b/receiver/namedpipereceiver/namedpipe_test.go
@@ -41,7 +41,7 @@ func TestLoadConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
-	sub, err := cm.Sub(component.NewID("namedpipe").String())
+	sub, err := cm.Sub(component.MustNewID("namedpipe").String())
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 

--- a/receiver/opencensusreceiver/internal/ocmetrics/opencensus_test.go
+++ b/receiver/opencensusreceiver/internal/ocmetrics/opencensus_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus"
 )
 
-var receiverID = component.NewID("opencensus")
+var receiverID = component.MustNewID("opencensus")
 
 func TestReceiver_endToEnd(t *testing.T) {
 	tt, err := componenttest.SetupTelemetry(receiverID)

--- a/receiver/opencensusreceiver/internal/octrace/observability_test.go
+++ b/receiver/opencensusreceiver/internal/octrace/observability_test.go
@@ -23,7 +23,7 @@ import (
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
 )
 
-var receiverID = component.NewID("opencensus")
+var receiverID = component.MustNewID("opencensus")
 
 // Ensure that if we add a metrics exporter that our target metrics
 // will be recorded but also with the proper tag keys and values.

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -354,7 +354,7 @@ func TestAppendExemplarWithEmptyLabelArray(t *testing.T) {
 
 func nopObsRecv(t *testing.T) *receiverhelper.ObsReport {
 	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
-		ReceiverID:             component.NewID("prometheus"),
+		ReceiverID:             component.MustNewID("prometheus"),
 		Transport:              transport,
 		ReceiverCreateSettings: receivertest.NewNopCreateSettings(),
 	})

--- a/receiver/purefareceiver/internal/bearertoken_test.go
+++ b/receiver/purefareceiver/internal/bearertoken_test.go
@@ -27,7 +27,7 @@ func TestBearerToken(t *testing.T) {
 	baExt, err := baFactory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), baCfg)
 	require.NoError(t, err)
 
-	baComponentName := component.NewIDWithName("bearertokenauth", "array01")
+	baComponentName := component.MustNewIDWithName("bearertokenauth", "array01")
 
 	host := &mockHost{
 		Host: componenttest.NewNopHost(),

--- a/receiver/purefareceiver/internal/scraper_test.go
+++ b/receiver/purefareceiver/internal/scraper_test.go
@@ -32,7 +32,7 @@ func TestToPrometheusConfig(t *testing.T) {
 
 	host := &mockHost{
 		extensions: map[component.ID]component.Component{
-			component.NewIDWithName("bearertokenauth", "array01"): baExt,
+			component.MustNewIDWithName("bearertokenauth", "array01"): baExt,
 		},
 	}
 
@@ -42,7 +42,7 @@ func TestToPrometheusConfig(t *testing.T) {
 		{
 			Address: "array01",
 			Auth: configauth.Authentication{
-				AuthenticatorID: component.NewIDWithName("bearertokenauth", "array01"),
+				AuthenticatorID: component.MustNewIDWithName("bearertokenauth", "array01"),
 			},
 		},
 	}

--- a/receiver/purefbreceiver/internal/baerertoken_test.go
+++ b/receiver/purefbreceiver/internal/baerertoken_test.go
@@ -27,7 +27,7 @@ func TestBearerToken(t *testing.T) {
 	baExt, err := baFactory.CreateExtension(context.Background(), extensiontest.NewNopCreateSettings(), baCfg)
 	require.NoError(t, err)
 
-	baComponentName := component.NewIDWithName("bearertokenauth", "fb02")
+	baComponentName := component.MustNewIDWithName("bearertokenauth", "fb02")
 
 	host := &mockHost{
 		Host: componenttest.NewNopHost(),

--- a/receiver/purefbreceiver/internal/scraper_test.go
+++ b/receiver/purefbreceiver/internal/scraper_test.go
@@ -32,7 +32,7 @@ func TestToPrometheusConfig(t *testing.T) {
 
 	host := &mockHost{
 		extensions: map[component.ID]component.Component{
-			component.NewIDWithName("bearertokenauth", "fb01"): baExt,
+			component.MustNewIDWithName("bearertokenauth", "fb01"): baExt,
 		},
 	}
 
@@ -42,7 +42,7 @@ func TestToPrometheusConfig(t *testing.T) {
 		{
 			Address: "fb01",
 			Auth: configauth.Authentication{
-				AuthenticatorID: component.NewIDWithName("bearertokenauth", "fb01"),
+				AuthenticatorID: component.MustNewIDWithName("bearertokenauth", "fb01"),
 			},
 		},
 	}

--- a/receiver/receivercreator/config_test.go
+++ b/receiver/receivercreator/config_test.go
@@ -105,7 +105,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 				WatchObservers: []component.ID{
-					component.NewID("mock_observer"),
+					component.MustNewID("mock_observer"),
 					component.NewIDWithName("mock_observer", "with_name"),
 				},
 				ResourceAttributes: map[observer.EndpointType]map[string]string{

--- a/receiver/receivercreator/config_test.go
+++ b/receiver/receivercreator/config_test.go
@@ -72,7 +72,7 @@ func TestLoadConfig(t *testing.T) {
 			expected: createDefaultConfig(),
 		},
 		{
-			id:       component.NewIDWithName("receiver_creator", ""),
+			id:       component.MustNewIDWithName("receiver_creator", ""),
 			expected: createDefaultConfig(),
 		},
 		{
@@ -81,7 +81,7 @@ func TestLoadConfig(t *testing.T) {
 				receiverTemplates: map[string]receiverTemplate{
 					"examplereceiver/1": {
 						receiverConfig: receiverConfig{
-							id: component.NewIDWithName("examplereceiver", "1"),
+							id: component.MustNewIDWithName("examplereceiver", "1"),
 							config: userConfigMap{
 								"key": "value",
 							},
@@ -93,7 +93,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 					"nop/1": {
 						receiverConfig: receiverConfig{
-							id: component.NewIDWithName("nop", "1"),
+							id: component.MustNewIDWithName("nop", "1"),
 							config: userConfigMap{
 								endpointConfigKey: "localhost:12345",
 							},
@@ -106,7 +106,7 @@ func TestLoadConfig(t *testing.T) {
 				},
 				WatchObservers: []component.ID{
 					component.MustNewID("mock_observer"),
-					component.NewIDWithName("mock_observer", "with_name"),
+					component.MustNewIDWithName("mock_observer", "with_name"),
 				},
 				ResourceAttributes: map[observer.EndpointType]map[string]string{
 					observer.ContainerType:  {"container.key": "container.value"},

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -30,7 +30,7 @@ func TestOnAddForMetrics(t *testing.T) {
 	}{
 		{
 			name:                   "dynamically set with supported endpoint",
-			receiverTemplateID:     component.NewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 12345678},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -40,7 +40,7 @@ func TestOnAddForMetrics(t *testing.T) {
 		},
 		{
 			name:                   "inherits supported endpoint",
-			receiverTemplateID:     component.NewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "some.endpoint"},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -50,7 +50,7 @@ func TestOnAddForMetrics(t *testing.T) {
 		},
 		{
 			name:                   "not dynamically set with unsupported endpoint",
-			receiverTemplateID:     component.NewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 23456789, "not_endpoint": "not.an.endpoint"},
 			expectedReceiverType:   &nopWithoutEndpointReceiver{},
 			expectedReceiverConfig: &nopWithoutEndpointConfig{
@@ -60,7 +60,7 @@ func TestOnAddForMetrics(t *testing.T) {
 		},
 		{
 			name:                   "inherits unsupported endpoint",
-			receiverTemplateID:     component.NewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "unsupported.endpoint"},
 			expectedError:          "failed to load \"without.endpoint/some.name\" template config: 1 error(s) decoding:\n\n* '' has invalid keys: endpoint",
 		},
@@ -132,7 +132,7 @@ func TestOnAddForLogs(t *testing.T) {
 	}{
 		{
 			name:                   "dynamically set with supported endpoint",
-			receiverTemplateID:     component.NewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 12345678},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -142,7 +142,7 @@ func TestOnAddForLogs(t *testing.T) {
 		},
 		{
 			name:                   "inherits supported endpoint",
-			receiverTemplateID:     component.NewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "some.endpoint"},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -152,7 +152,7 @@ func TestOnAddForLogs(t *testing.T) {
 		},
 		{
 			name:                   "not dynamically set with unsupported endpoint",
-			receiverTemplateID:     component.NewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 23456789, "not_endpoint": "not.an.endpoint"},
 			expectedReceiverType:   &nopWithoutEndpointReceiver{},
 			expectedReceiverConfig: &nopWithoutEndpointConfig{
@@ -162,7 +162,7 @@ func TestOnAddForLogs(t *testing.T) {
 		},
 		{
 			name:                   "inherits unsupported endpoint",
-			receiverTemplateID:     component.NewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "unsupported.endpoint"},
 			expectedError:          "failed to load \"without.endpoint/some.name\" template config: 1 error(s) decoding:\n\n* '' has invalid keys: endpoint",
 		},
@@ -234,7 +234,7 @@ func TestOnAddForTraces(t *testing.T) {
 	}{
 		{
 			name:                   "dynamically set with supported endpoint",
-			receiverTemplateID:     component.NewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 12345678},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -244,7 +244,7 @@ func TestOnAddForTraces(t *testing.T) {
 		},
 		{
 			name:                   "inherits supported endpoint",
-			receiverTemplateID:     component.NewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "some.endpoint"},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -254,7 +254,7 @@ func TestOnAddForTraces(t *testing.T) {
 		},
 		{
 			name:                   "not dynamically set with unsupported endpoint",
-			receiverTemplateID:     component.NewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 23456789, "not_endpoint": "not.an.endpoint"},
 			expectedReceiverType:   &nopWithoutEndpointReceiver{},
 			expectedReceiverConfig: &nopWithoutEndpointConfig{
@@ -264,7 +264,7 @@ func TestOnAddForTraces(t *testing.T) {
 		},
 		{
 			name:                   "inherits unsupported endpoint",
-			receiverTemplateID:     component.NewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "unsupported.endpoint"},
 			expectedError:          "failed to load \"without.endpoint/some.name\" template config: 1 error(s) decoding:\n\n* '' has invalid keys: endpoint",
 		},
@@ -329,7 +329,7 @@ func TestOnAddForTraces(t *testing.T) {
 func TestOnRemoveForMetrics(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	rcvrCfg := receiverConfig{
-		id:         component.NewIDWithName("with.endpoint", "some.name"),
+		id:         component.MustNewIDWithName("with.endpoint", "some.name"),
 		config:     userConfigMap{"endpoint": "some.endpoint"},
 		endpointID: portEndpoint.ID,
 	}
@@ -358,7 +358,7 @@ func TestOnRemoveForMetrics(t *testing.T) {
 func TestOnRemoveForLogs(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	rcvrCfg := receiverConfig{
-		id:         component.NewIDWithName("with.endpoint", "some.name"),
+		id:         component.MustNewIDWithName("with.endpoint", "some.name"),
 		config:     userConfigMap{"endpoint": "some.endpoint"},
 		endpointID: portEndpoint.ID,
 	}
@@ -387,7 +387,7 @@ func TestOnRemoveForLogs(t *testing.T) {
 func TestOnChange(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	rcvrCfg := receiverConfig{
-		id:         component.NewIDWithName("with.endpoint", "some.name"),
+		id:         component.MustNewIDWithName("with.endpoint", "some.name"),
 		config:     userConfigMap{"endpoint": "some.endpoint"},
 		endpointID: portEndpoint.ID,
 	}
@@ -478,7 +478,7 @@ func newMockRunner(t *testing.T) *mockRunner {
 	return &mockRunner{
 		receiverRunner: receiverRunner{
 			params:      cs,
-			idNamespace: component.NewIDWithName("some.type", "some.name"),
+			idNamespace: component.MustNewIDWithName("some.type", "some.name"),
 			host:        newMockHost(t, componenttest.NewNopHost()),
 		},
 	}
@@ -491,7 +491,7 @@ func newObserverHandler(
 	nextTraces consumer.Traces,
 ) (*observerHandler, *mockRunner) {
 	set := receivertest.NewNopCreateSettings()
-	set.ID = component.NewIDWithName("some.type", "some.name")
+	set.ID = component.MustNewIDWithName("some.type", "some.name")
 	mr := newMockRunner(t)
 	return &observerHandler{
 		params:                set,

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -30,7 +30,7 @@ func TestOnAddForMetrics(t *testing.T) {
 	}{
 		{
 			name:                   "dynamically set with supported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 12345678},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -40,7 +40,7 @@ func TestOnAddForMetrics(t *testing.T) {
 		},
 		{
 			name:                   "inherits supported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "some.endpoint"},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -50,7 +50,7 @@ func TestOnAddForMetrics(t *testing.T) {
 		},
 		{
 			name:                   "not dynamically set with unsupported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 23456789, "not_endpoint": "not.an.endpoint"},
 			expectedReceiverType:   &nopWithoutEndpointReceiver{},
 			expectedReceiverConfig: &nopWithoutEndpointConfig{
@@ -60,9 +60,9 @@ func TestOnAddForMetrics(t *testing.T) {
 		},
 		{
 			name:                   "inherits unsupported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "unsupported.endpoint"},
-			expectedError:          "failed to load \"without.endpoint/some.name\" template config: 1 error(s) decoding:\n\n* '' has invalid keys: endpoint",
+			expectedError:          "failed to load \"without_endpoint/some.name\" template config: 1 error(s) decoding:\n\n* '' has invalid keys: endpoint",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -132,7 +132,7 @@ func TestOnAddForLogs(t *testing.T) {
 	}{
 		{
 			name:                   "dynamically set with supported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 12345678},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -142,7 +142,7 @@ func TestOnAddForLogs(t *testing.T) {
 		},
 		{
 			name:                   "inherits supported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "some.endpoint"},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -152,7 +152,7 @@ func TestOnAddForLogs(t *testing.T) {
 		},
 		{
 			name:                   "not dynamically set with unsupported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 23456789, "not_endpoint": "not.an.endpoint"},
 			expectedReceiverType:   &nopWithoutEndpointReceiver{},
 			expectedReceiverConfig: &nopWithoutEndpointConfig{
@@ -162,9 +162,9 @@ func TestOnAddForLogs(t *testing.T) {
 		},
 		{
 			name:                   "inherits unsupported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "unsupported.endpoint"},
-			expectedError:          "failed to load \"without.endpoint/some.name\" template config: 1 error(s) decoding:\n\n* '' has invalid keys: endpoint",
+			expectedError:          "failed to load \"without_endpoint/some.name\" template config: 1 error(s) decoding:\n\n* '' has invalid keys: endpoint",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -234,7 +234,7 @@ func TestOnAddForTraces(t *testing.T) {
 	}{
 		{
 			name:                   "dynamically set with supported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 12345678},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -244,7 +244,7 @@ func TestOnAddForTraces(t *testing.T) {
 		},
 		{
 			name:                   "inherits supported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("with.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("with_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "some.endpoint"},
 			expectedReceiverType:   &nopWithEndpointReceiver{},
 			expectedReceiverConfig: &nopWithEndpointConfig{
@@ -254,7 +254,7 @@ func TestOnAddForTraces(t *testing.T) {
 		},
 		{
 			name:                   "not dynamically set with unsupported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"int_field": 23456789, "not_endpoint": "not.an.endpoint"},
 			expectedReceiverType:   &nopWithoutEndpointReceiver{},
 			expectedReceiverConfig: &nopWithoutEndpointConfig{
@@ -264,9 +264,9 @@ func TestOnAddForTraces(t *testing.T) {
 		},
 		{
 			name:                   "inherits unsupported endpoint",
-			receiverTemplateID:     component.MustNewIDWithName("without.endpoint", "some.name"),
+			receiverTemplateID:     component.MustNewIDWithName("without_endpoint", "some.name"),
 			receiverTemplateConfig: userConfigMap{"endpoint": "unsupported.endpoint"},
-			expectedError:          "failed to load \"without.endpoint/some.name\" template config: 1 error(s) decoding:\n\n* '' has invalid keys: endpoint",
+			expectedError:          "failed to load \"without_endpoint/some.name\" template config: 1 error(s) decoding:\n\n* '' has invalid keys: endpoint",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -329,7 +329,7 @@ func TestOnAddForTraces(t *testing.T) {
 func TestOnRemoveForMetrics(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	rcvrCfg := receiverConfig{
-		id:         component.MustNewIDWithName("with.endpoint", "some.name"),
+		id:         component.MustNewIDWithName("with_endpoint", "some.name"),
 		config:     userConfigMap{"endpoint": "some.endpoint"},
 		endpointID: portEndpoint.ID,
 	}
@@ -358,7 +358,7 @@ func TestOnRemoveForMetrics(t *testing.T) {
 func TestOnRemoveForLogs(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	rcvrCfg := receiverConfig{
-		id:         component.MustNewIDWithName("with.endpoint", "some.name"),
+		id:         component.MustNewIDWithName("with_endpoint", "some.name"),
 		config:     userConfigMap{"endpoint": "some.endpoint"},
 		endpointID: portEndpoint.ID,
 	}
@@ -387,7 +387,7 @@ func TestOnRemoveForLogs(t *testing.T) {
 func TestOnChange(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	rcvrCfg := receiverConfig{
-		id:         component.MustNewIDWithName("with.endpoint", "some.name"),
+		id:         component.MustNewIDWithName("with_endpoint", "some.name"),
 		config:     userConfigMap{"endpoint": "some.endpoint"},
 		endpointID: portEndpoint.ID,
 	}
@@ -450,8 +450,8 @@ type mockHost struct {
 func newMockHost(t *testing.T, host component.Host) *mockHost {
 	factories, err := otelcoltest.NopFactories()
 	require.NoError(t, err)
-	factories.Receivers["with.endpoint"] = &nopWithEndpointFactory{Factory: receivertest.NewNopFactory()}
-	factories.Receivers["without.endpoint"] = &nopWithoutEndpointFactory{Factory: receivertest.NewNopFactory()}
+	factories.Receivers[component.MustNewType("with_endpoint")] = &nopWithEndpointFactory{Factory: receivertest.NewNopFactory()}
+	factories.Receivers[component.MustNewType("without_endpoint")] = &nopWithoutEndpointFactory{Factory: receivertest.NewNopFactory()}
 	return &mockHost{t: t, factories: factories, Host: host}
 }
 
@@ -478,7 +478,7 @@ func newMockRunner(t *testing.T) *mockRunner {
 	return &mockRunner{
 		receiverRunner: receiverRunner{
 			params:      cs,
-			idNamespace: component.MustNewIDWithName("some.type", "some.name"),
+			idNamespace: component.MustNewIDWithName("some_type", "some.name"),
 			host:        newMockHost(t, componenttest.NewNopHost()),
 		},
 	}
@@ -491,7 +491,7 @@ func newObserverHandler(
 	nextTraces consumer.Traces,
 ) (*observerHandler, *mockRunner) {
 	set := receivertest.NewNopCreateSettings()
-	set.ID = component.MustNewIDWithName("some.type", "some.name")
+	set.ID = component.MustNewIDWithName("some_type", "some.name")
 	mr := newMockRunner(t)
 	return &observerHandler{
 		params:                set,

--- a/receiver/receivercreator/receiver_test.go
+++ b/receiver/receivercreator/receiver_test.go
@@ -66,7 +66,7 @@ func TestMockedEndToEnd(t *testing.T) {
 
 	host := &mockHostFactories{Host: componenttest.NewNopHost(), factories: factories}
 	host.extensions = map[component.ID]component.Component{
-		component.NewID("mock_observer"):                      &mockObserver{},
+		component.MustNewID("mock_observer"):                      &mockObserver{},
 		component.NewIDWithName("mock_observer", "with_name"): &mockObserver{},
 	}
 

--- a/receiver/receivercreator/receiver_test.go
+++ b/receiver/receivercreator/receiver_test.go
@@ -67,7 +67,7 @@ func TestMockedEndToEnd(t *testing.T) {
 	host := &mockHostFactories{Host: componenttest.NewNopHost(), factories: factories}
 	host.extensions = map[component.ID]component.Component{
 		component.MustNewID("mock_observer"):                      &mockObserver{},
-		component.NewIDWithName("mock_observer", "with_name"): &mockObserver{},
+		component.MustNewIDWithName("mock_observer", "with_name"): &mockObserver{},
 	}
 
 	cfg := factory.CreateDefaultConfig()

--- a/receiver/receivercreator/runner_test.go
+++ b/receiver/receivercreator/runner_test.go
@@ -68,7 +68,7 @@ func TestValidateSetEndpointFromConfig(t *testing.T) {
 		Endpoint any `mapstructure:"endpoint"`
 	}
 
-	receiverWithEndpoint := receiver.NewFactory("with.endpoint", func() component.Config {
+	receiverWithEndpoint := receiver.NewFactory(component.MustNewType("with_endpoint"), func() component.Config {
 		return &configWithEndpoint{}
 	})
 
@@ -76,7 +76,7 @@ func TestValidateSetEndpointFromConfig(t *testing.T) {
 		NotEndpoint any `mapstructure:"not.endpoint"`
 	}
 
-	receiverWithoutEndpoint := receiver.NewFactory("without.endpoint", func() component.Config {
+	receiverWithoutEndpoint := receiver.NewFactory(component.MustNewType("without_endpoint"), func() component.Config {
 		return &configWithoutEndpoint{}
 	})
 

--- a/receiver/receivercreator/runner_test.go
+++ b/receiver/receivercreator/runner_test.go
@@ -43,7 +43,7 @@ func Test_loadAndCreateMetricsRuntimeReceiver(t *testing.T) {
 	t.Run("test create receiver from loaded config", func(t *testing.T) {
 		recvr, err := run.createMetricsRuntimeReceiver(
 			exampleFactory,
-			component.NewIDWithName("nop", "1/receiver_creator/1{endpoint=\"localhost:12345\"}/endpoint.id"),
+			component.MustNewIDWithName("nop", "1/receiver_creator/1{endpoint=\"localhost:12345\"}/endpoint.id"),
 			loadedConfig,
 			nil)
 		require.NoError(t, err)

--- a/receiver/skywalkingreceiver/skywalking_receiver_test.go
+++ b/receiver/skywalkingreceiver/skywalking_receiver_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	skywalkingReceiver = component.NewIDWithName("skywalking", "receiver_test")
+	skywalkingReceiver = component.MustNewIDWithName("skywalking", "receiver_test")
 )
 
 var traceJSON = []byte(`

--- a/receiver/solacereceiver/factory_test.go
+++ b/receiver/solacereceiver/factory_test.go
@@ -31,7 +31,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 
 	set := receivertest.NewNopCreateSettings()
-	set.ID = component.NewIDWithName("solace", "factory")
+	set.ID = component.MustNewIDWithName("solace", "factory")
 	receiver, err := factory.CreateTracesReceiver(
 		context.Background(),
 		set,
@@ -95,7 +95,7 @@ func TestCreateTracesReceiverBadMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, component.UnmarshalConfig(sub, cfg))
 	set := receivertest.NewNopCreateSettings()
-	set.ID = component.NewIDWithName("solace", "factory")
+	set.ID = component.MustNewIDWithName("solace", "factory")
 	receiver, err := factory.CreateTracesReceiver(
 		context.Background(),
 		set,

--- a/receiver/splunkenterprisereceiver/client_test.go
+++ b/receiver/splunkenterprisereceiver/client_test.go
@@ -37,7 +37,7 @@ func TestClientCreation(t *testing.T) {
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint: "https://localhost:8089",
 			Auth: &configauth.Authentication{
-				AuthenticatorID: component.NewID("basicauth/client"),
+				AuthenticatorID: component.MustNewID("basicauth/client"),
 			},
 		},
 		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
@@ -49,7 +49,7 @@ func TestClientCreation(t *testing.T) {
 
 	host := &mockHost{
 		extensions: map[component.ID]component.Component{
-			component.NewID("basicauth/client"): auth.NewClient(),
+			component.MustNewID("basicauth/client"): auth.NewClient(),
 		},
 	}
 	// create a client from an example config
@@ -68,7 +68,7 @@ func TestClientCreateRequest(t *testing.T) {
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint: "https://localhost:8089",
 			Auth: &configauth.Authentication{
-				AuthenticatorID: component.NewID("basicauth/client"),
+				AuthenticatorID: component.MustNewID("basicauth/client"),
 			},
 		},
 		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
@@ -80,7 +80,7 @@ func TestClientCreateRequest(t *testing.T) {
 
 	host := &mockHost{
 		extensions: map[component.ID]component.Component{
-			component.NewID("basicauth/client"): auth.NewClient(),
+			component.MustNewID("basicauth/client"): auth.NewClient(),
 		},
 	}
 	// create a client from an example config
@@ -150,7 +150,7 @@ func TestAPIRequestCreate(t *testing.T) {
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint: "https://localhost:8089",
 			Auth: &configauth.Authentication{
-				AuthenticatorID: component.NewID("basicauth/client"),
+				AuthenticatorID: component.MustNewID("basicauth/client"),
 			},
 		},
 		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
@@ -162,7 +162,7 @@ func TestAPIRequestCreate(t *testing.T) {
 
 	host := &mockHost{
 		extensions: map[component.ID]component.Component{
-			component.NewID("basicauth/client"): auth.NewClient(),
+			component.MustNewID("basicauth/client"): auth.NewClient(),
 		},
 	}
 	// create a client from an example config

--- a/receiver/splunkenterprisereceiver/client_test.go
+++ b/receiver/splunkenterprisereceiver/client_test.go
@@ -37,7 +37,7 @@ func TestClientCreation(t *testing.T) {
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint: "https://localhost:8089",
 			Auth: &configauth.Authentication{
-				AuthenticatorID: component.MustNewID("basicauth/client"),
+				AuthenticatorID: component.MustNewIDWithName("basicauth", "client"),
 			},
 		},
 		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
@@ -49,7 +49,7 @@ func TestClientCreation(t *testing.T) {
 
 	host := &mockHost{
 		extensions: map[component.ID]component.Component{
-			component.MustNewID("basicauth/client"): auth.NewClient(),
+			component.MustNewIDWithName("basicauth", "client"): auth.NewClient(),
 		},
 	}
 	// create a client from an example config
@@ -68,7 +68,7 @@ func TestClientCreateRequest(t *testing.T) {
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint: "https://localhost:8089",
 			Auth: &configauth.Authentication{
-				AuthenticatorID: component.MustNewID("basicauth/client"),
+				AuthenticatorID: component.MustNewIDWithName("basicauth", "client"),
 			},
 		},
 		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
@@ -80,7 +80,7 @@ func TestClientCreateRequest(t *testing.T) {
 
 	host := &mockHost{
 		extensions: map[component.ID]component.Component{
-			component.MustNewID("basicauth/client"): auth.NewClient(),
+			component.MustNewIDWithName("basicauth", "client"): auth.NewClient(),
 		},
 	}
 	// create a client from an example config
@@ -150,7 +150,7 @@ func TestAPIRequestCreate(t *testing.T) {
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint: "https://localhost:8089",
 			Auth: &configauth.Authentication{
-				AuthenticatorID: component.MustNewID("basicauth/client"),
+				AuthenticatorID: component.MustNewIDWithName("basicauth", "client"),
 			},
 		},
 		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
@@ -162,7 +162,7 @@ func TestAPIRequestCreate(t *testing.T) {
 
 	host := &mockHost{
 		extensions: map[component.ID]component.Component{
-			component.MustNewID("basicauth/client"): auth.NewClient(),
+			component.MustNewIDWithName("basicauth", "client"): auth.NewClient(),
 		},
 	}
 	// create a client from an example config

--- a/receiver/splunkenterprisereceiver/scraper_test.go
+++ b/receiver/splunkenterprisereceiver/scraper_test.go
@@ -87,7 +87,7 @@ func TestScraper(t *testing.T) {
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint: ts.URL,
 			Auth: &configauth.Authentication{
-				AuthenticatorID: component.NewID("basicauth/client"),
+				AuthenticatorID: component.MustNewID("basicauth/client"),
 			},
 		},
 		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
@@ -100,7 +100,7 @@ func TestScraper(t *testing.T) {
 
 	host := &mockHost{
 		extensions: map[component.ID]component.Component{
-			component.NewID("basicauth/client"): auth.NewClient(),
+			component.MustNewID("basicauth/client"): auth.NewClient(),
 		},
 	}
 

--- a/receiver/splunkenterprisereceiver/scraper_test.go
+++ b/receiver/splunkenterprisereceiver/scraper_test.go
@@ -87,7 +87,7 @@ func TestScraper(t *testing.T) {
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint: ts.URL,
 			Auth: &configauth.Authentication{
-				AuthenticatorID: component.MustNewID("basicauth/client"),
+				AuthenticatorID: component.MustNewIDWithName("basicauth", "client"),
 			},
 		},
 		ScraperControllerSettings: scraperhelper.ScraperControllerSettings{
@@ -100,7 +100,7 @@ func TestScraper(t *testing.T) {
 
 	host := &mockHost{
 		extensions: map[component.ID]component.Component{
-			component.MustNewID("basicauth/client"): auth.NewClient(),
+			component.MustNewIDWithName("basicauth", "client"): auth.NewClient(),
 		},
 	}
 

--- a/receiver/sqlqueryreceiver/receiver.go
+++ b/receiver/sqlqueryreceiver/receiver.go
@@ -41,7 +41,7 @@ func createMetricsReceiverFunc(sqlOpenerFunc sqlquery.SQLOpenerFunc, clientProvi
 			if len(query.Metrics) == 0 {
 				continue
 			}
-			id := component.NewIDWithName("sqlqueryreceiver", fmt.Sprintf("query-%d: %s", i, query.SQL))
+			id := component.MustNewIDWithName("sqlqueryreceiver", fmt.Sprintf("query-%d: %s", i, query.SQL))
 			dbProviderFunc := func() (*sql.DB, error) {
 				return sqlOpenerFunc(sqlCfg.Driver, sqlCfg.DataSource)
 			}

--- a/receiver/sshcheckreceiver/internal/configssh/configssh_test.go
+++ b/receiver/sshcheckreceiver/internal/configssh/configssh_test.go
@@ -24,7 +24,7 @@ type mockHost struct {
 func TestAllSSHClientSettings(t *testing.T) {
 	host := &mockHost{
 		ext: map[component.ID]extension.Extension{
-			component.NewID("testauth"): &authtest.MockClient{},
+			component.MustNewID("testauth"): &authtest.MockClient{},
 		},
 	}
 
@@ -127,7 +127,7 @@ func TestAllSSHClientSettings(t *testing.T) {
 func Test_Client_Dial(t *testing.T) {
 	host := &mockHost{
 		ext: map[component.ID]extension.Extension{
-			component.NewID("testauth"): &authtest.MockClient{},
+			component.MustNewID("testauth"): &authtest.MockClient{},
 		},
 	}
 
@@ -201,7 +201,7 @@ func Test_Client_Dial(t *testing.T) {
 func Test_Client_ToSFTPClient(t *testing.T) {
 	host := &mockHost{
 		ext: map[component.ID]extension.Extension{
-			component.NewID("testauth"): &authtest.MockClient{},
+			component.MustNewID("testauth"): &authtest.MockClient{},
 		},
 	}
 


### PR DESCRIPTION
**Description:** 

Runs the following commands:

- `rg "component.NewID\(\".*?\"\)" -l | xargs sd 'component.NewID\((".*?")\)' 'component.MustNewID($1)'`
- `rg "component.NewIDWithName\(\".*?\"" -l | xargs sd 'component.NewIDWithName\((".*?")' 'component. MustNewIDWithName($1'`

Additionally, makes some manual fixes

Needed for open-telemetry/opentelemetry-collector/pull/9472

**Link to tracking Issue:** open-telemetry/opentelemetry-collector/issues/9208
