### PR TITLE
[cmd/telemetrygen] Remove WithBlock from telemetrygen metrics/traces

### DIFF
--- a/.chloggen/dev_fix-tls-handshake-telemetrygen.yaml
+++ b/.chloggen/dev_fix-tls-handshake-telemetrygen.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: telemetrygen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not use WithBlock when forming grpc connections for metrics/traces in telemetrygen to avoid infinite retry after failure
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31401]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/telemetrygen/internal/metrics/exporter.go
+++ b/cmd/telemetrygen/internal/metrics/exporter.go
@@ -8,7 +8,6 @@ import (
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
-	"google.golang.org/grpc"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/common"
 )
@@ -18,9 +17,6 @@ import (
 func grpcExporterOptions(cfg *Config) ([]otlpmetricgrpc.Option, error) {
 	grpcExpOpt := []otlpmetricgrpc.Option{
 		otlpmetricgrpc.WithEndpoint(cfg.Endpoint()),
-		otlpmetricgrpc.WithDialOption(
-			grpc.WithBlock(),
-		),
 	}
 
 	if cfg.Insecure {

--- a/cmd/telemetrygen/internal/traces/exporter.go
+++ b/cmd/telemetrygen/internal/traces/exporter.go
@@ -8,7 +8,6 @@ import (
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
-	"google.golang.org/grpc"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/common"
 )
@@ -18,9 +17,6 @@ import (
 func grpcExporterOptions(cfg *Config) ([]otlptracegrpc.Option, error) {
 	grpcExpOpt := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(cfg.Endpoint()),
-		otlptracegrpc.WithDialOption(
-			grpc.WithBlock(),
-		),
 	}
 
 	if cfg.Insecure {


### PR DESCRIPTION
**Description:**

Metrics and traces in telemetrygen were sent with WithBlock() which was a blocking call waiting on a successful connection to be formed. In the event a connection could not succeed, like a TLS handshake failure, the block would loop indefinitely.

**Link to tracking Issue:** Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31401

**Testing:**

- Run telemetrygen on main pointed at a host that won't resolve TLS and observe that the command loops indefinitely
- Run telemetrygen on this commit pointed at that same host and observe it exit after failing

**Documentation:** <Describe the documentation added.>