### PR TITLE
[processor/deltatocumulative] Adjust Config struct and MaxStreams validates

### DIFF
--- a/processor/deltatocumulativeprocessor/config.go
+++ b/processor/deltatocumulativeprocessor/config.go
@@ -13,8 +13,8 @@ import (
 var _ component.ConfigValidator = (*Config)(nil)
 
 type Config struct {
-	MaxStale   time.Duration `json:"max_stale"`
-	MaxStreams int           `json:"max_streams"`
+	MaxStale   time.Duration `mapstructure:"max_stale"`
+	MaxStreams int           `mapstructure:"max_streams"`
 }
 
 func (c *Config) Validate() error {

--- a/processor/deltatocumulativeprocessor/config.go
+++ b/processor/deltatocumulativeprocessor/config.go
@@ -21,7 +21,7 @@ func (c *Config) Validate() error {
 	if c.MaxStale <= 0 {
 		return fmt.Errorf("max_stale must be a positive duration (got %s)", c.MaxStale)
 	}
-	if c.MaxStreams <= 0 {
+	if c.MaxStreams < 0 {
 		return fmt.Errorf("max_streams must be a positive number (got %d)", c.MaxStreams)
 	}
 	return nil

--- a/processor/deltatocumulativeprocessor/config_test.go
+++ b/processor/deltatocumulativeprocessor/config_test.go
@@ -1,0 +1,65 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package deltatocumulativeprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/confmap/confmaptest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/metadata"
+)
+
+func TestLoadConfig(t *testing.T) {
+	t.Parallel()
+
+	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		id       component.ID
+		expected component.Config
+	}{
+		{
+			id: component.NewIDWithName(metadata.Type, "all"),
+			expected: &Config{
+				MaxStale:   1 * time.Minute,
+				MaxStreams: 10,
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "set-valid-max_stale"),
+			expected: &Config{
+				MaxStale:   2 * time.Minute,
+				MaxStreams: 0,
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "set-valid-max_streams"),
+			expected: &Config{
+				MaxStale:   5 * time.Minute,
+				MaxStreams: 20,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.id.String(), func(t *testing.T) {
+			factory := NewFactory()
+			cfg := factory.CreateDefaultConfig()
+
+			sub, err := cm.Sub(tt.id.String())
+			require.NoError(t, err)
+			require.NoError(t, component.UnmarshalConfig(sub, cfg))
+
+			assert.NoError(t, component.ValidateConfig(cfg))
+			assert.Equal(t, tt.expected, cfg)
+		})
+	}
+}

--- a/processor/deltatocumulativeprocessor/testdata/config.yaml
+++ b/processor/deltatocumulativeprocessor/testdata/config.yaml
@@ -1,0 +1,7 @@
+deltatocumulative/all:
+  max_stale: 1m
+  max_streams: 10
+deltatocumulative/set-valid-max_stale:
+  max_stale: 2m
+deltatocumulative/set-valid-max_streams:
+  max_streams: 20


### PR DESCRIPTION
**Description:** The Config struct was changed from JSON to mapstructure to parse the configuration correctly. Additionally, the validation of MaxStreams was adjusted to consider values of 0.

**Testing:** Unit tests were added for the config.go file.
