### PR TITLE
[chore][pkg/stanza] Fix loop variable captures

### DIFF
--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -713,6 +713,7 @@ func TestRestartOffsets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -906,8 +907,8 @@ func TestEncodings(t *testing.T) {
 		{
 			"Nop",
 			[]byte{0xc5, '\n'},
-			"",
-			[][]byte{{0xc5}},
+			"nop",
+			[][]byte{{0xc5, '\n'}},
 		},
 		{
 			"InvalidUTFReplacement",
@@ -954,6 +955,7 @@ func TestEncodings(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
+++ b/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
@@ -109,6 +109,7 @@ func TestNew(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Fixes variables captured by loops. In one case, a test was effectively being skipped which needed to also be updated.