### PR TITLE
[pkg/stanza/fileconsumer] Establish options pattern for Build

### DIFF
--- a/.chloggen/pkg-stanza-fileconsumer-build-opts.yaml
+++ b/.chloggen/pkg-stanza-fileconsumer-build-opts.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate fileconsumer.BuildWithSplitFunc in favor of Build with options pattern
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31596]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -87,20 +87,35 @@ type HeaderConfig struct {
 	MetadataOperators []operator.Config `mapstructure:"metadata_operators"`
 }
 
-// Build will build a file input operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback) (*Manager, error) {
+// Deprecated [v0.97.0] Use Build and WithSplitFunc option instead
+func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit emit.Callback, splitFunc bufio.SplitFunc) (*Manager, error) {
+	return c.Build(logger, emit, WithSplitFunc(splitFunc))
+}
+
+func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback, opts ...Option) (*Manager, error) {
 	if err := c.validate(); err != nil {
 		return nil, err
+	}
+	if emit == nil {
+		return nil, fmt.Errorf("must provide emit function")
+	}
+
+	o := new(options)
+	for _, opt := range opts {
+		opt(o)
 	}
 
 	enc, err := decode.LookupEncoding(c.Encoding)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to find encoding: %w", err)
 	}
 
-	splitFunc, err := c.SplitConfig.Func(enc, false, int(c.MaxLogSize))
-	if err != nil {
-		return nil, err
+	splitFunc := o.splitFunc
+	if splitFunc == nil {
+		splitFunc, err = c.SplitConfig.Func(enc, false, int(c.MaxLogSize))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	trimFunc := trim.Nop
@@ -108,21 +123,6 @@ func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback) (*Manager, 
 		trimFunc = c.TrimConfig.Func()
 	}
 
-	return c.buildManager(logger, emit, splitFunc, trimFunc)
-}
-
-// BuildWithSplitFunc will build a file input operator with customized splitFunc function
-func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit emit.Callback, splitFunc bufio.SplitFunc) (*Manager, error) {
-	if err := c.validate(); err != nil {
-		return nil, err
-	}
-	return c.buildManager(logger, emit, splitFunc, c.TrimConfig.Func())
-}
-
-func (c Config) buildManager(logger *zap.SugaredLogger, emit emit.Callback, splitFunc bufio.SplitFunc, trimFunc trim.Func) (*Manager, error) {
-	if emit == nil {
-		return nil, fmt.Errorf("must provide emit function")
-	}
 	var startAtBeginning bool
 	switch c.StartAt {
 	case "beginning":
@@ -131,11 +131,6 @@ func (c Config) buildManager(logger *zap.SugaredLogger, emit emit.Callback, spli
 		startAtBeginning = false
 	default:
 		return nil, fmt.Errorf("invalid start_at location '%s'", c.StartAt)
-	}
-
-	enc, err := decode.LookupEncoding(c.Encoding)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find encoding: %w", err)
 	}
 
 	var hCfg *header.Config
@@ -231,4 +226,17 @@ func (c Config) validate() error {
 	}
 
 	return nil
+}
+
+type options struct {
+	splitFunc bufio.SplitFunc
+}
+
+type Option func(*options)
+
+// WithSplitFunc overrides the split func which is normally built from other settings on the config
+func WithSplitFunc(f bufio.SplitFunc) Option {
+	return func(o *options) {
+		o.splitFunc = f
+	}
 }


### PR DESCRIPTION
This PR takes a step towards modularizing the fileconsumer package. It's become increasingly clear that several different aspects of the package should support alternative implementations. For example, how to find and filter files, how to track them (fingerprints vs path vs none), how to interpret and tokenize, or how to trigger the overall behavior.

This PR takes a small step towards enabling that pattern by establishing an options pattern for building the fileconsumer.Manager. Future work can establish interfaces for alternative behaviors and allow them to be specified via options.

Supports #31534