### PR TITLE
[chore] [mdatagen] Use directory name as package name for generated files

### DIFF
--- a/cmd/mdatagen/main.go
+++ b/cmd/mdatagen/main.go
@@ -43,6 +43,7 @@ func run(ymlPath string) error {
 	}
 
 	ymlDir := filepath.Dir(ymlPath)
+	packageName := filepath.Base(ymlDir)
 
 	md, err := loadMetadata(ymlPath)
 	if err != nil {
@@ -75,7 +76,7 @@ func run(ymlPath string) error {
 
 	if md.Tests != nil {
 		if err = generateFile(filepath.Join(tmplDir, "component_test.go.tmpl"),
-			filepath.Join(ymlDir, "generated_component_test.go"), md, md.ShortFolderName+md.Status.Class); err != nil {
+			filepath.Join(ymlDir, "generated_component_test.go"), md, packageName); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Use the directory name for the package in generated files. Composing the name doesn't match the reality for extensions.
