### PR TITLE
[connector/servicegraph] amend README example

### DIFF
--- a/connector/servicegraphconnector/README.md
+++ b/connector/servicegraphconnector/README.md
@@ -153,7 +153,7 @@ receivers:
 
 connectors:
   servicegraph:
-    latency_histogram_buckets: [1,2,3,4,5]
+    latency_histogram_buckets: [100ms, 250ms, 1s, 5s, 10s]
     dimensions:
       - dimension-1
       - dimension-2


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR amends the example configuration for the servicegraph processor to a more meaningful example

**Link to tracking Issue:** <Issue number if applicable> None filed

**Testing:** <Describe what testing was performed and which tests were added.> None

**Documentation:** <Describe the documentation added.>

The type of `latency_histogram_buckets` being []time.Duration leads to the provided values here to be actually `["1ns", "2ns", "3ns", "4ns", "5ns"]` which a) is not useful, and b) is probably not what a user expects when reading this.

This PR amends the example to use actual durations, so that the intent is clearer.