### PR TITLE
Add http2 timouts to close bad TCP connection

### DIFF
--- a/.chloggen/add-http2-timeout-aws-xray-connection.yaml
+++ b/.chloggen/add-http2-timeout-aws-xray-connection.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "add http2 connection timout to close bad TCP connection with AWS ALB"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [ 76540 ]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  add http2 connection timout to close bad TCP connection with AWS ALB.
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [ user ]

--- a/internal/aws/awsutil/conn.go
+++ b/internal/aws/awsutil/conn.go
@@ -62,14 +62,24 @@ func newHTTPClient(logger *zap.Logger, maxIdle int, requestTimeout int, noVerify
 	transport := &http.Transport{
 		MaxIdleConnsPerHost: maxIdle,
 		TLSClientConfig:     tls,
+		IdleConnTimeout:     90 * time.Second, // Should be longer than PutTelemetryRecords call frequency: 60 seconds
 		Proxy:               http.ProxyURL(proxyURL),
 	}
 
 	// is not enabled by default as we configure TLSClientConfig for supporting SSL to data plane.
 	// http2.ConfigureTransport will setup transport layer to use HTTP2
-	if err = http2.ConfigureTransport(transport); err != nil {
-		logger.Error("unable to configure http2 transport", zap.Error(err))
-		return nil, err
+	h2transport, err := http2.ConfigureTransports(transport)
+	if err != nil {
+		logger.Warn("Failed to configure HTTP2 transport: %v", zap.Error(err))
+	} else {
+		// Adding timeout settings to the http2 transport to prevent bad tcp connection hanging the requests for too long
+		// See: https://t.corp.amazon.com/P104567981
+		// Doc: https://pkg.go.dev/golang.org/x/net/http2#Transport
+		//  - ReadIdleTimeout is the time before a ping is sent when no frame has been received from a connection
+		//  - PingTimeout is the time before the TCP connection being closed if a Ping response is not received
+		// So in total, if a TCP connection goes bad, it would take the combined time before the TCP connection is closed
+		h2transport.ReadIdleTimeout = 1 * time.Second
+		h2transport.PingTimeout = 2 * time.Second
 	}
 
 	http := &http.Client{


### PR DESCRIPTION
Add http2 timouts to close bad TCP connection

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
During ALB maintainance, there could be cases where the TCP connection from Daemon to X-Ray ALB is not properly closed, the Daemon client will not know the TCP connection is no longer working, and will be kept using it for sending new HTTP2 requests as HTTP2 multplexes all the requests in a single TCP connection, this would results in repeated request timeouts and evetually losing data.

In this change 2 timeouts has been added:

* ReadIdleTimeout time.Duration

        ReadIdleTimeout is the timeout after which a health check using ping frame will be carried out if no frame is received on the connection. Note that a ping response will is considered a received frame, so if there is no other traffic on the connection, the health check will be performed every ReadIdleTimeout interval. If zero, no health check is performed.

 * PingTimeout time.Duration

        PingTimeout is the timeout after which the connection will be closed if a response to Ping is not received. Defaults to 3s (read idle timeout + ping timeout).

So in the case of a TCP connection not being closed properly, the http2 transport would detect there is no frame is being received, then send out a Ping, and if no response is received after the PintTimeout, it would close the connection. Existing pending requests would receive an connection error, which would be retried, and subsequent requests would result in a new connection being created.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

Verified the changes in https://github.com/aws/aws-xray-daemon

**Documentation:** <Describe the documentation added.>
https://github.com/aws/aws-xray-daemon/pull/216