### PR TITLE
[chore] Add build-and-test, build-and-test-windows, changelog and telemetrygen to merge group

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -6,6 +6,7 @@ on:
       - 'releases/**'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,6 +4,7 @@ on:
     branches: [ main ]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
+  merge_group:
   pull_request:
 env:
   TEST_RESULTS: testbed/tests/results/junit/results.xml

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,6 +6,7 @@
 name: changelog
 
 on:
+  merge_group:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:

--- a/.github/workflows/telemetrygen.yml
+++ b/.github/workflows/telemetrygen.yml
@@ -4,6 +4,7 @@ on:
     branches: [ main ]
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
+  merge_group:
   pull_request:
 env:
   # Make sure to exit early if cache segment download times out after 2 minutes.


### PR DESCRIPTION
**Description:** 

Adds CI jobs that have required jobs to merge group. Needed for the merge queue requested on  open-telemetry/community/issues/1936

**Link to tracking Issue:** #30880
