### PR TITLE
[telemetrygen] Fix case where CA is intentionally unset to derive from host CA pool

### DIFF
--- a/cmd/telemetrygen/internal/common/tls_utils.go
+++ b/cmd/telemetrygen/internal/common/tls_utils.go
@@ -29,15 +29,20 @@ func caPool(caFile string) (*x509.CertPool, error) {
 }
 
 func GetTLSCredentialsForGRPCExporter(caFile string, cAuth ClientAuth) (credentials.TransportCredentials, error) {
-
 	pool, err := caPool(caFile)
 	if err != nil {
 		return nil, err
 	}
 
-	creds := credentials.NewTLS(&tls.Config{
-		RootCAs: pool,
-	})
+    var creds credentials.TransportCredentials
+
+    if caFile != "" {
+	    creds = credentials.NewTLS(&tls.Config{
+		    RootCAs: pool,
+	    })
+	} else {
+	    creds = credentials.NewTLS(&tls.Config{})
+	}
 
 	// Configuration for mTLS
 	if cAuth.Enabled {
@@ -60,8 +65,14 @@ func GetTLSCredentialsForHTTPExporter(caFile string, cAuth ClientAuth) (*tls.Con
 		return nil, err
 	}
 
-	tlsCfg := tls.Config{
-		RootCAs: pool,
+	var tlsCfg tls.Config
+
+    if caFile != "" {
+	    tlsCfg = tls.Config{
+		    RootCAs: pool,
+	    }
+	} else {
+	    tlsCfg = tls.Config{}
 	}
 
 	// Configuration for mTLS


### PR DESCRIPTION
**Description:**

The introduction of TLS configuration broke cases where an individual wants to use the default root CAs provided by the host environment. This adds that functionality back by saying that if a CA file is provided, we will adjust the root CA pool, but not otherwise.

**Link to tracking Issue:** [31191](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31191)

**Testing:** Run telemetrygen against metrics, traces, logs http and grpc endpoints. Test by explicitly providing the root CA cert and not.

**Documentation:** <Describe the documentation added.>