### PR TITLE
Fixed bug with batch's creation parameters

### DIFF
--- a/.chloggen/fix_awskinesisexporter_batch_initialize_bug.yaml
+++ b/.chloggen/fix_awskinesisexporter_batch_initialize_bug.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/awskinesisexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the capacity of records slices in the initialized batch
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [20914]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/awskinesisexporter/internal/batch/batch.go
+++ b/exporter/awskinesisexporter/internal/batch/batch.go
@@ -67,7 +67,7 @@ func New(opts ...Option) *Batch {
 		maxBatchSize:  MaxBatchedRecords,
 		maxRecordSize: MaxRecordSize,
 		compression:   compress.NewNoopCompressor(),
-		records:       make([]types.PutRecordsRequestEntry, 0, MaxRecordSize),
+		records:       make([]types.PutRecordsRequestEntry, 0, MaxBatchedRecords),
 	}
 
 	for _, op := range opts {

--- a/exporter/awskinesisexporter/internal/batch/batch_max_records_test.go
+++ b/exporter/awskinesisexporter/internal/batch/batch_max_records_test.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package batch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchRecordsCapacity(t *testing.T) {
+	t.Parallel()
+
+	b := New()
+
+	assert.Equal(t, MaxBatchedRecords, cap(b.records), "Must have correct value set")
+}


### PR DESCRIPTION
Description:
When a new Batch is created, it's slice capacity for the number of records should be set to the maximum number of records, not the max record size, an error that can cause memory to be allocated frequently.
[awskinesisexporter/internal/batch/batch.go#L76-L82](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/41b5f81343828a37f709acf7788b08eb2c66730e/exporter/awskinesisexporter/internal/batch/batch.go#L76-L82)
[awskinesisexporter/internal/batch/batch.go#L28-L29](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/41b5f81343828a37f709acf7788b08eb2c66730e/exporter/awskinesisexporter/internal/batch/batch.go#L28-L29)


This is a copy of the original PR with the same fix found here:
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/20862

I've simply made the change to the tests that was requested in the original PR.

Link to tracking Issue:
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/20914