### PR TITLE
[pkg/ottl]: Add ParseXML converter

### DIFF
--- a/.chloggen/feat_ottl_xml-parse-function.yaml
+++ b/.chloggen/feat_ottl_xml-parse-function.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `ParseXML` function for parsing XML from a target string.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31133]

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -480,7 +480,7 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
-			statement: `set(attributes["test"], ParseXML("<Log id="1"><Message>This is a log message!</Message></Log>"))`,
+			statement: `set(attributes["test"], ParseXML("<Log id=\"1\"><Message>This is a log message!</Message></Log>"))`,
 			want: func(tCtx ottllog.TransformContext) {
 				log := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				log.PutStr("tag", "Log")
@@ -492,7 +492,7 @@ func Test_e2e_converters(t *testing.T) {
 
 				message := logChildren.AppendEmpty().SetEmptyMap()
 				message.PutStr("tag", "Message")
-				message.PutStr("content", "This is a log message")
+				message.PutStr("content", "This is a log message!")
 			},
 		},
 		{

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -480,6 +480,22 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
+			statement: `set(attributes["test"], ParseXML("<Log id="1"><Message>This is a log message!</Message></Log>"))`,
+			want: func(tCtx ottllog.TransformContext) {
+				log := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
+				log.PutStr("tag", "Log")
+
+				attrs := log.PutEmptyMap("attributes")
+				attrs.PutStr("id", "1")
+
+				logChildren := log.PutEmptySlice("children")
+
+				message := logChildren.AppendEmpty().SetEmptyMap()
+				message.PutStr("tag", "Message")
+				message.PutStr("content", "This is a log message")
+			},
+		},
+		{
 			statement: `set(attributes["test"], Seconds(Duration("1m")))`,
 			want: func(tCtx ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutDouble("test", 60)

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -909,10 +909,10 @@ If `target` is not a string, nil, or cannot be parsed as XML, `ParseXML` will re
 
 Unmarshalling XML is done using the following rules:
 1. All character data for an XML element is trimmed, joined, and placed into the `content` field.
-2. The tag for an XML element is trimmed, and placed into a `tag` field.
+2. The tag for an XML element is trimmed, and placed into the `tag` field.
 3. The attributes for an XML element is placed as a `pcommon.Map` into the `attribute` field.
 4. Processing instructions, directives, and comments are ignored and not represented in the resultant map.
-5. All child elements are parsed as above, and placed in a `pcommon.Slice`, which is then placed in the `children` field.
+5. All child elements are parsed as above, and placed in a `pcommon.Slice`, which is then placed into the `children` field.
 
 For example, the following XML document:
 ```xml

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -402,6 +402,7 @@ Available Converters:
 - [ParseCSV](#parsecsv)
 - [ParseJSON](#parsejson)
 - [ParseKeyValue](#parsekeyvalue)
+- [ParseXML](#parsexml)
 - [Seconds](#seconds)
 - [SHA1](#sha1)
 - [SHA256](#sha256)
@@ -895,6 +896,78 @@ Examples:
 - `ParseKeyValue("k1=v1 k2=v2 k3=v3")`
 - `ParseKeyValue("k1!v1_k2!v2_k3!v3", "!", "_")`
 - `ParseKeyValue(attributes["pairs"])`
+
+
+### ParseXML
+
+`ParseXML(target)`
+
+The `ParseXML` Converter returns a `pcommon.Map` struct that is the result of parsing the target string as an XML document.
+
+`target` is a Getter that returns a string. This string should be in XML format.
+If `target` is not a string, nil, or cannot be parsed as XML, `ParseXML` will return an error.
+
+Unmarshalling XML is done using the following rules:
+1. All character data for an XML element is trimmed, joined, and placed in the `content` field
+2. The tag for an XML element is trimmed, and placed in a `tag` field
+3. The attributes for an XML element is placed as a `pcommon.Map` in the `attribute` field
+4. Processing instructions, directives, and comments are ignored and not represented in to resultant map
+5. All child elements are parsed as above, and placed in a `pcommon.Slice`, which is then placed in the `children` field.
+
+For example, the following XML document:
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<Log>
+  <User>
+    <ID>00001</ID>
+    <Name type="first">Joe</Name>
+    <Email>joe.smith@example.com</Email>
+  </User>
+  <Text>User fired alert A</Text>
+</Log>
+```
+
+will be parsed as:
+```json
+{
+  "tag": "Log",
+  "children": [
+    {
+      "tag": "User",
+      "children": [
+        {
+          "tag": "ID",
+          "content": "00001"
+        },
+        {
+          "tag": "Name",
+          "content": "Joe",
+          "attributes": {
+            "type": "first"
+          }
+        },
+        {
+          "tag": "Email",
+          "content": "joe.smith@example.com"
+        }
+      ]
+    },
+    {
+      "tag": "Text",
+      "content": "User fired alert A"
+    }
+  ]
+}
+```
+
+Examples:
+
+- `ParseXML(body)`
+
+- `ParseXML(attributes[""])`
+
+- `ParseXML("<HostInfo hostname=\"example.com\" zone=\"east-1\" cloudprovider=\"aws\" />")`
+
 
 
 ### Seconds

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -908,10 +908,10 @@ The `ParseXML` Converter returns a `pcommon.Map` struct that is the result of pa
 If `target` is not a string, nil, or cannot be parsed as XML, `ParseXML` will return an error.
 
 Unmarshalling XML is done using the following rules:
-1. All character data for an XML element is trimmed, joined, and placed in the `content` field
-2. The tag for an XML element is trimmed, and placed in a `tag` field
-3. The attributes for an XML element is placed as a `pcommon.Map` in the `attribute` field
-4. Processing instructions, directives, and comments are ignored and not represented in to resultant map
+1. All character data for an XML element is trimmed, joined, and placed into the `content` field.
+2. The tag for an XML element is trimmed, and placed into a `tag` field.
+3. The attributes for an XML element is placed as a `pcommon.Map` into the `attribute` field.
+4. Processing instructions, directives, and comments are ignored and not represented in the resultant map.
 5. All child elements are parsed as above, and placed in a `pcommon.Slice`, which is then placed in the `children` field.
 
 For example, the following XML document:

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -964,7 +964,7 @@ Examples:
 
 - `ParseXML(body)`
 
-- `ParseXML(attributes[""])`
+- `ParseXML(attributes["xml"])`
 
 - `ParseXML("<HostInfo hostname=\"example.com\" zone=\"east-1\" cloudprovider=\"aws\" />")`
 

--- a/pkg/ottl/ottlfuncs/func_parse_xml.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 
 import (

--- a/pkg/ottl/ottlfuncs/func_parse_xml.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -43,6 +44,10 @@ func parseXML[K any](target ottl.StringGetter[K]) ottl.ExprFunc[K] {
 		err = decoder.Decode(&parsedXML)
 		if err != nil {
 			return nil, fmt.Errorf("unmarshal xml: %w", err)
+		}
+
+		if decoder.InputOffset() != int64(len(targetVal)) {
+			return nil, errors.New("leftover bytes after parsing xml")
 		}
 
 		parsedMap := pcommon.NewMap()

--- a/pkg/ottl/ottlfuncs/func_parse_xml.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml.go
@@ -1,0 +1,174 @@
+package ottlfuncs
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type ParseXMLArguments[K any] struct {
+	Target ottl.StringGetter[K]
+}
+
+func NewParseXMLFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("ParseXML", &ParseXMLArguments[K]{}, createParseXMLFunction[K])
+}
+
+func createParseXMLFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*ParseXMLArguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("ParseXMLFactory args must be of type *ParseXMLArguments[K]")
+	}
+
+	return parseXML(args.Target, true), nil
+}
+
+// parseXML returns a `pcommon.Map` struct that is a result of parsing the target string as XML
+// parseXML unmarshals an XML node to a map by:
+//   - Placing the tag name in the #tag field
+//   - Place any attributes in a field `@${attributeName}`, where attributeName is the name of the attribute
+//   - Placing any trimmed text in the node into the #text field (only if there was any text)
+//   - Placing any children into a key `${tag}#${position}`, where tag is the tag of the child,
+//     and position is the 0-based index of the element.
+func parseXML[K any](target ottl.StringGetter[K], strict bool) ottl.ExprFunc[K] {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		targetVal, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		parsedXML := anyXML{}
+
+		decoder := xml.NewDecoder(strings.NewReader(targetVal))
+		decoder.Strict = strict
+		err = decoder.Decode(&parsedXML)
+		if err != nil {
+			return nil, fmt.Errorf("unmarshal xml: %w", err)
+		}
+
+		parsedMap := parsedXML.toMap()
+
+		e := json.NewEncoder(os.Stdout)
+		e.SetIndent("", "\t")
+		_ = e.Encode(parsedMap)
+
+		m := pcommon.NewMap()
+		err = m.FromRaw(parsedMap)
+		if err != nil {
+			return nil, fmt.Errorf("create pcommon.Map: %w", err)
+		}
+
+		return m, nil
+	}
+}
+
+const (
+	// attributePrefix is deliberitely chosen to be a character that cannot start a name or token in XML
+	// See: https://www.w3.org/TR/REC-xml/#d0e804
+	attributePrefix = "@"
+	// These fields are also chosen to start with a character that cannot start a name or token in XML (#)
+	textField = "#chardata"
+	tagField  = "#tag"
+)
+
+type anyXML struct {
+	tag        string
+	attributes []xml.Attr
+	text       string
+	children   []anyXML
+}
+
+func (a *anyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	a.tag = start.Name.Local
+	a.attributes = start.Attr
+
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return fmt.Errorf("decode next token: %w", err)
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			child := anyXML{}
+			err := d.DecodeElement(&child, &t)
+			if err != nil {
+				return fmt.Errorf("decode start element: %w", err)
+			}
+
+			a.children = append(a.children, child)
+		case xml.EndElement:
+			// End element means we've reached the end of parsing
+			return nil
+		case xml.CharData:
+			// Strip leading/trailing spaces to ignore newlines and
+			// indentation in formatted XML
+			a.text += string(bytes.TrimSpace([]byte(t)))
+		case xml.Comment: // ignore comments
+		case xml.ProcInst: // ignore processing instructions
+		case xml.Directive: // ignore directives
+		default:
+			return fmt.Errorf("unexpected token type %T", t)
+		}
+
+	}
+}
+
+func (a anyXML) toMap() map[string]any {
+	// 1 tag filed + 1 text field + 1 per attribute + 1 per child
+	mapSize := 2 + len(a.attributes) + len(a.children)
+	m := make(map[string]any, mapSize)
+
+	m[tagField] = a.tag
+
+	if a.text != "" {
+		m[textField] = a.text
+	}
+
+	for _, attr := range a.attributes {
+		m[attributePrefix+attr.Name.Local] = attr.Value
+	}
+
+	hasCollisions := xmlChildrenHaveNameCollisions(a.children)
+	xmlAddChildrenToMap(m, a.children, hasCollisions)
+
+	return m
+}
+
+func xmlAddChildrenToMap(m map[string]any, children []anyXML, includeSequenceNumber bool) {
+	// Pad the number out so that the keys will sort properly for the same elements
+	seqNumberDigits := int(math.Log10(float64(len(children)))) + 1
+
+	for i, child := range children {
+		mapKey := child.tag
+		if includeSequenceNumber {
+			mapKey = fmt.Sprintf("%s#%0*d", mapKey, seqNumberDigits, i)
+		}
+		m[mapKey] = child.toMap()
+	}
+}
+
+// xmlChildrenHaveNameCollisions determines if children has any name collisions.
+// if it does, we must add a sequence number to the name to avoid the collisions.
+func xmlChildrenHaveNameCollisions(children []anyXML) bool {
+	tagSet := make(map[string]struct{}, len(children))
+
+	for _, child := range children {
+		if _, ok := tagSet[child.tag]; ok {
+			return true
+		}
+
+		tagSet[child.tag] = struct{}{}
+	}
+
+	return false
+}

