### PR TITLE
[cmd/telemetrygen] Fix logs telemetry attributes key mapping

### DIFF
--- a/.chloggen/fix-telemetrygen-log-attributes.yaml
+++ b/.chloggen/fix-telemetrygen-log-attributes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/telemetrygen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed key mapping for logs telemetry attributes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31309]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/telemetrygen/internal/logs/worker.go
+++ b/cmd/telemetrygen/internal/logs/worker.go
@@ -49,8 +49,8 @@ func (w worker) simulateLogs(res *resource.Resource, exporter exporter, telemetr
 		lattrs := log.Attributes()
 		lattrs.PutStr("app", "server")
 
-		for i, key := range telemetryAttributes {
-			lattrs.PutStr(key.Value.AsString(), telemetryAttributes[i].Value.AsString())
+		for i, attr := range telemetryAttributes {
+			lattrs.PutStr(string(attr.Key), telemetryAttributes[i].Value.AsString())
 		}
 
 		if err := exporter.export(logs); err != nil {

--- a/cmd/telemetrygen/internal/logs/worker_test.go
+++ b/cmd/telemetrygen/internal/logs/worker_test.go
@@ -4,6 +4,7 @@
 package logs
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -145,6 +146,13 @@ func TestLogsWithOneTelemetryAttributes(t *testing.T) {
 		for i := 0; i < rlogs.Len(); i++ {
 			attrs := rlogs.At(i).ScopeLogs().At(0).LogRecords().At(0).Attributes()
 			assert.Equal(t, 2, attrs.Len(), "shouldn't have less than 2 attributes")
+
+			val, ok := attrs.Get(telemetryAttrKeyOne)
+			assert.True(t, ok, fmt.Sprintf("there should be an attribute with key %s", telemetryAttrKeyOne))
+			if ok {
+				assert.EqualValues(t, val.AsString(), telemetryAttrValueOne)
+			}
+
 		}
 	}
 }

--- a/cmd/telemetrygen/internal/logs/worker_test.go
+++ b/cmd/telemetrygen/internal/logs/worker_test.go
@@ -4,7 +4,6 @@
 package logs
 
 import (
-	"fmt"
 	"testing"
 	"time"
 

--- a/cmd/telemetrygen/internal/logs/worker_test.go
+++ b/cmd/telemetrygen/internal/logs/worker_test.go
@@ -148,7 +148,7 @@ func TestLogsWithOneTelemetryAttributes(t *testing.T) {
 			assert.Equal(t, 2, attrs.Len(), "shouldn't have less than 2 attributes")
 
 			val, ok := attrs.Get(telemetryAttrKeyOne)
-			assert.True(t, ok, fmt.Sprintf("there should be an attribute with key %s", telemetryAttrKeyOne))
+			assert.Truef(t, ok, "there should be an attribute with key %s", telemetryAttrKeyOne)
 			if ok {
 				assert.EqualValues(t, val.AsString(), telemetryAttrValueOne)
 			}


### PR DESCRIPTION
**Description:**
This PR addresses a bug in the telemetry attribute key mapping for the logs. Previously, the attribute key was incorrectly mapped to the value property, leading to incorrect data representation on the exported logs.

**Changes:**
Corrected the attribute key mapping logic to ensure the key is mapped to the key, not the value.

**Testing:**
The changes have been thoroughly tested under various scenarios to ensure the bug has been fixed.