### PR TITLE
feat: expose setting custom marshalers in kafka exporter

### DIFF
--- a/exporter/kafkaexporter/factory.go
+++ b/exporter/kafkaexporter/factory.go
@@ -43,8 +43,8 @@ const (
 // FactoryOption applies changes to kafkaExporterFactory.
 type FactoryOption func(factory *kafkaExporterFactory)
 
-// withTracesMarshalers adds tracesMarshalers.
-func withTracesMarshalers(tracesMarshalers ...TracesMarshaler) FactoryOption {
+// WithTracesMarshalers adds tracesMarshalers.
+func WithTracesMarshalers(tracesMarshalers ...TracesMarshaler) FactoryOption {
 	return func(factory *kafkaExporterFactory) {
 		for _, marshaler := range tracesMarshalers {
 			factory.tracesMarshalers[marshaler.Encoding()] = marshaler
@@ -52,8 +52,8 @@ func withTracesMarshalers(tracesMarshalers ...TracesMarshaler) FactoryOption {
 	}
 }
 
-// withMetricsMarshalers adds additional metric marshalers to the exporter factory.
-func withMetricsMarshalers(metricMarshalers ...MetricsMarshaler) FactoryOption {
+// WithMetricsMarshalers adds additional metric marshalers to the exporter factory.
+func WithMetricsMarshalers(metricMarshalers ...MetricsMarshaler) FactoryOption {
 	return func(factory *kafkaExporterFactory) {
 		for _, marshaler := range metricMarshalers {
 			factory.metricsMarshalers[marshaler.Encoding()] = marshaler
@@ -61,8 +61,8 @@ func withMetricsMarshalers(metricMarshalers ...MetricsMarshaler) FactoryOption {
 	}
 }
 
-// withLogsMarshalers adds additional log marshalers to the exporter factory.
-func withLogsMarshalers(logsMarshalers ...LogsMarshaler) FactoryOption {
+// WithLogsMarshalers adds additional log marshalers to the exporter factory.
+func WithLogsMarshalers(logsMarshalers ...LogsMarshaler) FactoryOption {
 	return func(factory *kafkaExporterFactory) {
 		for _, marshaler := range logsMarshalers {
 			factory.logsMarshalers[marshaler.Encoding()] = marshaler

--- a/exporter/kafkaexporter/factory_test.go
+++ b/exporter/kafkaexporter/factory_test.go
@@ -118,7 +118,7 @@ func TestCreateMetricExporter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			f := NewFactory(withMetricsMarshalers(tc.marshalers...))
+			f := NewFactory(WithMetricsMarshalers(tc.marshalers...))
 			exporter, err := f.CreateMetricsExporter(
 				context.Background(),
 				exportertest.NewNopCreateSettings(),
@@ -192,7 +192,7 @@ func TestCreateLogExporter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			f := NewFactory(withLogsMarshalers(tc.marshalers...))
+			f := NewFactory(WithLogsMarshalers(tc.marshalers...))
 			exporter, err := f.CreateLogsExporter(
 				context.Background(),
 				exportertest.NewNopCreateSettings(),
@@ -266,7 +266,7 @@ func TestCreateTraceExporter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			f := NewFactory(withTracesMarshalers(tc.marshalers...))
+			f := NewFactory(WithTracesMarshalers(tc.marshalers...))
 			exporter, err := f.CreateTracesExporter(
 				context.Background(),
 				exportertest.NewNopCreateSettings(),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
I have a use case where I would like to extend the kafka exporter, specifically I want to be able to write metrics in a proprietary format to kafka, and the existing exporter works almost exactly how I would need if I would just be able to configure the custom Marshaler.

Similar use case to: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29589