### PR TITLE
[chore] Fix args order to ptracetest/CompareSpan

### DIFF
--- a/pkg/pdatatest/ptracetest/testdata/ignore-attribute-value/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-attribute-value/actual.yaml
@@ -20,7 +20,7 @@ resourceSpans:
           - attributes:
               - key: testKey2
                 value:
-                  stringValue: teststringvalue2
+                  stringValue: unpredictable
             parentSpanId: ""
             spanId: ""
             status: {}

--- a/pkg/pdatatest/ptracetest/testdata/ignore-attribute-value/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-attribute-value/expected.yaml
@@ -20,7 +20,7 @@ resourceSpans:
           - attributes:
               - key: testKey2
                 value:
-                  stringValue: unpredictable
+                  stringValue: teststringvalue2
             parentSpanId: ""
             spanId: ""
             status: {}

--- a/pkg/pdatatest/ptracetest/testdata/ignore-end-timestamp/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-end-timestamp/actual.yaml
@@ -16,7 +16,5 @@ resourceSpans:
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b
-            endTimeUnixNano: "11651379494838206464"
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
-

--- a/pkg/pdatatest/ptracetest/testdata/ignore-end-timestamp/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-end-timestamp/expected.yaml
@@ -16,5 +16,7 @@ resourceSpans:
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b
+            endTimeUnixNano: "11651379494838206464"
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
+

--- a/pkg/pdatatest/ptracetest/testdata/ignore-end-timestamp/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-end-timestamp/expected.yaml
@@ -19,4 +19,3 @@ resourceSpans:
             endTimeUnixNano: "11651379494838206464"
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
-

--- a/pkg/pdatatest/ptracetest/testdata/ignore-spanid/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-spanid/actual.yaml
@@ -15,7 +15,5 @@ resourceSpans:
                   stringValue: value1
             name: span1
             parentSpanId: ""
-            spanId: fd0da883bb27cd6b
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
-

--- a/pkg/pdatatest/ptracetest/testdata/ignore-spanid/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-spanid/expected.yaml
@@ -15,5 +15,6 @@ resourceSpans:
                   stringValue: value1
             name: span1
             parentSpanId: ""
+            spanId: fd0da883bb27cd6b
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/ignore-start-timestamp/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-start-timestamp/actual.yaml
@@ -16,7 +16,5 @@ resourceSpans:
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b
-            startTimeUnixNano: "11651379494838206464"
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
-

--- a/pkg/pdatatest/ptracetest/testdata/ignore-start-timestamp/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-start-timestamp/expected.yaml
@@ -19,4 +19,3 @@ resourceSpans:
             startTimeUnixNano: "11651379494838206464"
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
-

--- a/pkg/pdatatest/ptracetest/testdata/ignore-start-timestamp/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-start-timestamp/expected.yaml
@@ -16,5 +16,7 @@ resourceSpans:
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b
+            startTimeUnixNano: "11651379494838206464"
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
+

--- a/pkg/pdatatest/ptracetest/testdata/ignore-traceid/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-traceid/actual.yaml
@@ -17,5 +17,3 @@ resourceSpans:
             parentSpanId: ""
             spanId: fd0da883bb27cd6b
             status: {}
-            traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
-

--- a/pkg/pdatatest/ptracetest/testdata/ignore-traceid/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-traceid/expected.yaml
@@ -17,3 +17,5 @@ resourceSpans:
             parentSpanId: ""
             spanId: fd0da883bb27cd6b
             status: {}
+            traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
+

--- a/pkg/pdatatest/ptracetest/testdata/ignore-traceid/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/ignore-traceid/expected.yaml
@@ -18,4 +18,3 @@ resourceSpans:
             spanId: fd0da883bb27cd6b
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
-

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-attributes-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-attributes-mismatch/actual.yaml
@@ -20,7 +20,7 @@ resourceSpans:
           - attributes:
               - key: key2
                 value:
-                  stringValue: value2
+                  stringValue: value3
             parentSpanId: ""
             spanId: ""
             status: {}

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-attributes-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-attributes-mismatch/expected.yaml
@@ -20,7 +20,7 @@ resourceSpans:
           - attributes:
               - key: key2
                 value:
