### PR TITLE
Improve OTTL error message

### DIFF
--- a/pkg/ottl/contexts/internal/errors.go
+++ b/pkg/ottl/contexts/internal/errors.go
@@ -6,7 +6,7 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 import "fmt"
 
 const (
-	DefaultErrorMessage = "%v is not a valid path for the %v context - review %v to see all valid paths"
+	DefaultErrorMessage = "%q is not a valid OTTL keyword nor a valid path for the %v context - review %v to see all valid paths"
 
 	ResourceContextRef      = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlresource"
 	InstrumentationScopeRef = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlscope"

--- a/pkg/ottl/contexts/internal/errors.go
+++ b/pkg/ottl/contexts/internal/errors.go
@@ -1,0 +1,22 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
+
+import "fmt"
+
+const (
+	DefaultErrorMessage = "%v is not a valid path for the %v context - review %v to see all valid paths"
+
+	ResourceContextRef      = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlresource"
+	InstrumentationScopeRef = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlscope"
+	SpanRef                 = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlspan"
+	SpanEventRef            = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlspanevent"
+	MetricRef               = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlmetric"
+	DataPointRef            = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottldatapoint"
+	LogRef                  = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog"
+)
+
+func FormatDefaultErrorMessage(path, context, ref string) error {
+	return fmt.Errorf(DefaultErrorMessage, path, context, ref)
+}

--- a/pkg/ottl/contexts/internal/errors.go
+++ b/pkg/ottl/contexts/internal/errors.go
@@ -6,7 +6,7 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 import "fmt"
 
 const (
-	DefaultErrorMessage = "%q is not a valid OTTL keyword nor a valid path for the %v context - review %v to see all valid paths"
+	DefaultErrorMessage = "segment %q from path %q is not a valid path nor a valid OTTL keyword for the %v context - review %v to see all valid paths"
 
 	ResourceContextRef      = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlresource"
 	InstrumentationScopeRef = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlscope"
@@ -17,6 +17,6 @@ const (
 	LogRef                  = "https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottllog"
 )
 
-func FormatDefaultErrorMessage(path, context, ref string) error {
-	return fmt.Errorf(DefaultErrorMessage, path, context, ref)
+func FormatDefaultErrorMessage(pathSegment, fullPath, context, ref string) error {
+	return fmt.Errorf(DefaultErrorMessage, pathSegment, fullPath, context, ref)
 }

--- a/pkg/ottl/contexts/internal/metric.go
+++ b/pkg/ottl/contexts/internal/metric.go
@@ -5,7 +5,6 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
@@ -48,7 +47,7 @@ func MetricPathGetSetter[K MetricContext](path ottl.Path[K]) (ottl.GetSetter[K],
 	case "data_points":
 		return accessDataPoints[K](), nil
 	default:
-		return nil, fmt.Errorf("invalid metric path expression %v", path)
+		return nil, FormatDefaultErrorMessage(path.Name(), "Metric", MetricRef)
 	}
 }
 

--- a/pkg/ottl/contexts/internal/metric.go
+++ b/pkg/ottl/contexts/internal/metric.go
@@ -47,7 +47,7 @@ func MetricPathGetSetter[K MetricContext](path ottl.Path[K]) (ottl.GetSetter[K],
 	case "data_points":
 		return accessDataPoints[K](), nil
 	default:
-		return nil, FormatDefaultErrorMessage(path.Name(), "Metric", MetricRef)
+		return nil, FormatDefaultErrorMessage(path.String(), "Metric", MetricRef)
 	}
 }
 

--- a/pkg/ottl/contexts/internal/metric.go
+++ b/pkg/ottl/contexts/internal/metric.go
@@ -47,7 +47,7 @@ func MetricPathGetSetter[K MetricContext](path ottl.Path[K]) (ottl.GetSetter[K],
 	case "data_points":
 		return accessDataPoints[K](), nil
 	default:
-		return nil, FormatDefaultErrorMessage(path.String(), "Metric", MetricRef)
+		return nil, FormatDefaultErrorMessage(path.Name(), path.String(), "Metric", MetricRef)
 	}
 }
 

