### PR TITLE
[chore] remove next nil consumer check

### DIFF
--- a/receiver/snowflakereceiver/factory_test.go
+++ b/receiver/snowflakereceiver/factory_test.go
@@ -62,23 +62,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 				require.NoError(t, err, "failed to create metrics receiver with valid inputs")
 			},
 		},
-		{
-			desc: "Missing consumer",
-			run: func(t *testing.T) {
-				t.Parallel()
-
-				cfg := createDefaultConfig().(*Config)
-
-				_, err := createMetricsReceiver(
-					context.Background(),
-					receivertest.NewNopCreateSettings(),
-					cfg,
-					nil,
-				)
-
-				require.Error(t, err, "created metrics receiver without consumer")
-			},
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, test.run)


### PR DESCRIPTION
**Description:**
We are looking to deprecate component.ErrNilNextConsumer and have pipelines check it rather than set it the expectation on every component that the next component may be nil.

See https://github.com/open-telemetry/opentelemetry-collector/pull/9526 for context.