### PR TITLE
[chore] [exporter/awsemfexporter] fix failing tests when valid config is present

### DIFF
--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -46,7 +46,16 @@ func (p *mockPusher) ForceFlush() error {
 	return nil
 }
 
+// set fake environment variables for testing
+func setupTestEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("AWS_REGION", "us-west-2")
+	t.Setenv("AWS_ACCESS_KEY_ID", "fake")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "fake")
+}
+
 func TestConsumeMetrics(t *testing.T) {
+	setupTestEnv(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	factory := NewFactory()
@@ -166,6 +175,7 @@ func TestConsumeMetricsWithOutputDestination(t *testing.T) {
 }
 
 func TestConsumeMetricsWithLogGroupStreamConfig(t *testing.T) {
+	setupTestEnv(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	factory := NewFactory()
@@ -193,6 +203,7 @@ func TestConsumeMetricsWithLogGroupStreamConfig(t *testing.T) {
 }
 
 func TestConsumeMetricsWithLogGroupStreamValidPlaceholder(t *testing.T) {
+	setupTestEnv(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	factory := NewFactory()
@@ -224,6 +235,7 @@ func TestConsumeMetricsWithLogGroupStreamValidPlaceholder(t *testing.T) {
 }
 
 func TestConsumeMetricsWithOnlyLogStreamPlaceholder(t *testing.T) {
+	setupTestEnv(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	factory := NewFactory()
@@ -255,6 +267,7 @@ func TestConsumeMetricsWithOnlyLogStreamPlaceholder(t *testing.T) {
 }
 
 func TestConsumeMetricsWithWrongPlaceholder(t *testing.T) {
+	setupTestEnv(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	factory := NewFactory()


### PR DESCRIPTION
**Description:** 
fixing a bug where tests were failing when valid aws credentials are set

**Link to tracking Issue:** #31010 

**Testing:** 
<details>
<summary> before: </summary>

```
go test ./... -parallel 4 -count 1                                                                                                                                                                                
?       github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter/internal/metadata     [no test files]
--- FAIL: TestConsumeMetrics (2.34s)
    emf_exporter_test.go:64: 
                Error Trace:    /Users/berkeli/Git/oss/opentelemetry-collector-contrib/exporter/awsemfexporter/emf_exporter_test.go:64
                Error:          An error is expected but got nil.
                Test:           TestConsumeMetrics
{"Version":"1","_aws":{"CloudWatchMetrics":[{"Namespace":"default","Dimensions":[[]],"Metrics":[{"Name":"metric_1"},{"Name":"metric_2"}]}],"Timestamp":1707506318134},"metric_1":100,"metric_2":4}
--- FAIL: TestConsumeMetricsWithLogGroupStreamConfig (2.33s)
    emf_exporter_test.go:185: 
                Error Trace:    /Users/berkeli/Git/oss/opentelemetry-collector-contrib/exporter/awsemfexporter/emf_exporter_test.go:185
                Error:          An error is expected but got nil.
                Test:           TestConsumeMetricsWithLogGroupStreamConfig
--- FAIL: TestConsumeMetricsWithLogGroupStreamValidPlaceholder (2.32s)
    emf_exporter_test.go:216: 
                Error Trace:    /Users/berkeli/Git/oss/opentelemetry-collector-contrib/exporter/awsemfexporter/emf_exporter_test.go:216
                Error:          An error is expected but got nil.
                Test:           TestConsumeMetricsWithLogGroupStreamValidPlaceholder
--- FAIL: TestConsumeMetricsWithOnlyLogStreamPlaceholder (1.49s)
    emf_exporter_test.go:247: 
                Error Trace:    /Users/berkeli/Git/oss/opentelemetry-collector-contrib/exporter/awsemfexporter/emf_exporter_test.go:247
                Error:          An error is expected but got nil.
                Test:           TestConsumeMetricsWithOnlyLogStreamPlaceholder
--- FAIL: TestConsumeMetricsWithWrongPlaceholder (1.48s)
    emf_exporter_test.go:278: 
                Error Trace:    /Users/berkeli/Git/oss/opentelemetry-collector-contrib/exporter/awsemfexporter/emf_exporter_test.go:278
                Error:          An error is expected but got nil.
                Test:           TestConsumeMetricsWithWrongPlaceholder
FAIL
FAIL    github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter 
```

</details>

<details>
<summary> after: </summary>

```
go test ./... -parallel 4 -count 1                                                                                                                                                                                
?       github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter/internal/metadata     [no test files]
ok      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter 
```

</details>

**Documentation:** n/a