### PR TITLE
[processor/deltatocumulative]: bugfix - permit advancing start-time

### DIFF
--- a/.chloggen/deltatocumulative-advancing-starttime.yaml
+++ b/.chloggen/deltatocumulative-advancing-starttime.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: deltatocumulativeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: permits advancing delta start timestamps, as required by spec.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31365]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: 
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/deltatocumulativeprocessor/internal/delta/delta.go
+++ b/processor/deltatocumulativeprocessor/internal/delta/delta.go
@@ -34,29 +34,21 @@ type Accumulator[D data.Point[D]] struct {
 // Aggregate implements delta-to-cumulative aggregation as per spec:
 // https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums-delta-to-cumulative
 func (a *Accumulator[D]) Aggregate(id streams.Ident, dp D) (D, error) {
-	// make the accumulator to start with the current sample, discarding any
-	// earlier data. return after use
-	reset := func() (D, error) {
+	aggr, ok := a.dps[id]
+
+	// new series: initialize with current sample
+	if !ok {
 		a.dps[id] = dp.Clone()
 		return a.dps[id], nil
 	}
 
-	aggr, ok := a.dps[id]
-
-	// new series: reset
-	if !ok {
-		return reset()
-	}
-	// belongs to older series: drop
-	if dp.StartTimestamp() < aggr.StartTimestamp() {
+	// drop bad samples
+	switch {
+	case dp.StartTimestamp() < aggr.StartTimestamp():
+		// belongs to older series
 		return aggr, ErrOlderStart{Start: aggr.StartTimestamp(), Sample: dp.StartTimestamp()}
-	}
-	// belongs to later series: reset
-	if dp.StartTimestamp() > aggr.StartTimestamp() {
-		return reset()
-	}
-	// out of order: drop
-	if dp.Timestamp() <= aggr.Timestamp() {
+	case dp.Timestamp() <= aggr.Timestamp():
+		// out of order
 		return aggr, ErrOutOfOrder{Last: aggr.Timestamp(), Sample: dp.Timestamp()}
 	}
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>

The [spec](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#sums-delta-to-cumulative) allows the `StartTimestamp` of a delta stream to advance over time, without affecting the aggregation.

Previously, the running counter was reset with each start-time change. This was violating the spec and also effectively prevented meaningful aggregation as series were reset all the time.

**Testing:**

A test-case was modified to explicitly check this behavior is permitted and handled correctly.
