### PR TITLE
[exporter/datadog][connector/datadog] Add trace config peer_tags

### DIFF
--- a/.chloggen/dd-connector-peer-tags.yaml
+++ b/.chloggen/dd-connector-peer-tags.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a trace config `peer_tags` on supplementary peer tags on APM stats.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31158]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dd-exporter-peer-tags.yaml
+++ b/.chloggen/dd-exporter-peer-tags.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add a trace config `peer_tags` on supplementary peer tags on APM stats.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31158]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/datadogconnector/README.md
+++ b/connector/datadogconnector/README.md
@@ -162,6 +162,12 @@ connectors:
         ## setting a higher `trace_buffer` to avoid traces being dropped.
         #
         # trace_buffer: 1000
+
+        ## @param peer_tags - [BETA] Optional list of supplementary peer tags that go beyond the defaults. The Datadog backend validates all tags
+        ## and will drop ones that are unapproved. The default set of peer tags can be found at
+        ## https://github.com/DataDog/datadog-agent/blob/505170c4ac8c3cbff1a61cf5f84b28d835c91058/pkg/trace/stats/concentrator.go#L55.
+        #
+        # peer_tags: ["tag"]
 ```
 
 **NOTE**: `compute_stats_by_span_kind` and `peer_tags_aggregation` only work when the feature gate `connector.datadogconnector.performance` is enabled. See below for details on this feature gate.

--- a/connector/datadogconnector/config.go
+++ b/connector/datadogconnector/config.go
@@ -55,6 +55,11 @@ type TracesConfig struct {
 	// The default list of peer tags can be found in https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/concentrator.go.
 	PeerTagsAggregation bool `mapstructure:"peer_tags_aggregation"`
 
+	// [BETA] Optional list of supplementary peer tags that go beyond the defaults. The Datadog backend validates all tags
+	// and will drop ones that are unapproved. The default set of peer tags can be found at
+	// https://github.com/DataDog/datadog-agent/blob/505170c4ac8c3cbff1a61cf5f84b28d835c91058/pkg/trace/stats/concentrator.go#L55.
+	PeerTags []string `mapstructure:"peer_tags"`
+
 	// TraceBuffer specifies the number of Datadog Agent TracerPayloads to buffer before dropping.
 	// The default value is 1000.
 	TraceBuffer int `mapstructure:"trace_buffer"`

--- a/connector/datadogconnector/config_test.go
+++ b/connector/datadogconnector/config_test.go
@@ -64,6 +64,12 @@ func TestValidate(t *testing.T) {
 			}},
 			err: "Trace buffer must be non-negative",
 		},
+		{
+			name: "With peer_tags",
+			cfg: &Config{
+				Traces: TracesConfig{PeerTags: []string{"tag1", "tag2"}},
+			},
+		},
 	}
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {

--- a/connector/datadogconnector/connector.go
+++ b/connector/datadogconnector/connector.go
@@ -76,6 +76,7 @@ func getTraceAgentCfg(cfg TracesConfig) *traceconfig.AgentConfig {
 	acfg.Ignore["resource"] = cfg.IgnoreResources
 	acfg.ComputeStatsBySpanKind = cfg.ComputeStatsBySpanKind
 	acfg.PeerTagsAggregation = cfg.PeerTagsAggregation
+	acfg.PeerTags = cfg.PeerTags
 	if v := cfg.TraceBuffer; v > 0 {
 		acfg.TraceBuffer = v
 	}

--- a/connector/datadogconnector/examples/config.yaml
+++ b/connector/datadogconnector/examples/config.yaml
@@ -74,6 +74,12 @@ connectors:
       #
       trace_buffer: 500
 
+      ## @param peer_tags - [BETA] Optional list of supplementary peer tags that go beyond the defaults. The Datadog backend validates all tags
+      ## and will drop ones that are unapproved. The default set of peer tags can be found at
+      ## https://github.com/DataDog/datadog-agent/blob/505170c4ac8c3cbff1a61cf5f84b28d835c91058/pkg/trace/stats/concentrator.go#L55.
+      #
+      peer_tags: ["tag"]
+
 exporters:
   debug:
     verbosity: detailed

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -292,6 +292,11 @@ type TracesConfig struct {
 	// The default list of peer tags can be found in https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/stats/concentrator.go.
 	PeerTagsAggregation bool `mapstructure:"peer_tags_aggregation"`
 
+	// [BETA] Optional list of supplementary peer tags that go beyond the defaults. The Datadog backend validates all tags
+	// and will drop ones that are unapproved. The default set of peer tags can be found at
+	// https://github.com/DataDog/datadog-agent/blob/505170c4ac8c3cbff1a61cf5f84b28d835c91058/pkg/trace/stats/concentrator.go#L55.
+	PeerTags []string `mapstructure:"peer_tags"`
+
 	// TraceBuffer specifies the number of Datadog Agent TracerPayloads to buffer before dropping.
 	// The default value is 0, meaning the Datadog Agent TracerPayloads are unbuffered.
 	TraceBuffer int `mapstructure:"trace_buffer"`

--- a/exporter/datadogexporter/config_test.go
+++ b/exporter/datadogexporter/config_test.go
@@ -108,6 +108,13 @@ func TestValidate(t *testing.T) {
 				Traces: TracesConfig{TraceBuffer: 10},
 			},
 		},
+		{
+			name: "With peer_tags",
+			cfg: &Config{
+				API:    APIConfig{Key: "notnull"},
+				Traces: TracesConfig{PeerTags: []string{"tag1", "tag2"}},
+			},
+		},
 	}
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {

--- a/exporter/datadogexporter/examples/collector.yaml
+++ b/exporter/datadogexporter/examples/collector.yaml
@@ -356,6 +356,12 @@ exporters:
       #
       # peer_tags_aggregation: false
 
+      ## @param peer_tags - [BETA] Optional list of supplementary peer tags that go beyond the defaults. The Datadog backend validates all tags
+      ## and will drop ones that are unapproved. The default set of peer tags can be found at
+      ## https://github.com/DataDog/datadog-agent/blob/505170c4ac8c3cbff1a61cf5f84b28d835c91058/pkg/trace/stats/concentrator.go#L55.
+      #
+      # peer_tags: ["tag"]
+
       ## @param trace_buffer - specifies the number of outgoing trace payloads to buffer before dropping - optional
       ## If unset, the default value is 0, meaning the outgoing trace payloads are unbuffered.
       ## If you start seeing log messages like `Payload in channel full. Dropped 1 payload.` in the datadog exporter, consider

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -200,6 +200,7 @@ func newTraceAgent(ctx context.Context, params exporter.CreateSettings, cfg *Con
 	acfg.ComputeStatsBySpanKind = cfg.Traces.ComputeStatsBySpanKind
 	acfg.PeerServiceAggregation = cfg.Traces.PeerServiceAggregation
 	acfg.PeerTagsAggregation = cfg.Traces.PeerTagsAggregation
+	acfg.PeerTags = cfg.Traces.PeerTags
 	if v := cfg.Traces.flushInterval; v > 0 {
 		acfg.TraceWriter.FlushPeriodSeconds = v
 	}


### PR DESCRIPTION
This config mirrors https://github.com/DataDog/datadog-agent/blob/64e39b562df7ad3f40880ba603f70469f6659f17/pkg/config/config_template.yaml#L1532.