--- a/pkg/ottl/contexts/internal/path.go
+++ b/pkg/ottl/contexts/internal/path.go
@@ -32,6 +32,10 @@ func (p *TestPath[K]) Keys() []ottl.Key[K] {
 	return p.KeySlice
 }
 
+func (p *TestPath[K]) String() string {
+	return p.N
+}
+
 var _ ottl.Key[any] = &TestKey[any]{}
 
 type TestKey[K any] struct {

--- a/pkg/ottl/contexts/internal/resource.go
+++ b/pkg/ottl/contexts/internal/resource.go
@@ -5,7 +5,6 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
@@ -29,7 +28,7 @@ func ResourcePathGetSetter[K ResourceContext](path ottl.Path[K]) (ottl.GetSetter
 	case "dropped_attributes_count":
 		return accessResourceDroppedAttributesCount[K](), nil
 	default:
-		return nil, fmt.Errorf("invalid resource path expression %v", path)
+		return nil, FormatDefaultErrorMessage(path.Name(), "Resource", ResourceContextRef)
 	}
 }
 

--- a/pkg/ottl/contexts/internal/resource.go
+++ b/pkg/ottl/contexts/internal/resource.go
@@ -28,7 +28,7 @@ func ResourcePathGetSetter[K ResourceContext](path ottl.Path[K]) (ottl.GetSetter
 	case "dropped_attributes_count":
 		return accessResourceDroppedAttributesCount[K](), nil
 	default:
-		return nil, FormatDefaultErrorMessage(path.String(), "Resource", ResourceContextRef)
+		return nil, FormatDefaultErrorMessage(path.Name(), path.String(), "Resource", ResourceContextRef)
 	}
 }
 

--- a/pkg/ottl/contexts/internal/resource.go
+++ b/pkg/ottl/contexts/internal/resource.go
@@ -28,7 +28,7 @@ func ResourcePathGetSetter[K ResourceContext](path ottl.Path[K]) (ottl.GetSetter
 	case "dropped_attributes_count":
 		return accessResourceDroppedAttributesCount[K](), nil
 	default:
-		return nil, FormatDefaultErrorMessage(path.Name(), "Resource", ResourceContextRef)
+		return nil, FormatDefaultErrorMessage(path.String(), "Resource", ResourceContextRef)
 	}
 }
 

--- a/pkg/ottl/contexts/internal/scope.go
+++ b/pkg/ottl/contexts/internal/scope.go
@@ -33,7 +33,7 @@ func ScopePathGetSetter[K InstrumentationScopeContext](path ottl.Path[K]) (ottl.
 	case "dropped_attributes_count":
 		return accessInstrumentationScopeDroppedAttributesCount[K](), nil
 	default:
-		return nil, FormatDefaultErrorMessage(path.Name(), "Instrumentation Scope", InstrumentationScopeRef)
+		return nil, FormatDefaultErrorMessage(path.String(), "Instrumentation Scope", InstrumentationScopeRef)
 	}
 }
 

--- a/pkg/ottl/contexts/internal/scope.go
+++ b/pkg/ottl/contexts/internal/scope.go
@@ -5,7 +5,6 @@ package internal // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 
@@ -34,7 +33,7 @@ func ScopePathGetSetter[K InstrumentationScopeContext](path ottl.Path[K]) (ottl.
 	case "dropped_attributes_count":
 		return accessInstrumentationScopeDroppedAttributesCount[K](), nil
 	default:
-		return nil, fmt.Errorf("invalid scope path expression %v", path)
+		return nil, FormatDefaultErrorMessage(path.Name(), "Instrumentation Scope", InstrumentationScopeRef)
 	}
 }
 

