### PR TITLE
[processor/logstransform]: Fix shutdown ordering leading to panic

### DIFF
--- a/.chloggen/fix_log-transform-shutdown.yaml
+++ b/.chloggen/fix_log-transform-shutdown.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: logstransformprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix potential panic on shutdown due to incorrect shutdown order
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31139]

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -114,7 +114,8 @@ func (ltp *logsTransformProcessor) startConverterLoop(ctx context.Context) {
 	go ltp.converterLoop(wg, ctx)
 
 	ltp.shutdownFns = append(ltp.shutdownFns, func(ctx context.Context) error {
-		return waitForWgOrCtx(wg, ctx)
+		wg.Wait()
+		return nil
 	})
 }
 
@@ -145,7 +146,8 @@ func (ltp *logsTransformProcessor) startEmitterLoop(ctx context.Context) {
 	wg.Add(1)
 	go ltp.emitterLoop(wg, ctx)
 	ltp.shutdownFns = append(ltp.shutdownFns, func(ctx context.Context) error {
-		return waitForWgOrCtx(wg, ctx)
+		wg.Wait()
+		return nil
 	})
 }
 
@@ -166,7 +168,8 @@ func (ltp *logsTransformProcessor) startConsumerLoop(ctx context.Context) {
 	wg.Add(1)
 	go ltp.consumerLoop(wg, ctx)
 	ltp.shutdownFns = append(ltp.shutdownFns, func(ctx context.Context) error {
-		return waitForWgOrCtx(wg, ctx)
+		wg.Wait()
+		return nil
 	})
 }
 
@@ -247,20 +250,4 @@ func (ltp *logsTransformProcessor) consumerLoop(wg *sync.WaitGroup, ctx context.
 			}
 		}
 	}
