### PR TITLE
[exporter/loadbalancing] Do not block resolver by the exporter shutdown

### DIFF
--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -148,7 +148,11 @@ func (lb *loadBalancer) removeExtraExporters(ctx context.Context, endpoints []st
 	}
 	for existing := range lb.exporters {
 		if !endpointFound(existing, endpointsWithPort) {
-			_ = lb.exporters[existing].Shutdown(ctx)
+			exp := lb.exporters[existing]
+			// Shutdown the exporter asynchronously to avoid blocking the resolver
+			go func() {
+				_ = exp.Shutdown(ctx)
+			}()
 			delete(lb.exporters, existing)
 		}
 	}


### PR DESCRIPTION
This resolves the issues seen in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31410 after merging https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31456