### PR TITLE
[exporter/loadbalancing] Set a placeholder endpoint

### DIFF
--- a/.chloggen/lb-exporter-dummy-endpoint.yaml
+++ b/.chloggen/lb-exporter-dummy-endpoint.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: loadbalancingexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: A change to the OTLP exporter causes the load-balancing exporter to fail during startup as no endpoints are defined at that stage.
+note: Fixes a bug where the endpoint become required, despite not being used by the load balancing exporter.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [31371]

--- a/.chloggen/lb-exporter-dummy-endpoint.yaml
+++ b/.chloggen/lb-exporter-dummy-endpoint.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: loadbalancingexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: A change to the OTLP exporter causes the load-balancing exporter to fail during startup as no endpoints are defined at that stage.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31371]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -32,6 +32,7 @@ func NewFactory() exporter.Factory {
 func createDefaultConfig() component.Config {
 	otlpFactory := otlpexporter.NewFactory()
 	otlpDefaultCfg := otlpFactory.CreateDefaultConfig().(*otlpexporter.Config)
+	otlpDefaultCfg.Endpoint = "placeholder"
 
 	return &Config{
 		Protocol: Protocol{

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -46,3 +46,15 @@ func TestLogExporterGetsCreatedWithValidConfiguration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, exp)
 }
+
+func TestOTLPConfigIsValid(t *testing.T) {
+	// prepare
+	factory := NewFactory()
+	defaultCfg := factory.CreateDefaultConfig().(*Config)
+
+	// test
+	otlpCfg := defaultCfg.Protocol.OTLP
+
+	// verify
+	assert.NoError(t, otlpCfg.Validate())
+}


### PR DESCRIPTION
As part of https://github.com/open-telemetry/opentelemetry-collector/pull/9523, the OTLP Exporter configuration used by the load balancing exporter is being validates automatically. However, the endpoint is the only thing users should NOT set, as it will be set at a later point in time by the load balancer.

This PR sets a placeholder value for the endpoint so that the validation passes.

Fixes #31371

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
