### PR TITLE
[chore] Add quotes for string-type configs with int values in test yaml files

### DIFF
--- a/cmd/mdatagen/metadata-sample.yaml
+++ b/cmd/mdatagen/metadata-sample.yaml
@@ -106,7 +106,7 @@ metrics:
   optional.metric:
     enabled: false
     description: "[DEPRECATED] Gauge double metric disabled by default."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [string_attr, boolean_attr]

--- a/cmd/mdatagen/testdata/invalid_type_attr.yaml
+++ b/cmd/mdatagen/testdata/invalid_type_attr.yaml
@@ -18,7 +18,7 @@ metrics:
   metric:
     enabled: true
     description: Metric.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [used_attr]

--- a/cmd/mdatagen/testdata/no_type_attr.yaml
+++ b/cmd/mdatagen/testdata/no_type_attr.yaml
@@ -17,7 +17,7 @@ metrics:
   metric:
     enabled: true
     description: Metric.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [used_attr]

--- a/cmd/mdatagen/testdata/unused_attribute.yaml
+++ b/cmd/mdatagen/testdata/unused_attribute.yaml
@@ -23,7 +23,7 @@ metrics:
   metric:
     enabled: true
     description: Metric.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [used_attr]

--- a/exporter/alertmanagerexporter/testdata/config.yaml
+++ b/exporter/alertmanagerexporter/testdata/config.yaml
@@ -18,5 +18,5 @@ alertmanager/2:
     max_elapsed_time: 10m
   headers:
     "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
-    header1: 234
+    header1: "234"
     another: "somevalue"

--- a/exporter/opencensusexporter/testdata/config.yaml
+++ b/exporter/opencensusexporter/testdata/config.yaml
@@ -7,7 +7,7 @@ opencensus/2:
     ca_file: /var/lib/mycert.pem
   headers:
     "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
-    header1: 234
+    header1: "234"
     another: "somevalue"
   balancer_name: "round_robin"
   keepalive:

--- a/exporter/otelarrowexporter/testdata/config.yaml
+++ b/exporter/otelarrowexporter/testdata/config.yaml
@@ -18,7 +18,7 @@ auth:
   authenticator: nop
 headers:
   "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
-  header1: 234
+  header1: "234"
   another: "somevalue"
 keepalive:
   time: 20s

--- a/exporter/prometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/prometheusremotewriteexporter/testdata/config.yaml
@@ -14,7 +14,7 @@ prometheusremotewrite/2:
   add_metric_suffixes: false
   headers:
     Prometheus-Remote-Write-Version: "0.1.0"
-    X-Scope-OrgID: 234
+    X-Scope-OrgID: "234"
   external_labels:
     key1: value1
     key2: value2

--- a/exporter/skywalkingexporter/testdata/config.yaml
+++ b/exporter/skywalkingexporter/testdata/config.yaml
@@ -9,7 +9,7 @@ skywalking/2:
   timeout: 10s
   headers:
     "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
-    header1: 234
+    header1: "234"
     another: "somevalue"
   balancer_name: "round_robin"
   keepalive:

--- a/receiver/bigipreceiver/metadata.yaml
+++ b/receiver/bigipreceiver/metadata.yaml
@@ -105,14 +105,14 @@ metrics:
     enabled: true
   bigip.virtual_server.availability:
     description: Availability of the virtual server.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [availability.status]
     enabled: true
   bigip.virtual_server.enabled:
     description: Enabled state of of the virtual server.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [enabled.status]
@@ -162,14 +162,14 @@ metrics:
     enabled: true
   bigip.pool.availability:
     description: Availability of the pool.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [availability.status]
     enabled: true
   bigip.pool.enabled:
     description: Enabled state of of the pool.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [enabled.status]
@@ -218,14 +218,14 @@ metrics:
     enabled: true
   bigip.pool_member.availability:
     description: Availability of the pool member.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [availability.status]
     enabled: true
   bigip.pool_member.enabled:
     description: Enabled state of of the pool member.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [enabled.status]
@@ -274,14 +274,14 @@ metrics:
     enabled: true
   bigip.node.availability:
     description: Availability of the node.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [availability.status]
     enabled: true
   bigip.node.enabled:
     description: Enabled state of of the node.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [enabled.status]

