### PR TITLE
[exporter/datadog] include version in stats payloads from dd connector

### DIFF
--- a/.chloggen/andrew.glaude_ddexporter-add-agent-version.yaml
+++ b/.chloggen/andrew.glaude_ddexporter-add-agent-version.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Attach the collector version to stats payloads to improve the debugging experience.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31454]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: ["user"]

--- a/exporter/datadogexporter/integrationtest/integration_test.go
+++ b/exporter/datadogexporter/integrationtest/integration_test.go
@@ -116,6 +116,7 @@ func TestIntegration(t *testing.T) {
 					var spl pb.StatsPayload
 					require.NoError(t, msgp.Decode(gz, &spl))
 					for _, csps := range spl.Stats {
+						assert.Equal(t, "datadogexporter-otelcol-tests", spl.AgentVersion)
 						for _, csbs := range csps.Stats {
 							stats = append(stats, csbs.Stats...)
 							for _, stat := range csbs.Stats {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The dd connector doesn't attach the version of the collector that generated the stats - to ensure the version is attached the exporter should attach the version. This improves the debugging experience by giving improved visibility into exactly which collector versions are sending payloads. 

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** 
Modified integration test to ensure coverage of new line

**Documentation:** <Describe the documentation added.>