### PR TITLE
Round 2: Adapt to randomly generated nop component names in unit tests

### DIFF
--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -1397,7 +1397,7 @@ func TestHeartbeatStartupFailed(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualError(t,
 		exporter.Start(context.Background(), componenttest.NewNopHost()),
-		fmt.Sprintf("%s: heartbeat on startup failed: HTTP 403 \"Forbidden\"", params.ID.Type()),
+		fmt.Sprintf("%s: heartbeat on startup failed: HTTP 403 \"Forbidden\"", params.ID.String()),
 	)
 	assert.NoError(t, exporter.Shutdown(context.Background()))
 }

--- a/receiver/filelogreceiver/storage_test.go
+++ b/receiver/filelogreceiver/storage_test.go
@@ -41,7 +41,8 @@ func TestStorage(t *testing.T) {
 	ext := storagetest.NewFileBackedStorageExtension("test", storageDir)
 	host := storagetest.NewStorageHost().WithExtension(ext.ID, ext)
 	sink := new(consumertest.LogsSink)
-	rcvr, err := f.CreateLogsReceiver(ctx, receivertest.NewNopCreateSettings(), cfg, sink)
+	set := receivertest.NewNopCreateSettings()
+	rcvr, err := f.CreateLogsReceiver(ctx, set, cfg, sink)
 	require.NoError(t, err, "failed to create receiver")
 	require.NoError(t, rcvr.Start(ctx, host))
 
@@ -72,7 +73,7 @@ func TestStorage(t *testing.T) {
 	// Start the components again
 	ext = storagetest.NewFileBackedStorageExtension("test", storageDir)
 	host = storagetest.NewStorageHost().WithExtension(ext.ID, ext)
-	rcvr, err = f.CreateLogsReceiver(ctx, receivertest.NewNopCreateSettings(), cfg, sink)
+	rcvr, err = f.CreateLogsReceiver(ctx, set, cfg, sink)
 	require.NoError(t, err, "failed to create receiver")
 	require.NoError(t, rcvr.Start(ctx, host))
 	sink.Reset()
@@ -117,7 +118,7 @@ func TestStorage(t *testing.T) {
 	// Start the components again
 	ext = storagetest.NewFileBackedStorageExtension("test", storageDir)
 	host = storagetest.NewStorageHost().WithExtension(ext.ID, ext)
-	rcvr, err = f.CreateLogsReceiver(ctx, receivertest.NewNopCreateSettings(), cfg, sink)
+	rcvr, err = f.CreateLogsReceiver(ctx, set, cfg, sink)
 	require.NoError(t, err, "failed to create receiver")
 	require.NoError(t, rcvr.Start(ctx, host))
 	sink.Reset()


### PR DESCRIPTION
**Description:**

Follow-up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31640

I didn't realize the contrib test stopped after the first failure, so there were a few more failures for https://github.com/open-telemetry/opentelemetry-collector/pull/9637.

I verified that this passes the contrib-tests check for the core repo locally, so this should be the rest of them.

For the splunkhec exporter, the exporter actually uses `ID.String()`: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/4c5b5e934484ae3084565abbd3746a98e7f27721/exporter/splunkhecexporter/client.go#L71

The filelog receiver was assuming that `NewNopCreateSettings` returned the same ID, so I re-used the create settings in the test.

**Link to tracking Issue:**

Blocking https://github.com/open-telemetry/opentelemetry-collector/pull/9637

@dmitryax @Aneurysm9 @codeboten