### PR TITLE
[chore] add cparkins to azureeventhubreceiver

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -191,7 +191,7 @@ receiver/awsecscontainermetricsreceiver/                 @open-telemetry/collect
 receiver/awsfirehosereceiver/                            @open-telemetry/collector-contrib-approvers @Aneurysm9
 receiver/awsxrayreceiver/                                @open-telemetry/collector-contrib-approvers @wangzlei @srprash
 receiver/azureblobreceiver/                              @open-telemetry/collector-contrib-approvers @eedorenko @mx-psi
-receiver/azureeventhubreceiver/                          @open-telemetry/collector-contrib-approvers @atoulme @djaglowski
+receiver/azureeventhubreceiver/                          @open-telemetry/collector-contrib-approvers @atoulme @djaglowski @cparkins
 receiver/azuremonitorreceiver/                           @open-telemetry/collector-contrib-approvers @nslaughter @codeboten
 receiver/bigipreceiver/                                  @open-telemetry/collector-contrib-approvers @djaglowski @StefanKurek
 receiver/carbonreceiver/                                 @open-telemetry/collector-contrib-approvers @aboguszewski-sumo

--- a/receiver/azureeventhubreceiver/README.md
+++ b/receiver/azureeventhubreceiver/README.md
@@ -6,7 +6,7 @@
 | Stability     | [alpha]: metrics, logs   |
 | Distributions | [contrib], [observiq], [splunk], [sumo] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fazureeventhub%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fazureeventhub) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fazureeventhub%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fazureeventhub) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@atoulme](https://www.github.com/atoulme), [@djaglowski](https://www.github.com/djaglowski) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@atoulme](https://www.github.com/atoulme), [@djaglowski](https://www.github.com/djaglowski), [@cparkins](https://www.github.com/cparkins) |
 
 [alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/azureeventhubreceiver/metadata.yaml
+++ b/receiver/azureeventhubreceiver/metadata.yaml
@@ -6,7 +6,7 @@ status:
     alpha: [metrics, logs]
   distributions: [contrib, splunk, observiq, sumo]
   codeowners:
-    active: [atoulme, djaglowski]
+    active: [atoulme, djaglowski, cparkins]
 
 tests:
   config:


### PR DESCRIPTION
**Description:**
Add @cparkins to codeowners of azure event hub receiver.
**Link to tracking Issue:**
Fixes #31269 