### PR TITLE
[chore] lint fix in cmd/checkapi

### DIFF
--- a/cmd/checkapi/main.go
+++ b/cmd/checkapi/main.go
@@ -47,10 +47,11 @@ func run(folder string, allowlistFilePath string) error {
 	}
 	allowlist := strings.Split(string(allowlistData), "\n")
 	var errs []error
-	err = filepath.Walk(folder, func(path string, info fs.FileInfo, err error) error {
+	err = filepath.Walk(folder, func(path string, info fs.FileInfo, _ error) error {
 		if info.Name() == "go.mod" {
 			base := filepath.Dir(path)
-			relativeBase, err := filepath.Rel(folder, base)
+			var relativeBase string
+			relativeBase, err = filepath.Rel(folder, base)
 			if err != nil {
 				return err
 			}
@@ -67,7 +68,7 @@ func run(folder string, allowlistFilePath string) error {
 					return nil
 				}
 			}
-			if err := walkFolder(base, componentType); err != nil {
+			if err = walkFolder(base, componentType); err != nil {
 				errs = append(errs, err)
 			}
 		}


### PR DESCRIPTION
**Description:** 
linting error with:

```
INFO [runner] linters took 1.336744316s with stages: goanalysis_metalinter: 1.334941582s 
opentelemetry-collector-contrib/cmd/checkapi/main.go:50:66: unused-parameter: parameter 'err' seems to be unused, consider removing or renaming it as _ (revive)
	err = filepath.Walk(folder, func(path string, info fs.FileInfo, err error) error {
	                                                                ^
```
and: 
```
INFO [runner] linters took 1.806204856s with stages: goanalysis_metalinter: 1.80522593s 
opentelemetry-collector-contrib/cmd/checkapi/main.go:53:18: shadow: declaration of "err" shadows declaration at line 44 (govet)
			relativeBase, err := filepath.Rel(folder, base)
			              ^
```

**Link to tracking Issue:** <Issue number if applicable>
- #31240


**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>