### PR TITLE
[chore] only run weekly report on the opentelemetry repository

### DIFF
--- a/.github/workflows/generate-weekly-report.yml
+++ b/.github/workflows/generate-weekly-report.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   get_issues:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v4
       - run: npm install js-yaml


### PR DESCRIPTION
This is to avoid the proliferation of the weekly report issues in forks of the repository.