### PR TITLE
[pkg/golden]: Add option to skip normalizing timestamps when writing metrics

### DIFF
--- a/.chloggen/feat_optional-metric-timestamp-normalization.yaml
+++ b/.chloggen/feat_optional-metric-timestamp-normalization.yaml
@@ -1,0 +1,15 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/golden
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added an option to skip the metric timestamp normalization for WriteMetrics.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30919]
+
+change_logs: ["api"]

--- a/pkg/golden/golden.go
+++ b/pkg/golden/golden.go
@@ -37,8 +37,8 @@ func ReadMetrics(filePath string) (pmetric.Metrics, error) {
 }
 
 // WriteMetrics writes a pmetric.Metrics to the specified file in YAML format.
-func WriteMetrics(t testing.TB, filePath string, metrics pmetric.Metrics) error {
-	if err := writeMetrics(filePath, metrics); err != nil {
+func WriteMetrics(t testing.TB, filePath string, metrics pmetric.Metrics, opts ...WriteMetricsOption) error {
+	if err := writeMetrics(filePath, metrics, opts...); err != nil {
 		return err
 	}
 	t.Logf("Golden file successfully written to %s.", filePath)
@@ -68,9 +68,20 @@ func MarshalMetricsYAML(metrics pmetric.Metrics) ([]byte, error) {
 }
 
 // writeMetrics writes a pmetric.Metrics to the specified file in YAML format.
-func writeMetrics(filePath string, metrics pmetric.Metrics) error {
+func writeMetrics(filePath string, metrics pmetric.Metrics, opts ...WriteMetricsOption) error {
+	optsStruct := writeMetricsOptions{
+		normalizeTimestamps: true,
+	}
+
+	for _, opt := range opts {
+		opt(&optsStruct)
+	}
+
 	sortMetrics(metrics)
-	normalizeTimestamps(metrics)
+	if optsStruct.normalizeTimestamps {
+		normalizeTimestamps(metrics)
+	}
+
 	b, err := MarshalMetricsYAML(metrics)
 	if err != nil {
 		return err

--- a/pkg/golden/metrics_options.go
+++ b/pkg/golden/metrics_options.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package golden
+package golden // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
 
 // WriteMetricsOption is an option for the WriteMetrics function
 type WriteMetricsOption func(*writeMetricsOptions)

--- a/pkg/golden/metrics_options.go
+++ b/pkg/golden/metrics_options.go
@@ -1,0 +1,15 @@
+package golden
+
+// WriteMetricsOption is an option for the WriteMetrics function
+type WriteMetricsOption func(*writeMetricsOptions)
+
+type writeMetricsOptions struct {
+	normalizeTimestamps bool
+}
+
+// SkipMetricTimestampNormalization is an option that skips normalizing timestamps before writing metrics to disk.
+func SkipMetricTimestampNormalization() WriteMetricsOption {
+	return func(wmo *writeMetricsOptions) {
+		wmo.normalizeTimestamps = false
+	}
+}

--- a/pkg/golden/metrics_options.go
+++ b/pkg/golden/metrics_options.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package golden
 
 // WriteMetricsOption is an option for the WriteMetrics function

--- a/pkg/golden/testdata/skip-timestamp-norm/expected.yaml
+++ b/pkg/golden/testdata/skip-timestamp-norm/expected.yaml
@@ -1,0 +1,66 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - description: multi gauge
+            gauge:
+              dataPoints:
+                - asDouble: 2
+                  attributes:
+                    - key: testKey1
+                      value:
+                        stringValue: teststringvalue1
+                    - key: testKey2
+                      value:
+                        stringValue: testvalue1
+                  timeUnixNano: "11651379494838206464"
+                - asDouble: 2
+                  attributes:
+                    - key: testKey1
+                      value:
+                        stringValue: teststringvalue2
+                    - key: testKey2
+                      value:
+                        stringValue: testvalue2
+                  timeUnixNano: "11651379494838206464"
+            name: test gauge multi
+            unit: "1"
+          - description: single gauge
+            gauge:
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: testKey2
+                      value:
+                        stringValue: teststringvalue2
+                  timeUnixNano: "11651379494838206464"
+            name: test gauge single
+            unit: By
+          - description: multi sum
+            name: test delta sum multi
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: testKey2
+                      value:
+                        stringValue: teststringvalue2
+                  timeUnixNano: "11651379494838206464"
+                - asInt: "2"
+                  attributes:
+                    - key: testKey2
+                      value:
+                        stringValue: teststringvalue2
+                  timeUnixNano: "11651379494838206464"
+            unit: s
+          - description: single sum
+            name: test cumulative sum single
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 2
+                  timeUnixNano: "869965261000000001"
+              isMonotonic: true
+            unit: 1/s
+        scope: {}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
* Adds a new WriteMetricsOption type, which can be specified when calling WriteMetrics
* Adds a WriteMetricsOption for skipping the timestamp normalization step.

**Link to tracking Issue:** Closes #30919

**Testing:** <Describe what testing was performed and which tests were added.>
* Unit test added for new functionality
