### PR TITLE
[adapter] pass context with root span to consumer

### DIFF
--- a/pkg/stanza/adapter/receiver.go
+++ b/pkg/stanza/adapter/receiver.go
@@ -122,7 +122,7 @@ func (r *receiver) consumerLoop(ctx context.Context) {
 			}
 			obsrecvCtx := r.obsrecv.StartLogsOp(ctx)
 			logRecordCount := pLogs.LogRecordCount()
-			cErr := r.consumer.ConsumeLogs(ctx, pLogs)
+			cErr := r.consumer.ConsumeLogs(obsrecvCtx, pLogs)
 			if cErr != nil {
 				r.logger.Error("ConsumeLogs() failed", zap.Error(cErr))
 			}


### PR DESCRIPTION
**Description:** 
This PR fixes the issue of incorrect context passing to the consumer. The context being passed to the consumer should include the root span of the internal telemetry.