### PR TITLE
[pkg/stanza] Fix "matched files" log formatting

### DIFF
--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -130,7 +130,7 @@ func (m *Manager) poll(ctx context.Context) {
 	if err != nil {
 		m.Warnf("finding files: %v", err)
 	}
-	m.Debugf("matched files", zap.Strings("paths", matches))
+	m.Debugw("matched files", zap.Strings("paths", matches))
 
 	for len(matches) > m.maxBatchFiles {
 		m.consume(ctx, matches[:m.maxBatchFiles])


### PR DESCRIPTION
**Description:**
`Debugf` function was used instead of the structured interface making log output less readable:

```
matched files%!(EXTRA zapcore.Field={...
```

**Link to tracking Issue:**
N/A -- creating an issue for this fix seems too much

**Testing:**
A test for this also seems excessive, however this is the actual output I am seeing after the change:

```
.../prj/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/logger.go:146: 2024-02-29T17:01:46.158-0800	DEBUG	matched files	{"component": "fileconsumer", "paths": ["/var/folders/q3/ggh_tr0j6097j4_3mzvxys540000gp/T/TestReadNewLogs3743368306/001/4019652275"]}
```

**Documentation:**
N/A