### PR TITLE
[chore] remove more tests check for errors reported on next nil consumer

### DIFF
--- a/receiver/kafkametricsreceiver/factory_test.go
+++ b/receiver/kafkametricsreceiver/factory_test.go
@@ -21,17 +21,6 @@ func TestCreateDefaultConfig(t *testing.T) {
 	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 }
 
-func TestCreateMetricsReceiver_errors(t *testing.T) {
-	factory := NewFactory()
-	cfg := factory.CreateDefaultConfig().(*Config)
-	cfg.Brokers = []string{"invalid:9092"}
-	cfg.ProtocolVersion = "2.0.0"
-	cfg.Scrapers = []string{"topics"}
-	r, err := createMetricsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, nil)
-	assert.Error(t, err)
-	assert.Nil(t, r)
-}
-
 func TestCreateMetricsReceiver(t *testing.T) {
 	prev := newMetricsReceiver
 	newMetricsReceiver = func(context.Context, Config, receiver.CreateSettings, consumer.Metrics) (receiver.Metrics, error) {

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -39,17 +39,6 @@ func TestCreateTracesReceiver(t *testing.T) {
 	require.Error(t, r.Start(context.Background(), componenttest.NewNopHost()))
 }
 
-func TestCreateTracesReceiver_error(t *testing.T) {
-	cfg := createDefaultConfig().(*Config)
-	cfg.ProtocolVersion = "2.0.0"
-	// disable contacting broker at startup
-	cfg.Metadata.Full = false
-	f := kafkaReceiverFactory{tracesUnmarshalers: defaultTracesUnmarshalers()}
-	r, err := f.createTracesReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, nil)
-	require.NoError(t, err)
-	assert.NotNil(t, r)
-}
-
 func TestWithTracesUnmarshalers(t *testing.T) {
 	unmarshaler := &customTracesUnmarshaler{}
 	f := NewFactory(withTracesUnmarshalers(unmarshaler))
@@ -89,17 +78,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 	require.Error(t, r.Start(context.Background(), componenttest.NewNopHost()))
 }
 
-func TestCreateMetricsReceiver_error(t *testing.T) {
-	cfg := createDefaultConfig().(*Config)
-	cfg.ProtocolVersion = "2.0.0"
-	// disable contacting broker at startup
-	cfg.Metadata.Full = false
-	f := kafkaReceiverFactory{metricsUnmarshalers: defaultMetricsUnmarshalers()}
-	r, err := f.createMetricsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, nil)
-	require.NoError(t, err)
-	assert.NotNil(t, r)
-}
-
 func TestWithMetricsUnmarshalers(t *testing.T) {
 	unmarshaler := &customMetricsUnmarshaler{}
 	f := NewFactory(withMetricsUnmarshalers(unmarshaler))
@@ -137,17 +115,6 @@ func TestCreateLogsReceiver(t *testing.T) {
 	require.NoError(t, err)
 	// no available broker
 	require.Error(t, r.Start(context.Background(), componenttest.NewNopHost()))
-}
-
-func TestCreateLogsReceiver_error(t *testing.T) {
-	cfg := createDefaultConfig().(*Config)
-	cfg.ProtocolVersion = "2.0.0"
-	// disable contacting broker at startup
-	cfg.Metadata.Full = false
-	f := kafkaReceiverFactory{logsUnmarshalers: defaultLogsUnmarshalers("Test Version", zap.NewNop())}
-	r, err := f.createLogsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, nil)
-	require.NoError(t, err)
-	assert.NotNil(t, r)
 }
 
 func TestGetLogsUnmarshaler_encoding_text_error(t *testing.T) {

--- a/receiver/otelarrowreceiver/factory_test.go
+++ b/receiver/otelarrowreceiver/factory_test.go
@@ -191,16 +191,6 @@ func TestCreateLogReceiver(t *testing.T) {
 			wantStartErr: true,
 			sink:         new(consumertest.LogsSink),
 		},
-		{
-			name: "no_next_consumer",
-			cfg: &Config{
-				Protocols: Protocols{
-					GRPC: defaultGRPCSettings,
-				},
-			},
-			wantErr: true,
-			sink:    nil,
-		},
 	}
 	ctx := context.Background()
 	creationSet := receivertest.NewNopCreateSettings()

--- a/receiver/prometheusreceiver/factory_test.go
+++ b/receiver/prometheusreceiver/factory_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
@@ -30,7 +31,7 @@ func TestCreateReceiver(t *testing.T) {
 	// The default config does not provide scrape_config so we expect that metrics receiver
 	// creation must also fail.
 	creationSet := receivertest.NewNopCreateSettings()
-	mReceiver, _ := createMetricsReceiver(context.Background(), creationSet, cfg, nil)
+	mReceiver, _ := createMetricsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NotNil(t, mReceiver)
 	assert.NotNil(t, mReceiver.(*pReceiver).cfg.PrometheusConfig.GlobalConfig)
 }


### PR DESCRIPTION
**Description:**
We are looking to deprecate component.ErrNilNextConsumer and have pipelines check it rather than set it the expectation on every component that the next component may be nil.

See https://github.com/open-telemetry/opentelemetry-collector/pull/9526 for context.