--- a/pkg/ottl/contexts/internal/scope.go
+++ b/pkg/ottl/contexts/internal/scope.go
@@ -33,7 +33,7 @@ func ScopePathGetSetter[K InstrumentationScopeContext](path ottl.Path[K]) (ottl.
 	case "dropped_attributes_count":
 		return accessInstrumentationScopeDroppedAttributesCount[K](), nil
 	default:
-		return nil, FormatDefaultErrorMessage(path.String(), "Instrumentation Scope", InstrumentationScopeRef)
+		return nil, FormatDefaultErrorMessage(path.Name(), path.String(), "Instrumentation Scope", InstrumentationScopeRef)
 	}
 }
 

--- a/pkg/ottl/contexts/internal/span.go
+++ b/pkg/ottl/contexts/internal/span.go
@@ -48,7 +48,7 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			if nextPath.Name() == "string" {
 				return accessStringTraceID[K](), nil
 			}
-			return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
+			return nil, FormatDefaultErrorMessage(nextPath.Name(), nextPath.String(), SpanContextName, SpanRef)
 		}
 		return accessTraceID[K](), nil
 	case "span_id":
@@ -57,7 +57,7 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			if nextPath.Name() == "string" {
 				return accessStringSpanID[K](), nil
 			}
-			return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
+			return nil, FormatDefaultErrorMessage(nextPath.Name(), nextPath.String(), SpanContextName, SpanRef)
 		}
 		return accessSpanID[K](), nil
 	case "trace_state":
@@ -72,7 +72,7 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			if nextPath.Name() == "string" {
 				return accessStringParentSpanID[K](), nil
 			}
-			return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
+			return nil, FormatDefaultErrorMessage(nextPath.Name(), nextPath.String(), SpanContextName, SpanRef)
 		}
 		return accessParentSpanID[K](), nil
 	case "name":
@@ -86,7 +86,7 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			case "deprecated_string":
 				return accessDeprecatedStringKind[K](), nil
 			default:
-				return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
+				return nil, FormatDefaultErrorMessage(nextPath.Name(), nextPath.String(), SpanContextName, SpanRef)
 			}
 		}
 		return accessKind[K](), nil
@@ -123,12 +123,12 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			case "message":
 				return accessStatusMessage[K](), nil
 			default:
-				return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
+				return nil, FormatDefaultErrorMessage(nextPath.Name(), nextPath.String(), SpanContextName, SpanRef)
 			}
 		}
 		return accessStatus[K](), nil
 	default:
-		return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
+		return nil, FormatDefaultErrorMessage(path.Name(), path.String(), SpanContextName, SpanRef)
 	}
 }
 

--- a/pkg/ottl/contexts/internal/span.go
+++ b/pkg/ottl/contexts/internal/span.go
@@ -17,6 +17,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
+const (
+	SpanContextName = "Span"
+)
+
 type SpanContext interface {
 	GetSpan() ptrace.Span
 }