--- a/receiver/dockerstatsreceiver/metadata.yaml
+++ b/receiver/dockerstatsreceiver/metadata.yaml
@@ -180,7 +180,7 @@ metrics:
   container.memory.percent:
     enabled: true
     description: "Percentage of memory used."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
   container.memory.cache:

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -209,7 +209,7 @@ metrics:
     enabled: true
   elasticsearch.breaker.tripped:
     description: Total number of times the circuit breaker has been triggered and prevented an out of memory error.
-    unit: 1
+    unit: "1"
     sum:
       monotonic: true
       aggregation_temporality: cumulative
@@ -482,14 +482,14 @@ metrics:
   # See https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics/docs/target-systems/jvm.md
   jvm.classes.loaded:
     description: The number of loaded classes
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: []
     enabled: true
   jvm.gc.collections.count:
     description: The total number of garbage collections that have occurred
-    unit: 1
+    unit: "1"
     sum:
       monotonic: true
       aggregation_temporality: cumulative
@@ -521,7 +521,7 @@ metrics:
     enabled: true
   jvm.memory.heap.utilization:
     description: Fraction of heap memory usage
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: []
@@ -563,7 +563,7 @@ metrics:
     enabled: true
   jvm.threads.count:
     description: The current number of threads
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: []
@@ -638,21 +638,21 @@ metrics:
     enabled: true
   elasticsearch.os.cpu.load_avg.1m:
     description: One-minute load average on the system (field is not present if one-minute load average is not available).
-    unit: 1.0
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
     enabled: true
   elasticsearch.os.cpu.load_avg.5m:
     description: Five-minute load average on the system (field is not present if five-minute load average is not available).
-    unit: 1.0
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
     enabled: true
   elasticsearch.os.cpu.load_avg.15m:
     description: Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).
-    unit: 1.0
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
@@ -675,7 +675,7 @@ metrics:
     enabled: true
   elasticsearch.indexing_pressure.memory.total.primary_rejections:
     description: Cumulative number of indexing requests rejected in the primary stage.
-    unit: 1
+    unit: "1"
     sum:
       monotonic: true
       aggregation_temporality: cumulative
@@ -684,7 +684,7 @@ metrics:
     enabled: true
   elasticsearch.indexing_pressure.memory.total.replica_rejections:
     description: Number of indexing requests rejected in the replica stage.
-    unit: 1
+    unit: "1"
     sum:
       monotonic: true
       aggregation_temporality: cumulative
@@ -700,7 +700,7 @@ metrics:
     enabled: true
   elasticsearch.cluster.state_queue:
     description: Number of cluster states in queue.
-    unit: 1
+    unit: "1"
     sum:
       monotonic: false
       aggregation_temporality: cumulative
@@ -709,7 +709,7 @@ metrics:
     enabled: true
   elasticsearch.cluster.published_states.full:
     description: Number of published cluster states.
-    unit: 1
+    unit: "1"
     sum:
       monotonic: false
       aggregation_temporality: cumulative
@@ -718,7 +718,7 @@ metrics:
     enabled: true
   elasticsearch.cluster.published_states.differences:
     description: Number of differences between published cluster states.
-    unit: 1
+    unit: "1"
     sum:
       monotonic: false
       aggregation_temporality: cumulative
@@ -727,7 +727,7 @@ metrics:
     enabled: true
   elasticsearch.cluster.state_update.count:
     description: The number of cluster state update attempts that changed the cluster state since the node started.
-    unit: 1
+    unit: "1"
     sum:
       monotonic: true
       aggregation_temporality: cumulative
@@ -817,7 +817,7 @@ metrics:
     enabled: true
   elasticsearch.node.script.cache_evictions:
     description: Total number of times the script cache has evicted old data.
-    unit: 1
+    unit: "1"
     sum:
       monotonic: true
       aggregation_temporality: cumulative
@@ -826,7 +826,7 @@ metrics:
     enabled: true
   elasticsearch.node.script.compilation_limit_triggered:
     description: Total number of times the script compilation circuit breaker has limited inline script compilations.
-    unit: 1
+    unit: "1"
     sum:
       monotonic: true
       aggregation_temporality: cumulative
