### PR TITLE
[chore][extension/jaegarremotesampling] Enable goleak check

### DIFF
--- a/extension/jaegerremotesampling/extension_test.go
+++ b/extension/jaegerremotesampling/extension_test.go
@@ -120,6 +120,7 @@ func TestRemote(t *testing.T) {
 				resp, err := http.Get("http://127.0.0.1:5778/sampling?service=foo")
 				assert.NoError(t, err)
 				assert.Equal(t, 200, resp.StatusCode)
+				assert.NoError(t, resp.Body.Close())
 			}
 
 			// shut down the server
@@ -137,6 +138,8 @@ func TestRemote(t *testing.T) {
 					assert.Equal(t, []string{string(expectedHeaderValue)}, md.Get(expectedHeaderName))
 				}
 			}
+
+			server.Stop()
 		})
 	}
 }

--- a/extension/jaegerremotesampling/extension_test.go
+++ b/extension/jaegerremotesampling/extension_test.go
@@ -94,6 +94,7 @@ func TestRemote(t *testing.T) {
 				err = server.Serve(lis)
 				require.NoError(t, err)
 			}()
+			defer func() { server.Stop() }()
 
 			// create the config, pointing to the mock server
 			cfg := testConfig()
@@ -138,8 +139,6 @@ func TestRemote(t *testing.T) {
 					assert.Equal(t, []string{string(expectedHeaderValue)}, md.Get(expectedHeaderName))
 				}
 			}
-
-			server.Stop()
 		})
 	}
 }

--- a/extension/jaegerremotesampling/go.mod
+++ b/extension/jaegerremotesampling/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.1.0
 	go.opentelemetry.io/otel/metric v1.23.0
 	go.opentelemetry.io/otel/trace v1.23.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.26.0
 	google.golang.org/grpc v1.61.0
 )

--- a/extension/jaegerremotesampling/go.sum
+++ b/extension/jaegerremotesampling/go.sum
@@ -165,6 +165,7 @@ go.opentelemetry.io/otel/sdk/metric v1.23.0/go.mod h1:2LUOToN/FdX6wtfpHybOnCZjoZ
 go.opentelemetry.io/otel/trace v1.23.0 h1:37Ik5Ib7xfYVb4V1UtnT97T1jI+AoIYkJyPkuL4iJgI=
 go.opentelemetry.io/otel/trace v1.23.0/go.mod h1:GSGTbIClEsuZrGIzoEHqsVfxgn5UkggkflQwDScNUsk=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=

--- a/extension/jaegerremotesampling/package_test.go
+++ b/extension/jaegerremotesampling/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package jaegerremotesampling
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This enables `goleak` checks on the `jaegarremotesampling` extension, to help ensure no goroutines are leaking. This is a test only change, a couple close/stop calls were missing.

**Link to tracking Issue:** <Issue number if applicable>
#30438

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, as well as added goleak check.