### PR TITLE
[pkg/stanza] Add monitoring metrics for open and harvested files in fileconsumer

### DIFF
--- a/.chloggen/add_filelog_metrics.yaml
+++ b/.chloggen/add_filelog_metrics.yaml
@@ -10,7 +10,7 @@ component: stanza
 note: Add monitoring metrics for open and harvested files in fileconsumer
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [31544, 31256]
+issues: [31256]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]

--- a/.chloggen/add_filelog_metrics.yaml
+++ b/.chloggen/add_filelog_metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add monitoring metrics for open and harvested files in fileconsumer
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31544, 31256]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -35,6 +35,8 @@ const (
 	defaultMaxConcurrentFiles = 1024
 	defaultEncoding           = "utf-8"
 	defaultPollInterval       = 200 * time.Millisecond
+	openFilesMetric           = "fileconsumer/open_files"
+	readingFilesMetric        = "fileconsumer/reading_files"
 )
 
 var allowFileDeletion = featuregate.GlobalRegistry().MustRegister(
@@ -176,8 +178,8 @@ func (c Config) Build(set component.TelemetrySettings, emit emit.Callback, opts 
 
 	meter := set.MeterProvider.Meter("otelcol/fileconsumer")
 
-	openedFiles, err := meter.Int64UpDownCounter(
-		"fileconsumer"+"/"+"open_files",
+	openFiles, err := meter.Int64UpDownCounter(
+		openFilesMetric,
 		metric.WithDescription("Number of open files"),
 		metric.WithUnit("1"),
 	)
@@ -185,7 +187,7 @@ func (c Config) Build(set component.TelemetrySettings, emit emit.Callback, opts 
 		return nil, err
 	}
 	readingFiles, err := meter.Int64UpDownCounter(
-		"fileconsumer"+"/"+"reading_files",
+		readingFilesMetric,
 		metric.WithDescription("Number of open files that are being read"),
 		metric.WithUnit("1"),
 	)
@@ -200,7 +202,7 @@ func (c Config) Build(set component.TelemetrySettings, emit emit.Callback, opts 
 		maxBatchFiles: c.MaxConcurrentFiles / 2,
 		maxBatches:    c.MaxBatches,
 		tracker:       t,
-		openFiles:     openedFiles,
+		openFiles:     openFiles,
 		readingFiles:  readingFiles,
 	}, nil
 }

--- a/pkg/stanza/fileconsumer/file_other.go
+++ b/pkg/stanza/fileconsumer/file_other.go
@@ -50,7 +50,9 @@ OUTER:
 		lostWG.Add(1)
 		go func(r *reader.Reader) {
 			defer lostWG.Done()
+			m.readingFiles.Add(ctx, 1)
 			r.ReadToEnd(ctx)
+			m.readingFiles.Add(ctx, -1)
 		}(lostReader)
 	}
 	lostWG.Wait()

--- a/pkg/stanza/fileconsumer/internal/tracker/tracker_other.go
+++ b/pkg/stanza/fileconsumer/internal/tracker/tracker_other.go
@@ -12,10 +12,11 @@ import (
 
 // On non-windows platforms, we keep files open between poll cycles so that we can detect
 // and read "lost" files, which have been moved out of the matching pattern.
-func (t *fileTracker) EndConsume() {
-	t.ClosePreviousFiles()
+func (t *fileTracker) EndConsume() (filesClosed int) {
+	filesClosed = t.ClosePreviousFiles()
 
 	// t.currentPollFiles -> t.previousPollFiles
 	t.previousPollFiles = t.currentPollFiles
 	t.currentPollFiles = fileset.New[*reader.Reader](t.maxBatchFiles)
+	return
 }

--- a/pkg/stanza/fileconsumer/internal/tracker/tracker_windows.go
+++ b/pkg/stanza/fileconsumer/internal/tracker/tracker_windows.go
@@ -12,9 +12,10 @@ import (
 )
 
 // On windows, we close files immediately after reading because they cannot be moved while open.
-func (t *fileTracker) EndConsume() {
+func (t *fileTracker) EndConsume() (filesClosed int) {
 	// t.currentPollFiles -> t.previousPollFiles
 	t.previousPollFiles = t.currentPollFiles
-	t.ClosePreviousFiles()
+	filesClosed = t.ClosePreviousFiles()
 	t.currentPollFiles = fileset.New[*reader.Reader](t.maxBatchFiles)
+	return
 }

--- a/pkg/stanza/go.mod
+++ b/pkg/stanza/go.mod
@@ -23,14 +23,6 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.8.0
 	go.opentelemetry.io/collector/pdata v1.8.0
 	go.opentelemetry.io/collector/receiver v0.101.0
-	go.opentelemetry.io/collector/component v0.100.1-0.20240517133416-ede9e304314d
-	go.opentelemetry.io/collector/config/configtls v0.100.1-0.20240517133416-ede9e304314d
-	go.opentelemetry.io/collector/confmap v0.100.1-0.20240517133416-ede9e304314d
-	go.opentelemetry.io/collector/consumer v0.100.1-0.20240517133416-ede9e304314d
-	go.opentelemetry.io/collector/extension v0.100.1-0.20240517133416-ede9e304314d
-	go.opentelemetry.io/collector/featuregate v1.7.1-0.20240517133416-ede9e304314d
-	go.opentelemetry.io/collector/pdata v1.7.1-0.20240517133416-ede9e304314d
-	go.opentelemetry.io/collector/receiver v0.100.1-0.20240517133416-ede9e304314d
 	go.opentelemetry.io/otel/metric v1.26.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0

--- a/pkg/stanza/go.mod
+++ b/pkg/stanza/go.mod
@@ -23,6 +23,15 @@ require (
 	go.opentelemetry.io/collector/featuregate v1.8.0
 	go.opentelemetry.io/collector/pdata v1.8.0
 	go.opentelemetry.io/collector/receiver v0.101.0
+	go.opentelemetry.io/collector/component v0.100.1-0.20240517133416-ede9e304314d
+	go.opentelemetry.io/collector/config/configtls v0.100.1-0.20240517133416-ede9e304314d
+	go.opentelemetry.io/collector/confmap v0.100.1-0.20240517133416-ede9e304314d
+	go.opentelemetry.io/collector/consumer v0.100.1-0.20240517133416-ede9e304314d
+	go.opentelemetry.io/collector/extension v0.100.1-0.20240517133416-ede9e304314d
+	go.opentelemetry.io/collector/featuregate v1.7.1-0.20240517133416-ede9e304314d
+	go.opentelemetry.io/collector/pdata v1.7.1-0.20240517133416-ede9e304314d
+	go.opentelemetry.io/collector/receiver v0.100.1-0.20240517133416-ede9e304314d
+	go.opentelemetry.io/otel/metric v1.26.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
@@ -62,7 +71,6 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.101.0 // indirect
 	go.opentelemetry.io/otel v1.26.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.48.0 // indirect
-	go.opentelemetry.io/otel/metric v1.26.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.26.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.26.0 // indirect
 	go.opentelemetry.io/otel/trace v1.26.0 // indirect

--- a/receiver/filelogreceiver/README.md
+++ b/receiver/filelogreceiver/README.md
@@ -200,3 +200,9 @@ Exactly how this information is serialized depends on the type of storage being 
 ### Tracking symlinked files
 If the receiver is being used to track a symlinked file and the symlink target is expected to change frequently, make sure 
 to set the value of the `poll_interval` setting to something lower than the symlink update frequency.
+
+### Telemetry metrics
+Enabling [Collector metrics](https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#metrics)
+will also provide telemetry metrics for the state of the receiver's file consumption.
+Specifically, the `otelcol_fileconsumer_open_files` and `otelcol_fileconsumer_reading_files` metrics
+are provided.


### PR DESCRIPTION
Blocked on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31618

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This PR adds support for filelog receiver to emit observable metrics about its current state: how many files are opened, and harvested.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31256

**Testing:** <Describe what testing was performed and which tests were added.>

#### How to test this manually

1. Use the following collector config:
```yaml
receivers:
  filelog:
    start_at: end
    include:
    - /var/log/busybox/monitoring/*.log
exporters:
  debug:
    verbosity: detailed
service:
  telemetry:
    metrics:
      level: detailed
      address: ":8888"
  pipelines:
    logs:
      receivers: [filelog]
      exporters: [debug]
      processors: []
```

2. Build and run the collector: `make otelcontribcol && ./bin/otelcontribcol_linux_amd64 --config ~/otelcol/monitoring_telemetry/config.yaml`
3. Produce some logs:
```console
echo 'some line' >> /var/log/busybox/monitoring/1.log
while true; do echo -e "This is a log line" >> /var/log/busybox/monitoring/2.log; done
```
4. Verify that metrics are produced:
```console
curl 0.0.0.0:8888/metrics | grep _files
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4002    0  4002    0     0  1954k      0 --:--:-- --:--:-- --:--:-- 1954k
# HELP otelcol_fileconsumer_open_files Number of open files
# TYPE otelcol_fileconsumer_open_files gauge
otelcol_fileconsumer_open_files{service_instance_id="72b4899d-6ce3-41de-a25b-8f0370e22ec1",service_name="otelcontribcol",service_version="0.99.0-dev"} 2
# HELP otelcol_fileconsumer_reading_files Number of open files that are being read
# TYPE otelcol_fileconsumer_reading_files gauge
otelcol_fileconsumer_reading_files{service_instance_id="72b4899d-6ce3-41de-a25b-8f0370e22ec1",service_name="otelcontribcol",service_version="0.99.0-dev"} 1
```

**Documentation:** <Describe the documentation added.>
Added a respective section in Filelog receiver's docs.