@@ -39,21 +43,23 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 	}
 	switch path.Name() {
 	case "trace_id":
-		if path.Next() != nil {
-			if path.Next().Name() == "string" {
+		nextPath := path.Next()
+		if nextPath != nil {
+			if nextPath.Name() == "string" {
 				return accessStringTraceID[K](), nil
 			}
-		} else {
-			return accessTraceID[K](), nil
+			return nil, FormatDefaultErrorMessage("trace_id."+nextPath.Name(), SpanContextName, SpanRef)
 		}
+		return accessTraceID[K](), nil
 	case "span_id":
-		if path.Next() != nil {
-			if path.Next().Name() == "string" {
+		nextPath := path.Next()
+		if nextPath != nil {
+			if nextPath.Name() == "string" {
 				return accessStringSpanID[K](), nil
 			}
-		} else {
-			return accessSpanID[K](), nil
+			return nil, FormatDefaultErrorMessage("span_id."+nextPath.Name(), SpanContextName, SpanRef)
 		}
+		return accessSpanID[K](), nil
 	case "trace_state":
 		mapKey := path.Keys()
 		if mapKey == nil {
@@ -61,13 +67,14 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 		}
 		return accessTraceStateKey[K](mapKey)
 	case "parent_span_id":
-		if path.Next() != nil {
-			if path.Next().Name() == "string" {
+		nextPath := path.Next()
+		if nextPath != nil {
+			if nextPath.Name() == "string" {
 				return accessStringParentSpanID[K](), nil
 			}
-		} else {
-			return accessParentSpanID[K](), nil
+			return nil, FormatDefaultErrorMessage("parent_span_id."+nextPath.Name(), SpanContextName, SpanRef)
 		}
+		return accessParentSpanID[K](), nil
 	case "name":
 		return accessSpanName[K](), nil
 	case "kind":
@@ -79,11 +86,10 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			case "deprecated_string":
 				return accessDeprecatedStringKind[K](), nil
 			default:
-				return nil, fmt.Errorf("invalid span path expression %v", nextPath.Name())
+				return nil, FormatDefaultErrorMessage("kind."+nextPath.Name(), SpanContextName, SpanRef)
 			}
-		} else {
-			return accessKind[K](), nil
 		}
+		return accessKind[K](), nil
 	case "start_time_unix_nano":
 		return accessStartTimeUnixNano[K](), nil
 	case "end_time_unix_nano":
@@ -117,13 +123,13 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			case "message":
 				return accessStatusMessage[K](), nil
 			default:
-				return nil, fmt.Errorf("invalid span path expression %v", nextPath.Name())
+				return nil, FormatDefaultErrorMessage("status."+nextPath.Name(), SpanContextName, SpanRef)
 			}
-		} else {
-			return accessStatus[K](), nil
 		}
+		return accessStatus[K](), nil
+	default:
+		return nil, FormatDefaultErrorMessage(path.Name(), SpanContextName, SpanRef)
 	}
-	return nil, fmt.Errorf("invalid span path expression %v", path)
 }
 
 func accessSpan[K SpanContext]() ottl.StandardGetSetter[K] {

--- a/pkg/ottl/contexts/internal/span.go
+++ b/pkg/ottl/contexts/internal/span.go
@@ -48,7 +48,7 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			if nextPath.Name() == "string" {
 				return accessStringTraceID[K](), nil
 			}
-			return nil, FormatDefaultErrorMessage("trace_id."+nextPath.Name(), SpanContextName, SpanRef)
+			return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
 		}
 		return accessTraceID[K](), nil
 	case "span_id":
@@ -57,7 +57,7 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			if nextPath.Name() == "string" {
 				return accessStringSpanID[K](), nil
 			}
-			return nil, FormatDefaultErrorMessage("span_id."+nextPath.Name(), SpanContextName, SpanRef)
+			return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
 		}
 		return accessSpanID[K](), nil
 	case "trace_state":
@@ -72,7 +72,7 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			if nextPath.Name() == "string" {
 				return accessStringParentSpanID[K](), nil
 			}
-			return nil, FormatDefaultErrorMessage("parent_span_id."+nextPath.Name(), SpanContextName, SpanRef)
+			return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
 		}
 		return accessParentSpanID[K](), nil
 	case "name":
@@ -86,7 +86,7 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			case "deprecated_string":
 				return accessDeprecatedStringKind[K](), nil
 			default:
-				return nil, FormatDefaultErrorMessage("kind."+nextPath.Name(), SpanContextName, SpanRef)
+				return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
 			}
 		}
 		return accessKind[K](), nil
@@ -123,12 +123,12 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 			case "message":
 				return accessStatusMessage[K](), nil
 			default:
-				return nil, FormatDefaultErrorMessage("status."+nextPath.Name(), SpanContextName, SpanRef)
+				return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
 			}
 		}
 		return accessStatus[K](), nil
 	default:
-		return nil, FormatDefaultErrorMessage(path.Name(), SpanContextName, SpanRef)
+		return nil, FormatDefaultErrorMessage(path.String(), SpanContextName, SpanRef)
 	}
 }
 

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -201,7 +201,7 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			case "bucket_counts":
 				return accessPositiveBucketCounts(), nil
 			default:
-				return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.DataPointRef)
+				return nil, internal.FormatDefaultErrorMessage(nextPath.Name(), path.String(), contextName, internal.DataPointRef)
 			}
 		}
 		return accessPositive(), nil
@@ -214,14 +214,14 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			case "bucket_counts":
 				return accessNegativeBucketCounts(), nil
 			default:
-				return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.DataPointRef)
+				return nil, internal.FormatDefaultErrorMessage(nextPath.Name(), path.String(), contextName, internal.DataPointRef)
 			}
 		}
 		return accessNegative(), nil
 	case "quantile_values":
 		return accessQuantileValues(), nil
 	default:
-		return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.DataPointRef)
+		return nil, internal.FormatDefaultErrorMessage(path.Name(), path.String(), contextName, internal.DataPointRef)
 	}
 }
 

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -16,6 +16,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/internal"
 )
 
+const (
+	contextName = "DataPoint"
+)
+
 var _ internal.ResourceContext = TransformContext{}
 var _ internal.InstrumentationScopeContext = TransformContext{}
 
@@ -197,11 +201,10 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			case "bucket_counts":
 				return accessPositiveBucketCounts(), nil
 			default:
-				return nil, fmt.Errorf("invalid span path expression %v", nextPath.Name())
+				return nil, internal.FormatDefaultErrorMessage("positive."+nextPath.Name(), contextName, internal.DataPointRef)
 			}
-		} else {
-			return accessPositive(), nil
 		}
+		return accessPositive(), nil
 	case "negative":
 		nextPath := path.Next()
 		if nextPath != nil {
@@ -211,15 +214,15 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			case "bucket_counts":
 				return accessNegativeBucketCounts(), nil
 			default:
-				return nil, fmt.Errorf("invalid span path expression %v", nextPath.Name())
+				return nil, internal.FormatDefaultErrorMessage("negative."+nextPath.Name(), contextName, internal.DataPointRef)
 			}
-		} else {
-			return accessNegative(), nil
 		}
+		return accessNegative(), nil
 	case "quantile_values":
 		return accessQuantileValues(), nil
+	default:
+		return nil, internal.FormatDefaultErrorMessage(path.Name(), contextName, internal.DataPointRef)
 	}
-	return nil, fmt.Errorf("invalid path expression %v", path)
 }
 
 func accessCache() ottl.StandardGetSetter[TransformContext] {

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -201,7 +201,7 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			case "bucket_counts":
 				return accessPositiveBucketCounts(), nil
 			default:
-				return nil, internal.FormatDefaultErrorMessage("positive."+nextPath.Name(), contextName, internal.DataPointRef)
+				return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.DataPointRef)
 			}
 		}
 		return accessPositive(), nil
@@ -214,14 +214,14 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			case "bucket_counts":
 				return accessNegativeBucketCounts(), nil
 			default:
-				return nil, internal.FormatDefaultErrorMessage("negative."+nextPath.Name(), contextName, internal.DataPointRef)
+				return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.DataPointRef)
 			}
 		}
 		return accessNegative(), nil
 	case "quantile_values":
 		return accessQuantileValues(), nil
 	default:
-		return nil, internal.FormatDefaultErrorMessage(path.Name(), contextName, internal.DataPointRef)
+		return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.DataPointRef)
 	}
 }
 

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -182,7 +182,7 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			if nextPath.Name() == "string" {
 				return accessStringBody(), nil
 			}