--- a/pkg/ottl/ottlfuncs/func_parse_xml.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml.go
@@ -75,7 +75,7 @@ func (a *anyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			child := anyXML{}
 			err := d.DecodeElement(&child, &t)
 			if err != nil {
-				return fmt.Errorf("decode start element: %w", err)
+				return err
 			}
 
 			a.children = append(a.children, child)

--- a/pkg/ottl/ottlfuncs/func_parse_xml.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml.go
@@ -47,7 +47,7 @@ func parseXML[K any](target ottl.StringGetter[K]) ottl.ExprFunc[K] {
 		}
 
 		if decoder.InputOffset() != int64(len(targetVal)) {
-			return nil, errors.New("leftover bytes after parsing xml")
+			return nil, errors.New("trailing bytes after parsing xml")
 		}
 
 		parsedMap := pcommon.NewMap()

--- a/pkg/ottl/ottlfuncs/func_parse_xml.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml.go
@@ -1,4 +1,4 @@
-package ottlfuncs
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
 
 import (
 	"bytes"
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
 type ParseXMLArguments[K any] struct {

--- a/pkg/ottl/ottlfuncs/func_parse_xml.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml.go
@@ -42,7 +42,7 @@ func parseXML[K any](target ottl.StringGetter[K]) ottl.ExprFunc[K] {
 			return nil, err
 		}
 
-		parsedXML := anyXML{}
+		parsedXML := xmlElement{}
 
 		decoder := xml.NewDecoder(strings.NewReader(targetVal))
 		err = decoder.Decode(&parsedXML)
@@ -61,15 +61,15 @@ func parseXML[K any](target ottl.StringGetter[K]) ottl.ExprFunc[K] {
 	}
 }
 
-type anyXML struct {
+type xmlElement struct {
 	tag        string
 	attributes []xml.Attr
 	text       string
-	children   []anyXML
+	children   []xmlElement
 }
 
 // UnmarshalXML implements xml.Unmarshaler for anyXML
-func (a *anyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (a *xmlElement) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	a.tag = start.Name.Local
 	a.attributes = start.Attr
 
@@ -81,7 +81,7 @@ func (a *anyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 
 		switch t := tok.(type) {
 		case xml.StartElement:
-			child := anyXML{}
+			child := xmlElement{}
 			err := d.DecodeElement(&child, &t)
 			if err != nil {
 				return err
@@ -105,7 +105,7 @@ func (a *anyXML) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 }
 
 // intoMap converts and adds the anyXML into the provided pcommon.Map.
-func (a anyXML) intoMap(m pcommon.Map) {
+func (a xmlElement) intoMap(m pcommon.Map) {
 	m.EnsureCapacity(4)
 
 	m.PutStr("tag", a.tag)

--- a/pkg/ottl/ottlfuncs/func_parse_xml.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml.go
@@ -68,7 +68,7 @@ type xmlElement struct {
 	children   []xmlElement
 }
 
-// UnmarshalXML implements xml.Unmarshaler for anyXML
+// UnmarshalXML implements xml.Unmarshaler for xmlElement
 func (a *xmlElement) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	a.tag = start.Name.Local
 	a.attributes = start.Attr
@@ -104,7 +104,7 @@ func (a *xmlElement) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 	}
 }
 
-// intoMap converts and adds the anyXML into the provided pcommon.Map.
+// intoMap converts and adds the xmlElement into the provided pcommon.Map.
 func (a xmlElement) intoMap(m pcommon.Map) {
 	m.EnsureCapacity(4)
 

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package ottlfuncs
 
 import (

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -180,6 +180,17 @@ func Test_ParseXML(t *testing.T) {
 			parseError: "unmarshal xml: decode next token: XML syntax error on line 1: element <Text> closed by </Log>",
 		},
 		{
+			name: "Multiple XML elements in payload (trailing bytes)",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log></Log><Log></Log>`, nil
+					},
+				},
+			},
+			parseError: "leftover bytes after parsing xml",
+		},
+		{
 			name: "Error getting target",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -128,6 +128,32 @@ func Test_ParseXML(t *testing.T) {
 			},
 		},
 		{
+			name: "Multiple lines of contend",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log>
+						This record has multiple lines of
+						<User id="0001"/>
+						text content
+						</Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "This record has multiple lines oftext content",
+				"children": []any{
+					map[string]any{
+						"tag": "User",
+						"attributes": map[string]any{
+							"id": "0001",
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Attribute only element",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
 func Test_ParseXML(t *testing.T) {

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -1,7 +1,224 @@
 package ottlfuncs
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
 
 func Test_ParseXML(t *testing.T) {
+	tests := []struct {
+		name        string
+		oArgs       ottl.Arguments
+		want        map[string]any
+		createError string
+		parseError  string
+	}{
+		{
+			name: "Text values in nested elements",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return "<Log><User><ID>00001</ID><Name>Joe</Name><Email>joe.smith@example.com</Email></User><Text>User did a thing</Text></Log>", nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag": "Log",
+				"children": []any{
+					map[string]any{
+						"tag": "User",
+						"children": []any{
+							map[string]any{
+								"tag":     "ID",
+								"content": "00001",
+							},
+							map[string]any{
+								"tag":     "Name",
+								"content": "Joe",
+							},
+							map[string]any{
+								"tag":     "Email",
+								"content": "joe.smith@example.com",
+							},
+						},
+					},
+					map[string]any{
+						"tag":     "Text",
+						"content": "User did a thing",
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple tags with the same name",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log>This record has a collision<User id="0001"/><User id="0002"/></Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "This record has a collision",
+				"children": []any{
+					map[string]any{
+						"tag": "User",
+						"attributes": map[string]any{
+							"id": "0001",
+						},
+					},
+					map[string]any{
+						"tag": "User",
+						"attributes": map[string]any{
+							"id": "0002",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Attribute only element",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<HostInfo hostname="example.com" zone="east-1" cloudprovider="aws" />`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag": "HostInfo",
+				"attributes": map[string]any{
+					"hostname":      "example.com",
+					"zone":          "east-1",
+					"cloudprovider": "aws",
+				},
+			},
+		},
+		{
+			name: "Ignores XML declaration",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<?xml version="1.0" encoding="UTF-8" ?><Log>Log content</Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "Log content",
+			},
+		},
+		{
+			name: "Ignores comments",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log>This has a comment <!-- This is comment text --></Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "This has a comment",
+			},
+		},
+		{
+			name: "Ignores processing instructions",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log><?xml-stylesheet type="text/xsl" href="style.xsl"?>Log content</Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "Log content",
+			},
+		},
+		{
+			name: "Ignores directives",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log><!ELEMENT xi:fallback ANY>Log content</Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "Log content",
+			},
+		},
+		{
+			name: "Missing closing element",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log id="1">`, nil
+					},
+				},
+			},
+			parseError: "unmarshal xml: decode next token: XML syntax error on line 1: unexpected EOF",
+		},
+		{
+			name: "Missing nested closing element",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log><Text></Log>`, nil
+					},
+				},
+			},
+			parseError: "unmarshal xml: decode next token: XML syntax error on line 1: element <Text> closed by </Log>",
+		},
+		{
+			name: "Error getting target",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return "", fmt.Errorf("failed to get string")
+					},
+				},
+			},
+			parseError: "error getting value in ottl.StandardStringGetter[interface {}]: failed to get string",
+		},
+		{
+			name:        "Invalid arguments",
+			oArgs:       nil,
+			createError: "ParseXMLFactory args must be of type *ParseXMLArguments[K]",
+		},
+	}
 
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := createParseXMLFunction[any](ottl.FunctionContext{}, tt.oArgs)
+			if tt.createError != "" {
+				require.ErrorContains(t, err, tt.createError)
+				return
+			}
+
+			require.NoError(t, err)
+
+			result, err := exprFunc(context.Background(), nil)
+			if tt.parseError != "" {
+				require.ErrorContains(t, err, tt.parseError)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			resultMap, ok := result.(pcommon.Map)
+			require.True(t, ok)
+
+			require.Equal(t, tt.want, resultMap.AsRaw())
+		})
+	}
 }

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -1,0 +1,7 @@
+package ottlfuncs
+
+import "testing"
+
+func Test_ParseXML(t *testing.T) {
+
+}

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -56,6 +56,50 @@ func Test_ParseXML(t *testing.T) {
 			},
 		},
 		{
+			name: "Formatted example",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `
+						<Log>
+						  <User>
+						    <ID>00001</ID>
+							<Name>Joe</Name>
+							<Email>joe.smith@example.com</Email>
+						  </User>
+						  <Text>User did a thing</Text>
+						</Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag": "Log",
+				"children": []any{
+					map[string]any{
+						"tag": "User",
+						"children": []any{
+							map[string]any{
+								"tag":     "ID",
+								"content": "00001",
+							},
+							map[string]any{
+								"tag":     "Name",
+								"content": "Joe",
+							},
+							map[string]any{
+								"tag":     "Email",
+								"content": "joe.smith@example.com",
+							},
+						},
+					},
+					map[string]any{
+						"tag":     "Text",
+						"content": "User did a thing",
+					},
+				},
+			},
+		},
+		{
 			name: "Multiple tags with the same name",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -188,7 +188,7 @@ func Test_ParseXML(t *testing.T) {
 					},
 				},
 			},
-			parseError: "leftover bytes after parsing xml",
+			parseError: "trailing bytes after parsing xml",
 		},
 		{
 			name: "Error getting target",

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -132,7 +132,7 @@ func Test_ParseXML(t *testing.T) {
 			},
 		},
 		{
-			name: "Multiple lines of contend",
+			name: "Multiple lines of content",
 			oArgs: &ParseXMLArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
 					Getter: func(_ context.Context, _ any) (any, error) {

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -60,6 +60,7 @@ func converters[K any]() []ottl.Factory[K] {
 		NewParseCSVFactory[K](),
 		NewParseJSONFactory[K](),
 		NewParseKeyValueFactory[K](),
+		NewParseXMLFactory[K](),
 		NewSecondsFactory[K](),
 		NewSHA1Factory[K](),
 		NewSHA256Factory[K](),


### PR DESCRIPTION
**Description:**
* Adds a ParseXML converter function that can be used to parse an XML document to a pcommon.Map value

**Link to tracking Issue:** Closes #31133

**Testing:**
Unit tests
Manually tested parsing XML logs

**Documentation:**
Added documentation for the ParseXML function to the ottl_funcs README.