### PR TITLE
[receiver/awsxrayreceiver] Add local namespace support

### DIFF
--- a/.chloggen/xray-local-ns.yaml
+++ b/.chloggen/xray-local-ns.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for local namespace in subsegment
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31514]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/aws/xray/testdata/indepSubsegmentWithLocalNamespace.txt
+++ b/internal/aws/xray/testdata/indepSubsegmentWithLocalNamespace.txt
@@ -1,0 +1,11 @@
+{
+    "name": "localNamespaceTest",
+    "id": "53995c3f42cd8ad8",
+    "start_time": 1478293361.271,
+    "end_time": 1478293361.449,
+    "type": "subsegment",
+    "trace_id": "1-581cf771-a006649127e371903a2de979",
+    "parent_id": "defdfd9912dc5a56",
+    "namespace": "local",
+    "traced": true
+}

--- a/receiver/awsxrayreceiver/internal/translator/name.go
+++ b/receiver/awsxrayreceiver/internal/translator/name.go
@@ -14,6 +14,7 @@ import (
 const (
 	validAWSNamespace    = "aws"
 	validRemoteNamespace = "remote"
+	validLocalNamespace  = "local"
 )
 
 func addNameAndNamespace(seg *awsxray.Segment, span ptrace.Span) error {
@@ -29,7 +30,7 @@ func addNameAndNamespace(seg *awsxray.Segment, span ptrace.Span) error {
 		span.SetKind(ptrace.SpanKindServer)
 	}
 
-	if seg.Namespace == nil {
+	if seg.Namespace == nil || *seg.Namespace == validLocalNamespace {
 		if span.Kind() == ptrace.SpanKindUnspecified {
 			span.SetKind(ptrace.SpanKindInternal)
 		}
@@ -49,6 +50,7 @@ func addNameAndNamespace(seg *awsxray.Segment, span ptrace.Span) error {
 
 	case validRemoteNamespace:
 		// no op
+
 	default:
 		return fmt.Errorf("unexpected namespace: %s", *seg.Namespace)
 	}


### PR DESCRIPTION
**Description:**
Support local namespace in X-Ray subsegment. The subsegment with local namespace will be translated into Internal span kind.

**Testing:**
Added unit test case with local namespace.

