### PR TITLE
Change the way that X-Ray exporter annotation converter work

### DIFF
--- a/.chloggen/xray_exporter_allow_dot_annotation.yaml
+++ b/.chloggen/xray_exporter_allow_dot_annotation.yaml
@@ -15,8 +15,7 @@ issues: [31732]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:  In the past, X-Ray doesn’t support “.”. So we have a translator in x-ray export to translates it to “_” before sending traces to X-Ray Service. | To match otel naming style, x-ray service team decide to change their service to support both "." type and "" type of naming. In this case 
-  the translator that translate "." to "" is no-longer needed. This PR change the way this translator work | X-Ray PMs agree on rolling out this change by using feature-gate
+subtext:  In the past, X-Ray doesn’t support “.”. So we have a translator in x-ray export to translates it to “_” before sending traces to X-Ray Service. | To match otel naming style, x-ray service team decide to change their service to support both "." type and "" type of naming. In this case the translator that translate "." to "" is no-longer needed. This PR change the way this translator work | X-Ray PMs agree on rolling out this change by using feature-gate
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/xray_exporter_allow_dot_annotation.yaml
+++ b/.chloggen/xray_exporter_allow_dot_annotation.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: change x-ray exporter's translator to make "." split annotation pass as-is
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31732]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:  In the past, X-Ray doesn’t support “.”. So we have a translator in x-ray export to translates it to “_” before sending traces to X-Ray Service. | To match otel naming style, x-ray service team decide to change their service to support both "." type and "" type of naming. In this case 
+  the translator that translate "." to "" is no-longer needed. This PR change the way this translator work | X-Ray PMs agree on rolling out this change by using feature-gate
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	awsP "github.com/aws/aws-sdk-go/aws"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.8.0"
@@ -44,6 +45,15 @@ var (
 	// reInvalidSpanCharacters defines the invalid letters in a span name as per
 	// https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html
 	reInvalidSpanCharacters = regexp.MustCompile(`[^ 0-9\p{L}N_.:/%&#=+,\-@]`)
+)
+
+var (
+	remoteXrayExporterDotConverter = featuregate.GlobalRegistry().MustRegister(
+		"exporter.xray.allowDot",
+		featuregate.StageAlpha,
+		featuregate.WithRegisterDescription("X-Ray Exporter will no longer convert . to _ in annotation keys when this feature gate is enabled. "),
+		featuregate.WithRegisterFromVersion("v0.97.0"),
+	)
 )
 
 const (
@@ -517,6 +527,8 @@ func fixAnnotationKey(key string) string {
 		case 'A' <= r && r <= 'Z':
 			fallthrough
 		case 'a' <= r && r <= 'z':
+			return r
+		case remoteXrayExporterDotConverter.IsEnabled() && r == '.':
 			return r
 		default:
 			return '_'

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -13,11 +13,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.8.0"
-
-	"go.opentelemetry.io/collector/featuregate"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
@@ -409,7 +408,8 @@ func TestFixSegmentName(t *testing.T) {
 }
 
 func TestFixAnnotationKey(t *testing.T) {
-	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+	assert.Nil(t, err)
 
 	validKey := "Key_1"
 	fixedKey := fixAnnotationKey(validKey)
@@ -423,7 +423,8 @@ func TestFixAnnotationKey(t *testing.T) {
 }
 
 func TestFixAnnotationKeyWithAllowDot(t *testing.T) {
-	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+	assert.Nil(t, err)
 
 	validKey := "Key_1"
 	fixedKey := fixAnnotationKey(validKey)
@@ -583,7 +584,8 @@ func TestSpanWithAttributesSegmentMetadata(t *testing.T) {
 }
 
 func TestResourceAttributesCanBeIndexed(t *testing.T) {
-	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+	assert.Nil(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
@@ -615,7 +617,8 @@ func TestResourceAttributesCanBeIndexed(t *testing.T) {
 }
 
 func TestResourceAttributesCanBeIndexedWithAllowDot(t *testing.T) {
-	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+	assert.Nil(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
@@ -668,7 +671,8 @@ func TestResourceAttributesNotIndexedIfSubsegment(t *testing.T) {
 }
 
 func TestSpanWithSpecialAttributesAsListed(t *testing.T) {
-	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+	assert.Nil(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
@@ -687,7 +691,8 @@ func TestSpanWithSpecialAttributesAsListed(t *testing.T) {
 }
 
 func TestSpanWithSpecialAttributesAsListedWithAllowDot(t *testing.T) {
-	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+	assert.Nil(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
@@ -706,7 +711,8 @@ func TestSpanWithSpecialAttributesAsListedWithAllowDot(t *testing.T) {
 }
 
 func TestSpanWithSpecialAttributesAsListedAndIndexAll(t *testing.T) {
-	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+	assert.Nil(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
@@ -724,7 +730,8 @@ func TestSpanWithSpecialAttributesAsListedAndIndexAll(t *testing.T) {
 }
 
 func TestSpanWithSpecialAttributesAsListedAndIndexAllWithAllowDot(t *testing.T) {
-	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+	assert.Nil(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -517,7 +517,6 @@ func TestSpanWithAttributesPartlyIndexed(t *testing.T) {
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, 1, len(segment.Annotations))
-
 	assert.Equal(t, "val1", segment.Annotations["attr1_1"])
 	assert.Equal(t, "val2", segment.Metadata["default"]["attr2@2"])
 }
@@ -536,7 +535,6 @@ func TestSpanWithAnnotationsAttribute(t *testing.T) {
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, 1, len(segment.Annotations))
-
 	assert.Equal(t, "val2", segment.Annotations["attr2_2"])
 	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
 }
@@ -545,7 +543,6 @@ func TestSpanWithAttributesAllIndexed(t *testing.T) {
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
-
 	attributes["attr1@1"] = "val1"
 	attributes["attr2@2"] = "val2"
 	resource := constructDefaultResource()

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -17,6 +17,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.8.0"
 
+	"go.opentelemetry.io/collector/featuregate"
+
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
 
@@ -407,9 +409,28 @@ func TestFixSegmentName(t *testing.T) {
 }
 
 func TestFixAnnotationKey(t *testing.T) {
+	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+
 	validKey := "Key_1"
 	fixedKey := fixAnnotationKey(validKey)
 	assert.Equal(t, validKey, fixedKey)
+	validDotKey := "Key.1"
+	fixedDotKey := fixAnnotationKey(validDotKey)
+	assert.Equal(t, "Key_1", fixedDotKey)
+	invalidKey := "Key@1"
+	fixedKey = fixAnnotationKey(invalidKey)
+	assert.Equal(t, "Key_1", fixedKey)
+}
+
+func TestFixAnnotationKeyWithAllowDot(t *testing.T) {
+	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+
+	validKey := "Key_1"
+	fixedKey := fixAnnotationKey(validKey)
+	assert.Equal(t, validKey, fixedKey)
+	validDotKey := "Key.1"
+	fixedDotKey := fixAnnotationKey(validDotKey)
+	assert.Equal(t, validDotKey, fixedDotKey)
 	invalidKey := "Key@1"
 	fixedKey = fixAnnotationKey(invalidKey)
 	assert.Equal(t, "Key_1", fixedKey)
@@ -496,6 +517,7 @@ func TestSpanWithAttributesPartlyIndexed(t *testing.T) {
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, 1, len(segment.Annotations))
+
 	assert.Equal(t, "val1", segment.Annotations["attr1_1"])
 	assert.Equal(t, "val2", segment.Metadata["default"]["attr2@2"])
 }
@@ -514,6 +536,7 @@ func TestSpanWithAnnotationsAttribute(t *testing.T) {
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, 1, len(segment.Annotations))
+
 	assert.Equal(t, "val2", segment.Annotations["attr2_2"])
 	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
 }
@@ -522,6 +545,7 @@ func TestSpanWithAttributesAllIndexed(t *testing.T) {
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
+
 	attributes["attr1@1"] = "val1"
 	attributes["attr2@2"] = "val2"
 	resource := constructDefaultResource()
@@ -562,12 +586,13 @@ func TestSpanWithAttributesSegmentMetadata(t *testing.T) {
 }
 
 func TestResourceAttributesCanBeIndexed(t *testing.T) {
+	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
-
 	segment, _ := MakeSegment(span, resource, []string{
 		"otel.resource.string.key",
 		"otel.resource.int.key",
@@ -583,7 +608,38 @@ func TestResourceAttributesCanBeIndexed(t *testing.T) {
 	assert.Equal(t, int64(10), segment.Annotations["otel_resource_int_key"])
 	assert.Equal(t, 5.0, segment.Annotations["otel_resource_double_key"])
 	assert.Equal(t, true, segment.Annotations["otel_resource_bool_key"])
+	expectedMap := make(map[string]any)
+	expectedMap["key1"] = int64(1)
+	expectedMap["key2"] = "value"
+	// Maps and arrays are not supported for annotations so still in metadata.
+	assert.Equal(t, expectedMap, segment.Metadata["default"]["otel.resource.map.key"])
+	expectedArr := []any{"foo", "bar"}
+	assert.Equal(t, expectedArr, segment.Metadata["default"]["otel.resource.array.key"])
+}
 
+func TestResourceAttributesCanBeIndexedWithAllowDot(t *testing.T) {
+	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]any)
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
+	segment, _ := MakeSegment(span, resource, []string{
+		"otel.resource.string.key",
+		"otel.resource.int.key",
+		"otel.resource.double.key",
+		"otel.resource.bool.key",
+		"otel.resource.map.key",
+		"otel.resource.array.key",
+	}, false, nil, false)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, 4, len(segment.Annotations))
+	assert.Equal(t, "string", segment.Annotations["otel.resource.string.key"])
+	assert.Equal(t, int64(10), segment.Annotations["otel.resource.int.key"])
+	assert.Equal(t, 5.0, segment.Annotations["otel.resource.double.key"])
+	assert.Equal(t, true, segment.Annotations["otel.resource.bool.key"])
 	expectedMap := make(map[string]any)
 	expectedMap["key1"] = int64(1)
 	expectedMap["key2"] = "value"
@@ -615,6 +671,8 @@ func TestResourceAttributesNotIndexedIfSubsegment(t *testing.T) {
 }
 
 func TestSpanWithSpecialAttributesAsListed(t *testing.T) {
+	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
@@ -631,7 +689,28 @@ func TestSpanWithSpecialAttributesAsListed(t *testing.T) {
 	assert.Equal(t, "rpc_method_val", segment.Annotations["rpc_method"])
 }
 
+func TestSpanWithSpecialAttributesAsListedWithAllowDot(t *testing.T) {
+	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]any)
+	attributes[awsxray.AWSOperationAttribute] = "aws_operation_val"
+	attributes[conventions.AttributeRPCMethod] = "rpc_method_val"
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventions.AttributeRPCMethod}, false, nil, false)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, 2, len(segment.Annotations))
+	assert.Equal(t, "aws_operation_val", segment.Annotations[awsxray.AWSOperationAttribute])
+	assert.Equal(t, "rpc_method_val", segment.Annotations[conventions.AttributeRPCMethod])
+}
+
 func TestSpanWithSpecialAttributesAsListedAndIndexAll(t *testing.T) {
+	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
+
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
@@ -645,6 +724,24 @@ func TestSpanWithSpecialAttributesAsListedAndIndexAll(t *testing.T) {
 	assert.NotNil(t, segment)
 	assert.Equal(t, "aws_operation_val", segment.Annotations["aws_operation"])
 	assert.Equal(t, "rpc_method_val", segment.Annotations["rpc_method"])
+}
+
+func TestSpanWithSpecialAttributesAsListedAndIndexAllWithAllowDot(t *testing.T) {
+	featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
+
+	spanName := "/api/locations"
+	parentSpanID := newSegmentID()
+	attributes := make(map[string]any)
+	attributes[awsxray.AWSOperationAttribute] = "aws_operation_val"
+	attributes[conventions.AttributeRPCMethod] = "rpc_method_val"
+	resource := constructDefaultResource()
+	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
+
+	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventions.AttributeRPCMethod}, true, nil, false)
+
+	assert.NotNil(t, segment)
+	assert.Equal(t, "aws_operation_val", segment.Annotations[awsxray.AWSOperationAttribute])
+	assert.Equal(t, "rpc_method_val", segment.Annotations[conventions.AttributeRPCMethod])
 }
 
 func TestSpanWithSpecialAttributesNotListedAndIndexAll(t *testing.T) {


### PR DESCRIPTION
Description:
In the past, X-Ray doesn’t support “.”. So we have a translator in x-ray export to translates it to “_” before sending traces to X-Ray Service.

To match otel naming style, x-ray service team decide to change their service to support both "." type and "" type of naming. In this case the translator that translate "." to "" is no-longer needed. This PR change the way this translator work

X-Ray PMs agree on rolling out this change by using feature-gate

Testing:
Unit test