### PR TITLE
[extension/storage/filestorage] Ensure fsync is turned on after compaction

### DIFF
--- a/.chloggen/ensure-fsync.yaml
+++ b/.chloggen/ensure-fsync.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: extension/storage
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure fsync is turned on after compaction
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [20266]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -37,17 +37,17 @@ type fileStorageClient struct {
 	closed          bool
 }
 
-func bboltOptions(timeout time.Duration, fSync bool) *bbolt.Options {
+func bboltOptions(timeout time.Duration, noSync bool) *bbolt.Options {
 	return &bbolt.Options{
 		Timeout:        timeout,
-		NoSync:         !fSync,
+		NoSync:         noSync,
 		NoFreelistSync: true,
 		FreelistType:   bbolt.FreelistMapType,
 	}
 }
 
-func newClient(logger *zap.Logger, filePath string, timeout time.Duration, compactionCfg *CompactionConfig, fSync bool) (*fileStorageClient, error) {
-	options := bboltOptions(timeout, fSync)
+func newClient(logger *zap.Logger, filePath string, timeout time.Duration, compactionCfg *CompactionConfig, noSync bool) (*fileStorageClient, error) {
+	options := bboltOptions(timeout, noSync)
 	db, err := bbolt.Open(filePath, 0600, options)
 	if err != nil {
 		return nil, err
@@ -172,7 +172,7 @@ func (c *fileStorageClient) Compact(compactionDirectory string, timeout time.Dur
 	}()
 
 	// use temporary file as compaction target
-	options := bboltOptions(timeout, !c.db.NoSync)
+	options := bboltOptions(timeout, c.db.NoSync)
 
 	c.compactionMutex.Lock()
 	defer c.compactionMutex.Unlock()

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -172,7 +172,7 @@ func (c *fileStorageClient) Compact(compactionDirectory string, timeout time.Dur
 	}()
 
 	// use temporary file as compaction target
-	options := bboltOptions(timeout, false)
+	options := bboltOptions(timeout, !c.db.NoSync)
 
 	c.compactionMutex.Lock()
 	defer c.compactionMutex.Unlock()

--- a/extension/storage/filestorage/extension.go
+++ b/extension/storage/filestorage/extension.go
@@ -64,7 +64,7 @@ func (lfs *localFileStorage) GetClient(_ context.Context, kind component.Kind, e
 		rawName = sanitize(rawName)
 	}
 	absoluteName := filepath.Join(lfs.cfg.Directory, rawName)
-	client, err := newClient(lfs.logger, absoluteName, lfs.cfg.Timeout, lfs.cfg.Compaction, lfs.cfg.FSync)
+	client, err := newClient(lfs.logger, absoluteName, lfs.cfg.Timeout, lfs.cfg.Compaction, !lfs.cfg.FSync)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Description:** 

Fsync was added to filestorage, but during compaction the database is re-opened which doesn't carry over the fsync configuration but always sets it to false(!)

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20266

**Testing:** -

**Documentation:** -