### PR TITLE
[chore] remove errnextnilconsumer tests

### DIFF
--- a/receiver/splunkenterprisereceiver/factory_test.go
+++ b/receiver/splunkenterprisereceiver/factory_test.go
@@ -66,23 +66,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 				require.NoError(t, err, "failed to create metrics receiver with valid inputs")
 			},
 		},
-		{
-			desc: "Missing consumer",
-			run: func(t *testing.T) {
-				t.Parallel()
-
-				cfg := createDefaultConfig().(*Config)
-
-				_, err := createMetricsReceiver(
-					context.Background(),
-					receivertest.NewNopCreateSettings(),
-					cfg,
-					nil,
-				)
-
-				require.Error(t, err, "created metrics receiver without consumer")
-			},
-		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, test.run)

--- a/receiver/webhookeventreceiver/factory_test.go
+++ b/receiver/webhookeventreceiver/factory_test.go
@@ -47,24 +47,6 @@ func TestCreateLogsReceiver(t *testing.T) {
 				require.NoError(t, err, "failed to create logs receiver")
 			},
 		},
-		{
-			desc: "Missing consumer",
-			run: func(t *testing.T) {
-				t.Parallel()
-
-				cfg := createDefaultConfig().(*Config)
-				cfg.Endpoint = "localhost:8080"
-				require.NoError(t, cfg.Validate(), "error validating default config")
-
-				_, err := createLogsReceiver(
-					context.Background(),
-					receivertest.NewNopCreateSettings(),
-					cfg,
-					nil,
-				)
-				require.Error(t, err, "Succeeded in creating a receiver without a consumer")
-			},
-		},
 	}
 
 	for _, test := range tests {

--- a/receiver/webhookeventreceiver/receiver_test.go
+++ b/receiver/webhookeventreceiver/receiver_test.go
@@ -55,11 +55,6 @@ func TestCreateNewLogReceiver(t *testing.T) {
 			},
 			consumer: consumertest.NewNop(),
 		},
-		{
-			desc: "Missing consumer fails",
-			cfg:  *defaultConfig,
-			err:  errNilLogsConsumer,
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**Description:**
We are looking to deprecate component.ErrNilNextConsumer and have pipelines check it rather than set it the expectation on every component that the next component may be nil.

See https://github.com/open-telemetry/opentelemetry-collector/pull/9526 for context.