### PR TITLE
[chore] upgrade `actions/upload-artifact` and `actions/download-artifact` to `v4`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -551,7 +551,7 @@ jobs:
       - name: Upload Packages
         uses: actions/upload-artifact@v4
         with:
-          name: collector-packages
+          name: collector-packages-${{ matrix.package_type }}
           path: ./dist/*
   windows-msi:
     if: false # skip. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10113
@@ -586,7 +586,7 @@ jobs:
       - name: Upload MSI
         uses: actions/upload-artifact@v4
         with:
-          name: collector-packages
+          name: collector-packages-msi
           path: ./dist/*.msi
 
   publish-check:
@@ -602,8 +602,9 @@ jobs:
       - name: Download Packages
         uses: actions/download-artifact@v4
         with:
-          name: collector-packages
+          merge-multiple: true
           path: ./dist/
+          pattern: collector-packages-*
       - name: Verify Distribution Files Exist
         id: check
         run: ./.github/workflows/scripts/verify-dist-files-exist.sh
@@ -644,8 +645,9 @@ jobs:
       - name: Download Packages
         uses: actions/download-artifact@v4
         with:
-          name: collector-packages
+          merge-multiple: true
           path: ./dist/
+          pattern: collector-packages-*
       - name: Add Permissions to Tool Binaries
         run: chmod -R +x ./dist
       - name: Verify Distribution Files Exist

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -287,7 +287,7 @@ jobs:
       - name: Run Unit Tests With Coverage
         if: startsWith( matrix.go-version, '1.21' ) # only run coverage on one version
         run: make gotest-with-cover GROUP=${{ matrix.group }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: startsWith( matrix.go-version, '1.21' ) # only upload artifact for one version
         with:
           name: coverage-artifacts
@@ -313,7 +313,7 @@ jobs:
     needs: [unittest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: coverage-artifacts
       - name: Upload coverage report
@@ -502,7 +502,7 @@ jobs:
       - name: Build Collector ${{ matrix.binary }}
         run: make GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} GOARM=${{ matrix.arm }} otelcontribcol
       - name: Upload Collector Binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: collector-binaries
           path: ./bin/*
@@ -525,7 +525,7 @@ jobs:
       - name: Install fpm
         run: gem install --no-document fpm -v 1.15.1
       - name: Download Collector Binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: collector-binaries
           path: bin/
@@ -549,7 +549,7 @@ jobs:
               ./internal/buildscripts/packaging/fpm/test.sh dist/otel-contrib-collector*x86_64.rpm examples/demo/otel-collector-config.yaml
           fi
       - name: Upload Packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: collector-packages
           path: ./dist/*
@@ -562,7 +562,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Download Binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: collector-binaries
           path: ./bin/
@@ -584,7 +584,7 @@ jobs:
       - name: Validate MSI
         run: .\internal\buildscripts\packaging\msi\make.ps1 Confirm-MSI
       - name: Upload MSI
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: collector-packages
           path: ./dist/*.msi
@@ -595,12 +595,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download Binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: collector-binaries
           path: ./bin/
       - name: Download Packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: collector-packages
           path: ./dist/
@@ -636,13 +636,13 @@ jobs:
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make install-tools
       - name: Download Binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: collector-binaries
           path: ./bin/
       - run: chmod +x bin/*
       - name: Download Packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: collector-packages
           path: ./dist/

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -290,7 +290,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: startsWith( matrix.go-version, '1.21' ) # only upload artifact for one version
         with:
-          name: coverage-artifacts
+          name: coverage-artifacts-${{ matrix.go-version }}-${{ matrix.group }}
           path: ${{ matrix.group }}-coverage.txt
   unittest:
     if: ${{ github.actor != 'dependabot[bot]' && always() }}
@@ -315,7 +315,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: coverage-artifacts
+          merge-multiple: true
+          pattern: coverage-artifacts-*
       - name: Upload coverage report
         uses: Wandalen/wretry.action@v1.3.0
         with:
@@ -504,7 +505,7 @@ jobs:
       - name: Upload Collector Binaries
         uses: actions/upload-artifact@v4
         with:
-          name: collector-binaries
+          name: collector-binaries-${{ matrix.os }}-${{ matrix.arch }}
           path: ./bin/*
 
   build-package:
@@ -527,8 +528,9 @@ jobs:
       - name: Download Collector Binaries
         uses: actions/download-artifact@v4
         with:
-          name: collector-binaries
+          merge-multiple: true
           path: bin/
+          pattern: collector-binaries-*
       - run: chmod +x bin/*
       - name: Set Release Tag
         id: github_tag
@@ -564,8 +566,9 @@ jobs:
       - name: Download Binaries
         uses: actions/download-artifact@v4
         with:
-          name: collector-binaries
+          merge-multiple: true
           path: ./bin/
+          pattern: collector-binaries-*
       - name: Cache Wix
         id: wix-cache
         uses: actions/cache@v3
@@ -597,8 +600,9 @@ jobs:
       - name: Download Binaries
         uses: actions/download-artifact@v4
         with:
-          name: collector-binaries
+          merge-multiple: true
           path: ./bin/
+          pattern: collector-binaries-*
       - name: Download Packages
         uses: actions/download-artifact@v4
         with:
@@ -639,8 +643,9 @@ jobs:
       - name: Download Binaries
         uses: actions/download-artifact@v4
         with:
-          name: collector-binaries
+          merge-multiple: true
           path: ./bin/
+          pattern: collector-binaries-*
       - run: chmod +x bin/*
       - name: Download Packages
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build Collector
         run: make otelcontribcol
       - name: Upload Collector Binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: collector-binary
           path: ./bin/*
@@ -66,7 +66,7 @@ jobs:
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload
       - name: Download Collector Binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: collector-binary
           path: bin/
@@ -104,7 +104,7 @@ jobs:
         run: |
           docker save otelcontribcol:latest > /tmp/otelcontribcol.tar
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: otelcontribcol
           path: /tmp/otelcontribcol.tar
@@ -155,7 +155,7 @@ jobs:
         run: |
           kubectl get csr -o=jsonpath='{range.items[?(@.spec.signerName=="kubernetes.io/kubelet-serving")]}{.metadata.name}{" "}{end}' | xargs kubectl certificate approve
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: otelcontribcol
           path: /tmp

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -46,7 +46,7 @@ jobs:
         run: make install-tools
       - run: make oteltestbedcol
       - name: Upload Collector Binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: collector-binaries
           path: ./bin/*
@@ -84,7 +84,7 @@ jobs:
         run: make install-tools
       - run: mkdir -p results && touch results/TESTRESULTS.md
       - name: Download Collector Binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: collector-binaries
           path: bin/
@@ -103,12 +103,12 @@ jobs:
       - name: Upload Test Results
         if: ${{ failure() || success() }}
         continue-on-error: true
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./*.tar
       - run: cp testbed/tests/results/benchmarks.json testbed/tests/results/${{steps.filename.outputs.name}}.json
       - name: Upload benchmarks.json
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
           path: testbed/tests/results/${{steps.filename.outputs.name}}.json
@@ -123,7 +123,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: benchmark-results
           path: results

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -45,10 +45,10 @@ jobs:
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make install-tools
       - run: make oteltestbedcol
-      - name: Upload Collector Binaries
+      - name: Upload Testbed Binaries
         uses: actions/upload-artifact@v4
         with:
-          name: collector-binaries
+          name: testbed-binaries
           path: ./bin/*
       - name: Split Loadtest Jobs
         id: splitloadtest
@@ -83,10 +83,10 @@ jobs:
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make install-tools
       - run: mkdir -p results && touch results/TESTRESULTS.md
-      - name: Download Collector Binaries
+      - name: Download Testbed Binaries
         uses: actions/download-artifact@v4
         with:
-          name: collector-binaries
+          name: testbed-binaries
           path: bin/
       - run: chmod +x bin/*
       - name: Loadtest


### PR DESCRIPTION
**Description:**

The upgrade of `actions/upload-artifact` and `actions/download-artifact` is a breaking change.

1. Both actions need to be upgraded together, as downloading artifacts uploaded with previous version does not work.
2. A breaking change in `upload-artifact` is that you cannot upload to the same artifact name twice.

The second point lead to the changes in this pull request. I have modified the names of artifacts to hopefully prevent conflicts.

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30102

**Testing:**

The changes to the `build-and-test` and `e2e-test` workflows are tested in this PR's checks. The changes to the `load-test` workflow can only be tested after merging to main, I'm afraid, as this is when this workflow is triggered.

**Documentation:**

No changes needed.