### PR TITLE
[receiver/prometheus] Use confighttp for target allocator client

### DIFF
--- a/.chloggen/receiver_prometheus_confighttp-ta.yaml
+++ b/.chloggen/receiver_prometheus_confighttp-ta.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use confighttp for target allocator client
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31449]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -141,6 +141,11 @@ receivers:
       interval: 30s
       collector_id: collector-1
 ```
+
+The `target_allocator` section embeds the full [confighttp client configuration][confighttp].
+
+[confighttp]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp#client-configuration
+
 ## Exemplars
 This receiver accepts exemplars coming in Prometheus format and converts it to OTLP format.
 1. Value is expected to be received in `float64` format

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -16,6 +16,7 @@ import (
 	promconfig "github.com/prometheus/prometheus/config"
 	promHTTP "github.com/prometheus/prometheus/discovery/http"
 	"github.com/prometheus/prometheus/discovery/kubernetes"
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/confmap"
 	"gopkg.in/yaml.v2"
 )
@@ -52,10 +53,10 @@ func (cfg *Config) Validate() error {
 }
 
 type TargetAllocator struct {
-	Endpoint     string            `mapstructure:"endpoint"`
-	Interval     time.Duration     `mapstructure:"interval"`
-	CollectorID  string            `mapstructure:"collector_id"`
-	HTTPSDConfig *PromHTTPSDConfig `mapstructure:"http_sd_config"`
+	confighttp.ClientConfig `mapstructure:",squash"`
+	Interval                time.Duration     `mapstructure:"interval"`
+	CollectorID             string            `mapstructure:"collector_id"`
+	HTTPSDConfig            *PromHTTPSDConfig `mapstructure:"http_sd_config"`
 }
 
 func (cfg *TargetAllocator) Validate() error {

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -71,8 +71,11 @@ func TestLoadTargetAllocatorConfig(t *testing.T) {
 	r0 := cfg.(*Config)
 	assert.NotNil(t, r0.PrometheusConfig)
 	assert.Equal(t, "http://localhost:8080", r0.TargetAllocator.Endpoint)
+	assert.Equal(t, 5*time.Second, r0.TargetAllocator.Timeout)
+	assert.Equal(t, "client.crt", r0.TargetAllocator.TLSSetting.CertFile)
 	assert.Equal(t, 30*time.Second, r0.TargetAllocator.Interval)
 	assert.Equal(t, "collector-1", r0.TargetAllocator.CollectorID)
+	assert.NotNil(t, r0.PrometheusConfig)
 
 	sub, err = cm.Sub(component.NewIDWithName(metadata.Type, "withScrape").String())
 	require.NoError(t, err)

--- a/receiver/prometheusreceiver/go.mod
+++ b/receiver/prometheusreceiver/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
@@ -162,7 +163,6 @@ require (
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/receiver/prometheusreceiver/testdata/config_target_allocator.yaml
+++ b/receiver/prometheusreceiver/testdata/config_target_allocator.yaml
@@ -1,6 +1,9 @@
 prometheus:
   target_allocator:
     endpoint: http://localhost:8080
+    timeout: 5s
+    tls:
+      cert_file: "client.crt"
     interval: 30s
     collector_id: collector-1
 prometheus/withScrape:


### PR DESCRIPTION
**Description:** 
Use confighttp for target allocator http client in prometheus receiver.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31449

**Testing:**
Added some simple config tests.

**Documentation:**
Added a note to the README.