-			return nil, internal.FormatDefaultErrorMessage("body."+nextPath.Name(), contextName, internal.LogRef)
+			return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.LogRef)
 		}
 		if path.Keys() == nil {
 			return accessBody(), nil
@@ -203,7 +203,7 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			if path.Next().Name() == "string" {
 				return accessStringTraceID(), nil
 			}
-			return nil, internal.FormatDefaultErrorMessage("trace_id."+nextPath.Name(), contextName, internal.LogRef)
+			return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.LogRef)
 		}
 		return accessTraceID(), nil
 	case "span_id":
@@ -212,11 +212,11 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			if nextPath.Name() == "string" {
 				return accessStringSpanID(), nil
 			}
-			return nil, internal.FormatDefaultErrorMessage("span_id."+nextPath.Name(), contextName, internal.LogRef)
+			return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.LogRef)
 		}
 		return accessSpanID(), nil
 	default:
-		return nil, internal.FormatDefaultErrorMessage(path.Name(), contextName, internal.LogRef)
+		return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.LogRef)
 	}
 }
 

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -182,7 +182,7 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			if nextPath.Name() == "string" {
 				return accessStringBody(), nil
 			}
-			return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.LogRef)
+			return nil, internal.FormatDefaultErrorMessage(nextPath.Name(), nextPath.String(), contextName, internal.LogRef)
 		}
 		if path.Keys() == nil {
 			return accessBody(), nil
@@ -200,10 +200,10 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 	case "trace_id":
 		nextPath := path.Next()
 		if nextPath != nil {
-			if path.Next().Name() == "string" {
+			if nextPath.Name() == "string" {
 				return accessStringTraceID(), nil
 			}
-			return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.LogRef)
+			return nil, internal.FormatDefaultErrorMessage(nextPath.Name(), nextPath.String(), contextName, internal.LogRef)
 		}
 		return accessTraceID(), nil
 	case "span_id":
@@ -212,11 +212,11 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 			if nextPath.Name() == "string" {
 				return accessStringSpanID(), nil
 			}
-			return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.LogRef)
+			return nil, internal.FormatDefaultErrorMessage(nextPath.Name(), path.String(), contextName, internal.LogRef)
 		}
 		return accessSpanID(), nil
 	default:
-		return nil, internal.FormatDefaultErrorMessage(path.String(), contextName, internal.LogRef)
+		return nil, internal.FormatDefaultErrorMessage(path.Name(), path.String(), contextName, internal.LogRef)
 	}
 }
 

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -18,6 +18,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/internal/ottlcommon"
 )
 
+const (
+	contextName = "Log"
+)
+
 var _ internal.ResourceContext = TransformContext{}
 var _ internal.InstrumentationScopeContext = TransformContext{}
 
@@ -173,16 +177,17 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 	case "severity_text":
 		return accessSeverityText(), nil
 	case "body":