@@ -944,7 +944,7 @@ metrics:
     enabled: false
   elasticsearch.index.cache.size:
     description: The number of elements of the query cache for an index.
-    unit: 1
+    unit: "1"
     sum:
       monotonic: false
       aggregation_temporality: cumulative
@@ -971,7 +971,7 @@ metrics:
     enabled: false
   elasticsearch.process.cpu.usage:
     description: CPU usage in percent.
-    unit: 1.0
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]

--- a/receiver/expvarreceiver/metadata.yaml
+++ b/receiver/expvarreceiver/metadata.yaml
@@ -261,7 +261,7 @@ metrics:
     enabled: true
     description: The fraction of this program's available CPU time used by the GC since the program started.
     extended_documentation: As defined by https://pkg.go.dev/runtime#MemStats
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
 tests:

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -28,7 +28,7 @@ metrics:
   system.cpu.utilization:
     enabled: false
     description: Difference in system.cpu.time since the last measurement per logical CPU, divided by the elapsed time (value in interval [0,1]).
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [cpu, state]

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
@@ -50,7 +50,7 @@ metrics:
   system.filesystem.utilization:
     enabled: false
     description: Fraction of filesystem bytes used.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [device, mode, mountpoint, type]

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -33,7 +33,7 @@ metrics:
   system.memory.utilization:
     enabled: false
     description: Percentage of memory bytes in use.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [state]

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
@@ -58,7 +58,7 @@ metrics:
   system.paging.utilization:
     enabled: false
     description: Swap (unix) or pagefile (windows) utilization.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [device, state]

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -87,7 +87,7 @@ metrics:
       Percentage of total CPU time used by the process since last scrape,
       expressed as a value between 0 and 1.
       On the first scrape, no data point is emitted for this metric.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [state]
@@ -113,7 +113,7 @@ metrics:
   process.memory.utilization:
     enabled: false
     description: Percentage of total physical memory that is used by the process.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
 

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -36,7 +36,7 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
       monotonic: false
-    unit: 1
+    unit: "1"
     attributes: [http.url, http.status_code, http.method, http.status_class]
   httpcheck.duration:
     description: Measures the duration of the HTTP check.

--- a/receiver/kafkametricsreceiver/metadata.yaml
+++ b/receiver/kafkametricsreceiver/metadata.yaml
@@ -42,14 +42,14 @@ metrics:
   kafka.partition.current_offset:
     enabled: true
     description: Current offset of partition of topic.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [topic, partition]
   kafka.partition.oldest_offset:
     enabled: true
     description: Oldest offset of partition of topic
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [topic, partition]
@@ -84,28 +84,28 @@ metrics:
   kafka.consumer_group.offset:
     enabled: true
     description: Current offset of the consumer group at partition of topic
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [group, topic, partition]
   kafka.consumer_group.offset_sum:
     enabled: true
     description: Sum of consumer group offset across partitions of topic
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [group, topic]
   kafka.consumer_group.lag:
     enabled: true
     description: Current approximate lag of consumer group at partition of topic
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [group, topic, partition]
   kafka.consumer_group.lag_sum:
     enabled: true
     description: Current approximate sum of consumer group lag across all partitions of topic
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [group, topic]

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -93,7 +93,7 @@ metrics:
     description: "Node CPU utilization"
     warnings:
       if_enabled: "WARNING: This metric will be disabled in a future release. Use metric k8s.node.cpu.usage instead."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: []
@@ -137,14 +137,14 @@ metrics:
   k8s.node.memory.page_faults:
     enabled: true
     description: "Node memory page_faults"
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: []
   k8s.node.memory.major_page_faults:
     enabled: true
     description: "Node memory major_page_faults"
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: []
@@ -181,7 +181,7 @@ metrics:
   k8s.node.network.errors:
     enabled: true
     description: "Node network errors"
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: true
@@ -208,7 +208,7 @@ metrics:
     description: "Pod CPU utilization"
     warnings:
       if_enabled: "This metric will be disabled in a future release. Use metric k8s.pod.cpu.usage instead."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
