### PR TITLE
[chore][pkg/stanza] Make fingerprint.FirstBytes private

### DIFF
--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -201,7 +201,7 @@ func (m *Manager) makeFingerprint(path string) (*fingerprint.Fingerprint, *os.Fi
 		return nil, nil
 	}
 
-	if len(fp.FirstBytes) == 0 {
+	if fp.Len() == 0 {
 		// Empty file, don't read it until we can compare its fingerprint
 		if err = file.Close(); err != nil {
 			m.Debugw("problem closing file", zap.Error(err))

--- a/pkg/stanza/fileconsumer/internal/checkpoint/checkpoint_test.go
+++ b/pkg/stanza/fileconsumer/internal/checkpoint/checkpoint_test.go
@@ -53,7 +53,7 @@ func TestNopEncodingDifferentLogSizes(t *testing.T) {
 			[]*reader.Metadata{
 				{
 					FileAttributes: make(map[string]any),
-					Fingerprint:    &fingerprint.Fingerprint{FirstBytes: []byte("foo")},
+					Fingerprint:    fingerprint.New([]byte("foo")),
 					Offset:         3,
 				},
 			},
@@ -63,12 +63,12 @@ func TestNopEncodingDifferentLogSizes(t *testing.T) {
 			[]*reader.Metadata{
 				{
 					FileAttributes: make(map[string]any),
-					Fingerprint:    &fingerprint.Fingerprint{FirstBytes: []byte("foo")},
+					Fingerprint:    fingerprint.New([]byte("foo")),
 					Offset:         3,
 				},
 				{
 					FileAttributes: make(map[string]any),
-					Fingerprint:    &fingerprint.Fingerprint{FirstBytes: []byte("barrrr")},
+					Fingerprint:    fingerprint.New([]byte("barrrr")),
 					Offset:         6,
 				},
 			},
@@ -77,7 +77,7 @@ func TestNopEncodingDifferentLogSizes(t *testing.T) {
 			"other_fields",
 			[]*reader.Metadata{
 				{
-					Fingerprint: &fingerprint.Fingerprint{FirstBytes: []byte("foo")},
+					Fingerprint: fingerprint.New([]byte("foo")),
 					Offset:      3,
 					FileAttributes: map[string]any{
 						"hello": "world",
@@ -85,12 +85,12 @@ func TestNopEncodingDifferentLogSizes(t *testing.T) {
 				},
 				{
 					FileAttributes:  make(map[string]any),
-					Fingerprint:     &fingerprint.Fingerprint{FirstBytes: []byte("barrrr")},
+					Fingerprint:     fingerprint.New([]byte("barrrr")),
 					Offset:          6,
 					HeaderFinalized: true,
 				},
 				{
-					Fingerprint: &fingerprint.Fingerprint{FirstBytes: []byte("ab")},
+					Fingerprint: fingerprint.New([]byte("ab")),
 					Offset:      2,
 					FileAttributes: map[string]any{
 						"hello2": "world2",
@@ -121,7 +121,7 @@ func TestMigrateHeaderAttributes(t *testing.T) {
 	p := testutil.NewUnscopedMockPersister()
 	saveDeprecated(t, p, &deprecatedMetadata{
 		Metadata: reader.Metadata{
-			Fingerprint: &fingerprint.Fingerprint{FirstBytes: []byte("foo")},
+			Fingerprint: fingerprint.New([]byte("foo")),
 			Offset:      3,
 			FileAttributes: map[string]any{
 				"HeaderAttributes": map[string]any{
@@ -134,7 +134,7 @@ func TestMigrateHeaderAttributes(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []*reader.Metadata{
 		{
-			Fingerprint: &fingerprint.Fingerprint{FirstBytes: []byte("foo")},
+			Fingerprint: fingerprint.New([]byte("foo")),
 			Offset:      3,
 			FileAttributes: map[string]any{
 				"hello": "world",

--- a/pkg/stanza/fileconsumer/internal/fileset/fileset_test.go
+++ b/pkg/stanza/fileconsumer/internal/fileset/fileset_test.go
@@ -59,20 +59,11 @@ func match[T Matchable](ele T, expect bool) func(t *testing.T, fileset *Fileset[
 	}
 }
 
-func newFingerprint(bytes []byte) *fingerprint.Fingerprint {
-	return &fingerprint.Fingerprint{
-		FirstBytes: bytes,
-	}
-}
-func newMetadata(bytes []byte) *reader.Metadata {
-	return &reader.Metadata{
-		Fingerprint: newFingerprint(bytes),
-	}
-}
-
 func newReader(bytes []byte) *reader.Reader {
 	return &reader.Reader{
-		Metadata: newMetadata(bytes),
+		Metadata: &reader.Metadata{
+			Fingerprint: fingerprint.New(bytes),
+		},
 	}
 }
 

--- a/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint.go
+++ b/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint.go
@@ -5,6 +5,7 @@ package fingerprint // import "github.com/open-telemetry/opentelemetry-collector
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -18,32 +19,31 @@ const MinSize = 16 // bytes
 // Fingerprint is used to identify a file
 // A file's fingerprint is the first N bytes of the file
 type Fingerprint struct {
-	FirstBytes []byte
+	firstBytes []byte
 }
 
-// New creates a new fingerprint from an open file
-func New(file *os.File, size int) (*Fingerprint, error) {
-	buf := make([]byte, size)
+func New(first []byte) *Fingerprint {
+	return &Fingerprint{firstBytes: first}
+}
 
+func NewFromFile(file *os.File, size int) (*Fingerprint, error) {
+	buf := make([]byte, size)
 	n, err := file.ReadAt(buf, 0)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("reading fingerprint bytes: %w", err)
 	}
-
-	fp := &Fingerprint{
-		FirstBytes: buf[:n],
-	}
-
-	return fp, nil
+	return New(buf[:n]), nil
 }
 
 // Copy creates a new copy of the fingerprint
 func (f Fingerprint) Copy() *Fingerprint {
-	buf := make([]byte, len(f.FirstBytes), cap(f.FirstBytes))
-	n := copy(buf, f.FirstBytes)
-	return &Fingerprint{
-		FirstBytes: buf[:n],
-	}
+	buf := make([]byte, len(f.firstBytes), cap(f.firstBytes))
+	n := copy(buf, f.firstBytes)
+	return New(buf[:n])
+}
+
+func (f *Fingerprint) Len() int {
+	return len(f.firstBytes)
 }
 
 // Equal returns true if the fingerprints have the same FirstBytes,
@@ -51,13 +51,13 @@ func (f Fingerprint) Copy() *Fingerprint {
 // because the primary purpose of a fingerprint is to convey a unique
 // identity, and only the FirstBytes field contributes to this goal.
 func (f Fingerprint) Equal(other *Fingerprint) bool {
-	l0 := len(other.FirstBytes)
-	l1 := len(f.FirstBytes)
+	l0 := len(other.firstBytes)
+	l1 := len(f.firstBytes)
 	if l0 != l1 {
 		return false
 	}
 	for i := 0; i < l0; i++ {
-		if other.FirstBytes[i] != f.FirstBytes[i] {
+		if other.firstBytes[i] != f.firstBytes[i] {
 			return false
 		}
 	}
@@ -71,13 +71,31 @@ func (f Fingerprint) Equal(other *Fingerprint) bool {
 // a fingerprint. As the file grows, its fingerprint is updated
 // until it reaches a maximum size, as configured on the operator
 func (f Fingerprint) StartsWith(old *Fingerprint) bool {
-	l0 := len(old.FirstBytes)
+	l0 := len(old.firstBytes)
 	if l0 == 0 {
 		return false
 	}
-	l1 := len(f.FirstBytes)
+	l1 := len(f.firstBytes)
 	if l0 > l1 {
 		return false
 	}
-	return bytes.Equal(old.FirstBytes[:l0], f.FirstBytes[:l0])
+	return bytes.Equal(old.firstBytes[:l0], f.firstBytes[:l0])
+}
+
+func (f *Fingerprint) MarshalJSON() ([]byte, error) {
+	m := marshal{FirstBytes: f.firstBytes}
+	return json.Marshal(&m)
+}
+
+func (f *Fingerprint) UnmarshalJSON(data []byte) error {
+	m := new(marshal)
+	if err := json.Unmarshal(data, m); err != nil {
+		return err
+	}
+	f.firstBytes = m.FirstBytes
+	return nil
+}
+
+type marshal struct {
+	FirstBytes []byte `json:"first_bytes"`
 }

--- a/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
+++ b/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
@@ -36,11 +36,11 @@ func TestNewDoesNotModifyOffset(t *testing.T) {
 	_, err = temp.Seek(0, 0)
 	require.NoError(t, err)
 
-	fp, err := New(temp, len(fingerprint))
+	fp, err := NewFromFile(temp, len(fingerprint))
 	require.NoError(t, err)
 
 	// Validate the fingerprint is the correct size
-	require.Equal(t, len(fingerprint), len(fp.FirstBytes))
+	require.Equal(t, len(fingerprint), len(fp.firstBytes))
 
 	// Validate that reading the fingerprint did not adjust the
 	// file descriptor's internal offset (as using Seek does)
@@ -52,6 +52,11 @@ func TestNewDoesNotModifyOffset(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
+	fp := New([]byte("hello"))
+	require.Equal(t, []byte("hello"), fp.firstBytes)
+}
+
+func TestNewFromFile(t *testing.T) {
 	cases := []struct {
 		name            string
 		fingerprintSize int
@@ -109,6 +114,7 @@ func TestNew(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -125,15 +131,15 @@ func TestNew(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.fileSize, int(info.Size()))
 
-			fp, err := New(temp, tc.fingerprintSize)
+			fp, err := NewFromFile(temp, tc.fingerprintSize)
 			require.NoError(t, err)
 
-			require.Equal(t, tc.expectedLen, len(fp.FirstBytes))
+			require.Equal(t, tc.expectedLen, len(fp.firstBytes))
 		})
 	}
 }
 
-func TestFingerprintCopy(t *testing.T) {
+func TestCopy(t *testing.T) {
 	t.Parallel()
 	cases := []string{
 		"",
@@ -145,36 +151,36 @@ func TestFingerprintCopy(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		fp := &Fingerprint{FirstBytes: []byte(tc)}
+		fp := New([]byte(tc))
 
 		cp := fp.Copy()
 
 		// Did not change original
-		require.Equal(t, tc, string(fp.FirstBytes))
+		require.Equal(t, tc, string(fp.firstBytes))
 
 		// Copy is also good
-		require.Equal(t, tc, string(cp.FirstBytes))
+		require.Equal(t, tc, string(cp.firstBytes))
 
 		// Modify copy
-		cp.FirstBytes = append(cp.FirstBytes, []byte("also")...)
+		cp.firstBytes = append(cp.firstBytes, []byte("also")...)
 
 		// Still did not change original
-		require.Equal(t, tc, string(fp.FirstBytes))
+		require.Equal(t, tc, string(fp.firstBytes))
 
 		// Copy is modified
-		require.Equal(t, tc+"also", string(cp.FirstBytes))
+		require.Equal(t, tc+"also", string(cp.firstBytes))
 	}
 }
 
 func TestEqual(t *testing.T) {
-	empty := &Fingerprint{FirstBytes: []byte("")}
-	empty2 := &Fingerprint{FirstBytes: []byte("")}
-	hello := &Fingerprint{FirstBytes: []byte("hello")}
-	hello2 := &Fingerprint{FirstBytes: []byte("hello")}
-	world := &Fingerprint{FirstBytes: []byte("world")}
-	world2 := &Fingerprint{FirstBytes: []byte("world")}
-	helloworld := &Fingerprint{FirstBytes: []byte("helloworld")}
-	helloworld2 := &Fingerprint{FirstBytes: []byte("helloworld")}
+	empty := New([]byte(""))
+	empty2 := New([]byte(""))
+	hello := New([]byte("hello"))
+	hello2 := New([]byte("hello"))
+	world := New([]byte("world"))
+	world2 := New([]byte("world"))
+	helloworld := New([]byte("helloworld"))
+	helloworld2 := New([]byte("helloworld"))
 
 	require.True(t, empty.Equal(empty2))
 	require.True(t, hello.Equal(hello2))
@@ -192,10 +198,10 @@ func TestEqual(t *testing.T) {
 }
 
 func TestStartsWith(t *testing.T) {
-	empty := &Fingerprint{FirstBytes: []byte("")}
-	hello := &Fingerprint{FirstBytes: []byte("hello")}
-	world := &Fingerprint{FirstBytes: []byte("world")}
-	helloworld := &Fingerprint{FirstBytes: []byte("helloworld")}
+	empty := New([]byte(""))
+	hello := New([]byte("hello"))
+	world := New([]byte("world"))
+	helloworld := New([]byte("helloworld"))
 
 	// Empty never matches
 	require.False(t, hello.StartsWith(empty))
@@ -244,7 +250,7 @@ func TestStartsWith_FromFile(t *testing.T) {
 	_, err = fullFile.Write(content)
 	require.NoError(t, err)
 
-	fff, err := New(fullFile, fingerprintSize)
+	fff, err := NewFromFile(fullFile, fingerprintSize)
 	require.NoError(t, err)
 
 	partialFile, err := os.CreateTemp(tempDir, "")
@@ -262,7 +268,7 @@ func TestStartsWith_FromFile(t *testing.T) {
 		_, err = partialFile.Write(content[i:i])
 		require.NoError(t, err)
 
-		pff, err := New(partialFile, fingerprintSize)
+		pff, err := NewFromFile(partialFile, fingerprintSize)
 		require.NoError(t, err)
 
 		require.True(t, fff.StartsWith(pff))
@@ -276,4 +282,15 @@ func tokenWithLength(length int) []byte {
 		b[i] = charset[rand.Intn(len(charset))]
 	}
 	return b
+}
+
+func TestMarshalUnmarshal(t *testing.T) {
+	fp := New([]byte("hello"))
+	b, err := fp.MarshalJSON()
+	require.NoError(t, err)
+
+	fp2 := new(Fingerprint)
+	require.NoError(t, fp2.UnmarshalJSON(b))
+
+	require.Equal(t, fp, fp2)
 }

--- a/pkg/stanza/fileconsumer/internal/reader/fingerprint_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/fingerprint_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/scanner"
 )
 
@@ -291,7 +292,7 @@ func (tc updateFingerprintTest) run(bufferSize int) func(*testing.T) {
 		} else {
 			assert.Equal(t, int64(len(tc.initBytes)), r.Offset)
 		}
-		assert.Equal(t, tc.initBytes, r.Fingerprint.FirstBytes)
+		assert.Equal(t, fingerprint.New(tc.initBytes), r.Fingerprint)
 
 		i, err := temp.Write(tc.moreBytes)
 		require.NoError(t, err)
@@ -302,7 +303,7 @@ func (tc updateFingerprintTest) run(bufferSize int) func(*testing.T) {
 		sink.ExpectTokens(t, tc.expectTokens...)
 
 		assert.Equal(t, tc.expectOffset, r.Offset)
-		assert.Equal(t, tc.expectFingerprint, r.Fingerprint.FirstBytes)
+		assert.Equal(t, fingerprint.New(tc.expectFingerprint), r.Fingerprint)
 	}
 }
 
@@ -340,9 +341,9 @@ func TestReadingWithLargeFingerPrintSizeAndFileLargerThanScannerBuf(t *testing.T
 	r, err := f.NewReader(temp, fp)
 	require.NoError(t, err)
 
-	initialFingerPrintSize := len(r.Fingerprint.FirstBytes)
+	initialFingerPrintSize := r.Fingerprint.Len()
 	r.ReadToEnd(context.Background())
-	require.Equal(t, initialFingerPrintSize, len(r.Fingerprint.FirstBytes))
+	require.Equal(t, initialFingerPrintSize, r.Fingerprint.Len())
 
 	sink.ExpectTokens(t, expected...)
 }

--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -158,7 +158,7 @@ func (r *Reader) Read(dst []byte) (n int, err error) {
 		return
 	}
 
-	if !r.needsUpdateFingerprint && len(r.Fingerprint.FirstBytes) < r.fingerprintSize {
+	if !r.needsUpdateFingerprint && r.Fingerprint.Len() < r.fingerprintSize {
 		r.needsUpdateFingerprint = true
 	}
 	return
@@ -173,7 +173,7 @@ func (r *Reader) Validate() bool {
 	if r.file == nil {
 		return false
 	}
-	refreshedFingerprint, err := fingerprint.New(r.file, r.fingerprintSize)
+	refreshedFingerprint, err := fingerprint.NewFromFile(r.file, r.fingerprintSize)
 	if err != nil {
 		return false
 	}
@@ -192,12 +192,12 @@ func (r *Reader) updateFingerprint() {
 	if r.file == nil {
 		return
 	}
-	refreshedFingerprint, err := fingerprint.New(r.file, r.fingerprintSize)
+	refreshedFingerprint, err := fingerprint.NewFromFile(r.file, r.fingerprintSize)
 	if err != nil {
 		return
 	}
-	if len(r.Fingerprint.FirstBytes) > 0 && !refreshedFingerprint.StartsWith(r.Fingerprint) {
+	if r.Fingerprint.Len() > 0 && !refreshedFingerprint.StartsWith(r.Fingerprint) {
 		return // fingerprint tampered, likely due to truncation
 	}
-	r.Fingerprint.FirstBytes = refreshedFingerprint.FirstBytes
+	r.Fingerprint = refreshedFingerprint
 }

--- a/pkg/stanza/fileconsumer/internal/reader/split_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/split_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/header"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex"
@@ -215,5 +216,5 @@ func TestHeaderFingerprintIncluded(t *testing.T) {
 
 	r.ReadToEnd(context.Background())
 
-	require.Equal(t, []byte("#header-line\naaa\n"), r.Fingerprint.FirstBytes)
+	require.Equal(t, fingerprint.New([]byte("#header-line\naaa\n")), r.Fingerprint)
 }

--- a/pkg/stanza/fileconsumer/rotation_test.go
+++ b/pkg/stanza/fileconsumer/rotation_test.go
@@ -64,7 +64,7 @@ func TestCopyTruncate(t *testing.T) {
 			for rotationNum := 0; rotationNum < numRotations; rotationNum++ {
 				for messageNum := 0; messageNum < numMessages; messageNum++ {
 					filetest.WriteString(t, file, getMessage(fn, rotationNum, messageNum)+"\n")
-					time.Sleep(10 * time.Millisecond)
+					time.Sleep(5 * time.Millisecond)
 				}
 				require.NoError(t, file.Sync())
 				_, err := file.Seek(0, 0)

--- a/pkg/stanza/fileconsumer/rotation_test.go
+++ b/pkg/stanza/fileconsumer/rotation_test.go
@@ -64,7 +64,7 @@ func TestCopyTruncate(t *testing.T) {
 			for rotationNum := 0; rotationNum < numRotations; rotationNum++ {
 				for messageNum := 0; messageNum < numMessages; messageNum++ {
 					filetest.WriteString(t, file, getMessage(fn, rotationNum, messageNum)+"\n")
-					time.Sleep(5 * time.Millisecond)
+					time.Sleep(10 * time.Millisecond)
 				}
 				require.NoError(t, file.Sync())
 				_, err := file.Seek(0, 0)


### PR DESCRIPTION
Depends on #31251

This is in preparation for adding additional fields to the fingerprint struct. The goal is to write the same data to storage while ensuring consistency between the fields of the struct. This problem does not present until there is a second field in the struct, but this PR prepares for that problem without adding the new field. See #31317 for additional detail.