### PR TITLE
Add connection pooling

### DIFF
--- a/.chloggen/receiver-postgresql-connection-pool.yaml
+++ b/.chloggen/receiver-postgresql-connection-pool.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: postgresqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `receiver.postgresql.connectionPool` feature gate to reuse database connections"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30831]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The default implementation recreates and closes connections on each scrape per database configured/discovered.
+  This change offers a feature gated alternative to keep connections open. Also, it exposes connection configuration to control the behavior of the pool.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/postgresqlreceiver/README.md
+++ b/receiver/postgresqlreceiver/README.md
@@ -74,6 +74,36 @@ receivers:
 
 The full list of settings exposed for this receiver are documented [here](./config.go) with detailed sample configurations [here](./testdata/config.yaml). TLS config is documented further under the [opentelemetry collector's configtls package](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md).
 
+## Connection pool feature
+
+The feature gate `receiver.postgresql.connectionPool` allows to enable the creation & reuse of a pool per database for the connections instead of creating & closing on each scrape.
+This is generally a useful optimization but also alleviates the volume of generated audit logs when the PostgreSQL instance is configured with `log_connections=on` and/or `log_disconnections=on`.
+
+When this feature gate is enabled, the following optional settings are available nested under `connection_pool` to help configure the connection pools:
+
+- `max_idle_time`: The maximum amount of time a connection may be idle before being closed.
+- `max_lifetime`: The maximum amount of time a connection may be reused.
+- `max_idle`: The maximum number of connections in the idle connection pool.
+- `max_open`: The maximum number of open connections to the database.
+
+Those settings and their defaults are further documented in the `sql/database` package [here](https://pkg.go.dev/database/sql#DB).
+
+### Example Configuration
+
+```yaml
+receivers:
+  postgresql:
+    endpoint: localhost:5432
+    transport: tcp
+    username: otel
+    password: ${env:POSTGRESQL_PASSWORD}
+    connection_pool:
+      max_idle_time: 10m
+      max_lifetime: 0
+      max_idle: 2
+      max_open: 5
+```
+
 ## Metrics
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lib/pq"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/featuregate"
@@ -60,8 +59,8 @@ type client interface {
 }
 
 type postgreSQLClient struct {
-	client   *sql.DB
-	database string
+	client  *sql.DB
+	closeFn func() error
 }
 
 var _ client = (*postgreSQLClient)(nil)
@@ -102,41 +101,32 @@ func sslConnectionString(tls configtls.TLSClientSetting) string {
 	return conn
 }
 
-func newPostgreSQLClient(conf postgreSQLConfig) (*postgreSQLClient, error) {
+func (c postgreSQLConfig) ConnectionString() (string, error) {
 	// postgres will assume the supplied user as the database name if none is provided,
-	// so we must specify a databse name even when we are just collecting the list of databases.
-	dbField := "dbname=postgres"
-	if conf.database != "" {
-		dbField = fmt.Sprintf("dbname=%s ", conf.database)
+	// so we must specify a database name even when we are just collecting the list of databases.
+	database := defaultPostgreSQLDatabase
+	if c.database != "" {
+		database = c.database
 	}
 
-	host, port, err := net.SplitHostPort(conf.address.Endpoint)
+	host, port, err := net.SplitHostPort(c.address.Endpoint)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	if conf.address.Transport == "unix" {
+	if c.address.Transport == "unix" {
 		// lib/pg expects a unix socket host to start with a "/" and appends the appropriate .s.PGSQL.port internally
 		host = fmt.Sprintf("/%s", host)
 	}
 
-	connStr := fmt.Sprintf("port=%s host=%s user=%s password=%s %s %s", port, host, conf.username, conf.password, dbField, sslConnectionString(conf.tls))
-
-	conn, err := pq.NewConnector(connStr)
-	if err != nil {
-		return nil, err
-	}
-
-	db := sql.OpenDB(conn)
-
-	return &postgreSQLClient{
-		client:   db,
-		database: conf.database,
-	}, nil
+	return fmt.Sprintf("port=%s host=%s user=%s password=%s dbname=%s %s", port, host, c.username, c.password, database, sslConnectionString(c.tls)), nil
 }
 
 func (c *postgreSQLClient) Close() error {
-	return c.client.Close()
+	if c.closeFn != nil {
+		return c.closeFn()
+	}
+	return nil
 }
 
 type databaseStats struct {

--- a/receiver/postgresqlreceiver/client_factory.go
+++ b/receiver/postgresqlreceiver/client_factory.go
@@ -1,0 +1,155 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package postgresqlreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver"
+
+import (
+	"database/sql"
+	"sync"
+
+	"github.com/lib/pq"
+	"go.opentelemetry.io/collector/featuregate"
+	"go.uber.org/multierr"
+)
+
+const connectionPoolGateID = "receiver.postgresql.connectionPool"
+
+var (
+	connectionPoolGate = featuregate.GlobalRegistry().MustRegister(
+		connectionPoolGateID,
+		featuregate.StageAlpha,
+		featuregate.WithRegisterDescription("Use of connection pooling"),
+		featuregate.WithRegisterFromVersion("0.96.0"),
+		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30831"),
+	)
+)
+
+type postgreSQLClientFactory interface {
+	getClient(database string) (client, error)
+	close() error
+}
+
+// defaultClientFactory creates one PG connection per call
+type defaultClientFactory struct {
+	baseConfig postgreSQLConfig
+}
+
+func newDefaultClientFactory(cfg *Config) *defaultClientFactory {
+	return &defaultClientFactory{
+		baseConfig: postgreSQLConfig{
+			username: cfg.Username,
+			password: string(cfg.Password),
+			address:  cfg.AddrConfig,
+			tls:      cfg.TLSClientSetting,
+		},
+	}
+}
+
+func (d *defaultClientFactory) getClient(database string) (client, error) {
+	db, err := getDB(d.baseConfig, database)
+	if err != nil {
+		return nil, err
+	}
+	return &postgreSQLClient{client: db, closeFn: db.Close}, nil
+}
+
+func (d *defaultClientFactory) close() error {
+	return nil
+}
+
+// poolClientFactory creates one PG connection per database, keeping a pool of connections
+type poolClientFactory struct {
+	sync.Mutex
+	baseConfig postgreSQLConfig
+	poolConfig *ConnectionPool
+	pool       map[string]*sql.DB
+	closed     bool
+}
+
+func newPoolClientFactory(cfg *Config) *poolClientFactory {
+	poolCfg := cfg.ConnectionPool
+	return &poolClientFactory{
+		baseConfig: postgreSQLConfig{
+			username: cfg.Username,
+			password: string(cfg.Password),
+			address:  cfg.AddrConfig,
+			tls:      cfg.TLSClientSetting,
+		},
+		poolConfig: &poolCfg,
+		pool:       make(map[string]*sql.DB),
+		closed:     false,
+	}
+}
+
+func (p *poolClientFactory) getClient(database string) (client, error) {
+	p.Lock()
+	defer p.Unlock()
+	db, ok := p.pool[database]
+	if !ok {
+		var err error
+		db, err = getDB(p.baseConfig, database)
+		p.setPoolSettings(db)
+		if err != nil {
+			return nil, err
+		}
+		p.pool[database] = db
+	}
+	return &postgreSQLClient{client: db, closeFn: nil}, nil
+}
+
+func (p *poolClientFactory) close() error {
+	p.Lock()
+	defer p.Unlock()
+
+	if p.closed {
+		return nil
+	}
+
+	if p.pool != nil {
+		var err error
+		for _, db := range p.pool {
+			if closeErr := db.Close(); closeErr != nil {
+				err = multierr.Append(err, closeErr)
+			}
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	p.closed = true
+	return nil
+}
+
+func (p *poolClientFactory) setPoolSettings(db *sql.DB) {
+	if p.poolConfig == nil {
+		return
+	}
+	if p.poolConfig.MaxIdleTime != nil {
+		db.SetConnMaxIdleTime(*p.poolConfig.MaxIdleTime)
+	}
+	if p.poolConfig.MaxLifetime != nil {
+		db.SetConnMaxLifetime(*p.poolConfig.MaxLifetime)
+	}
+	if p.poolConfig.MaxIdle != nil {
+		db.SetMaxIdleConns(*p.poolConfig.MaxIdle)
+	}
+	if p.poolConfig.MaxOpen != nil {
+		db.SetMaxOpenConns(*p.poolConfig.MaxOpen)
+	}
+}
+
+func getDB(cfg postgreSQLConfig, database string) (*sql.DB, error) {
+	if database != "" {
+		cfg.database = database
+	}
+	connectionString, err := cfg.ConnectionString()
+	if err != nil {
+		return nil, err
+	}
+	conn, err := pq.NewConnector(connectionString)
+	if err != nil {
+		return nil, err
+	}
+	return sql.OpenDB(conn), nil
+}

--- a/receiver/postgresqlreceiver/config.go
+++ b/receiver/postgresqlreceiver/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configopaque"
@@ -34,7 +35,15 @@ type Config struct {
 	ExcludeDatabases                        []string                       `mapstructure:"exclude_databases"`
 	confignet.AddrConfig                    `mapstructure:",squash"`       // provides Endpoint and Transport
 	configtls.TLSClientSetting              `mapstructure:"tls,omitempty"` // provides SSL details
+	ConnectionPool                          `mapstructure:"connection_pool,omitempty"`
 	metadata.MetricsBuilderConfig           `mapstructure:",squash"`
+}
+
+type ConnectionPool struct {
+	MaxIdleTime *time.Duration `mapstructure:"max_idle_time,omitempty"`
+	MaxLifetime *time.Duration `mapstructure:"max_lifetime,omitempty"`
+	MaxIdle     *int           `mapstructure:"max_idle,omitempty"`
+	MaxOpen     *int           `mapstructure:"max_open,omitempty"`
 }
 
 func (cfg *Config) Validate() error {

--- a/receiver/postgresqlreceiver/factory.go
+++ b/receiver/postgresqlreceiver/factory.go
@@ -50,8 +50,15 @@ func createMetricsReceiver(
 ) (receiver.Metrics, error) {
 	cfg := rConf.(*Config)
 
-	ns := newPostgreSQLScraper(params, cfg, &defaultClientFactory{})
-	scraper, err := scraperhelper.NewScraper(metadata.Type.String(), ns.scrape)
+	var clientFactory postgreSQLClientFactory
+	if connectionPoolGate.IsEnabled() {
+		clientFactory = newPoolClientFactory(cfg)
+	} else {
+		clientFactory = newDefaultClientFactory(cfg)
+	}
+
+	ns := newPostgreSQLScraper(params, cfg, clientFactory)
+	scraper, err := scraperhelper.NewScraper(metadata.Type.String(), ns.scrape, scraperhelper.WithShutdown(ns.shutdown))
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/postgresqlreceiver/integration_test.go
+++ b/receiver/postgresqlreceiver/integration_test.go
@@ -24,6 +24,7 @@ const postgresqlPort = "5432"
 
 func TestIntegration(t *testing.T) {
 	defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, false)()
+	defer testutil.SetFeatureGateForTest(t, connectionPoolGate, false)()
 	t.Run("single_db", integrationTest("single_db", []string{"otel"}))
 	t.Run("multi_db", integrationTest("multi_db", []string{"otel", "otel2"}))
 	t.Run("all_db", integrationTest("all_db", []string{}))
@@ -31,9 +32,18 @@ func TestIntegration(t *testing.T) {
 
 func TestIntegrationWithSeparateSchemaAttr(t *testing.T) {
 	defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, true)()
+	defer testutil.SetFeatureGateForTest(t, connectionPoolGate, false)()
 	t.Run("single_db_schemaattr", integrationTest("single_db_schemaattr", []string{"otel"}))
 	t.Run("multi_db_schemaattr", integrationTest("multi_db_schemaattr", []string{"otel", "otel2"}))
 	t.Run("all_db_schemaattr", integrationTest("all_db_schemaattr", []string{}))
+}
+
+func TestIntegrationWithConnectionPool(t *testing.T) {
+	defer testutil.SetFeatureGateForTest(t, separateSchemaAttrGate, false)()
+	defer testutil.SetFeatureGateForTest(t, connectionPoolGate, true)()
+	t.Run("single_db_connpool", integrationTest("single_db_connpool", []string{"otel"}))
+	t.Run("multi_db_connpool", integrationTest("multi_db_connpool", []string{"otel", "otel2"}))
+	t.Run("all_db_connpool", integrationTest("all_db_connpool", []string{}))
 }
 
 func integrationTest(name string, databases []string) func(*testing.T) {

--- a/receiver/postgresqlreceiver/scraper.go
+++ b/receiver/postgresqlreceiver/scraper.go
@@ -23,6 +23,8 @@ import (
 const (
 	readmeURL            = "https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.88.0/receiver/postgresqlreceiver/README.md"
 	separateSchemaAttrID = "receiver.postgresql.separateSchemaAttr"
+
+	defaultPostgreSQLDatabase = "postgres"
 )
 
 var (
@@ -68,22 +70,6 @@ func (e *errsMux) combine() error {
 	return e.errs.Combine()
 }
 
-type postgreSQLClientFactory interface {
-	getClient(c *Config, database string) (client, error)
-}
-
-type defaultClientFactory struct{}
-
-func (d *defaultClientFactory) getClient(c *Config, database string) (client, error) {
-	return newPostgreSQLClient(postgreSQLConfig{
-		username: c.Username,
-		password: string(c.Password),
-		database: database,
-		tls:      c.TLSClientSetting,
-		address:  c.AddrConfig,
-	})
-}
-
 func newPostgreSQLScraper(
 	settings receiver.CreateSettings,
 	config *Config,
@@ -122,7 +108,7 @@ type dbRetrieval struct {
 // scrape scrapes the metric stats, transforms them and attributes them into a metric slices.
 func (p *postgreSQLScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	databases := p.config.Databases
-	listClient, err := p.clientFactory.getClient(p.config, "")
+	listClient, err := p.clientFactory.getClient(defaultPostgreSQLDatabase)
 	if err != nil {
 		p.logger.Error("Failed to initialize connection to postgres", zap.Error(err))
 		return pmetric.NewMetrics(), err
@@ -130,10 +116,10 @@ func (p *postgreSQLScraper) scrape(ctx context.Context) (pmetric.Metrics, error)
 	defer listClient.Close()
 
 	if len(databases) == 0 {
-		dbList, err := listClient.listDatabases(ctx)
-		if err != nil {
-			p.logger.Error("Failed to request list of databases from postgres", zap.Error(err))
-			return pmetric.NewMetrics(), err
+		dbList, dbErr := listClient.listDatabases(ctx)
+		if dbErr != nil {
+			p.logger.Error("Failed to request list of databases from postgres", zap.Error(dbErr))
+			return pmetric.NewMetrics(), dbErr
 		}
 		databases = dbList
 	}
@@ -156,10 +142,10 @@ func (p *postgreSQLScraper) scrape(ctx context.Context) (pmetric.Metrics, error)
 	p.retrieveDBMetrics(ctx, listClient, databases, r, &errs)
 
 	for _, database := range databases {
-		dbClient, err := p.clientFactory.getClient(p.config, database)
-		if err != nil {
-			errs.add(err)
-			p.logger.Error("Failed to initialize connection to postgres", zap.String("database", database), zap.Error(err))
+		dbClient, dbErr := p.clientFactory.getClient(database)
+		if dbErr != nil {
+			errs.add(dbErr)
+			p.logger.Error("Failed to initialize connection to postgres", zap.String("database", database), zap.Error(dbErr))
 			continue
 		}
 		defer dbClient.Close()
@@ -177,6 +163,13 @@ func (p *postgreSQLScraper) scrape(ctx context.Context) (pmetric.Metrics, error)
 	p.collectDatabaseLocks(ctx, now, listClient, &errs)
 
 	return p.mb.Emit(), errs.combine()
+}
+
+func (p *postgreSQLScraper) shutdown(_ context.Context) error {
+	if p.clientFactory != nil {
+		p.clientFactory.close()
+	}
+	return nil
 }
 
 func (p *postgreSQLScraper) retrieveDBMetrics(

--- a/receiver/postgresqlreceiver/testdata/config.yaml
+++ b/receiver/postgresqlreceiver/testdata/config.yaml
@@ -1,7 +1,15 @@
-postgresql:
+postgresql/minimal:
   endpoint: localhost:5432
   username: otel
   password: ${env:POSTGRESQL_PASSWORD}
+postgresql/pool:
+  endpoint: localhost:5432
+  transport: tcp
+  username: otel
+  password: ${env:POSTGRESQL_PASSWORD}
+  connection_pool:
+    max_idle_time: 30s
+    max_idle: 5
 postgresql/all:
   endpoint: localhost:5432
   transport: tcp
@@ -18,3 +26,8 @@ postgresql/all:
     ca_file: /home/otel/authorities.crt
     cert_file: /home/otel/mypostgrescert.crt
     key_file: /home/otel/mypostgreskey.key
+  connection_pool:
+    max_idle_time: 30s
+    max_lifetime: 1m
+    max_idle: 5
+    max_open: 10

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_db_connpool.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_db_connpool.yaml
@@ -1,0 +1,1266 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: postgres
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "705"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7248408"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{deadlock}'
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "58"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{temp_file}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: public.table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{sequential_scan}'
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: public.table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{sequential_scan}'
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "181"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7305752"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{deadlock}'
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{temp_file}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+        - key: postgresql.index.name
+          value:
+            stringValue: table1_pkey
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+        - key: postgresql.index.name
+          value:
+            stringValue: table2_pkey
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: public.test2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "1"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "4"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "2"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{sequential_scan}'
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: public.test1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{sequential_scan}'
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "182"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7346712"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{deadlock}'
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{temp_file}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: test1
+        - key: postgresql.index.name
+          value:
+            stringValue: test1_pkey
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: test2
+        - key: postgresql.index.name
+          value:
+            stringValue: test2_pkey
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "16384"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: test1
+        - key: postgresql.index.name
+          value:
+            stringValue: otelindex
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: test2
+        - key: postgresql.index.name
+          value:
+            stringValue: otel2index
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "16384"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - description: Number of buffers allocated.
+            name: postgresql.bgwriter.buffers.allocated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "964"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: Number of buffers written.
+            name: postgresql.bgwriter.buffers.writes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "60"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: The number of checkpoints performed.
+            name: postgresql.bgwriter.checkpoint.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: requested
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "0"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: scheduled
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: '{checkpoints}'
+          - description: Total time spent writing and syncing files to disk by checkpoints.
+            name: postgresql.bgwriter.duration
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 9
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asDouble: 6
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: ms
+          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+            name: postgresql.bgwriter.maxwritten
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+              isMonotonic: true
+            unit: "1"
+          - description: Configured maximum number of client connections allowed
+            gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            name: postgresql.connection.max
+            unit: '{connections}'
+          - description: Number of user databases.
+            name: postgresql.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            unit: '{databases}'
+          - description: The number of database locks.
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_relname_nsp_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_tblspc_relfilenode_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_locks
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_oid_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802467703361527"
+                  timeUnixNano: "1706802526712082422"
+            name: postgresql.database.locks
+            unit: '{lock}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_connpool.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_connpool.yaml
@@ -1,0 +1,1189 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: public.table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{sequential_scan}'
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: public.table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{sequential_scan}'
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "181"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7297560"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{deadlock}'
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{temp_file}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+        - key: postgresql.index.name
+          value:
+            stringValue: table2_pkey
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+        - key: postgresql.index.name
+          value:
+            stringValue: table1_pkey
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: public.test2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "1"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "4"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "2"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{sequential_scan}'
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: public.test1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{sequential_scan}'
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "182"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7338520"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{deadlock}'
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{temp_file}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: test2
+        - key: postgresql.index.name
+          value:
+            stringValue: otel2index
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "16384"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: test1
+        - key: postgresql.index.name
+          value:
+            stringValue: test1_pkey
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: test2
+        - key: postgresql.index.name
+          value:
+            stringValue: test2_pkey
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "16384"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel2
+        - key: postgresql.table.name
+          value:
+            stringValue: test1
+        - key: postgresql.index.name
+          value:
+            stringValue: otelindex
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - description: Number of buffers allocated.
+            name: postgresql.bgwriter.buffers.allocated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "766"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: Number of buffers written.
+            name: postgresql.bgwriter.buffers.writes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "60"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: The number of checkpoints performed.
+            name: postgresql.bgwriter.checkpoint.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: requested
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "0"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: scheduled
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: '{checkpoints}'
+          - description: Total time spent writing and syncing files to disk by checkpoints.
+            name: postgresql.bgwriter.duration
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 9
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asDouble: 6
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: ms
+          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+            name: postgresql.bgwriter.maxwritten
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+              isMonotonic: true
+            unit: "1"
+          - description: Configured maximum number of client connections allowed
+            gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            name: postgresql.connection.max
+            unit: '{connections}'
+          - description: Number of user databases.
+            name: postgresql.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            unit: '{databases}'
+          - description: The number of database locks.
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_relname_nsp_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_tblspc_relfilenode_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_locks
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_oid_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802402706723341"
+                  timeUnixNano: "1706802461712893428"
+            name: postgresql.database.locks
+            unit: '{lock}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_single_db_connpool.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_single_db_connpool.yaml
@@ -1,0 +1,656 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: public.table2
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: '{sequential_scan}'
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: public.table1
+    scopeMetrics:
+      - metrics:
+          - description: The number of blocks read.
+            name: postgresql.blocks_read
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_read
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: heap_hit
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_read
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: idx_hit
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_hit
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: toast_read
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_read
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: tidx_hit
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of db row operations.
+            name: postgresql.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: ins
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: del
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: upd
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: hot_upd
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: "1"
+          - description: The number of rows in the database.
+            name: postgresql.rows
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: dead
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: live
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            unit: "1"
+          - description: The number of sequential scans.
+            name: postgresql.sequential_scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: '{sequential_scan}'
+          - description: Disk space used by a table.
+            name: postgresql.table.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            unit: By
+          - description: Number of times a table has manually been vacuumed.
+            name: postgresql.table.vacuum.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: '{vacuums}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+    scopeMetrics:
+      - metrics:
+          - description: The number of backends.
+            name: postgresql.backends
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            unit: "1"
+          - description: The number of commits.
+            name: postgresql.commits
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "181"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: "1"
+          - description: The database disk usage.
+            name: postgresql.db_size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7305752"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            unit: By
+          - description: The number of deadlocks.
+            name: postgresql.deadlocks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: '{deadlock}'
+          - description: The number of rollbacks.
+            name: postgresql.rollbacks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: "1"
+          - description: Number of user tables in a database.
+            name: postgresql.table.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            unit: '{table}'
+          - description: The number of temp files.
+            name: postgresql.temp_files
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: '{temp_file}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: table1
+        - key: postgresql.index.name
+          value:
+            stringValue: table1_pkey
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: postgresql.database.name
+          value:
+            stringValue: otel
+        - key: postgresql.table.name
+          value:
+            stringValue: table2
+        - key: postgresql.index.name
+          value:
+            stringValue: table2_pkey
+    scopeMetrics:
+      - metrics:
+          - description: The number of index scans on a table.
+            name: postgresql.index.scans
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: '{scans}'
+          - description: The size of the index on disk.
+            gauge:
+              dataPoints:
+                - asInt: "8192"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            name: postgresql.index.size
+            unit: By
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - description: Number of buffers allocated.
+            name: postgresql.bgwriter.buffers.allocated
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "841"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: Number of buffers written.
+            name: postgresql.bgwriter.buffers.writes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: bgwriter
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "5"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "60"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: checkpoints
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: source
+                      value:
+                        stringValue: backend_fsync
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: '{buffers}'
+          - description: The number of checkpoints performed.
+            name: postgresql.bgwriter.checkpoint.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: requested
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "0"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: scheduled
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: '{checkpoints}'
+          - description: Total time spent writing and syncing files to disk by checkpoints.
+            name: postgresql.bgwriter.duration
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 12
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: sync
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asDouble: 7
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: ms
+          - description: Number of times the background writer stopped a cleaning scan because it had written too many buffers.
+            name: postgresql.bgwriter.maxwritten
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+              isMonotonic: true
+            unit: "1"
+          - description: Configured maximum number of client connections allowed
+            gauge:
+              dataPoints:
+                - asInt: "100"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            name: postgresql.connection.max
+            unit: '{connections}'
+          - description: Number of user databases.
+            name: postgresql.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            unit: '{databases}'
+          - description: The number of database locks.
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_relname_nsp_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_tblspc_relfilenode_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_locks
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+                - asInt: "1"
+                  attributes:
+                    - key: relation
+                      value:
+                        stringValue: pg_class_oid_index
+                    - key: mode
+                      value:
+                        stringValue: AccessShareLock
+                    - key: lock_type
+                      value:
+                        stringValue: relation
+                  startTimeUnixNano: "1706802337738657906"
+                  timeUnixNano: "1706802396744882628"
+            name: postgresql.database.locks
+            unit: '{lock}'
+        scope:
+          name: otelcol/postgresqlreceiver
+          version: latest


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Reuse of connections created per database (configured or discovered) vs current behavior to create & close connection per database on each scrape.

**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30831

**Testing:** 
Updated unit & integration tests. Also, ran locally multiple scenario:
- no feature gate specified (default): current behavior maintained, connections created/closed on each database per scrape
- feature gate connection pool enabled, no connection pool config specified (default): reduction of the number of connections created/closed
- feature gate connection pool enabled, connection pool config tweaked: connections created on first scrape & closed when configured lifetime reached or collector shutdown

**Documentation:**
- change log
- readme for the feature gate & related optional configurations linked to this feature

**Note**
Checking internally for getting the CLA signed