### PR TITLE
telemetrygen: Fix cmd docs examples

### DIFF
--- a/cmd/telemetrygen/internal/common/config.go
+++ b/cmd/telemetrygen/internal/common/config.go
@@ -126,18 +126,18 @@ func (c *Config) CommonFlags(fs *pflag.FlagSet) {
 	c.Headers = make(map[string]string)
 	fs.Var(&c.Headers, "otlp-header", "Custom header to be passed along with each OTLP request. The value is expected in the format key=\"value\". "+
 		"Note you may need to escape the quotes when using the tool from a cli. "+
-		"Flag may be repeated to set multiple headers (e.g --otlp-header \"key1=\\\"value1\\\"\" --otlp-header \"key2=\\\"value2\\\"\")")
+		`Flag may be repeated to set multiple headers (e.g --otlp-header key1=\"value1\" --otlp-header key2=\"value2\")`)
 
 	// custom resource attributes
 	c.ResourceAttributes = make(map[string]string)
 	fs.Var(&c.ResourceAttributes, "otlp-attributes", "Custom resource attributes to use. The value is expected in the format key=\"value\". "+
 		"Note you may need to escape the quotes when using the tool from a cli. "+
-		"Flag may be repeated to set multiple attributes (e.g --otlp-attributes \"key1=\\\"value1\\\"\" --otlp-attributes \"key2=\\\"value2\\\"\")")
+		`Flag may be repeated to set multiple attributes (e.g --otlp-attributes key1=\"value1\" --otlp-attributes key2=\"value2\")`)
 
 	c.TelemetryAttributes = make(map[string]string)
 	fs.Var(&c.TelemetryAttributes, "telemetry-attributes", "Custom telemetry attributes to use. The value is expected in the format key=\"value\". "+
 		"Note you may need to escape the quotes when using the tool from a cli. "+
-		"Flag may be repeated to set multiple attributes (e.g --telemetry-attributes \"key1=\\\"value1\\\"\" --telemetry-attributes \"key2=\\\"value2\\\"\")")
+		`Flag may be repeated to set multiple attributes (e.g --telemetry-attributes key1=\"value1\" --telemetry-attributes key2=\"value2\")`)
 
 	// TLS CA configuration
 	fs.StringVar(&c.CaFile, "ca-cert", "", "Trusted Certificate Authority to verify server certificate")

--- a/cmd/telemetrygen/internal/common/config.go
+++ b/cmd/telemetrygen/internal/common/config.go
@@ -124,18 +124,19 @@ func (c *Config) CommonFlags(fs *pflag.FlagSet) {
 
 	// custom headers
 	c.Headers = make(map[string]string)
-	fs.Var(&c.Headers, "otlp-header", "Custom header to be passed along with each OTLP request. The value is expected in the format key=\"value\"."+
-		"Note you may need to escape the quotes when using the tool from a cli."+
-		"Flag may be repeated to set multiple headers (e.g -otlp-header key1=value1 -otlp-header key2=value2)")
+	fs.Var(&c.Headers, "otlp-header", "Custom header to be passed along with each OTLP request. The value is expected in the format key=\"value\". "+
+		"Note you may need to escape the quotes when using the tool from a cli. "+
+		"Flag may be repeated to set multiple headers (e.g --otlp-header \"key1=\\\"value1\\\"\" --otlp-header \"key2=\\\"value2\\\"\")")
 
 	// custom resource attributes
 	c.ResourceAttributes = make(map[string]string)
-	fs.Var(&c.ResourceAttributes, "otlp-attributes", "Custom resource attributes to use. The value is expected in the format key=\"value\"."+
-		"Note you may need to escape the quotes when using the tool from a cli."+
-		"Flag may be repeated to set multiple attributes (e.g --otlp-attributes key1=\"value1\" --otlp-attributes key2=\"value2\")")
+	fs.Var(&c.ResourceAttributes, "otlp-attributes", "Custom resource attributes to use. The value is expected in the format key=\"value\". "+
+		"Note you may need to escape the quotes when using the tool from a cli. "+
+		"Flag may be repeated to set multiple attributes (e.g --otlp-attributes \"key1=\\\"value1\\\"\" --otlp-attributes \"key2=\\\"value2\\\"\")")
 
 	c.TelemetryAttributes = make(map[string]string)
-	fs.Var(&c.TelemetryAttributes, "telemetry-attributes", "Custom telemetry attributes to use. The value is expected in the format \"key=\\\"value\\\"\". "+
+	fs.Var(&c.TelemetryAttributes, "telemetry-attributes", "Custom telemetry attributes to use. The value is expected in the format key=\"value\". "+
+		"Note you may need to escape the quotes when using the tool from a cli. "+
 		"Flag may be repeated to set multiple attributes (e.g --telemetry-attributes \"key1=\\\"value1\\\"\" --telemetry-attributes \"key2=\\\"value2\\\"\")")
 
 	// TLS CA configuration


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
No functional change. Update cmd docs.

1. Update example to use --otlp-header instead of -otlp-header
2. Align examples to be more consistent with quoting

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