@@ -238,28 +238,28 @@ metrics:
   k8s.pod.cpu_limit_utilization:
     enabled: false
     description: "Pod cpu utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
   k8s.pod.cpu_request_utilization:
     enabled: false
     description: "Pod cpu utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
   k8s.pod.memory_limit_utilization:
     enabled: false
     description: "Pod memory utilization as a ratio of the pod's total container limits. If any container is missing a limit the metric is not emitted."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
   k8s.pod.memory_request_utilization:
     enabled: false
     description: "Pod memory utilization as a ratio of the pod's total container requests. If any container is missing a request the metric is not emitted."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
@@ -280,14 +280,14 @@ metrics:
   k8s.pod.memory.page_faults:
     enabled: true
     description: "Pod memory page_faults"
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: []
   k8s.pod.memory.major_page_faults:
     enabled: true
     description: "Pod memory major_page_faults"
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: []
@@ -324,7 +324,7 @@ metrics:
   k8s.pod.network.errors:
     enabled: true
     description: "Pod network errors"
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: true
@@ -351,7 +351,7 @@ metrics:
     description: "Container CPU utilization"
     warnings:
       if_enabled: "WARNING: This metric will be disabled in a future release. Use metric container.cpu.usage instead."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
@@ -381,28 +381,28 @@ metrics:
   k8s.container.cpu_limit_utilization:
     enabled: false
     description: "Container cpu utilization as a ratio of the container's limits"
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
   k8s.container.cpu_request_utilization:
     enabled: false
     description: "Container cpu utilization as a ratio of the container's requests"
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
   k8s.container.memory_limit_utilization:
     enabled: false
     description: "Container memory utilization as a ratio of the container's limits"
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
   k8s.container.memory_request_utilization:
     enabled: false
     description: "Container memory utilization as a ratio of the container's requests"
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     attributes: [ ]
@@ -423,14 +423,14 @@ metrics:
   container.memory.page_faults:
     enabled: true
     description: "Container memory page_faults"
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: []
   container.memory.major_page_faults:
     enabled: true
     description: "Container memory major_page_faults"
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: []
@@ -481,21 +481,21 @@ metrics:
   k8s.volume.inodes:
     enabled: true
     description: "The total inodes in the filesystem."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: []
   k8s.volume.inodes.free:
     enabled: true
     description: "The free inodes in the filesystem."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: []
   k8s.volume.inodes.used:
     enabled: true
     description: "The inodes used by the filesystem. This may not equal inodes - free because filesystem may share inodes with other filesystems."
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: []

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -246,7 +246,7 @@ metrics:
     enabled: true
     description: Amount of data flushed in the background
     extended_documentation: MongoDB Metric BACKGROUND_FLUSH_AVG
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
   mongodbatlas.process.cache.io:
@@ -280,7 +280,7 @@ metrics:
     enabled: true
     description: CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_CPU_KERNEL, MAX_PROCESS_CPU_USER
-    unit: 1
+    unit: "1"
     attributes: [cpu_state]
     gauge:
       value_type: double
@@ -288,7 +288,7 @@ metrics:
     enabled: true
     description: CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_CPU_KERNEL, PROCESS_CPU_USER
-    unit: 1
+    unit: "1"
     attributes: [cpu_state]
     gauge:
       value_type: double
