### PR TITLE
[chore][headerssetter] Update docs to clarify how to use "from_context"

### DIFF
--- a/extension/headerssetterextension/README.md
+++ b/extension/headerssetterextension/README.md
@@ -42,6 +42,11 @@ The following settings are required:
 
 The `value` and `from_context` properties are mutually exclusive.
 
+In order for `from_context` to work, other components in the pipeline also need to be configured appropriately:
+* The [batch processor][batch-processor] must be configured to [preserve client metadata][batch-processor-preserve-metadata]. 
+  Add the value which `from_context` needs to the `metadata_keys` of the batch processor.
+* Receivers must be configured with `include_metadata: true` so that metadata keys are available to the pipeline.
+
 #### Configuration Example
 
 ```yaml
@@ -87,6 +92,9 @@ service:
       processors: [ nop ]
       exporters: [ loki ]
 ```
+
+[batch-processor]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor/README.md
+[batch-processor-preserve-metadata]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor/README.md#batching-and-client-metadata
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/extension/headerssetterextension/README.md
+++ b/extension/headerssetterextension/README.md
@@ -43,7 +43,7 @@ The following settings are required:
 The `value` and `from_context` properties are mutually exclusive.
 
 In order for `from_context` to work, other components in the pipeline also need to be configured appropriately:
-* The [batch processor][batch-processor] must be configured to [preserve client metadata][batch-processor-preserve-metadata]. 
+* If a [batch processor][batch-processor] is present in the pipeline, it must be configured to [preserve client metadata][batch-processor-preserve-metadata]. 
   Add the value which `from_context` needs to the `metadata_keys` of the batch processor.
 * Receivers must be configured with `include_metadata: true` so that metadata keys are available to the pipeline.
 

--- a/extension/headerssetterextension/README.md
+++ b/extension/headerssetterextension/README.md
@@ -72,7 +72,10 @@ receivers:
         include_metadata: true
 
 processors:
-  nop:
+  batch:
+    # Preserve the tenant-id metadata.
+    metadata_keys:
+    - tenant_id
 
 exporters:
   loki:
@@ -89,7 +92,7 @@ service:
   pipelines:
     traces:
       receivers: [ otlp ]
-      processors: [ nop ]
+      processors: [ batch ]
       exporters: [ loki ]
 ```
 


### PR DESCRIPTION
This clarifies potential confusion about how to access metadata using the `from_context` configuration argument.

A few months ago I submitted #27465 to remove an obsolete warning, but then a user [asked](https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/d50e094b89ff6b5db1ad84dc855d6901ef1b2fc7#commitcomment-131957576) about why their `from_context` isn't working properly with a batch processor. I agree that it's not obvious, so I hope this PR clarifies it enough.

I did not try running the update example, so I hope it works :) 

cc @jpkrohling 