-}
-
-func waitForWgOrCtx(wg *sync.WaitGroup, ctx context.Context) error {
-	doneChan := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(doneChan)
-	}()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-doneChan: // OK
-	}
-
-	return nil
 }

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -78,7 +78,7 @@ func (ltp *logsTransformProcessor) Shutdown(ctx context.Context) error {
 }
 
 func (ltp *logsTransformProcessor) Start(ctx context.Context, _ component.Host) error {
-	// create all objects before starting them, since the consumer loops depend on the converters not being nil.
+	// create all objects before starting them, since the loops (consumerLoop, converterLoop) depend on these converters not being nil.
 	ltp.converter = adapter.NewConverter(ltp.logger)
 
 	wkrCount := int(math.Max(1, float64(runtime.NumCPU())))

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -198,7 +198,7 @@ func generateLogData(messages []testLogMessage) plog.Logs {
 }
 
 // laggy operator is a test operator that simulates heavy processing that takes a large amount of time.
-// The heavey processing only occurs for every 100th log
+// The heavy processing only occurs for every 100th log
 type laggyOperator struct {
 	helper.WriterOperator
 	logsCount int
@@ -280,9 +280,4 @@ func TestProcessorShutdownWithSlowOperator(t *testing.T) {
 
 	err = ltp.Shutdown(context.Background())
 	require.NoError(t, err)
-
-	// We should ensure that all channels are drained and all logs
-	// are put into ConsumeLogs are emitted to the consumer at this point,
-	// but this is not the case right now.
-	// require.Equal(t, 500, tln.LogRecordCount())
 }

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -5,7 +5,6 @@ package logstransformprocessor
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -195,23 +194,4 @@ func generateLogData(messages []testLogMessage) plog.Logs {
 	}
 
 	return ld
-}
-
-func TestWaitForWgOrCtx(t *testing.T) {
-	t.Run("Waitgroup is done, context is not", func(t *testing.T) {
-		wg := &sync.WaitGroup{}
-		err := waitForWgOrCtx(wg, context.Background())
-		require.NoError(t, err)
-	})
-
-	t.Run("Context is done, wait group is not", func(t *testing.T) {
-		wg := &sync.WaitGroup{}
-		wg.Add(1)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		err := waitForWgOrCtx(wg, ctx)
-		require.ErrorIs(t, err, context.Canceled)
-	})
 }

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -206,12 +206,9 @@ type laggyOperator struct {
 
 func (t *laggyOperator) Process(ctx context.Context, e *entry.Entry) error {
 
+	// Wait for a large amount of time every 100 logs
 	if t.logsCount%100 == 0 {
-		select {
-		case <-time.After(100 * time.Millisecond): // OK
-			// case <-ctx.Done(): // operator should return immediately
-			// 	return nil
-		}
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	t.logsCount++

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -5,6 +5,7 @@ package logstransformprocessor
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -194,4 +195,23 @@ func generateLogData(messages []testLogMessage) plog.Logs {
 	}
 
 	return ld
+}
+
+func TestWaitForWgOrCtx(t *testing.T) {
+	t.Run("Waitgroup is done, context is not", func(t *testing.T) {
+		wg := &sync.WaitGroup{}
+		err := waitForWgOrCtx(wg, context.Background())
+		require.NoError(t, err)
+	})
+
+	t.Run("Context is done, wait group is not", func(t *testing.T) {
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := waitForWgOrCtx(wg, ctx)
+		require.ErrorIs(t, err, context.Canceled)
+	})
 }

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/processor/processortest"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/plogtest"
@@ -194,4 +195,97 @@ func generateLogData(messages []testLogMessage) plog.Logs {
 	}
 
 	return ld
+}
+
+// laggy operator is a test operator that simulates heavy processing that takes a large amount of time.
+// The heavey processing only occurs for every 100th log
+type laggyOperator struct {
+	helper.WriterOperator
+	logsCount int
+}
+
+func (t *laggyOperator) Process(ctx context.Context, e *entry.Entry) error {
+
+	if t.logsCount%100 == 0 {
+		select {
+		case <-time.After(100 * time.Millisecond): // OK
+			// case <-ctx.Done(): // operator should return immediately
+			// 	return nil
+		}
+	}
+
+	t.logsCount++
+
+	t.Write(ctx, e)
+	return nil
+}
+
+func (t *laggyOperator) CanProcess() bool {
+	return true
+}
+
+type laggyOperatorConfig struct {
+	helper.WriterConfig
+}
+
+func (l *laggyOperatorConfig) Build(s *zap.SugaredLogger) (operator.Operator, error) {
+	wo, err := l.WriterConfig.Build(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &laggyOperator{
+		WriterOperator: wo,
+	}, nil
+}
+
+func TestProcessorShutdownWithSlowOperator(t *testing.T) {
+	operator.Register("laggy", func() operator.Builder { return &laggyOperatorConfig{} })
+
+	config := &Config{
+		BaseConfig: adapter.BaseConfig{
+			Operators: []operator.Config{
+				{
+					Builder: func() *laggyOperatorConfig {
+						l := &laggyOperatorConfig{}
+						l.OperatorType = "laggy"
+						return l
+					}(),
+				},
+			},
+		},
+	}
+
+	tln := new(consumertest.LogsSink)
+	factory := NewFactory()
+	ltp, err := factory.CreateLogsProcessor(context.Background(), processortest.NewNopCreateSettings(), config, tln)
+	require.NoError(t, err)
+	assert.True(t, ltp.Capabilities().MutatesData)
+
+	err = ltp.Start(context.Background(), nil)
+	require.NoError(t, err)
+
+	testLog := plog.NewLogs()
+	scopeLogs := testLog.ResourceLogs().AppendEmpty().
+		ScopeLogs().AppendEmpty()
+
+	for i := 0; i < 500; i++ {
+		lr := scopeLogs.LogRecords().AppendEmpty()
+		lr.Body().SetStr("Test message")
+	}
+
+	// The idea is to check that shutdown, when there are a lot of entries, doesn't try to write logs to
+	// a closed channel, since that'll cause a panic.
+	// In order to test, we send a lot of logs to be consumed, then shutdown immediately.
+
+	err = ltp.ConsumeLogs(context.Background(), testLog)
+	require.NoError(t, err)
+
+	err = ltp.Shutdown(context.Background())
+	require.NoError(t, err)
+
+	// We should ensure that all channels are drained and all logs
+	// are put into ConsumeLogs are emitted to the consumer at this point,
+	// but this is not the case right now.
+	// require.Equal(t, 500, tln.LogRecordCount())
 }


### PR DESCRIPTION
**Description:**
* re-order how we start and stop the different goroutines in the logstransform processor

The idea is, we start the goroutines from the consumer end up to the producer end, then shut them down in reverse order. This is similar to how stanza itself starts and stops it's operators, for instance (starts in reverse topological order, stops in topological order).

**Link to tracking Issue:** Closes #31139

**Testing:**
Added a unit test. This unit test regularly fails on the code on main (panics), but works consistently on this branch (I've run it 100 times to makes sure).
```sh
go test -timeout 10m -count=100 -v -run '^TestProcessorShutdownWithSlowOperator$' github.com/open-telemetry/opentelemetry-collector-contrib/processor/logstransformprocessor
```
