### PR TITLE
[chore] Fix configschema uses of component.Type

### DIFF
--- a/cmd/configschema/cfgmetadatagen/cfgmetadatagen/metadata_writer_test.go
+++ b/cmd/configschema/cfgmetadatagen/cfgmetadatagen/metadata_writer_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema"
 )
@@ -21,7 +22,7 @@ import (
 func TestMetadataFileWriter(t *testing.T) {
 	tempDir := t.TempDir()
 	w := newMetadataFileWriter(tempDir)
-	err := w.write(configschema.CfgInfo{Group: "mygroup", Type: "mytype"}, []byte("hello"))
+	err := w.write(configschema.CfgInfo{Group: "mygroup", Type: component.MustNewType("mytype")}, []byte("hello"))
 	require.NoError(t, err)
 	file, err := os.Open(filepath.Join(tempDir, "mygroup", "mytype.yaml"))
 	require.NoError(t, err)

--- a/cmd/configschema/docsgen/docsgen/cli.go
+++ b/cmd/configschema/docsgen/docsgen/cli.go
@@ -105,7 +105,7 @@ func writeConfigDoc(
 		panic(err)
 	}
 
-	mdBytes := renderHeader(string(ci.Type), ci.Group, f.Doc)
+	mdBytes := renderHeader(ci.Type.String(), ci.Group, f.Doc)
 
 	f.Name = typeToName(f.Type)
 


### PR DESCRIPTION
**Description:** Fixes configschema uses of `component.Type`

**Link to tracking Issue:** open-telemetry/opentelemetry-collector/issues/9208
