### PR TITLE
[receiver/filelog] Add support for telemetry metrics

### DIFF
--- a/pkg/stanza/adapter/benchmark_test.go
+++ b/pkg/stanza/adapter/benchmark_test.go
@@ -164,8 +164,8 @@ type BenchOpConfig struct {
 }
 
 // Build will build a noop operator.
-func (c BenchOpConfig) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c BenchOpConfig) Build(logger *zap.SugaredLogger, set component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(logger, set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/adapter/factory.go
+++ b/pkg/stanza/adapter/factory.go
@@ -56,7 +56,7 @@ func createLogsReceiver(logReceiverType LogReceiverType) rcvr.CreateLogsFunc {
 		pipe, err := pipeline.Config{
 			Operators:     operators,
 			DefaultOutput: emitter,
-		}.Build(params.Logger.Sugar())
+		}.Build(params.Logger.Sugar(), params.TelemetrySettings)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/stanza/adapter/integration_test.go
+++ b/pkg/stanza/adapter/integration_test.go
@@ -31,7 +31,7 @@ func createNoopReceiver(nextConsumer consumer.Logs) (*receiver, error) {
 				Builder: noop.NewConfig(),
 			},
 		},
-	}.Build(zap.NewNop().Sugar())
+	}.Build(zap.NewNop().Sugar(), componenttest.NewNopTelemetrySettings())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/adapter/mocks_test.go
+++ b/pkg/stanza/adapter/mocks_test.go
@@ -41,7 +41,7 @@ func NewUnstartableConfig() operator.Config {
 }
 
 // Build will build an unstartable operator
-func (c *UnstartableConfig) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c *UnstartableConfig) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	o, _ := c.OutputConfig.Build(logger)
 	return &UnstartableOperator{OutputOperator: o}, nil
 }

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -138,7 +138,7 @@ func BenchmarkReadLine(b *testing.B) {
 	pipe, err := pipeline.Config{
 		Operators:     operatorCfgs,
 		DefaultOutput: emitter,
-	}.Build(zap.NewNop().Sugar())
+	}.Build(zap.NewNop().Sugar(), componenttest.NewNopTelemetrySettings())
 	require.NoError(b, err)
 
 	// Populate the file that will be consumed
@@ -203,7 +203,7 @@ func BenchmarkParseAndMap(b *testing.B) {
 	pipe, err := pipeline.Config{
 		Operators:     operatorCfgs,
 		DefaultOutput: emitter,
-	}.Build(zap.NewNop().Sugar())
+	}.Build(zap.NewNop().Sugar(), componenttest.NewNopTelemetrySettings())
 	require.NoError(b, err)
 
 	// Populate the file that will be consumed

--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
@@ -167,7 +168,7 @@ func BenchmarkFileInput(b *testing.B) {
 				received <- token
 				return nil
 			}
-			op, err := cfg.Build(testutil.Logger(b), callback)
+			op, err := cfg.Build(testutil.Logger(b), componenttest.NewNopTelemetrySettings(), callback)
 			require.NoError(b, err)
 
 			// write half the lines before starting

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
@@ -88,11 +89,11 @@ type HeaderConfig struct {
 }
 
 // Deprecated [v0.97.0] Use Build and WithSplitFunc option instead
-func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit emit.Callback, splitFunc bufio.SplitFunc) (*Manager, error) {
-	return c.Build(logger, emit, WithSplitFunc(splitFunc))
+func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, set component.TelemetrySettings, emit emit.Callback, splitFunc bufio.SplitFunc) (*Manager, error) {
+	return c.Build(logger, set, emit, WithSplitFunc(splitFunc))
 }
 
