### PR TITLE
[chore] remove tests checking for component.ErrNilNextConsumer 

### DIFF
--- a/processor/spanprocessor/span_test.go
+++ b/processor/spanprocessor/span_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor"
@@ -27,11 +26,8 @@ func TestNewTracesProcessor(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	oCfg := cfg.(*Config)
 	oCfg.Rename.FromAttributes = []string{"foo"}
-	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, nil)
-	require.Error(t, component.ErrNilNextConsumer, err)
-	require.Nil(t, tp)
 
-	tp, err = factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
+	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopCreateSettings(), cfg, consumertest.NewNop())
 	require.NoError(t, err)
 	require.NotNil(t, tp)
 }

--- a/receiver/awsfirehosereceiver/metrics_receiver_test.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -41,9 +40,6 @@ func TestNewMetricsReceiver(t *testing.T) {
 		recordType string
 		wantErr    error
 	}{
-		"WithNilConsumer": {
-			wantErr: component.ErrNilNextConsumer,
-		},
 		"WithInvalidRecordType": {
 			consumer:   consumertest.NewNop(),
 			recordType: "test",

--- a/receiver/awsxrayreceiver/receiver_test.go
+++ b/receiver/awsxrayreceiver/receiver_test.go
@@ -38,28 +38,6 @@ const (
 	mockRegion           = "us-west-2"
 )
 
-func TestConsumerCantBeNil(t *testing.T) {
-	addr, err := net.ResolveUDPAddr(udppoller.Transport, "localhost:0")
-	assert.NoError(t, err, "should resolve UDP address")
-
-	sock, err := net.ListenUDP(udppoller.Transport, addr)
-	assert.NoError(t, err, "should be able to listen")
-	defer sock.Close()
-	address := sock.LocalAddr().String()
-
-	_, err = newReceiver(
-		&Config{
-			NetAddr: confignet.NetAddr{
-				Endpoint:  address,
-				Transport: udppoller.Transport,
-			},
-		},
-		nil,
-		receivertest.NewNopCreateSettings(),
-	)
-	assert.True(t, errors.Is(err, component.ErrNilNextConsumer), "consumer is nil should be detected")
-}
-
 func TestProxyCreationFailed(t *testing.T) {
 	addr, err := findAvailableUDPAddress()
 	assert.NoError(t, err, "there should be address available")

--- a/receiver/collectdreceiver/receiver_test.go
+++ b/receiver/collectdreceiver/receiver_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer"
@@ -43,18 +42,6 @@ func TestNewReceiver(t *testing.T) {
 		args    args
 		wantErr error
 	}{
-		{
-			name: "nil next Consumer",
-			args: args{
-				config: &Config{
-					ServerConfig: confighttp.ServerConfig{
-						Endpoint: ":0",
-					},
-				},
-				attrsPrefix: "default_attr_",
-			},
-			wantErr: component.ErrNilNextConsumer,
-		},
 		{
 			name: "happy path",
 			args: args{

--- a/receiver/couchdbreceiver/factory_test.go
+++ b/receiver/couchdbreceiver/factory_test.go
@@ -52,19 +52,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 
 			},
 		},
-		{
-			desc: "Nil consumer",
-			run: func(t *testing.T) {
-				t.Parallel()
-				_, err := createMetricsReceiver(
-					context.Background(),
-					receivertest.NewNopCreateSettings(),
-					createDefaultConfig(),
-					nil,
-				)
-				require.ErrorIs(t, err, component.ErrNilNextConsumer)
-			},
-		},
 	}
 
 	for _, testCase := range testCases {

--- a/receiver/elasticsearchreceiver/factory_test.go
+++ b/receiver/elasticsearchreceiver/factory_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
@@ -45,19 +44,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 					consumertest.NewNop(),
 				)
 				require.ErrorIs(t, err, errConfigNotES)
-			},
-		},
-		{
-			desc: "Nil consumer",
-			run: func(t *testing.T) {
-				t.Parallel()
-				_, err := createMetricsReceiver(
-					context.Background(),
-					receivertest.NewNopCreateSettings(),
-					createDefaultConfig(),
-					nil,
-				)
-				require.ErrorIs(t, err, component.ErrNilNextConsumer)
 			},
 		},
 	}

--- a/receiver/skywalkingreceiver/skywalking_receiver_test.go
+++ b/receiver/skywalkingreceiver/skywalking_receiver_test.go
@@ -66,15 +66,6 @@ var traceJSON = []byte(`
 	"traceSegmentId": "a12ff60b-5807-463b-a1f8-fb1c8608219e"
 }]`)
 
-func TestTraceSource(t *testing.T) {
-	set := receivertest.NewNopCreateSettings()
-	set.ID = skywalkingReceiver
-	mockSwReceiver := newSkywalkingReceiver(&configuration{}, set)
-	err := mockSwReceiver.registerTraceConsumer(nil)
-	assert.Equal(t, err, component.ErrNilNextConsumer)
-	require.NotNil(t, mockSwReceiver)
-}
-
 func TestStartAndShutdown(t *testing.T) {
 	port := 12800
 	config := &configuration{

--- a/receiver/solacereceiver/factory_test.go
+++ b/receiver/solacereceiver/factory_test.go
@@ -50,13 +50,6 @@ func TestCreateTracesReceiverWrongConfig(t *testing.T) {
 	assert.Equal(t, component.ErrDataTypeIsNotSupported, err)
 }
 
-func TestCreateTracesReceiverNilConsumer(t *testing.T) {
-	cfg := createDefaultConfig()
-	factory := NewFactory()
-	_, err := factory.CreateTracesReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, nil)
-	assert.Equal(t, component.ErrNilNextConsumer, err)
-}
-
 func TestCreateTracesReceiverBadConfigNoAuth(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Queue = "some-queue"

--- a/receiver/vcenterreceiver/factory_test.go
+++ b/receiver/vcenterreceiver/factory_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
@@ -42,19 +41,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 					consumertest.NewNop(),
 				)
 				require.ErrorIs(t, err, errConfigNotVcenter)
-			},
-		},
-		{
-			desc: "Nil consumer",
-			testFn: func(t *testing.T) {
-				t.Parallel()
-				_, err := createMetricsReceiver(
-					context.Background(),
-					receivertest.NewNopCreateSettings(),
-					createDefaultConfig(),
-					nil,
-				)
-				require.ErrorIs(t, err, component.ErrNilNextConsumer)
 			},
 		},
 	}

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -49,11 +49,6 @@ func TestNew(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "nil next Consumer",
-			args:    args{},
-			wantErr: component.ErrNilNextConsumer,
-		},
-		{
 			name: "happy path",
 			args: args{
 				nextConsumer: consumertest.NewNop(),


### PR DESCRIPTION
**Description:**
We are looking to deprecate component.ErrNilNextConsumer and have pipelines check it rather than set it the expectation on every component that the next component may be nil.

See https://github.com/open-telemetry/opentelemetry-collector/pull/9526 for context.