### PR TITLE
[chore] remove nil_nextConsumer tests as we don't allow passing a nil next consumer

### DIFF
--- a/processor/probabilisticsamplerprocessor/logsprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/logsprocessor_test.go
@@ -25,13 +25,6 @@ func TestNewLogsProcessor(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name: "nil_nextConsumer",
-			cfg: &Config{
-				SamplingPercentage: 15.5,
-			},
-			wantErr: true,
-		},
-		{
 			name:         "happy_path",
 			nextConsumer: consumertest.NewNop(),
 			cfg: &Config{

--- a/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
@@ -29,13 +29,6 @@ func TestNewTracesProcessor(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name: "nil_nextConsumer",
-			cfg: &Config{
-				SamplingPercentage: 15.5,
-			},
-			wantErr: true,
-		},
-		{
 			name:         "happy_path",
 			nextConsumer: consumertest.NewNop(),
 			cfg: &Config{

--- a/receiver/carbonreceiver/receiver_test.go
+++ b/receiver/carbonreceiver/receiver_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
@@ -56,13 +55,6 @@ func Test_carbonreceiver_New(t *testing.T) {
 				},
 				nextConsumer: consumertest.NewNop(),
 			},
-		},
-		{
-			name: "nil_nextConsumer",
-			args: args{
-				config: *defaultConfig,
-			},
-			wantErr: component.ErrNilNextConsumer,
 		},
 		{
 			name: "empty_endpoint",

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -50,13 +50,6 @@ func Test_signalfxeceiver_New(t *testing.T) {
 		wantStartErr error
 	}{
 		{
-			name: "nil_nextConsumer",
-			args: args{
-				config: *defaultConfig,
-			},
-			wantStartErr: component.ErrNilNextConsumer,
-		},
-		{
 			name: "default_endpoint",
 			args: args{
 				config:       *defaultConfig,

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -58,13 +58,6 @@ func Test_splunkhecreceiver_NewLogsReceiver(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "nil_nextConsumer",
-			args: args{
-				config: *defaultConfig,
-			},
-			wantErr: errNilNextLogsConsumer,
-		},
-		{
 			name: "empty_endpoint",
 			args: args{
 				config:       *emptyEndpointConfig,
@@ -117,13 +110,6 @@ func Test_splunkhecreceiver_NewMetricsReceiver(t *testing.T) {
 		args    args
 		wantErr error
 	}{
-		{
-			name: "nil_nextConsumer",
-			args: args{
-				config: *defaultConfig,
-			},
-			wantErr: errNilNextMetricsConsumer,
-		},
 		{
 			name: "empty_endpoint",
 			args: args{

--- a/receiver/statsdreceiver/receiver_test.go
+++ b/receiver/statsdreceiver/receiver_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/consumer"
@@ -23,33 +22,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport/client"
 )
-
-func Test_statsdreceiver_New(t *testing.T) {
-	defaultConfig := createDefaultConfig().(*Config)
-	type args struct {
-		config       Config
-		nextConsumer consumer.Metrics
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr error
-	}{
-		{
-			name: "nil_nextConsumer",
-			args: args{
-				config: *defaultConfig,
-			},
-			wantErr: component.ErrNilNextConsumer,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := newReceiver(receivertest.NewNopCreateSettings(), tt.args.config, tt.args.nextConsumer)
-			assert.Equal(t, tt.wantErr, err)
-		})
-	}
-}
 
 func Test_statsdreceiver_Start(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector/pull/9526 for context - we are removing the possibility that the next consumer passed in is nil in the pipelines builders.