-                  stringValue: value3
+                  stringValue: value2
             parentSpanId: ""
             spanId: ""
             status: {}

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedattributescount-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedattributescount-mismatch/actual.yaml
@@ -13,6 +13,7 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
+            droppedAttributesCount: 1
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedattributescount-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedattributescount-mismatch/expected.yaml
@@ -13,7 +13,6 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
-            droppedAttributesCount: 1
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedeventscount-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedeventscount-mismatch/actual.yaml
@@ -13,6 +13,7 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
+            droppedEventsCount: 1
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedeventscount-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedeventscount-mismatch/expected.yaml
@@ -13,7 +13,6 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
-            droppedEventsCount: 1
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedlinkscount-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedlinkscount-mismatch/actual.yaml
@@ -13,6 +13,7 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
+            droppedLinksCount: 1
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedlinkscount-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-droppedlinkscount-mismatch/expected.yaml
@@ -13,7 +13,6 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
-            droppedLinksCount: 1
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-endtimestamp-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-endtimestamp-mismatch/actual.yaml
@@ -13,7 +13,7 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
-            endTimeUnixNano: "11651379494838206464"
+            endTimeUnixNano: "11651379494838206400"
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-endtimestamp-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-endtimestamp-mismatch/expected.yaml
@@ -13,7 +13,7 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
-            endTimeUnixNano: "11651379494838206400"
+            endTimeUnixNano: "11651379494838206464"
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-events-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-events-mismatch/actual.yaml
@@ -13,8 +13,6 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
-            events:
-              - name: Sub span event
             parentSpanId: ""
             spanId: ""
             status: {}

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-events-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-events-mismatch/expected.yaml
@@ -13,6 +13,8 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
+            events:
+              - name: Sub span event
             parentSpanId: ""
             spanId: ""
             status: {}

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-events-name-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-events-name-mismatch/actual.yaml
@@ -14,7 +14,7 @@ resourceSpans:
                 value:
                   stringValue: value1
             events:
-              - name: event1
+              - name: event2
             parentSpanId: ""
             spanId: ""
             status: {}

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-events-name-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-events-name-mismatch/expected.yaml
@@ -14,7 +14,7 @@ resourceSpans:
                 value:
                   stringValue: value1
             events:
-              - name: event2
+              - name: event1
             parentSpanId: ""
             spanId: ""
             status: {}

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-kind-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-kind-mismatch/actual.yaml
@@ -13,7 +13,7 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
-            kind: 2
+            kind: 1
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-kind-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-kind-mismatch/expected.yaml
@@ -13,7 +13,7 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
-            kind: 1
+            kind: 2
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-links-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-links-mismatch/actual.yaml
@@ -13,16 +13,6 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
-            links:
-              - attributes:
-                  - key: testKey1
-                    value:
-                      stringValue: teststringvalue1
-                  - key: testKey2
-                    value:
-                      stringValue: teststringvalue2
-                spanId: fd0da883bb27cd6b
-                traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
             parentSpanId: ""
             spanId: ""
             status: {}

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-links-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-links-mismatch/expected.yaml
@@ -13,6 +13,16 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
+            links:
+              - attributes:
+                  - key: testKey1
+                    value:
+                      stringValue: teststringvalue1
+                  - key: testKey2
+                    value:
+                      stringValue: teststringvalue2
+                spanId: fd0da883bb27cd6b
+                traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
             parentSpanId: ""
             spanId: ""
             status: {}

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-links-spanid-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-links-spanid-mismatch/actual.yaml
@@ -14,7 +14,7 @@ resourceSpans:
                 value:
                   stringValue: value1
             links:
-              - spanId: ""
+              - spanId: fd0da883bb27cd6b
                 traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
             parentSpanId: ""
             spanId: ""

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-links-spanid-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-links-spanid-mismatch/expected.yaml
@@ -14,7 +14,7 @@ resourceSpans:
                 value:
                   stringValue: value1
             links:
-              - spanId: fd0da883bb27cd6b
+              - spanId: ""
                 traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
             parentSpanId: ""
             spanId: ""

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-parentspanid-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-parentspanid-mismatch/actual.yaml
@@ -13,7 +13,7 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
-            parentSpanId: bcff497b5a47310f
+            parentSpanId: 310fbcff497b5a47
             spanId: fd0da883bb27cd6b
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-parentspanid-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-parentspanid-mismatch/expected.yaml
@@ -13,7 +13,7 @@ resourceSpans:
               - key: key1
                 value:
                   stringValue: value1
-            parentSpanId: 310fbcff497b5a47
+            parentSpanId: bcff497b5a47310f
             spanId: fd0da883bb27cd6b
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-spanid-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-spanid-mismatch/actual.yaml
@@ -14,6 +14,6 @@ resourceSpans:
                 value:
                   stringValue: value1
             parentSpanId: ""
