### PR TITLE
[processor/deltotocumulative] Fix lint failure

### DIFF
--- a/processor/deltatocumulativeprocessor/processor.go
+++ b/processor/deltatocumulativeprocessor/processor.go
@@ -57,8 +57,8 @@ func newProcessor(cfg *Config, log *zap.Logger, next consumer.Metrics) *Processo
 	}
 	if cfg.MaxStreams > 0 {
 		lim := streams.Limit(dps, cfg.MaxStreams)
-		if proc.exp != nil {
-			lim.Evictor = proc.exp
+		if proc.stale != nil {
+			lim.Evictor = proc.stale
 		}
 		dps = lim
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31488 was recently merged and has broken `build-and-test` for all builds due to a lint failure. It looks like two PRs were worked on in parallel, the aforementioned one, as well as https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31625. #31625 renamed `exp` to `stale`, but the most recently merged PR was referencing the original `exp` variable.

This is an unreleased component, and is simply fixing a bug, so I don't think this should have a changelog.