-func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback, opts ...Option) (*Manager, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings, emit emit.Callback, opts ...Option) (*Manager, error) {
 	if err := c.validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
 
@@ -627,7 +629,7 @@ func TestBuild(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			input, err := cfg.Build(testutil.Logger(t), emittest.Nop)
+			input, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings(), emittest.Nop)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return
@@ -706,7 +708,7 @@ func TestBuildWithSplitFunc(t *testing.T) {
 				return len(data), data, nil
 			}
 
-			input, err := cfg.BuildWithSplitFunc(testutil.Logger(t), emittest.Nop, splitNone)
+			input, err := cfg.BuildWithSplitFunc(testutil.Logger(t), componenttest.NewNopTelemetrySettings(), emittest.Nop, splitNone)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return
@@ -793,7 +795,7 @@ func TestBuildWithHeader(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			input, err := cfg.Build(testutil.Logger(t), emittest.Nop)
+			input, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings(), emittest.Nop)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return
@@ -846,6 +848,6 @@ func newMockOperatorConfig(cfg *Config) *mockOperatorConfig {
 
 // This function is impelmented for compatibility with operatortest
 // but is not meant to be used directly
-func (h *mockOperatorConfig) Build(*zap.SugaredLogger) (operator.Operator, error) {
+func (h *mockOperatorConfig) Build(*zap.SugaredLogger, component.TelemetrySettings) (operator.Operator, error) {
 	panic("not impelemented")
 }

--- a/pkg/stanza/fileconsumer/internal/header/config.go
+++ b/pkg/stanza/fileconsumer/internal/header/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
 
@@ -39,7 +40,7 @@ func NewConfig(matchRegex string, metadataOperators []operator.Config, enc encod
 	p, err := pipeline.Config{
 		Operators:     metadataOperators,
 		DefaultOutput: newPipelineOutput(nopLogger),
-	}.Build(nopLogger)
+	}.Build(nopLogger, component.TelemetrySettings{})
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to build pipelines: %w", err)

--- a/pkg/stanza/fileconsumer/internal/header/reader.go
+++ b/pkg/stanza/fileconsumer/internal/header/reader.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 
@@ -31,7 +32,7 @@ func NewReader(logger *zap.SugaredLogger, cfg Config) (*Reader, error) {
 	r.pipeline, err = pipeline.Config{
 		Operators:     cfg.metadataOperators,
 		DefaultOutput: r.output,
-	}.Build(logger)
+	}.Build(logger, component.TelemetrySettings{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build pipeline: %w", err)
 	}

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/emittest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -18,7 +19,7 @@ func testManager(t *testing.T, cfg *Config) (*Manager, *emittest.Sink) {
 }
 
 func testManagerWithSink(t *testing.T, cfg *Config, sink *emittest.Sink) *Manager {
-	input, err := cfg.Build(testutil.Logger(t), sink.Callback)
+	input, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings(), sink.Callback)
 	require.NoError(t, err)
 	t.Cleanup(func() { input.closePreviousFiles() })
 	return input

--- a/pkg/stanza/operator/config.go
+++ b/pkg/stanza/operator/config.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.uber.org/zap"
 )
@@ -25,7 +26,7 @@ func NewConfig(b Builder) Config {
 type Builder interface {
 	ID() string
 	Type() string
-	Build(*zap.SugaredLogger) (Operator, error)
+	Build(*zap.SugaredLogger, component.TelemetrySettings) (Operator, error)
 	SetID(string)
 }
 

--- a/pkg/stanza/operator/config_test.go
+++ b/pkg/stanza/operator/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -18,7 +19,7 @@ type FakeBuilder struct {
 	Array        []string `json:"array" yaml:"array"`
 }
 
-func (f *FakeBuilder) Build(_ *zap.SugaredLogger) (Operator, error) {
+func (f *FakeBuilder) Build(_ *zap.SugaredLogger, _ component.TelemetrySettings) (Operator, error) {
 	return nil, nil
 }
 func (f *FakeBuilder) ID() string     { return "operator" }

--- a/pkg/stanza/operator/helper/helper_test.go
+++ b/pkg/stanza/operator/helper/helper_test.go
@@ -3,6 +3,7 @@
 package helper
 
 import (
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -35,6 +36,6 @@ func newHelpersConfig() *helpersConfig {
 
 // This function is impelmented for compatibility with operatortest
 // but is not meant to be used directly
-func (h *helpersConfig) Build(*zap.SugaredLogger) (operator.Operator, error) {
+func (h *helpersConfig) Build(*zap.SugaredLogger, component.TelemetrySettings) (operator.Operator, error) {
 	panic("not impelemented")
 }

--- a/pkg/stanza/operator/helper/input.go
+++ b/pkg/stanza/operator/helper/input.go
@@ -6,6 +6,7 @@ package helper // import "github.com/open-telemetry/opentelemetry-collector-cont
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -29,7 +30,7 @@ type InputConfig struct {
 }
 
 // Build will build a base producer.
-func (c InputConfig) Build(logger *zap.SugaredLogger) (InputOperator, error) {
+func (c InputConfig) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (InputOperator, error) {
 	writerOperator, err := c.WriterConfig.Build(logger)
 	if err != nil {
 		return InputOperator{}, errors.WithDetails(err, "operator_id", c.ID())

--- a/pkg/stanza/operator/helper/input_test.go
+++ b/pkg/stanza/operator/helper/input_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -20,7 +21,7 @@ func TestInputConfigMissingBase(t *testing.T) {
 		},
 	}
 
-	_, err := config.Build(testutil.Logger(t))
+	_, err := config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing required `type` field.")
 }
@@ -35,7 +36,7 @@ func TestInputConfigMissingOutput(t *testing.T) {
 		},
 	}
 
-	_, err := config.Build(testutil.Logger(t))
+	_, err := config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 }
 
@@ -50,7 +51,7 @@ func TestInputConfigValid(t *testing.T) {
 		},
 	}
 
-	_, err := config.Build(testutil.Logger(t))
+	_, err := config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 }
 

--- a/pkg/stanza/operator/input/file/config.go
+++ b/pkg/stanza/operator/input/file/config.go
@@ -4,6 +4,7 @@
 package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
 
 import (
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
@@ -38,8 +39,8 @@ type Config struct {
 }
 
 // Build will build a file input operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(logger *zap.SugaredLogger, set component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(logger, set)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +61,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		toBody:        toBody,
 	}
 
-	input.fileConsumer, err = c.Config.Build(logger, input.emit)
+	input.fileConsumer, err = c.Config.Build(logger, set, input.emit)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/file/config_test.go
+++ b/pkg/stanza/operator/input/file/config_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -537,7 +538,7 @@ func TestBuild(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return

--- a/pkg/stanza/operator/input/file/util_test.go
+++ b/pkg/stanza/operator/input/file/util_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -34,7 +35,7 @@ func newTestFileOperator(t *testing.T, cfgMod func(*Config)) (*Input, chan *entr
 	if cfgMod != nil {
 		cfgMod(cfg)
 	}
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	err = op.SetOutputs([]operator.Operator{fakeOutput})

--- a/pkg/stanza/operator/input/generate/generate.go
+++ b/pkg/stanza/operator/input/generate/generate.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -36,8 +37,8 @@ type Config struct {
 }
 
 // Build will build a generate input operator.
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c *Config) Build(logger *zap.SugaredLogger, set component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(logger, set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/generate/generate_test.go
+++ b/pkg/stanza/operator/input/generate/generate_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -21,7 +22,7 @@ func TestInputGenerate(t *testing.T) {
 		Body: "test message",
 	}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/input/journald/journald.go
+++ b/pkg/stanza/operator/input/journald/journald.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -34,8 +35,8 @@ func init() {
 }
 
 // Build will build a journald input operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(logger *zap.SugaredLogger, set component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(logger, set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/journald/journald_nonlinux.go
+++ b/pkg/stanza/operator/input/journald/journald_nonlinux.go
@@ -8,11 +8,12 @@ package journald // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"errors"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
-func (c Config) Build(_ *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(_ *zap.SugaredLogger, set component.TelemetrySettings) (operator.Operator, error) {
 	return nil, errors.New("journald input operator is only supported on linux")
 }

--- a/pkg/stanza/operator/input/journald/journald_test.go
+++ b/pkg/stanza/operator/input/journald/journald_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -55,7 +56,7 @@ func TestInputJournald(t *testing.T) {
 	cfg := NewConfigWithID("my_journald_input")
 	cfg.OutputIDs = []string{"output"}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	mockOutput := testutil.NewMockOperator("output")
@@ -233,7 +234,7 @@ func TestInputJournaldError(t *testing.T) {
 	cfg := NewConfigWithID("my_journald_input")
 	cfg.OutputIDs = []string{"output"}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	mockOutput := testutil.NewMockOperator("output")

--- a/pkg/stanza/operator/input/namedpipe/namedpipe.go
+++ b/pkg/stanza/operator/input/namedpipe/namedpipe.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"sync"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 
@@ -26,8 +27,8 @@ func init() {
 }
 
 // Build will build a namedpipe input operator.
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c *Config) Build(logger *zap.SugaredLogger, set component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(logger, set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/namedpipe/namedpipe_nonlinux.go
+++ b/pkg/stanza/operator/input/namedpipe/namedpipe_nonlinux.go
@@ -8,11 +8,12 @@ package namedpipe // import "github.com/open-telemetry/opentelemetry-collector-c
 import (
 	"errors"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
-func (c *Config) Build(_ *zap.SugaredLogger) (operator.Operator, error) {
+func (c *Config) Build(_ *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	return nil, errors.New("namedpipe input operator is only supported on linux")
 }

--- a/pkg/stanza/operator/input/namedpipe/namedpipe_test.go
+++ b/pkg/stanza/operator/input/namedpipe/namedpipe_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/sys/unix"
 
@@ -41,7 +42,7 @@ func TestCreatePipe(t *testing.T) {
 	conf.Path = filename(t)
 	conf.Permissions = 0666
 
-	op, err := conf.Build(zaptest.NewLogger(t).Sugar())
+	op, err := conf.Build(zaptest.NewLogger(t).Sugar(), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
@@ -69,7 +70,7 @@ func TestCreatePipeFailsWithFile(t *testing.T) {
 		require.NoError(t, pipe.Close())
 	}()
 
-	op, err := conf.Build(zaptest.NewLogger(t).Sugar())
+	op, err := conf.Build(zaptest.NewLogger(t).Sugar(), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	require.Error(t, op.Start(testutil.NewUnscopedMockPersister()))
@@ -83,7 +84,7 @@ func TestCreatePipeAlreadyExists(t *testing.T) {
 
 	require.NoError(t, unix.Mkfifo(conf.Path, conf.Permissions))
 
-	op, err := conf.Build(zaptest.NewLogger(t).Sugar())
+	op, err := conf.Build(zaptest.NewLogger(t).Sugar(), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
@@ -99,7 +100,7 @@ func TestPipeWrites(t *testing.T) {
 	conf.Permissions = 0666
 	conf.OutputIDs = []string{fake.ID()}
 
-	op, err := conf.Build(zaptest.NewLogger(t).Sugar())
+	op, err := conf.Build(zaptest.NewLogger(t).Sugar(), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	ops := []operator.Operator{op, fake}
 

--- a/pkg/stanza/operator/input/stdin/stdin.go
+++ b/pkg/stanza/operator/input/stdin/stdin.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sync"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -34,8 +35,8 @@ type Config struct {
 }
 
 // Build will build a stdin input operator.
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c *Config) Build(logger *zap.SugaredLogger, set component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(logger, set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/stdin/stdin_test.go
+++ b/pkg/stanza/operator/input/stdin/stdin_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -17,7 +18,7 @@ func TestStdin(t *testing.T) {
 	cfg := NewConfig("")
 	cfg.OutputIDs = []string{"fake"}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/input/syslog/syslog.go
+++ b/pkg/stanza/operator/input/syslog/syslog.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
 
@@ -45,8 +46,8 @@ type Config struct {
 	UDP                *udp.BaseConfig `mapstructure:"udp"`
 }
 
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputBase, err := c.InputConfig.Build(logger)
+func (c Config) Build(logger *zap.SugaredLogger, set component.TelemetrySettings) (operator.Operator, error) {
+	inputBase, err := c.InputConfig.Build(logger, set)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +56,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 	syslogParserCfg.BaseConfig = c.BaseConfig
 	syslogParserCfg.SetID(inputBase.ID() + "_internal_parser")
 	syslogParserCfg.OutputIDs = c.OutputIDs
-	syslogParser, err := syslogParserCfg.Build(logger)
+	syslogParser, err := syslogParserCfg.Build(logger, set)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve syslog config: %w", err)
 	}
@@ -67,7 +68,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 			tcpInputCfg.SplitFuncBuilder = OctetSplitFuncBuilder
 		}
 
-		tcpInput, err := tcpInputCfg.Build(logger)
+		tcpInput, err := tcpInputCfg.Build(logger, set)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve tcp config: %w", err)
 		}
@@ -94,7 +95,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 			return nil, errors.New("octet_counting and non_transparent_framing is not compatible with UDP")
 		}
 
-		udpInput, err := udpInputCfg.Build(logger)
+		udpInput, err := udpInputCfg.Build(logger, set)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve udp config: %w", err)
 		}

--- a/pkg/stanza/operator/input/syslog/syslog_test.go
+++ b/pkg/stanza/operator/input/syslog/syslog_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -88,7 +89,7 @@ func TestInput(t *testing.T) {
 }
 
 func InputTest(t *testing.T, cfg *Config, tc syslog.Case) {
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)
@@ -142,7 +143,7 @@ func TestSyslogIDs(t *testing.T) {
 
 	t.Run("TCP", func(t *testing.T) {
 		cfg := NewConfigWithTCP(basicConfig())
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 		syslogInputOp := op.(*Input)
 		require.Equal(t, "test_syslog_internal_tcp", syslogInputOp.tcp.ID())
@@ -153,7 +154,7 @@ func TestSyslogIDs(t *testing.T) {
 	})
 	t.Run("UDP", func(t *testing.T) {
 		cfg := NewConfigWithUDP(basicConfig())
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 		syslogInputOp := op.(*Input)
 		require.Equal(t, "test_syslog_internal_udp", syslogInputOp.udp.ID())

--- a/pkg/stanza/operator/input/tcp/tcp.go
+++ b/pkg/stanza/operator/input/tcp/tcp.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/jpillora/backoff"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
@@ -86,8 +87,8 @@ func (c Config) defaultSplitFuncBuilder(enc encoding.Encoding) (bufio.SplitFunc,
 }
 
 // Build will build a tcp input operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(logger *zap.SugaredLogger, set component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(logger, set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/tcp/tcp_test.go
+++ b/pkg/stanza/operator/input/tcp/tcp_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtls"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -78,7 +79,7 @@ func tcpInputTest(input []byte, expected []string) func(t *testing.T) {
 		cfg := NewConfigWithID("test_id")
 		cfg.ListenAddress = ":0"
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -127,7 +128,7 @@ func tcpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 		cfg.ListenAddress = ":0"
 		cfg.AddAttributes = true
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -213,7 +214,7 @@ func tlsInputTest(input []byte, expected []string) func(t *testing.T) {
 			},
 		}
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -343,7 +344,7 @@ func TestBuild(t *testing.T) {
 			cfg.ListenAddress = tc.inputBody.ListenAddress
 			cfg.MaxLogSize = tc.inputBody.MaxLogSize
 			cfg.TLS = tc.inputBody.TLS
-			_, err := cfg.Build(testutil.Logger(t))
+			_, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			if tc.expectErr {
 				require.Error(t, err)
 				return
@@ -388,7 +389,7 @@ func TestFailToBind(t *testing.T) {
 	var startTCP = func(int) (*Input, error) {
 		cfg := NewConfigWithID("test_id")
 		cfg.ListenAddress = net.JoinHostPort(ip, strconv.Itoa(port))
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 		mockOutput := testutil.Operator{}
 		tcpInput := op.(*Input)
@@ -415,7 +416,7 @@ func BenchmarkTCPInput(b *testing.B) {
 	cfg := NewConfigWithID("test_id")
 	cfg.ListenAddress = ":0"
 
-	op, err := cfg.Build(testutil.Logger(b))
+	op, err := cfg.Build(testutil.Logger(b), componenttest.NewNopTelemetrySettings())
 	require.NoError(b, err)
 
 	fakeOutput := testutil.NewFakeOutput(b)

--- a/pkg/stanza/operator/input/udp/udp.go
+++ b/pkg/stanza/operator/input/udp/udp.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"sync"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
 
@@ -80,8 +81,8 @@ type BaseConfig struct {
 }
 
 // Build will build a udp input operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(logger *zap.SugaredLogger, set component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(logger, set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/udp/udp_test.go
+++ b/pkg/stanza/operator/input/udp/udp_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -20,7 +21,7 @@ import (
 
 func udpInputTest(input []byte, expected []string, cfg *Config) func(t *testing.T) {
 	return func(t *testing.T) {
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -71,7 +72,7 @@ func udpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 		cfg.ListenAddress = ":0"
 		cfg.AddAttributes = true
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -179,7 +180,7 @@ func TestFailToBind(t *testing.T) {
 		cfg := NewConfigWithID("test_input")
 		cfg.ListenAddress = net.JoinHostPort(ip, strconv.Itoa(port))
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -211,7 +212,7 @@ func BenchmarkUDPInput(b *testing.B) {
 	cfg := NewConfigWithID("test_id")
 	cfg.ListenAddress = ":0"
 
-	op, err := cfg.Build(testutil.Logger(b))
+	op, err := cfg.Build(testutil.Logger(b), componenttest.NewNopTelemetrySettings())
 	require.NoError(b, err)
 
 	fakeOutput := testutil.NewFakeOutput(b)

--- a/pkg/stanza/operator/input/windows/operator.go
+++ b/pkg/stanza/operator/input/windows/operator.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -22,8 +23,8 @@ func init() {
 }
 
 // Build will build a windows event log operator.
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c *Config) Build(logger *zap.SugaredLogger, set component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(logger, set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/output/drop/drop.go
+++ b/pkg/stanza/operator/output/drop/drop.go
@@ -6,6 +6,7 @@ package drop // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -30,7 +31,7 @@ type Config struct {
 }
 
 // Build will build a drop output operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	outputOperator, err := c.OutputConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/output/drop/drop_test.go
+++ b/pkg/stanza/operator/output/drop/drop_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -15,21 +16,21 @@ import (
 
 func TestBuildValid(t *testing.T) {
 	cfg := NewConfig("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	require.IsType(t, &Output{}, op)
 }
 
 func TestBuildIvalid(t *testing.T) {
 	cfg := NewConfig("test")
-	_, err := cfg.Build(nil)
+	_, err := cfg.Build(nil, componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "build context is missing a logger")
 }
 
 func TestProcess(t *testing.T) {
 	cfg := NewConfig("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	entry := entry.New()

--- a/pkg/stanza/operator/output/file/file.go
+++ b/pkg/stanza/operator/output/file/file.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"sync"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -38,7 +39,7 @@ type Config struct {
 }
 
 // Build will build a file output operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	outputOperator, err := c.OutputConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/output/stdout/stdout.go
+++ b/pkg/stanza/operator/output/stdout/stdout.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"sync"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -37,7 +38,7 @@ type Config struct {
 }
 
 // Build will build a stdout operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	outputOperator, err := c.OutputConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/output/stdout/stdout_test.go
+++ b/pkg/stanza/operator/output/stdout/stdout_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -27,7 +28,7 @@ func TestOperator(t *testing.T) {
 		},
 	}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	var buf bytes.Buffer

--- a/pkg/stanza/operator/parser/csv/csv.go
+++ b/pkg/stanza/operator/parser/csv/csv.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/parseutils"
@@ -47,7 +48,7 @@ type Config struct {
 }
 
 // Build will build a csv parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	parserOperator, err := c.ParserConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/csv/csv_test.go
+++ b/pkg/stanza/operator/parser/csv/csv_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -19,7 +20,7 @@ var testHeader = "name,sev,msg"
 func newTestParser(t *testing.T) *Parser {
 	cfg := NewConfigWithID("test")
 	cfg.Header = testHeader
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -28,7 +29,7 @@ func newTestParserIgnoreQuotes(t *testing.T) *Parser {
 	cfg := NewConfigWithID("test")
 	cfg.Header = testHeader
 	cfg.IgnoreQuotes = true
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -36,7 +37,7 @@ func newTestParserIgnoreQuotes(t *testing.T) *Parser {
 func TestParserBuildFailure(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -46,7 +47,7 @@ func TestParserBuildFailureLazyIgnoreQuotes(t *testing.T) {
 	cfg.Header = testHeader
 	cfg.LazyQuotes = true
 	cfg.IgnoreQuotes = true
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.ErrorContains(t, err, "only one of 'ignore_quotes' or 'lazy_quotes' can be true")
 }
@@ -55,7 +56,7 @@ func TestParserBuildFailureInvalidDelimiter(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.Header = testHeader
 	cfg.FieldDelimiter = ";;"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid 'delimiter': ';;'")
 }
@@ -64,7 +65,7 @@ func TestParserBuildFailureBadHeaderConfig(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.Header = "testheader"
 	cfg.HeaderAttribute = "testheader"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "only one header parameter can be set: 'header' or 'header_attribute'")
 }
@@ -793,7 +794,7 @@ func TestParserCSV(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			if tc.expectBuildErr {
 				require.Error(t, err)
 				return
@@ -1037,7 +1038,7 @@ cc""",dddd,eeee`,
 			cfg.OutputIDs = []string{"fake"}
 			cfg.Header = "A,B,C,D,E"
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)
@@ -1059,7 +1060,7 @@ func TestParserCSVInvalidJSONInput(t *testing.T) {
 		cfg.OutputIDs = []string{"fake"}
 		cfg.Header = testHeader
 
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 
 		fake := testutil.NewFakeOutput(t)
@@ -1084,21 +1085,21 @@ func TestBuildParserCSV(t *testing.T) {
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicParser()
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 	})
 
 	t.Run("MissingHeaderField", func(t *testing.T) {
 		c := newBasicParser()
 		c.Header = ""
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.Error(t, err)
 	})
 
 	t.Run("InvalidHeaderFieldMissingDelimiter", func(t *testing.T) {
 		c := newBasicParser()
 		c.Header = "name"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing field delimiter in header")
 	})
@@ -1106,7 +1107,7 @@ func TestBuildParserCSV(t *testing.T) {
 	t.Run("InvalidHeaderFieldWrongDelimiter", func(t *testing.T) {
 		c := newBasicParser()
 		c.Header = "name;position;number"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.Error(t, err)
 	})
 
@@ -1114,7 +1115,7 @@ func TestBuildParserCSV(t *testing.T) {
 		c := newBasicParser()
 		c.Header = "name,position,number"
 		c.FieldDelimiter = ":"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing field delimiter in header")
 	})

--- a/pkg/stanza/operator/parser/json/json.go
+++ b/pkg/stanza/operator/parser/json/json.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	jsoniter "github.com/json-iterator/go"
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -39,7 +40,7 @@ type Config struct {
 }
 
 // Build will build a JSON parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	parserOperator, err := c.ParserConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/json/json_test.go
+++ b/pkg/stanza/operator/parser/json/json_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -18,14 +19,14 @@ import (
 
 func newTestParser(t *testing.T) *Parser {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	op, err := config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	return op.(*Parser)
 }
 
 func TestConfigBuild(t *testing.T) {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	op, err := config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	require.IsType(t, &Parser{}, op)
 }
@@ -33,7 +34,7 @@ func TestConfigBuild(t *testing.T) {
 func TestConfigBuildFailure(t *testing.T) {
 	config := NewConfigWithID("test")
 	config.OnError = "invalid_on_error"
-	_, err := config.Build(testutil.Logger(t))
+	_, err := config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -143,7 +144,7 @@ func TestParser(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/parser/jsonarray/json_array_parser.go
+++ b/pkg/stanza/operator/parser/jsonarray/json_array_parser.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/valyala/fastjson"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
 
@@ -52,7 +53,7 @@ type Config struct {
 }
 
 // Build will build a json array parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	parserOperator, err := c.ParserConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/jsonarray/json_array_parser_test.go
+++ b/pkg/stanza/operator/parser/jsonarray/json_array_parser_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -16,7 +17,7 @@ import (
 
 func newTestParser(t *testing.T) *Parser {
 	cfg := NewConfigWithID("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -24,7 +25,7 @@ func newTestParser(t *testing.T) *Parser {
 func TestParserBuildFailure(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -39,7 +40,7 @@ func TestParserInvalidType(t *testing.T) {
 func TestParserByteFailureHeadersMismatch(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.Header = "name,sev,msg"
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	parser := op.(*Parser)
 	_, err = parser.parse("[\"stanza\",\"INFO\",\"started agent\", 42, true]")
@@ -238,7 +239,7 @@ func TestParserJarray(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			if tc.expectBuildErr {
 				require.Error(t, err)
 				return
@@ -357,7 +358,7 @@ dd","eeee"]`,
 			cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
 			cfg.OutputIDs = []string{"fake"}
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)
@@ -382,7 +383,7 @@ func TestBuildParserJarray(t *testing.T) {
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicParser()
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 	})
 }

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/parseutils"
@@ -44,7 +45,7 @@ type Config struct {
 }
 
 // Build will build a key value parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	parserOperator, err := c.ParserConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -18,7 +19,7 @@ import (
 
 func newTestParser(t *testing.T) *Parser {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	op, err := config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -31,7 +32,7 @@ func TestInit(t *testing.T) {
 
 func TestConfigBuild(t *testing.T) {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	op, err := config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	require.IsType(t, &Parser{}, op)
 }
@@ -39,7 +40,7 @@ func TestConfigBuild(t *testing.T) {
 func TestConfigBuildFailure(t *testing.T) {
 	config := NewConfigWithID("test")
 	config.OnError = "invalid_on_error"
-	_, err := config.Build(testutil.Logger(t))
+	_, err := config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -133,7 +134,7 @@ func TestBuild(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := tc.input
-			_, err := cfg.Build(testutil.Logger(t))
+			_, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			if tc.expectErr {
 				require.Error(t, err)
 				return
@@ -695,7 +696,7 @@ key=value`,
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			if tc.expectBuildErr {
 				require.Error(t, err)
 				return

--- a/pkg/stanza/operator/parser/regex/regex.go
+++ b/pkg/stanza/operator/parser/regex/regex.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -46,7 +47,7 @@ type Config struct {
 }
 
 // Build will build a regex parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	parserOperator, err := c.ParserConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/regex/regex_test.go
+++ b/pkg/stanza/operator/parser/regex/regex_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -24,7 +25,7 @@ func newTestParser(t *testing.T, regex string, cacheSize uint16) *Parser {
 	if cacheSize > 0 {
 		cfg.Cache.Size = cacheSize
 	}
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -32,7 +33,7 @@ func newTestParser(t *testing.T, regex string, cacheSize uint16) *Parser {
 func TestParserBuildFailure(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -135,7 +136,7 @@ func TestParserRegex(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			defer func() {
@@ -167,28 +168,28 @@ func TestBuildParserRegex(t *testing.T) {
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicParser()
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 	})
 
 	t.Run("MissingRegexField", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = ""
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.Error(t, err)
 	})
 
 	t.Run("InvalidRegexField", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = "())()"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.Error(t, err)
 	})
 
 	t.Run("NoNamedGroups", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = ".*"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no named capture groups")
 	})
@@ -196,7 +197,7 @@ func TestBuildParserRegex(t *testing.T) {
 	t.Run("NoNamedGroups", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = "(.*)"
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no named capture groups")
 	})
@@ -231,7 +232,7 @@ func newTestBenchParser(t *testing.T, cacheSize uint16) *Parser {
 	cfg.Regex = benchParsePattern
 	cfg.Cache.Size = cacheSize
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	return op.(*Parser)
 }

--- a/pkg/stanza/operator/parser/scope/scope_name.go
+++ b/pkg/stanza/operator/parser/scope/scope_name.go
@@ -6,6 +6,7 @@ package scope // import "github.com/open-telemetry/opentelemetry-collector-contr
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -39,7 +40,7 @@ type Config struct {
 }
 
 // Build will build a logger name parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/scope/scope_name_test.go
+++ b/pkg/stanza/operator/parser/scope/scope_name_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -92,7 +93,7 @@ func TestScopeNameParser(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			parser, err := tc.config.Build(testutil.Logger(t))
+			parser, err := tc.config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			err = parser.Process(context.Background(), tc.input)

--- a/pkg/stanza/operator/parser/severity/severity.go
+++ b/pkg/stanza/operator/parser/severity/severity.go
@@ -6,6 +6,7 @@ package severity // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -39,7 +40,7 @@ type Config struct {
 }
 
 // Build will build a severity parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/severity/severity_test.go
+++ b/pkg/stanza/operator/parser/severity/severity_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -222,7 +223,7 @@ func TestSeverityParser(t *testing.T) {
 
 func runSeverityParseTest(cfg *Config, ent *entry.Entry, buildErr bool, parseErr bool, expected entry.Severity) func(*testing.T) {
 	return func(t *testing.T) {
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		if buildErr {
 			require.Error(t, err, "expected error when configuring operator")
 			return

--- a/pkg/stanza/operator/parser/syslog/config_test.go
+++ b/pkg/stanza/operator/parser/syslog/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -126,7 +127,7 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestParserMissingProtocol(t *testing.T) {
-	_, err := NewConfig().Build(testutil.Logger(t))
+	_, err := NewConfig().Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing field 'protocol'")
 }
@@ -213,7 +214,7 @@ func TestRFC6587ConfigOptions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := tc.cfg.Build(testutil.Logger(t))
+			_, err := tc.cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			if tc.errContents != "" {
 				require.ErrorContains(t, err, tc.errContents)
 			} else {
@@ -228,7 +229,7 @@ func TestParserInvalidLocation(t *testing.T) {
 	config.Location = "not_a_location"
 	config.Protocol = RFC3164
 
-	_, err := config.Build(testutil.Logger(t))
+	_, err := config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to load location "+config.Location)
 }

--- a/pkg/stanza/operator/parser/syslog/syslog.go
+++ b/pkg/stanza/operator/parser/syslog/syslog.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdata/go-syslog/v3/octetcounting"
 	"github.com/influxdata/go-syslog/v3/rfc3164"
 	"github.com/influxdata/go-syslog/v3/rfc5424"
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -68,7 +69,7 @@ type BaseConfig struct {
 }
 
 // Build will build a JSON parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	if c.ParserConfig.TimeParser == nil {
 		parseFromField := entry.NewAttributeField("timestamp")
 		c.ParserConfig.TimeParser = &helper.TimeParser{

--- a/pkg/stanza/operator/parser/syslog/syslog_test.go
+++ b/pkg/stanza/operator/parser/syslog/syslog_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -27,7 +28,7 @@ func TestParser(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			op, err := tc.Config.Build(testutil.Logger(t))
+			op, err := tc.Config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)
@@ -57,7 +58,7 @@ func TestSyslogParseRFC5424_SDNameTooLong(t *testing.T) {
 
 	body := `<86>1 2015-08-05T21:58:59.693Z 192.168.2.132 SecureAuth0 23108 ID52020 [verylongsdnamethatisgreaterthan32bytes@12345 UserHostAddress="192.168.2.132"] my message`
 
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)
@@ -82,14 +83,14 @@ func TestSyslogProtocolConfig(t *testing.T) {
 	for _, proto := range []string{"RFC5424", "rfc5424", "RFC3164", "rfc3164"} {
 		cfg := basicConfig()
 		cfg.Protocol = proto
-		_, err := cfg.Build(testutil.Logger(t))
+		_, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 	}
 
 	for _, proto := range []string{"RFC5424a", "rfc5424b", "RFC3164c", "rfc3164d"} {
 		cfg := basicConfig()
 		cfg.Protocol = proto
-		_, err := cfg.Build(testutil.Logger(t))
+		_, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.Error(t, err)
 	}
 }

--- a/pkg/stanza/operator/parser/time/time.go
+++ b/pkg/stanza/operator/parser/time/time.go
@@ -6,6 +6,7 @@ package time // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -39,7 +40,7 @@ type Config struct {
 }
 
 // Build will build a time parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/time/time_test.go
+++ b/pkg/stanza/operator/parser/time/time_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -63,7 +64,7 @@ func TestBuild(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := tc.input()
 			require.NoError(t, err, "expected nil error when running test cases input func")
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			if tc.expectErr {
 				require.Error(t, err, "expected error while building time_parser operator")
 				return
@@ -121,7 +122,7 @@ func TestProcess(t *testing.T) {
 				require.NoError(t, err)
 				return
 			}
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			if err != nil {
 				require.NoError(t, err)
 				return
@@ -501,7 +502,7 @@ func runTimeParseTest(t *testing.T, cfg *Config, ent *entry.Entry, buildErr bool
 
 func runLossyTimeParseTest(_ *testing.T, cfg *Config, ent *entry.Entry, buildErr bool, parseErr bool, expected time.Time, maxLoss time.Duration) func(*testing.T) {
 	return func(t *testing.T) {
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		if buildErr {
 			require.Error(t, err, "expected error when configuring operator")
 			return

--- a/pkg/stanza/operator/parser/trace/trace.go
+++ b/pkg/stanza/operator/parser/trace/trace.go
@@ -6,6 +6,7 @@ package trace // import "github.com/open-telemetry/opentelemetry-collector-contr
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -39,7 +40,7 @@ type Config struct {
 }
 
 // Build will build a trace parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/trace/trace_test.go
+++ b/pkg/stanza/operator/parser/trace/trace_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -22,7 +23,7 @@ func TestInit(t *testing.T) {
 }
 func TestDefaultParser(t *testing.T) {
 	traceParserConfig := NewConfig()
-	_, err := traceParserConfig.Build(testutil.Logger(t))
+	_, err := traceParserConfig.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 }
 
@@ -83,7 +84,7 @@ func TestBuild(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := tc.input()
 			require.NoError(t, err, "expected nil error when running test cases input func")
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			if tc.expectErr {
 				require.Error(t, err, "expected error while building trace_parser operator")
 				return
@@ -109,7 +110,7 @@ func TestProcess(t *testing.T) {
 			"no-op",
 			func() (operator.Operator, error) {
 				cfg := NewConfigWithID("test_id")
-				return cfg.Build(testutil.Logger(t))
+				return cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			},
 			&entry.Entry{
 				Body: "https://google.com:443/path?user=dev",
@@ -128,7 +129,7 @@ func TestProcess(t *testing.T) {
 				cfg.SpanID.ParseFrom = &spanFrom
 				cfg.TraceID.ParseFrom = &traceFrom
 				cfg.TraceFlags.ParseFrom = &flagsFrom
-				return cfg.Build(testutil.Logger(t))
+				return cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			},
 			&entry.Entry{
 				Body: map[string]any{
@@ -258,7 +259,7 @@ func TestTraceParserParse(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			traceParserConfig := NewConfigWithID("")
-			_, _ = traceParserConfig.Build(testutil.Logger(t))
+			_, _ = traceParserConfig.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			e := entry.New()
 			e.Body = tc.inputRecord
 			err := traceParserConfig.Parse(e)

--- a/pkg/stanza/operator/parser/uri/uri.go
+++ b/pkg/stanza/operator/parser/uri/uri.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -40,7 +41,7 @@ type Config struct {
 }
 
 // Build will build a uri parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	parserOperator, err := c.ParserConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/uri/uri_test.go
+++ b/pkg/stanza/operator/parser/uri/uri_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -17,7 +18,7 @@ import (
 
 func newTestParser(t *testing.T) *Parser {
 	cfg := NewConfigWithID("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -31,7 +32,7 @@ func TestInit(t *testing.T) {
 func TestParserBuildFailure(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -68,7 +69,7 @@ func TestProcess(t *testing.T) {
 			"default",
 			func() (operator.Operator, error) {
 				cfg := NewConfigWithID("test_id")
-				return cfg.Build(testutil.Logger(t))
+				return cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			},
 			&entry.Entry{
 				Body: "https://google.com:443/path?user=dev",
@@ -94,7 +95,7 @@ func TestProcess(t *testing.T) {
 				cfg := NewConfigWithID("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
 				cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField("url2")}
-				return cfg.Build(testutil.Logger(t))
+				return cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			},
 			&entry.Entry{
 				Body: map[string]any{
@@ -123,7 +124,7 @@ func TestProcess(t *testing.T) {
 			func() (operator.Operator, error) {
 				cfg := NewConfigWithID("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
-				return cfg.Build(testutil.Logger(t))
+				return cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			},
 			&entry.Entry{
 				Body: map[string]any{
@@ -490,7 +491,7 @@ func TestBuildParserURL(t *testing.T) {
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicParser()
-		_, err := c.Build(testutil.Logger(t))
+		_, err := c.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 	})
 }

--- a/pkg/stanza/operator/transformer/add/add.go
+++ b/pkg/stanza/operator/transformer/add/add.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/expr-lang/expr/vm"
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -42,7 +43,7 @@ type Config struct {
 }
 
 // Build will build an add operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/transformer/add/add_test.go
+++ b/pkg/stanza/operator/transformer/add/add_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -340,7 +341,7 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			add := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/assignkeys/assign_keys.go
+++ b/pkg/stanza/operator/transformer/assignkeys/assign_keys.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.uber.org/zap"
 
@@ -49,7 +50,7 @@ type Config struct {
 }
 
 // Build will build an assign_keys operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/transformer/assignkeys/assign_keys_test.go
+++ b/pkg/stanza/operator/transformer/assignkeys/assign_keys_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -129,7 +130,7 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			if tc.expectErr && err != nil {
 				require.Error(t, err)
 				t.SkipNow()

--- a/pkg/stanza/operator/transformer/copy/copy.go
+++ b/pkg/stanza/operator/transformer/copy/copy.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -40,7 +41,7 @@ type Config struct {
 }
 
 // Build will build a copy operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/transformer/copy/copy_test.go
+++ b/pkg/stanza/operator/transformer/copy/copy_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -287,7 +288,7 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			cp := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/filter/filter.go
+++ b/pkg/stanza/operator/transformer/filter/filter.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 
 	"github.com/expr-lang/expr/vm"
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -49,7 +50,7 @@ type Config struct {
 }
 
 // Build will build a filter operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformer, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/transformer/filter/filter_test.go
+++ b/pkg/stanza/operator/transformer/filter/filter_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -159,7 +160,7 @@ func TestTransformer(t *testing.T) {
 			cfg := NewConfigWithID("test")
 			cfg.Expression = tc.expression
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			filtered := true
@@ -184,7 +185,7 @@ func TestFilterDropRatio(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.Expression = `body.message == "test_message"`
 	cfg.DropRatio = 0.5
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	processedEntries := 0

--- a/pkg/stanza/operator/transformer/flatten/flatten.go
+++ b/pkg/stanza/operator/transformer/flatten/flatten.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -40,7 +41,7 @@ type Config struct {
 }
 
 // Build will build a Flatten operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/transformer/flatten/flatten_test.go
+++ b/pkg/stanza/operator/transformer/flatten/flatten_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -319,7 +320,7 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			if tc.expectErr && err != nil {
 				require.Error(t, err)
 				t.SkipNow()

--- a/pkg/stanza/operator/transformer/move/move.go
+++ b/pkg/stanza/operator/transformer/move/move.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -40,7 +41,7 @@ type Config struct {
 }
 
 // Build will build a Move operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/transformer/move/move_test.go
+++ b/pkg/stanza/operator/transformer/move/move_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -502,7 +503,7 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			move := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/noop/noop.go
+++ b/pkg/stanza/operator/transformer/noop/noop.go
@@ -6,6 +6,7 @@ package noop // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"context"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -37,7 +38,7 @@ type Config struct {
 }
 
 // Build will build a noop operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/transformer/noop/noop_test.go
+++ b/pkg/stanza/operator/transformer/noop/noop_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -16,14 +17,14 @@ import (
 
 func TestBuildValid(t *testing.T) {
 	cfg := NewConfigWithID("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	require.IsType(t, &Transformer{}, op)
 }
 
 func TestBuildInvalid(t *testing.T) {
 	cfg := NewConfigWithID("test")
-	_, err := cfg.Build(nil)
+	_, err := cfg.Build(nil, componenttest.NewNopTelemetrySettings())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "build context is missing a logger")
 }
@@ -31,7 +32,7 @@ func TestBuildInvalid(t *testing.T) {
 func TestProcess(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OutputIDs = []string{"fake"}
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/transformer/recombine/recombine.go
+++ b/pkg/stanza/operator/transformer/recombine/recombine.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -62,7 +63,7 @@ type Config struct {
 }
 
 // Build creates a new Transformer from a config
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c *Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformer, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build transformer config: %w", err)

--- a/pkg/stanza/operator/transformer/recombine/recombine_test.go
+++ b/pkg/stanza/operator/transformer/recombine/recombine_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -501,7 +502,7 @@ func TestTransformer(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			op, err := tc.config.Build(testutil.Logger(t))
+			op, err := tc.config.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 			require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
 			defer func() { require.NoError(t, op.Stop()) }()
@@ -530,7 +531,7 @@ func TestTransformer(t *testing.T) {
 		cfg.CombineField = entry.NewBodyField()
 		cfg.IsFirstEntry = MatchAll
 		cfg.OutputIDs = []string{"fake"}
-		op, err := cfg.Build(testutil.Logger(t))
+		op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 		require.NoError(t, err)
 		recombine := op.(*Transformer)
 
@@ -566,7 +567,7 @@ func BenchmarkRecombine(b *testing.B) {
 	cfg.IsFirstEntry = "body startsWith 'log-0'"
 	cfg.OutputIDs = []string{"fake"}
 	cfg.SourceIdentifier = entry.NewAttributeField("file.path")
-	op, err := cfg.Build(testutil.Logger(b))
+	op, err := cfg.Build(testutil.Logger(b), componenttest.NewNopTelemetrySettings())
 	require.NoError(b, err)
 	recombine := op.(*Transformer)
 
@@ -609,7 +610,7 @@ func BenchmarkRecombineLimitTrigger(b *testing.B) {
 	cfg.IsFirstEntry = "body == 'start'"
 	cfg.MaxLogSize = 6
 	cfg.OutputIDs = []string{"fake"}
-	op, err := cfg.Build(testutil.Logger(b))
+	op, err := cfg.Build(testutil.Logger(b), componenttest.NewNopTelemetrySettings())
 	require.NoError(b, err)
 	recombine := op.(*Transformer)
 
@@ -651,7 +652,7 @@ func TestTimeout(t *testing.T) {
 	cfg.IsFirstEntry = MatchAll
 	cfg.OutputIDs = []string{"fake"}
 	cfg.ForceFlushTimeout = 100 * time.Millisecond
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	recombine := op.(*Transformer)
 
@@ -694,7 +695,7 @@ func TestTimeoutWhenAggregationKeepHappen(t *testing.T) {
 	cfg.CombineWith = ""
 	cfg.OutputIDs = []string{"fake"}
 	cfg.ForceFlushTimeout = 100 * time.Millisecond
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	recombine := op.(*Transformer)
 
@@ -747,7 +748,7 @@ func TestSourceBatchDelete(t *testing.T) {
 	cfg.OutputIDs = []string{"fake"}
 	cfg.ForceFlushTimeout = 100 * time.Millisecond
 	cfg.MaxLogSize = 6
-	op, err := cfg.Build(testutil.Logger(t))
+	op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	recombine := op.(*Transformer)
 

--- a/pkg/stanza/operator/transformer/remove/remove.go
+++ b/pkg/stanza/operator/transformer/remove/remove.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -40,7 +41,7 @@ type Config struct {
 }
 
 // Build will build a Remove operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/transformer/remove/remove_test.go
+++ b/pkg/stanza/operator/transformer/remove/remove_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -252,7 +253,7 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			remove := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/retain/retain.go
+++ b/pkg/stanza/operator/transformer/retain/retain.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -40,7 +41,7 @@ type Config struct {
 }
 
 // Build will build a retain operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/transformer/retain/retain_test.go
+++ b/pkg/stanza/operator/transformer/retain/retain_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -384,7 +385,7 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			retain := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/router/router.go
+++ b/pkg/stanza/operator/transformer/router/router.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/expr-lang/expr/vm"
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -48,7 +49,7 @@ type RouteConfig struct {
 }
 
 // Build will build a router operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	basicOperator, err := c.BasicConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/transformer/router/router_test.go
+++ b/pkg/stanza/operator/transformer/router/router_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -183,7 +184,7 @@ func TestTransformer(t *testing.T) {
 			cfg.Routes = tc.routes
 			cfg.Default = tc.defaultOutput
 
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			results := map[string]int{}

--- a/pkg/stanza/operator/transformer/unquote/unquote.go
+++ b/pkg/stanza/operator/transformer/unquote/unquote.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -40,7 +41,7 @@ type Config struct {
 }
 
 // Build will build an unquote operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(logger *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	transformerOperator, err := c.TransformerConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/transformer/unquote/unquote_test.go
+++ b/pkg/stanza/operator/transformer/unquote/unquote_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -194,7 +195,7 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg := tc.cfg
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "send"
-			op, err := cfg.Build(testutil.Logger(t))
+			op, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 
 			unqouteOp := op.(*Transformer)

--- a/pkg/stanza/pipeline/config.go
+++ b/pkg/stanza/pipeline/config.go
@@ -6,6 +6,7 @@ package pipeline // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
@@ -19,7 +20,7 @@ type Config struct {
 }
 
 // Build will build a pipeline from the config.
-func (c Config) Build(logger *zap.SugaredLogger) (*DirectedPipeline, error) {
+func (c Config) Build(logger *zap.SugaredLogger, set component.TelemetrySettings) (*DirectedPipeline, error) {
 	if logger == nil {
 		return nil, errors.NewError("logger must be provided", "")
 	}
@@ -35,7 +36,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (*DirectedPipeline, error) {
 
 	ops := make([]operator.Operator, 0, len(c.Operators))
 	for _, opCfg := range c.Operators {
-		op, err := opCfg.Build(logger)
+		op, err := opCfg.Build(logger, set)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/stanza/pipeline/config_test.go
+++ b/pkg/stanza/pipeline/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/json"
@@ -25,7 +26,7 @@ func TestBuildPipelineSuccess(t *testing.T) {
 		},
 	}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	pipe, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	require.Equal(t, 1, len(pipe.Operators()))
 }
@@ -39,7 +40,7 @@ func TestBuildPipelineNoLogger(t *testing.T) {
 		},
 	}
 
-	pipe, err := cfg.Build(nil)
+	pipe, err := cfg.Build(nil, componenttest.NewNopTelemetrySettings())
 	require.EqualError(t, err, "logger must be provided")
 	require.Nil(t, pipe)
 }
@@ -47,7 +48,7 @@ func TestBuildPipelineNoLogger(t *testing.T) {
 func TestBuildPipelineNilOperators(t *testing.T) {
 	cfg := Config{}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	pipe, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.EqualError(t, err, "operators must be specified")
 	require.Nil(t, pipe)
 }
@@ -57,7 +58,7 @@ func TestBuildPipelineEmptyOperators(t *testing.T) {
 		Operators: []operator.Config{},
 	}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	pipe, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.EqualError(t, err, "empty pipeline not allowed")
 	require.Nil(t, pipe)
 }
@@ -75,7 +76,7 @@ func TestBuildAPipelineDefaultOperator(t *testing.T) {
 		DefaultOutput: testutil.NewFakeOutput(t),
 	}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	pipe, err := cfg.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 
 	ops := pipe.Operators()
@@ -359,7 +360,7 @@ func TestUpdateOutputIDs(t *testing.T) {
 			pipeline, err := Config{
 				Operators:     tc.ops(),
 				DefaultOutput: tc.defaultOut,
-			}.Build(testutil.Logger(t))
+			}.Build(testutil.Logger(t), componenttest.NewNopTelemetrySettings())
 			require.NoError(t, err)
 			ops := pipeline.Operators()
 

--- a/processor/logstransformprocessor/factory.go
+++ b/processor/logstransformprocessor/factory.go
@@ -47,5 +47,5 @@ func createLogsProcessor(
 		return nil, errors.New("no operators were configured for this logs transform processor")
 	}
 
-	return newProcessor(pCfg, nextConsumer, set.Logger)
+	return newProcessor(pCfg, nextConsumer, set.Logger, set.TelemetrySettings)
 }

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -35,7 +35,7 @@ type logsTransformProcessor struct {
 	shutdownFns   []component.ShutdownFunc
 }
 
-func newProcessor(config *Config, nextConsumer consumer.Logs, logger *zap.Logger) (*logsTransformProcessor, error) {
+func newProcessor(config *Config, nextConsumer consumer.Logs, logger *zap.Logger, set component.TelemetrySettings) (*logsTransformProcessor, error) {
 	p := &logsTransformProcessor{
 		logger:   logger,
 		config:   config,
@@ -48,7 +48,7 @@ func newProcessor(config *Config, nextConsumer consumer.Logs, logger *zap.Logger
 	pipe, err := pipeline.Config{
 		Operators:     baseCfg.Operators,
 		DefaultOutput: p.emitter,
-	}.Build(p.logger.Sugar())
+	}.Build(p.logger.Sugar(), set)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -225,7 +226,7 @@ type laggyOperatorConfig struct {
 	helper.WriterConfig
 }
 
-func (l *laggyOperatorConfig) Build(s *zap.SugaredLogger) (operator.Operator, error) {
+func (l *laggyOperatorConfig) Build(s *zap.SugaredLogger, _ component.TelemetrySettings) (operator.Operator, error) {
 	wo, err := l.WriterConfig.Build(s)
 	if err != nil {
 		return nil, err

--- a/receiver/otlpjsonfilereceiver/file.go
+++ b/receiver/otlpjsonfilereceiver/file.go
@@ -73,7 +73,7 @@ func createLogsReceiver(_ context.Context, settings receiver.CreateSettings, con
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(settings.Logger.Sugar(), settings.TelemetrySettings, func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartLogsOp(ctx)
 		var l plog.Logs
 		l, err = logsUnmarshaler.UnmarshalLogs(token)
@@ -106,7 +106,7 @@ func createMetricsReceiver(_ context.Context, settings receiver.CreateSettings, 
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(settings.Logger.Sugar(), settings.TelemetrySettings, func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartMetricsOp(ctx)
 		var m pmetric.Metrics
 		m, err = metricsUnmarshaler.UnmarshalMetrics(token)
@@ -138,7 +138,7 @@ func createTracesReceiver(_ context.Context, settings receiver.CreateSettings, c
 		return nil, err
 	}
 	cfg := configuration.(*Config)
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(settings.Logger.Sugar(), settings.TelemetrySettings, func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartTracesOp(ctx)
 		var t ptrace.Traces
 		t, err = tracesUnmarshaler.UnmarshalTraces(token)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This PR is the preliminary work for https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31544.
The goal is to pass in the `component.TelemetrySettings` so as to use them later to report the filelog's state stats -> https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31544/files#diff-8e7ca9f2b21f494d9f8629f816ee7c6b170d4f6948e952d0aeb013c64cafed11R175-R206.

ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31544#pullrequestreview-1917088163

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31256

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>