-            spanId: fd0da883bb27cd6b
+            spanId: d0dfa883bb27cd6b
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-spanid-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-spanid-mismatch/expected.yaml
@@ -14,6 +14,6 @@ resourceSpans:
                 value:
                   stringValue: value1
             parentSpanId: ""
-            spanId: d0dfa883bb27cd6b
+            spanId: fd0da883bb27cd6b
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-starttimestamp-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-starttimestamp-mismatch/actual.yaml
@@ -16,6 +16,6 @@ resourceSpans:
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b
-            startTimeUnixNano: "11651379494838206464"
+            startTimeUnixNano: "11651379494838206400"
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-starttimestamp-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-starttimestamp-mismatch/expected.yaml
@@ -16,6 +16,6 @@ resourceSpans:
             name: span1
             parentSpanId: ""
             spanId: fd0da883bb27cd6b
-            startTimeUnixNano: "11651379494838206400"
+            startTimeUnixNano: "11651379494838206464"
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-status-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-status-mismatch/actual.yaml
@@ -15,6 +15,5 @@ resourceSpans:
                   stringValue: value1
             parentSpanId: ""
             spanId: ""
-            status:
-              code: 1
+            status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-status-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-status-mismatch/expected.yaml
@@ -15,5 +15,6 @@ resourceSpans:
                   stringValue: value1
             parentSpanId: ""
             spanId: ""
-            status: {}
+            status:
+              code: 1
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-traceid-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-traceid-mismatch/actual.yaml
@@ -16,4 +16,4 @@ resourceSpans:
             parentSpanId: ""
             spanId: ""
             status: {}
-            traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
+            traceId: b8cb1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-traceid-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-traceid-mismatch/expected.yaml
@@ -16,4 +16,4 @@ resourceSpans:
             parentSpanId: ""
             spanId: ""
             status: {}
-            traceId: b8cb1765a7b0acf0b66aa4623fcb7bd5
+            traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-tracestate-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-tracestate-mismatch/actual.yaml
@@ -17,4 +17,4 @@ resourceSpans:
             spanId: fd0da883bb27cd6b
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
-            traceState: xx
+            traceState: yy

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-spans-tracestate-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-spans-tracestate-mismatch/expected.yaml
@@ -17,4 +17,4 @@ resourceSpans:
             spanId: fd0da883bb27cd6b
             status: {}
             traceId: 8c8b1765a7b0acf0b66aa4623fcb7bd5
-            traceState: yy
+            traceState: xx

--- a/pkg/pdatatest/ptracetest/traces.go
+++ b/pkg/pdatatest/ptracetest/traces.go
@@ -206,7 +206,7 @@ func CompareScopeSpans(expected, actual ptrace.ScopeSpans) error {
 	}
 
 	for as, es := range matchingSpans {
-		errs = multierr.Append(errs, internal.AddErrPrefix(fmt.Sprintf(`span "%s"`, es.Name()), CompareSpan(as, es)))
+		errs = multierr.Append(errs, internal.AddErrPrefix(fmt.Sprintf(`span "%s"`, es.Name()), CompareSpan(es, as)))
 	}
 
 	return errs
@@ -340,7 +340,7 @@ func compareSpanEventSlice(expected, actual ptrace.SpanEventSlice) (errs error) 
 	}
 
 	for ae, ee := range matchingSpanEvents {
-		errs = multierr.Append(errs, internal.AddErrPrefix(fmt.Sprintf(`span event "%s"`, ee.Name()), CompareSpanEvent(ae, ee)))
+		errs = multierr.Append(errs, internal.AddErrPrefix(fmt.Sprintf(`span event "%s"`, ee.Name()), CompareSpanEvent(ee, ae)))
 	}
 
 	return errs
@@ -420,7 +420,7 @@ func compareSpanLinkSlice(expected, actual ptrace.SpanLinkSlice) (errs error) {
 	}
 
 	for al, el := range matchingSpanLinks {
-		errs = multierr.Append(errs, internal.AddErrPrefix(fmt.Sprintf(`span link "%s"`, el.SpanID()), CompareSpanLink(al, el)))
+		errs = multierr.Append(errs, internal.AddErrPrefix(fmt.Sprintf(`span link "%s"`, el.SpanID()), CompareSpanLink(el, al)))
 	}
 
 	return errs


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Pass the correct `expected, actual` variables to CompareSpan fns in ptracetest. The errors show the reverse expected and actual trace due to this.

**Testing:** <Describe what testing was performed and which tests were added.>
Updated unit tests - swapped the actual/expected yamls for impacted tests.