### PR TITLE
[extension/jaegarremotesamplingextension/internal] fix leaking goroutine on shutdown

### DIFF
--- a/extension/jaegerremotesampling/internal/grpc.go
+++ b/extension/jaegerremotesampling/internal/grpc.go
@@ -89,7 +89,7 @@ func (s *SamplingGRPCServer) Start(ctx context.Context, host component.Host) err
 	return nil
 }
 
-// Shutdown stops the grps server gracefully.
+// Shutdown stops the grpc server gracefully.
 func (s *SamplingGRPCServer) Shutdown(_ context.Context) error {
 	if s.grpcServer == nil {
 		return errGRPCServerNotRunning

--- a/extension/jaegerremotesampling/internal/grpc.go
+++ b/extension/jaegerremotesampling/internal/grpc.go
@@ -99,6 +99,7 @@ func (s *SamplingGRPCServer) Shutdown(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		s.grpcServer.Stop()
+		<-ch // wait for the graceful stop goroutine to return
 	case <-ch:
 	}
 

--- a/extension/jaegerremotesampling/internal/package_test.go
+++ b/extension/jaegerremotesampling/internal/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
**Description:**  Fix goroutine leak on grpc server shutdown

**Link to tracking Issue:** #31157 

**Testing:** Add goleak check for internal package. Run make test at module level.

**Documentation:** <Describe the documentation added.>