@@ -296,7 +296,7 @@ metrics:
     enabled: true
     description: CPU Usage for child processes (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_CPU_CHILDREN_USER, MAX_PROCESS_CPU_CHILDREN_KERNEL
-    unit: 1
+    unit: "1"
     attributes: [cpu_state]
     gauge:
       value_type: double
@@ -304,7 +304,7 @@ metrics:
     enabled: true
     description: CPU Usage for child processes (%)
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_CPU_CHILDREN_KERNEL, PROCESS_CPU_CHILDREN_USER
-    unit: 1
+    unit: "1"
     attributes: [cpu_state]
     gauge:
       value_type: double
@@ -312,7 +312,7 @@ metrics:
     enabled: true
     description: CPU Usage for child processes, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, MAX_PROCESS_NORMALIZED_CPU_CHILDREN_USER
-    unit: 1
+    unit: "1"
     attributes: [cpu_state]
     gauge:
       value_type: double
@@ -320,7 +320,7 @@ metrics:
     enabled: true
     description: CPU Usage for child processes, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_CHILDREN_KERNEL, PROCESS_NORMALIZED_CPU_CHILDREN_USER
-    unit: 1
+    unit: "1"
     attributes: [cpu_state]
     gauge:
       value_type: double
@@ -328,7 +328,7 @@ metrics:
     enabled: true
     description: CPU Usage, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_PROCESS_NORMALIZED_CPU_USER, MAX_PROCESS_NORMALIZED_CPU_KERNEL
-    unit: 1
+    unit: "1"
     attributes: [cpu_state]
     gauge:
       value_type: double
@@ -336,7 +336,7 @@ metrics:
     enabled: true
     description: CPU Usage, normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics PROCESS_NORMALIZED_CPU_KERNEL, PROCESS_NORMALIZED_CPU_USER
-    unit: 1
+    unit: "1"
     attributes: [cpu_state]
     gauge:
       value_type: double
@@ -376,7 +376,7 @@ metrics:
     enabled: true
     description: Index miss ratio (%)
     extended_documentation: MongoDB Metric INDEX_COUNTERS_BTREE_MISS_RATIO
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
   mongodbatlas.process.index.counters:
@@ -534,7 +534,7 @@ metrics:
     description: System CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_CPU_SOFTIRQ, MAX_SYSTEM_CPU_IRQ, MAX_SYSTEM_CPU_GUEST, MAX_SYSTEM_CPU_IOWAIT, MAX_SYSTEM_CPU_NICE, MAX_SYSTEM_CPU_KERNEL, MAX_SYSTEM_CPU_USER, MAX_SYSTEM_CPU_STEAL
     attributes: [cpu_state]
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
   mongodbatlas.system.cpu.usage.average:
@@ -542,7 +542,7 @@ metrics:
     description: System CPU Usage (%)
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_CPU_USER, SYSTEM_CPU_GUEST, SYSTEM_CPU_SOFTIRQ, SYSTEM_CPU_IRQ, SYSTEM_CPU_KERNEL, SYSTEM_CPU_IOWAIT, SYSTEM_CPU_NICE, SYSTEM_CPU_STEAL
     attributes: [cpu_state]
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
   mongodbatlas.system.memory.usage.max:
@@ -582,7 +582,7 @@ metrics:
     description: System CPU Normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics MAX_SYSTEM_NORMALIZED_CPU_USER, MAX_SYSTEM_NORMALIZED_CPU_NICE, MAX_SYSTEM_NORMALIZED_CPU_IOWAIT, MAX_SYSTEM_NORMALIZED_CPU_SOFTIRQ, MAX_SYSTEM_NORMALIZED_CPU_STEAL, MAX_SYSTEM_NORMALIZED_CPU_KERNEL, MAX_SYSTEM_NORMALIZED_CPU_GUEST, MAX_SYSTEM_NORMALIZED_CPU_IRQ
     attributes: [cpu_state]
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
   mongodbatlas.system.cpu.normalized.usage.average:
@@ -590,7 +590,7 @@ metrics:
     description: System CPU Normalized to pct
     extended_documentation: Aggregate of MongoDB Metrics SYSTEM_NORMALIZED_CPU_IOWAIT, SYSTEM_NORMALIZED_CPU_GUEST, SYSTEM_NORMALIZED_CPU_IRQ, SYSTEM_NORMALIZED_CPU_KERNEL, SYSTEM_NORMALIZED_CPU_STEAL, SYSTEM_NORMALIZED_CPU_SOFTIRQ, SYSTEM_NORMALIZED_CPU_NICE, SYSTEM_NORMALIZED_CPU_USER
     attributes: [cpu_state]
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
   mongodbatlas.process.tickets:
@@ -621,7 +621,7 @@ metrics:
     enabled: true
     description: Disk partition usage (%)
     extended_documentation: Aggregate of MongoDB Metrics MAX_DISK_PARTITION_SPACE_PERCENT_USED, MAX_DISK_PARTITION_SPACE_PERCENT_FREE
-    unit: 1
+    unit: "1"
     attributes: [disk_status]
     gauge:
       value_type: double
@@ -629,7 +629,7 @@ metrics:
     enabled: true
     description: Disk partition usage (%)
     extended_documentation: Aggregate of MongoDB Metrics DISK_PARTITION_SPACE_PERCENT_FREE, DISK_PARTITION_SPACE_PERCENT_USED
-    unit: 1
+    unit: "1"
     attributes: [disk_status]
     gauge:
       value_type: double
@@ -637,14 +637,14 @@ metrics:
     enabled: true
     description: The maximum percentage of time during which requests are being issued to and serviced by the partition.
     extended_documentation: MongoDB Metrics MAX_DISK_PARTITION_UTILIZATION
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
   mongodbatlas.disk.partition.utilization.average:
     enabled: true
     description: The percentage of time during which requests are being issued to and serviced by the partition.
     extended_documentation: MongoDB Metrics DISK_PARTITION_UTILIZATION
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
   mongodbatlas.disk.partition.latency.max:
@@ -716,7 +716,7 @@ metrics:
     enabled: true
     description: Full-text search (%)
     extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_CPU_USER, FTS_PROCESS_CPU_KERNEL
-    unit: 1
+    unit: "1"
     attributes: [cpu_state]
     gauge:
       value_type: double
@@ -724,7 +724,7 @@ metrics:
     enabled: true
     description: Full text search disk usage (%)
     extended_documentation: Aggregate of MongoDB Metrics FTS_PROCESS_NORMALIZED_CPU_USER, FTS_PROCESS_NORMALIZED_CPU_KERNEL
-    unit: 1
+    unit: "1"
     attributes: [cpu_state]
     gauge:
       value_type: double

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -336,7 +336,7 @@ metrics:
     extended_documentation:
       A value of '1' indicates healthy.
       A value of '0' indicates unhealthy.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     attributes: [ ]

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -171,7 +171,7 @@ metrics:
   mysql.buffer_pool.pages:
     enabled: true
     description: The number of pages in the InnoDB buffer pool.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -181,7 +181,7 @@ metrics:
   mysql.buffer_pool.data_pages:
     enabled: true
     description: The number of data pages in the InnoDB buffer pool.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: false
@@ -190,7 +190,7 @@ metrics:
   mysql.buffer_pool.page_flushes:
     enabled: true
     description: The number of requests to flush pages from the InnoDB buffer pool.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -199,7 +199,7 @@ metrics:
   mysql.buffer_pool.operations:
     enabled: true
     description: The number of operations on the InnoDB buffer pool.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -227,7 +227,7 @@ metrics:
   mysql.prepared_statements:
     enabled: true
     description: The number of times each type of prepared statement command has been issued.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -237,7 +237,7 @@ metrics:
   mysql.commands:
     enabled: false
     description: The number of times each type of command has been executed.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -247,7 +247,7 @@ metrics:
   mysql.handlers:
     enabled: true
     description: The number of requests to various MySQL handlers.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -257,7 +257,7 @@ metrics:
   mysql.double_writes:
     enabled: true
     description: The number of writes to the InnoDB doublewrite buffer.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -267,7 +267,7 @@ metrics:
   mysql.log_operations:
     enabled: true
     description: The number of InnoDB log operations.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -277,7 +277,7 @@ metrics:
   mysql.operations:
     enabled: true
     description: The number of InnoDB operations.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -287,7 +287,7 @@ metrics:
   mysql.page_operations:
     enabled: true
     description: The number of InnoDB page operations.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -297,7 +297,7 @@ metrics:
   mysql.table.io.wait.count:
     enabled: true
     description: The total count of I/O wait events for a table.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: true
@@ -315,7 +315,7 @@ metrics:
   mysql.index.io.wait.count:
     enabled: true
     description: The total count of I/O wait events for an index.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: true
@@ -333,7 +333,7 @@ metrics:
   mysql.row_locks:
     enabled: true
     description: The number of InnoDB row locks.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -343,7 +343,7 @@ metrics:
   mysql.row_operations:
     enabled: true
     description: The number of InnoDB row operations.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -353,7 +353,7 @@ metrics:
   mysql.locks:
     enabled: true
     description: The number of MySQL locks.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -363,7 +363,7 @@ metrics:
   mysql.sorts:
     enabled: true
     description: The number of MySQL sorts.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -373,7 +373,7 @@ metrics:
   mysql.threads:
     enabled: true
     description: The state of MySQL threads.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -393,7 +393,7 @@ metrics:
   mysql.opened_resources:
     enabled: true
     description: The number of opened resources.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -448,7 +448,7 @@ metrics:
   mysql.connection.count:
     enabled: false
     description: The number of connection attempts (successful or not) to the MySQL server.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -457,7 +457,7 @@ metrics:
   mysql.connection.errors:
     enabled: false
     description: Errors that occur during the client connection process.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -468,7 +468,7 @@ metrics:
     enabled: true
     description: The number of mysqlx connections.
     extended_documentation: This metric is specific for MySQL working as Document Store (X-Plugin). [more docs](https://dev.mysql.com/doc/refman/8.0/en/document-store.html)
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -478,7 +478,7 @@ metrics:
   mysql.joins:
     enabled: false
     description: The number of joins that perform table scans.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -488,7 +488,7 @@ metrics:
   mysql.tmp_resources:
     enabled: true
     description: The number of created temporary resources.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -516,7 +516,7 @@ metrics:
   mysql.statement_event.count:
     enabled: false
     description: Summary of current and recent statement events.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: false
@@ -534,7 +534,7 @@ metrics:
   mysql.mysqlx_worker_threads:
     enabled: false
     description: The number of worker threads available.
-    unit: 1
+    unit: "1"
     extended_documentation: This metric is specific for MySQL working as Document Store (X-Plugin). [more docs](https://dev.mysql.com/doc/refman/8.0/en/document-store.html)
     sum:
       value_type: int
@@ -545,7 +545,7 @@ metrics:
   mysql.table_open_cache:
     enabled: false
     description: The number of hits, misses or overflows for open tables cache lookups.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -555,7 +555,7 @@ metrics:
   mysql.query.client.count:
     enabled: false
     description: The number of statements executed by the server. This includes only statements sent to the server by clients.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -564,7 +564,7 @@ metrics:
   mysql.query.count:
     enabled: false
     description: The number of statements executed by the server.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string
@@ -573,7 +573,7 @@ metrics:
   mysql.query.slow.count:
     enabled: false
     description: The number of slow queries.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       input_type: string

--- a/receiver/oracledbreceiver/metadata.yaml
+++ b/receiver/oracledbreceiver/metadata.yaml
@@ -129,7 +129,7 @@ metrics:
       monotonic: true
       value_type: int
       input_type: string
-    unit: 1
+    unit: "1"
   oracledb.sessions.usage:
     attributes:
       - session_type

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -134,11 +134,11 @@ metrics:
       aggregation_temporality: cumulative
       monotonic: true
       value_type: int
-    unit: 1
+    unit: "1"
   postgresql.blocks_read:
     enabled: true
     description: The number of blocks read.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: true
@@ -147,7 +147,7 @@ metrics:
   postgresql.commits:
     enabled: true
     description: The number of commits.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: true
@@ -178,7 +178,7 @@ metrics:
   postgresql.backends:
     enabled: true
     description: The number of backends.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: false
@@ -192,7 +192,7 @@ metrics:
   postgresql.rows:
     enabled: true
     description: The number of rows in the database.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: false
@@ -215,7 +215,7 @@ metrics:
   postgresql.operations:
     enabled: true
     description: The number of db row operations.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: true
@@ -231,7 +231,7 @@ metrics:
   postgresql.rollbacks:
     enabled: true
     description: The number of rollbacks.
-    unit: 1
+    unit: "1"
     sum:
       value_type: int
       monotonic: true

--- a/receiver/redisreceiver/metadata.yaml
+++ b/receiver/redisreceiver/metadata.yaml
@@ -226,7 +226,7 @@ metrics:
   redis.memory.fragmentation_ratio:
     enabled: true
     description: Ratio between used_memory_rss and used_memory
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
 

--- a/receiver/snmpreceiver/README.md
+++ b/receiver/snmpreceiver/README.md
@@ -180,7 +180,7 @@ receivers:
       # This metric will have multiple datapoints wil 1 attribute on each.
       # Each datapoint will have a (hopefully) different attribute value
       metric.name.1:
-        unit: 1
+        unit: "1"
         sum:
           aggregation: cumulative
           monotonic: true

--- a/receiver/snmpreceiver/testdata/config.yaml
+++ b/receiver/snmpreceiver/testdata/config.yaml
@@ -603,7 +603,7 @@ snmp/complex_good:
       oid: "1"
   metrics:
     m1:
-      unit: 1
+      unit: "1"
       sum:
         aggregation: cumulative
         monotonic: true
@@ -656,7 +656,7 @@ snmp/complex_good:
             - name: a1
               value: val1
     m6:
-      unit: 1
+      unit: "1"
       sum:
         aggregation: delta
         monotonic: true

--- a/receiver/snowflakereceiver/metadata.yaml
+++ b/receiver/snowflakereceiver/metadata.yaml
@@ -105,7 +105,7 @@ metrics:
   # Login (Security) metrics 
   snowflake.logins.total:
     description: Total login attempts for account over the last 24 hour window.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int 
     enabled: false 
@@ -114,28 +114,28 @@ metrics:
   # High level low dimensionality query metrics 
   snowflake.query.blocked:
     description: Blocked query count for warehouse over the last 24 hour window.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     enabled: true 
     attributes: [warehouse_name]
   snowflake.query.executed:
     description: Executed query count for warehouse over the last 24 hour window.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     enabled: true 
     attributes: [warehouse_name]
   snowflake.query.queued_overload:
     description: Overloaded query count for warehouse over the last 24 hour window.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     enabled: true 
     attributes: [warehouse_name]
   snowflake.query.queued_provision:
     description: Number of compute resources queued for provisioning over the last 24 hour window.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double 
     enabled: true 
@@ -144,7 +144,7 @@ metrics:
   # DB metrics
   snowflake.database.query.count:
     description: Total query count for database over the last 24 hour window.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int 
     enabled: true
@@ -193,7 +193,7 @@ metrics:
     attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
   snowflake.query.data_scanned_cache.avg:
     description: Average percentage of data scanned from cache over the last 24 hour window.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     enabled: false 
@@ -207,7 +207,7 @@ metrics:
     attributes: [schema_name, execution_status, error_message, query_type, warehouse_name, database_name, warehouse_size]
   snowflake.query.partitions_scanned.avg:
     description: Number of partitions scanned during query so far over the last 24 hour window. 
-    unit: 1
+    unit: "1"
     gauge:
       value_type: double
     enabled: false
@@ -279,7 +279,7 @@ metrics:
   # Session metric 
   snowflake.session_id.count:
     description: Distinct session id's associated with snowflake username over the last 24 hour window.
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
     enabled: false

--- a/receiver/sshcheckreceiver/metadata.yaml
+++ b/receiver/sshcheckreceiver/metadata.yaml
@@ -27,7 +27,7 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
       monotonic: false
-    unit: 1
+    unit: "1"
   sshcheck.duration:
     description: Measures the duration of SSH connection.
     enabled: true
@@ -50,7 +50,7 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
       monotonic: false
-    unit: 1
+    unit: "1"
   sshcheck.sftp_duration:
     description: Measures SFTP request duration.
     enabled: false

--- a/receiver/zookeeperreceiver/metadata.yaml
+++ b/receiver/zookeeperreceiver/metadata.yaml
@@ -150,7 +150,7 @@ metrics:
   zookeeper.ruok:
     enabled: true
     description: Response from zookeeper ruok command
-    unit: 1
+    unit: "1"
     gauge:
       value_type: int
 

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-ruok.yaml
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-ruok.yaml
@@ -8,4 +8,4 @@ resourceMetrics:
                 - asInt: "1"
                   startTimeUnixNano: "1642685966447704000"
                   timeUnixNano: "1642685966447860000"
-            unit: 1
+            unit: "1"


### PR DESCRIPTION
**Description:**
This is related to https://github.com/open-telemetry/opentelemetry-collector/issues/9532. Currently there are mixed use of 
1. explicitly quoted string configs 
2. implicit conversion from int to string 
 
in the test config yaml files in this repo. This PR changes the latter to explicitly quoted strings.

**Link to tracking Issue:**
https://github.com/open-telemetry/opentelemetry-collector/issues/9532