### PR TITLE
[chore] fix changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -84,7 +84,7 @@ jobs:
         run: make chlog-preview > changelog_preview.md
       - name: Install markdown-link-check
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
-        run: npm install -g markdown-link-check
+        run: npm install -g markdown-link-check@3.11.2
       - name: Run markdown-link-check
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: |


### PR DESCRIPTION
Fixes #31680

Let's pin markdown-link-check to the previous version v3.11.2 until the bug in the latest version v3.12.0 is fixed.