### PR TITLE
[processor/transform] fix typo in resource example for logs

### DIFF
--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -114,7 +114,7 @@ transform:
   log_statements:
     - context: resource
       statements:
-        - keep_keys(resource.attributes, ["service.name", "service.namespace", "cloud.region"])
+        - keep_keys(attributes, ["service.name", "service.namespace", "cloud.region"])
     - context: log
       statements:
         - set(severity_text, "FAIL") where body == "request failed"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Fixes a typo in the config example of resource context statements for logs.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>