### PR TITLE
[processor/resourcedetection] Add feature gate to change stepping to string

### DIFF
--- a/.chloggen/fix_cpu_stepping_type.yaml
+++ b/.chloggen/fix_cpu_stepping_type.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/resourcedetection
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `processor.resourcedetection.hostCPUSteppingAsString` feature gate to change the type of `host.cpu.stepping` from `int` to `string`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31136]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This feature gate will graduate to beta in the next release.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/resourcedetectionprocessor/internal/system/internal/metadata/generated_resource.go
+++ b/processor/resourcedetectionprocessor/internal/system/internal/metadata/generated_resource.go
@@ -57,9 +57,9 @@ func (rb *ResourceBuilder) SetHostCPUModelName(val string) {
 }
 
 // SetHostCPUStepping sets provided value as "host.cpu.stepping" attribute.
-func (rb *ResourceBuilder) SetHostCPUStepping(val int64) {
+func (rb *ResourceBuilder) SetHostCPUStepping(val string) {
 	if rb.config.HostCPUStepping.Enabled {
-		rb.res.Attributes().PutInt("host.cpu.stepping", val)
+		rb.res.Attributes().PutStr("host.cpu.stepping", val)
 	}
 }
 

--- a/processor/resourcedetectionprocessor/internal/system/internal/metadata/generated_resource_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/internal/metadata/generated_resource_test.go
@@ -18,7 +18,7 @@ func TestResourceBuilder(t *testing.T) {
 			rb.SetHostCPUFamily("host.cpu.family-val")
 			rb.SetHostCPUModelID("host.cpu.model.id-val")
 			rb.SetHostCPUModelName("host.cpu.model.name-val")
-			rb.SetHostCPUStepping(17)
+			rb.SetHostCPUStepping("host.cpu.stepping-val")
 			rb.SetHostCPUVendorID("host.cpu.vendor.id-val")
 			rb.SetHostID("host.id-val")
 			rb.SetHostIP([]any{"host.ip-item1", "host.ip-item2"})
@@ -70,7 +70,7 @@ func TestResourceBuilder(t *testing.T) {
 			val, ok = res.Attributes().Get("host.cpu.stepping")
 			assert.Equal(t, test == "all_set", ok)
 			if ok {
-				assert.EqualValues(t, 17, val.Int())
+				assert.EqualValues(t, "host.cpu.stepping-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("host.cpu.vendor.id")
 			assert.Equal(t, test == "all_set", ok)

--- a/processor/resourcedetectionprocessor/internal/system/internal/metadata/resource_int_version.go
+++ b/processor/resourcedetectionprocessor/internal/system/internal/metadata/resource_int_version.go
@@ -16,3 +16,10 @@ func (rb *ResourceBuilder) SetHostCPUModelIDAsInt(val int64) {
 		rb.res.Attributes().PutInt("host.cpu.model.id", val)
 	}
 }
+
+// SetHostCPUSteppingAsInt sets provided value as "host.cpu.stepping" attribute as int.
+func (rb *ResourceBuilder) SetHostCPUSteppingAsInt(val int64) {
+	if rb.config.HostCPUModelID.Enabled {
+		rb.res.Attributes().PutInt("host.cpu.stepping", val)
+	}
+}

--- a/processor/resourcedetectionprocessor/internal/system/metadata.yaml
+++ b/processor/resourcedetectionprocessor/internal/system/metadata.yaml
@@ -49,7 +49,7 @@ resource_attributes:
     enabled: false
   host.cpu.stepping:
     description: The host.cpu.stepping
-    type: int
+    type: string
     enabled: false
   host.cpu.cache.l2.size:
     description: The host.cpu.cache.l2.size


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31136

Description:

Add feature gate to change CPU stepping to string, to adapt to https://github.com/open-telemetry/semantic-conventions/issues/664.

Link to tracking Issue: Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31136

Testing: Tested with the sample configuration on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/26533.


### Logs

```console
2024-02-09T15:18:02.014+0200	info	service@v0.94.1/telemetry.go:59	Setting up own telemetry...
2024-02-09T15:18:02.014+0200	info	service@v0.94.1/telemetry.go:104	Serving metrics	{"address": ":8888", "level": "Basic"}
2024-02-09T15:18:02.015+0200	info	service@v0.94.1/service.go:140	Starting otelcontribcol...	{"Version": "0.94.0-dev", "NumCPU": 8}
2024-02-09T15:18:02.015+0200	info	extensions/extensions.go:34	Starting extensions...
2024-02-09T15:18:02.015+0200	info	internal/resourcedetection.go:125	began detecting resource information	{"kind": "processor", "name": "resourcedetection/system", "pipeline": "metrics"}
2024-02-09T15:18:02.015+0200	info	system/system.go:209	This attribute changed from int to string. Temporarily switch back to int using the feature gate.	{"kind": "processor", "name": "resourcedetection/system", "pipeline": "metrics", "attribute": "host.cpu.family", "feature gate": "processor.resourcedetection.hostCPUModelAndFamilyAsString"}
2024-02-09T15:18:02.015+0200	info	system/system.go:228	This attribute changed from int to string. Temporarily switch back to int using the feature gate.	{"kind": "processor", "name": "resourcedetection/system", "pipeline": "metrics", "attribute": "host.cpu.model.id", "feature gate": "processor.resourcedetection.hostCPUModelAndFamilyAsString"}
2024-02-09T15:18:02.015+0200	info	system/system.go:245	This attribute changed from int to string. Temporarily switch back to int using the feature gate.	{"kind": "processor", "name": "resourcedetection/system", "pipeline": "metrics", "attribute": "host.cpu.stepping", "feature gate": "processor.resourcedetection.hostCPUSteppingAsString"}
2024-02-09T15:18:02.015+0200	info	internal/resourcedetection.go:139	detected resource information	{"kind": "processor", "name": "resourcedetection/system", "pipeline": "metrics", "resource": {"host.cpu.cache.l2.size":12288,"host.cpu.family":"6","host.cpu.model.id":"140","host.cpu.model.name":"11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz","host.cpu.stepping":"%!f(int32=1)","host.cpu.vendor.id":"GenuineIntel","host.id":"d6488716404e4ce4854ff0e230944c6d","host.name":"chrismark-ThinkPad-X1-Carbon-Gen-9","os.type":"linux"}}
2024-02-09T15:18:02.016+0200	info	service@v0.94.1/service.go:166	Everything is ready. Begin running and processing data.
2024-02-09T15:18:02.016+0200	warn	localhostgate/featuregate.go:63	The default endpoints for all servers in components will change to use localhost instead of 0.0.0.0 in a future version. Use the feature gate to preview the new default.	{"feature gate ID": "component.UseLocalHostAsDefaultHost"}
```

### Sample output

```json
{"resourceMetrics":[{"resource":{"attributes":[{"key":"host.name","value":{"stringValue":"chrismark-ThinkPad-X1-Carbon-Gen-9"}},{"key":"os.type","value":{"stringValue":"linux"}},{"key":"host.id","value":{"stringValue":"d6488716404e4ce4854ff0e230944c6d"}},{"key":"host.cpu.vendor.id","value":{"stringValue":"GenuineIntel"}},{"key":"host.cpu.family","value":{"stringValue":"6"}},{"key":"host.cpu.model.id","value":{"stringValue":"140"}},{"key":"host.cpu.model.name","value":{"stringValue":"11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz"}},{"key":"host.cpu.stepping","value":{"stringValue":"%!f(int32=1)"}},{"key":"host.cpu.cache.l2.size","value":{"intValue":"12288"}}]},"scopeMetrics":[{"scope":{"name":"otelcol/hostmetricsreceiver/cpu","version":"0.94.0-dev"},"metrics":[{"name":"system.cpu.time","description":"Total seconds each logical CPU spent on each mode.","unit":"s","sum":{"dataPoints":[{"attributes":[{"key":"cpu","value":{"stringValue":"cpu0"}},{"key":"state","value":{"stringValue":"user"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":1273.45},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu0"}},{"key":"state","value":{"stringValue":"system"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":174.29},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu0"}},{"key":"state","value":{"stringValue":"idle"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":19845.95},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu0"}},{"key":"state","value":{"stringValue":"interrupt"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu0"}},{"key":"state","value":{"stringValue":"nice"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0.95},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu0"}},{"key":"state","value":{"stringValue":"softirq"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":18.22},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu0"}},{"key":"state","value":{"stringValue":"steal"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu0"}},{"key":"state","value":{"stringValue":"wait"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":29.94},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu1"}},{"key":"state","value":{"stringValue":"user"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":1327.97},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu1"}},{"key":"state","value":{"stringValue":"system"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":175.68},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu1"}},{"key":"state","value":{"stringValue":"idle"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":19804.5},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu1"}},{"key":"state","value":{"stringValue":"interrupt"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu1"}},{"key":"state","value":{"stringValue":"nice"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0.06},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu1"}},{"key":"state","value":{"stringValue":"softirq"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":9.11},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu1"}},{"key":"state","value":{"stringValue":"steal"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu1"}},{"key":"state","value":{"stringValue":"wait"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":28.7},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu2"}},{"key":"state","value":{"stringValue":"user"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":1249.04},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu2"}},{"key":"state","value":{"stringValue":"system"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":178.22},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu2"}},{"key":"state","value":{"stringValue":"idle"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":19846.01},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu2"}},{"key":"state","value":{"stringValue":"interrupt"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu2"}},{"key":"state","value":{"stringValue":"nice"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":2.48},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu2"}},{"key":"state","value":{"stringValue":"softirq"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":10.42},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu2"}},{"key":"state","value":{"stringValue":"steal"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu2"}},{"key":"state","value":{"stringValue":"wait"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":26.88},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu3"}},{"key":"state","value":{"stringValue":"user"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":1211.17},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu3"}},{"key":"state","value":{"stringValue":"system"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":176.69},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu3"}},{"key":"state","value":{"stringValue":"idle"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":19912.68},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu3"}},{"key":"state","value":{"stringValue":"interrupt"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu3"}},{"key":"state","value":{"stringValue":"nice"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0.45},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu3"}},{"key":"state","value":{"stringValue":"softirq"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":4.92},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu3"}},{"key":"state","value":{"stringValue":"steal"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu3"}},{"key":"state","value":{"stringValue":"wait"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":28.48},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu4"}},{"key":"state","value":{"stringValue":"user"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":1254.73},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu4"}},{"key":"state","value":{"stringValue":"system"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":179.59},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu4"}},{"key":"state","value":{"stringValue":"idle"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":19869.65},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu4"}},{"key":"state","value":{"stringValue":"interrupt"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu4"}},{"key":"state","value":{"stringValue":"nice"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0.11},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu4"}},{"key":"state","value":{"stringValue":"softirq"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":2.92},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu4"}},{"key":"state","value":{"stringValue":"steal"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu4"}},{"key":"state","value":{"stringValue":"wait"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":25.91},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu5"}},{"key":"state","value":{"stringValue":"user"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":1272.94},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu5"}},{"key":"state","value":{"stringValue":"system"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":176.64},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu5"}},{"key":"state","value":{"stringValue":"idle"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":19825.63},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu5"}},{"key":"state","value":{"stringValue":"interrupt"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu5"}},{"key":"state","value":{"stringValue":"nice"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0.01},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu5"}},{"key":"state","value":{"stringValue":"softirq"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":3.33},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu5"}},{"key":"state","value":{"stringValue":"steal"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu5"}},{"key":"state","value":{"stringValue":"wait"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":24.5},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu6"}},{"key":"state","value":{"stringValue":"user"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":1317.85},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu6"}},{"key":"state","value":{"stringValue":"system"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":176.44},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu6"}},{"key":"state","value":{"stringValue":"idle"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":19803.92},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu6"}},{"key":"state","value":{"stringValue":"interrupt"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu6"}},{"key":"state","value":{"stringValue":"nice"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0.7},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu6"}},{"key":"state","value":{"stringValue":"softirq"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":3.87},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu6"}},{"key":"state","value":{"stringValue":"steal"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu6"}},{"key":"state","value":{"stringValue":"wait"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":32.35},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu7"}},{"key":"state","value":{"stringValue":"user"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":1238.01},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu7"}},{"key":"state","value":{"stringValue":"system"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":198.62},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu7"}},{"key":"state","value":{"stringValue":"idle"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":19849},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu7"}},{"key":"state","value":{"stringValue":"interrupt"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu7"}},{"key":"state","value":{"stringValue":"nice"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0.84},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu7"}},{"key":"state","value":{"stringValue":"softirq"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":2.49},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu7"}},{"key":"state","value":{"stringValue":"steal"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":0},{"attributes":[{"key":"cpu","value":{"stringValue":"cpu7"}},{"key":"state","value":{"stringValue":"wait"}}],"startTimeUnixNano":"1707463254000000000","timeUnixNano":"1707484683016351289","asDouble":27.29}],"aggregationTemporality":2,"isMonotonic":true}}]}],"schemaUrl":"https://opentelemetry.io/schemas/1.9.0"}]}
```

cc: @mx-psi 