-		if path.Next() != nil {
-			if path.Next().Name() == "string" {
+		nextPath := path.Next()
+		if nextPath != nil {
+			if nextPath.Name() == "string" {
 				return accessStringBody(), nil
 			}
-		} else {
-			if path.Keys() == nil {
-				return accessBody(), nil
-			}
-			return accessBodyKey(path.Keys()), nil
+			return nil, internal.FormatDefaultErrorMessage("body."+nextPath.Name(), contextName, internal.LogRef)
 		}
+		if path.Keys() == nil {
+			return accessBody(), nil
+		}
+		return accessBodyKey(path.Keys()), nil
 	case "attributes":
 		if path.Keys() == nil {
 			return accessAttributes(), nil
@@ -193,23 +198,26 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 	case "flags":
 		return accessFlags(), nil
 	case "trace_id":
-		if path.Next() != nil {
+		nextPath := path.Next()
+		if nextPath != nil {
 			if path.Next().Name() == "string" {
 				return accessStringTraceID(), nil
 			}
-		} else {
-			return accessTraceID(), nil
+			return nil, internal.FormatDefaultErrorMessage("trace_id."+nextPath.Name(), contextName, internal.LogRef)
 		}
+		return accessTraceID(), nil
 	case "span_id":
-		if path.Next() != nil {
-			if path.Next().Name() == "string" {
+		nextPath := path.Next()
+		if nextPath != nil {
+			if nextPath.Name() == "string" {
 				return accessStringSpanID(), nil
 			}
-		} else {
-			return accessSpanID(), nil
+			return nil, internal.FormatDefaultErrorMessage("span_id."+nextPath.Name(), contextName, internal.LogRef)
 		}
+		return accessSpanID(), nil
+	default:
+		return nil, internal.FormatDefaultErrorMessage(path.Name(), contextName, internal.LogRef)
 	}
-	return nil, fmt.Errorf("invalid path expression %v", path)
 }
 
 func accessCache() ottl.StandardGetSetter[TransformContext] {

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -152,9 +152,10 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 		return accessSpanEventAttributesKey(path.Keys()), nil
 	case "dropped_attributes_count":
 		return accessSpanEventDroppedAttributeCount(), nil
+	default:
+		return nil, internal.FormatDefaultErrorMessage(path.Name(), "Span Event", internal.SpanEventRef)
 	}
 
-	return nil, fmt.Errorf("invalid scope path expression %v", path)
 }
 func accessCache() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -153,7 +153,7 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 	case "dropped_attributes_count":
 		return accessSpanEventDroppedAttributeCount(), nil
 	default:
-		return nil, internal.FormatDefaultErrorMessage(path.String(), "Span Event", internal.SpanEventRef)
+		return nil, internal.FormatDefaultErrorMessage(path.Name(), path.String(), "Span Event", internal.SpanEventRef)
 	}
 
 }

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -153,7 +153,7 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 	case "dropped_attributes_count":
 		return accessSpanEventDroppedAttributeCount(), nil
 	default:
-		return nil, internal.FormatDefaultErrorMessage(path.Name(), "Span Event", internal.SpanEventRef)
+		return nil, internal.FormatDefaultErrorMessage(path.String(), "Span Event", internal.SpanEventRef)
 	}
 
 }

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -49,17 +49,18 @@ func newPath[K any](fields []field) (*basePath[K], error) {
 	if len(fields) == 0 {
 		return nil, fmt.Errorf("cannot make a path from zero fields")
 	}
+	originalText := buildOriginalText(fields)
 	var current *basePath[K]
 	for i := len(fields) - 1; i >= 0; i-- {
 		current = &basePath[K]{
 			name:         fields[i].Name,
 			keys:         newKeys[K](fields[i].Keys),
 			nextPath:     current,
-			originalText: buildOriginalText(fields[i:]),
+			originalText: originalText,
 		}
 	}
 	current.fetched = true
-	current.originalText = buildOriginalText(fields)
+	current.originalText = originalText
 	return current, nil
 }
 

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/iancoleman/strcase"
@@ -21,6 +22,29 @@ type Enum int64
 
 type EnumSymbol string
 
+func buildOriginalText(fields []field) string {
+	var builder strings.Builder
+	for i, f := range fields {
+		builder.WriteString(f.Name)
+		if len(f.Keys) > 0 {
+			for _, k := range f.Keys {
+				builder.WriteString("[")
+				if k.Int != nil {
+					builder.WriteString(strconv.FormatInt(*k.Int, 10))
+				}
+				if k.String != nil {
+					builder.WriteString(*k.String)
+				}
+				builder.WriteString("]")
+			}
+		}
+		if i != len(fields)-1 {
+			builder.WriteString(".")
+		}
+	}
+	return builder.String()
+}
+
 func newPath[K any](fields []field) (*basePath[K], error) {
 	if len(fields) == 0 {
 		return nil, fmt.Errorf("cannot make a path from zero fields")
@@ -28,12 +52,14 @@ func newPath[K any](fields []field) (*basePath[K], error) {
 	var current *basePath[K]
 	for i := len(fields) - 1; i >= 0; i-- {
 		current = &basePath[K]{
-			name:     fields[i].Name,
-			keys:     newKeys[K](fields[i].Keys),
-			nextPath: current,
+			name:         fields[i].Name,
+			keys:         newKeys[K](fields[i].Keys),
+			nextPath:     current,
+			originalText: buildOriginalText(fields[i:]),
 		}
 	}
 	current.fetched = true
+	current.originalText = buildOriginalText(fields)
 	return current, nil
 }
 
@@ -51,16 +77,20 @@ type Path[K any] interface {
 	// Keys provides the Keys for this Path.
 	// Will return nil if there are no Keys.
 	Keys() []Key[K]
+
+	// String returns a string representation of this Path and the next Paths
+	String() string
 }
 
 var _ Path[any] = &basePath[any]{}
 
 type basePath[K any] struct {
-	name        string
-	keys        []Key[K]
-	nextPath    *basePath[K]
-	fetched     bool
-	fetchedKeys bool
+	name         string
+	keys         []Key[K]
+	nextPath     *basePath[K]
+	fetched      bool
+	fetchedKeys  bool
+	originalText string
 }
 
 func (p *basePath[K]) Name() string {
@@ -81,6 +111,10 @@ func (p *basePath[K]) Keys() []Key[K] {
 	}
 	p.fetchedKeys = true
 	return p.keys
+}
+
+func (p *basePath[K]) String() string {
+	return p.originalText
 }
 
 func (p *basePath[K]) isComplete() error {

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -2335,6 +2335,11 @@ func Test_newPath(t *testing.T) {
 		},
 		{
 			Name: "string",
+			Keys: []key{
+				{
+					String: ottltest.Strp("key"),
+				},
+			},
 		},
 	}
 	np, err := newPath[any](fields)
@@ -2342,10 +2347,18 @@ func Test_newPath(t *testing.T) {
 	p := Path[any](np)
 	assert.Equal(t, "body", p.Name())
 	assert.Nil(t, p.Keys())
+	assert.Equal(t, "body.string[key]", p.String())
 	p = p.Next()
 	assert.Equal(t, "string", p.Name())
-	assert.Nil(t, p.Keys())
+	assert.Equal(t, "string[key]", p.String())
 	assert.Nil(t, p.Next())
+	assert.Equal(t, 1, len(p.Keys()))
+	v, err := p.Keys()[0].String(context.Background(), struct{}{})
+	assert.NoError(t, err)
+	assert.Equal(t, "key", *v)
+	i, err := p.Keys()[0].Int(context.Background(), struct{}{})
+	assert.NoError(t, err)
+	assert.Nil(t, i)
 }
 
 func Test_baseKey_String(t *testing.T) {

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -2350,7 +2350,7 @@ func Test_newPath(t *testing.T) {
 	assert.Equal(t, "body.string[key]", p.String())
 	p = p.Next()
 	assert.Equal(t, "string", p.Name())
-	assert.Equal(t, "string[key]", p.String())
+	assert.Equal(t, "body.string[key]", p.String())
 	assert.Nil(t, p.Next())
 	assert.Equal(t, 1, len(p.Keys()))
 	v, err := p.Keys()[0].String(context.Background(), struct{}{})


### PR DESCRIPTION
**Description:**
Improve OTTL context error messages when an unknown path is used.

The new error message will look like:

```
Error: invalid configuration: processors::transform: unable to parse OTTL statement "set(attributes[\"test\"], trace_id.hex)": error while parsing arguments for call to "set": invalid argument at position 1: trace_id.hex is not a valid path for the Span context - review https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/ottl/contexts/ottlspan to see all valid paths
```

**Link to tracking Issue:** <Issue number if applicable>

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29871
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29922

**Testing:** <Describe what testing was performed and which tests were added.>

Unit tests